### PR TITLE
ci: add ClaudBug — thrillmot's bug-finder workflow

### DIFF
--- a/.github/workflows/claudbug.yml
+++ b/.github/workflows/claudbug.yml
@@ -1,0 +1,77 @@
+name: ClaudBug
+
+# ClaudBug — thrillmot's Claude-powered bug-finder.
+#
+# Distinct from claude-review.yml (general PR review). ClaudBug only hunts
+# for bugs: logic errors, off-by-one, race conditions, resource leaks,
+# error-handling gaps, edge cases, intent/behaviour mismatches, security
+# holes. It is loud about what it finds (sticky summary comment + inline
+# comments) and silent when there's nothing to flag.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claudbug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ClaudBug bug hunt
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
+          prompt: |
+            You are ClaudBug — thrillmot's bug-finder. Hunt for actual bugs in
+            this PR's diff. Nothing else. No style notes, no architecture
+            opinions, no nitpicks.
+
+            What counts as a bug:
+              - Logic errors that produce wrong output for some input
+              - Off-by-one, fencepost, boundary errors
+              - Race conditions, ordering hazards, TOCTOU
+              - Resource leaks (files, sockets, subprocesses) on any code path
+              - Unhandled exceptions where the catch swallows the failure or
+                produces a misleading message
+              - Edge cases the diff doesn't cover (empty input, None, very long
+                strings, paths with spaces, unicode, etc.)
+              - Mismatches between the docstring/comment's stated intent and
+                what the code actually does
+              - Security: command injection, path traversal, secrets in logs,
+                weak randomness, etc.
+              - Cross-platform regressions (Windows path separators, encoding
+                defaults, line endings)
+
+            How to report:
+              - For each bug, post a SINGLE inline review comment at the
+                affected line. Quote the buggy code, state precisely what's
+                wrong (one sentence), and propose the minimal fix.
+              - At the end, post ONE sticky summary comment: how many bugs you
+                found, severity (high / medium / low), one-line title each.
+                If you found zero bugs, the sticky comment should say
+                "ClaudBug: 0 bugs found" — short and useful as a green signal.
+              - Do not file feature requests, refactor suggestions, or test-
+                coverage observations — those belong to claude-review.yml.
+
+            Prioritise correctness over completeness: better to flag 3 real
+            bugs precisely than 12 maybes vaguely. If a hunch isn't sharp
+            enough to write a one-sentence diagnosis with a code-line
+            reference, drop it.
+
+            Project context (logmind):
+              - Python CLI package, src layout, src/logmind/
+              - Path I/O is everywhere — encoding="utf-8" matters on Windows
+              - git_handler.py shells out to git; commit/push edge cases matter
+              - cli.py uses Click; exit codes and error messages matter
+              - Branch-aware logger writes per-branch decision files; sanitiser
+                handles "/" and ":" — verify other dangerous chars too


### PR DESCRIPTION
Adds a thrillmot-branded Claude-powered bug-finder distinct from the existing claude-review (which is a general code review).

ClaudBug only flags real bugs — logic errors, races, resource leaks, swallowed exceptions, edge cases, security holes, cross-platform regressions. Posts inline review comments + one sticky summary per PR.

Same action + secret as claude-review.yml; no new infra.