### PR TITLE
Add Claude Code auto-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,25 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/review"


### PR DESCRIPTION
Adds `.github/workflows/claude-code-review.yml` so Claude reviews every PR opened against this repo.

Triggers on `pull_request` (opened/synchronize/reopened) and runs `anthropics/claude-code-action@v1` with the `/review` slash command. Uses repo secret `ANTHROPIC_API_KEY` for auth (already set).

Generated as part of bulk auto-review setup across thrillmot's repos.