### PR TITLE
v0.1.3: kill file-structure.md PR conflicts + fix post-log AGENTS.md drift

### DIFF
--- a/docs/decisions-branches/feat__v0.1.3-structural-fix.md
+++ b/docs/decisions-branches/feat__v0.1.3-structural-fix.md
@@ -1,0 +1,13 @@
+## 2026-05-15 10:56 - v0.1.3: kill file-structure conflicts + fix AGENTS.md drift after logmind log
+
+**Reasoning:** Two structural bugs surfaced from PR #24's CI: (1) docs/file-structure.md regeneration during 'logmind log' on a feature branch guarantees a merge conflict against main — PR #24 hit this against PR #23; (2) sync_agent_files_from_config ran AFTER log's commit, leaving refreshed AGENTS.md as dirty working-tree changes (the v0.1.2 PR commit, the AGENTS.md refresh commit, and a chore commit all hit this in sequence). Fix: skip file-structure regen on non-default branches and let the aggregator workflow regen on main after PR merge; move sync to BEFORE the commit and pass modified agent files into log's scoped staging.
+
+**Alternatives considered:** Gitignore docs/file-structure.md entirely — but loses GitHub rendering and the AGENTS.md install pointer that says 'read docs/file-structure.md', Always regenerate per-PR and let users resolve conflicts — current pain, demonstrated to fail, Keep AGENTS.md sync after commit, accept dirty tree — known footgun, just fixed
+
+**Implications:**
+- On feature branches, 'logmind log' no longer touches docs/file-structure.md → no per-PR conflicts
+- Aggregator action regenerates file-structure.md on main as part of the merge-aggregation commit, so main always reflects its own tree
+- AGENTS.md / CLAUDE.md / .cursorrules refreshes from sync_agent_files_from_config now ride inside the same commit as the decision log — no post-commit dirty tree
+- Adds _changed_agent_files helper to cli.py + extra_scoped_paths param to log() — both used by 'logmind log' but available for any caller
+
+---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.1.2"
+version = "0.1.3"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/actions/aggregate.py
+++ b/src/logmind/actions/aggregate.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from logmind.core.logger import _sanitize_branch
 from logmind.core.parser import iter_decisions
+from logmind.core.tree_gen import update_file_structure
 
 
 def aggregate(
@@ -62,6 +63,17 @@ def aggregate(
     decisions_path = docs_path / "decisions.md"
     existing = decisions_path.read_text(encoding="utf-8") if decisions_path.exists() else ""
     decisions_path.write_text(existing + entry, encoding="utf-8")
+
+    # Regenerate file-structure.md on main as part of the aggregation commit.
+    # `logmind log` on feature branches no longer touches this file (v0.1.3),
+    # so per-PR conflicts can't happen — main alone owns the tree snapshot.
+    try:
+        update_file_structure(docs_path)
+    except Exception:
+        # Don't fail aggregation if tree regen blows up — the decision entry
+        # is the load-bearing part.
+        pass
+
     return decisions_path
 
 

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for logmind."""
 
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -38,10 +39,55 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.1.2", prog_name="logmind")
+@click.version_option(version="0.1.3", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
+
+
+_AGENT_FILE_CANDIDATES = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".cursorrules",
+    ".windsurfrules",
+    ".continuerules",
+    ".clinerules",
+    ".aiderrules",
+    "CONVENTIONS.md",
+    ".github/copilot-instructions.md",
+    ".amazonq/rules.md",
+    ".sourcegraph/cody.json",
+    ".zed/settings.json",
+)
+
+
+def _changed_agent_files(root_path: Optional[Path] = None) -> list:
+    """Return agent files that are currently modified or untracked.
+
+    Used by `logmind log` (v0.1.3+) so the agent-file sync that ran just
+    before the commit can include refreshed files in the scoped staging
+    instead of leaving the working tree dirty after the commit.
+    """
+    if root_path is None:
+        root_path = Path.cwd()
+    changed: list = []
+    for rel in _AGENT_FILE_CANDIDATES:
+        path = root_path / rel
+        if not path.exists():
+            continue
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain", "--", rel],
+                cwd=root_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+        if result.stdout.strip():
+            changed.append(rel)
+    return changed
 
 
 def _install_github_action_templates(root_path: Path) -> list:
@@ -500,6 +546,19 @@ def log(
     should_push = config.auto_push if not no_push else False
 
     try:
+        # v0.1.3: run agent-file sync BEFORE the commit so refreshed AGENTS.md
+        # / CLAUDE.md / etc. are included in the scoped staging instead of
+        # left as dirty working-tree changes after the commit.
+        sync_messages = sync_agent_files_from_config()
+        for msg in sync_messages:
+            click.echo(msg)
+
+        # Snapshot agent files that the sync left modified so log_decision
+        # can include them in the scoped commit. We list a fixed set of
+        # known agent files (broader than the AGENTS.md auto-refresh, since
+        # other agents may have stubs).
+        extra_scoped_paths = _changed_agent_files()
+
         log_decision(
             decision=decision,
             reasoning=reasoning,
@@ -509,6 +568,7 @@ def log(
             auto_commit=should_commit,
             auto_push=should_push,
             stage=stage,
+            extra_scoped_paths=extra_scoped_paths,
         )
 
         click.secho(f"✓ Logged decision: \"{decision}\"", fg="green")
@@ -518,11 +578,6 @@ def log(
                 click.echo("✓ Committed and pushed changes")
             else:
                 click.echo("✓ Committed changes (push disabled)")
-
-        # Sync agent files from config
-        sync_messages = sync_agent_files_from_config()
-        for msg in sync_messages:
-            click.echo(msg)
 
     except Exception as e:
         click.secho(f"Error: {e}", fg="red")

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -225,6 +225,7 @@ def log(
     auto_commit: Optional[bool] = None,
     auto_push: Optional[bool] = None,
     stage: str = "scoped",
+    extra_scoped_paths: Optional[List[str]] = None,
 ) -> None:
     """
     Log a decision to the decision log.
@@ -293,11 +294,30 @@ def log(
         _archive_oldest_decision(decisions_path)
         archive_rotated = True
 
-    # Update file structure (if configured)
+    # Update file structure (if configured) — but skip on feature branches.
+    # Each PR would regenerate against its own working tree, guaranteeing
+    # a merge conflict against main. Per v0.1.3, the aggregator workflow
+    # regenerates file-structure.md on main after each PR merge, so
+    # per-branch regeneration is no longer needed.
+    #
+    # Project root is the parent of docs/ — check git there, NOT in cwd,
+    # so this works correctly when called from tests or other working dirs.
+    # Regenerate when: not a git repo OR HEAD is the default branch.
+    # Skip only when: in a git repo AND on a non-default branch.
+    project_root = docs_path.parent
     file_structure_updated = False
     if config.auto_update_file_structure:
-        update_file_structure(docs_path)
-        file_structure_updated = True
+        skip_regen = False
+        try:
+            if is_git_repo(project_root):
+                cur = current_branch(project_root)
+                if cur is not None and cur != default_branch(project_root):
+                    skip_regen = True
+        except Exception:
+            skip_regen = False
+        if not skip_regen:
+            update_file_structure(docs_path)
+            file_structure_updated = True
 
     # Commit and push if requested
     if auto_commit and is_git_repo():
@@ -313,6 +333,8 @@ def log(
                 scoped.append(str(docs_path / "file-structure.md"))
             if archive_rotated:
                 scoped.append(str(docs_path / "decisions-archive.md"))
+            if extra_scoped_paths:
+                scoped.extend(extra_scoped_paths)
             git_add(scoped)
 
         # Use configured commit message template

--- a/tests/test_v0_1_3_structural.py
+++ b/tests/test_v0_1_3_structural.py
@@ -1,0 +1,188 @@
+"""Regression tests for the v0.1.3 structural fixes.
+
+Two bugs resolved here:
+
+1. `logmind log` on a feature branch regenerated docs/file-structure.md
+   against the PR's working tree, guaranteeing a merge conflict against
+   main once another PR landed. Fix: skip regeneration on non-default
+   branches; let the aggregator workflow regenerate on main after PR
+   merge as part of the aggregation commit.
+
+2. `sync_agent_files_from_config()` ran AFTER `logmind log`'s commit,
+   leaving refreshed AGENTS.md / CLAUDE.md as dirty working-tree
+   modifications. Fix: run sync first, snapshot changed agent files,
+   include them in scoped staging.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from logmind.actions.aggregate import aggregate
+from logmind.core.logger import log
+
+
+def _git_init(path: Path, default_branch: str = "main") -> None:
+    subprocess.run(
+        ["git", "init", "-b", default_branch],
+        cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=path, check=True, capture_output=True,
+    )
+    (path / ".keep").write_text("", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", ".keep"], cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=path, check=True, capture_output=True,
+    )
+
+
+def _checkout(path: Path, branch: str) -> None:
+    subprocess.run(
+        ["git", "checkout", "-b", branch],
+        cwd=path, check=True, capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: file-structure.md must NOT regenerate on a feature branch
+# ---------------------------------------------------------------------------
+
+
+def test_log_on_feature_branch_does_not_touch_file_structure(tmp_path, monkeypatch):
+    """On a feature branch, `logmind log` should leave file-structure.md
+    alone — only main owns the tree snapshot now."""
+    _git_init(tmp_path, default_branch="main")
+    _checkout(tmp_path, "feat/something")
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    (docs / "decisions-branches").mkdir(parents=True)
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    fs_path = docs / "file-structure.md"
+    sentinel = "BASELINE-SENTINEL-DO-NOT-REGENERATE\n"
+    fs_path.write_text(sentinel, encoding="utf-8")
+
+    log("feature work", reasoning="r", docs_path=docs, auto_commit=False)
+
+    # file-structure.md must still contain the sentinel — proves no regen.
+    assert fs_path.read_text(encoding="utf-8") == sentinel
+
+
+def test_log_on_default_branch_does_regenerate_file_structure(tmp_path, monkeypatch):
+    """On the default branch, `logmind log` regenerates file-structure.md
+    so direct commits to main keep it fresh."""
+    _git_init(tmp_path, default_branch="main")
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    fs_path = docs / "file-structure.md"
+    fs_path.write_text("# placeholder\n", encoding="utf-8")
+
+    (tmp_path / "interesting.py").write_text("x = 1\n", encoding="utf-8")
+
+    log("main-branch decision", reasoning="r", docs_path=docs, auto_commit=False)
+
+    assert "interesting.py" in fs_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Bug #1 continued: aggregator regenerates file-structure.md on main
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_regenerates_file_structure(tmp_path):
+    """Aggregator output should include a fresh file-structure.md so main
+    catches up with whatever shape the merged branch left."""
+    docs = tmp_path / "docs"
+    branch_dir = docs / "decisions-branches"
+    branch_dir.mkdir(parents=True)
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+
+    # Per-branch file with a real decision the aggregator needs to summarise.
+    # Parser requires "## YYYY-MM-DD HH:MM - title" header form.
+    (branch_dir / "feat__x.md").write_text(
+        "# feat/x\n\n---\n## 2026-05-15 10:00 - decided\n\n**Reasoning:** r\n\n---\n",
+        encoding="utf-8",
+    )
+
+    # Marker file that should appear in the regenerated tree
+    (tmp_path / "fresh-thing.txt").write_text("hi", encoding="utf-8")
+
+    result = aggregate(
+        branch="feat/x", pr_number=42, pr_url="https://example/pr/42",
+        docs_path=docs,
+    )
+    assert result == docs / "decisions.md"
+
+    fs_path = docs / "file-structure.md"
+    assert fs_path.exists()
+    assert "fresh-thing.txt" in fs_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: agent-file refresh must be staged in the same commit
+# ---------------------------------------------------------------------------
+
+
+def test_log_stages_modified_agent_files_via_extra_scoped_paths(tmp_path, monkeypatch):
+    """When AGENTS.md is dirty (e.g. just refreshed by
+    sync_agent_files_from_config), `log()` with extra_scoped_paths should
+    include it in the same commit — not leave it as a working-tree drift."""
+    _git_init(tmp_path, default_branch="main")
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+
+    # Create an AGENTS.md that's tracked, then modify it to simulate a sync.
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("v1 content\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "AGENTS.md"], cwd=tmp_path,
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add agents"], cwd=tmp_path,
+        check=True, capture_output=True,
+    )
+    agents.write_text("v2 content (refreshed)\n", encoding="utf-8")
+
+    log(
+        "test agent staging",
+        reasoning="r",
+        docs_path=docs,
+        auto_commit=True,
+        auto_push=False,
+        stage="scoped",
+        extra_scoped_paths=["AGENTS.md"],
+    )
+
+    # Commit should include AGENTS.md, not leave it dirty
+    out = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=tmp_path, check=True, capture_output=True, text=True,
+    )
+    committed = {line for line in out.stdout.split() if line}
+    assert "AGENTS.md" in committed
+
+    status_out = subprocess.run(
+        ["git", "status", "--porcelain", "AGENTS.md"],
+        cwd=tmp_path, check=True, capture_output=True, text=True,
+    )
+    assert status_out.stdout.strip() == "", \
+        f"AGENTS.md should be clean after commit, got: {status_out.stdout!r}"


### PR DESCRIPTION
## Summary

Two structural bugs surfaced from PR #24's CI:

1. **`docs/file-structure.md` regeneration on every `logmind log` guaranteed PR/main conflicts.** PR #24 hit this against PR #23 — both regenerated the same file against their own trees, both touched the same `Last updated:` timestamp + tree layout, and the second to merge had to be rebased.
2. **`sync_agent_files_from_config()` ran AFTER `log_decision()`'s commit**, leaving refreshed `AGENTS.md` / `CLAUDE.md` / etc. as dirty working-tree modifications. PR #24's release commit + the follow-up AGENTS.md refresh commit + a chore commit all hit this.

## Fixes

### file-structure.md
- **`src/logmind/core/logger.py`**: skip `update_file_structure()` when in a git repo on a non-default branch. Project root resolved from `docs_path.parent` so git lookups are local to the project, not the caller's cwd.
- **`src/logmind/actions/aggregate.py`**: regenerate `docs/file-structure.md` as part of the merge-aggregation flow on main. The aggregator workflow already commits `docs/decisions.md`; expanding it to also pick up `docs/file-structure.md` keeps main always-fresh without any per-PR work.

Net behavior: feature branches never touch `docs/file-structure.md`. Direct commits to main regenerate it locally. Aggregator regenerates it post-PR-merge. Conflicts impossible by construction.

### AGENTS.md drift
- **`src/logmind/cli.py`**: move `sync_agent_files_from_config()` to BEFORE `log_decision()`. After sync, snapshot which agent files are now dirty via `_changed_agent_files()` (checks AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, .continuerules, .clinerules, .aiderrules, CONVENTIONS.md, .github/copilot-instructions.md, .amazonq/rules.md, .sourcegraph/cody.json, .zed/settings.json).
- **`src/logmind/core/logger.py`**: new `extra_scoped_paths` param on `log()` — adds caller-supplied paths to scoped staging. `cli.py` passes the changed agent file list through.

Net behavior: `logmind log` always leaves a clean working tree.

## Test plan

- [x] 4 new regression tests in `tests/test_v0_1_3_structural.py`:
  - `test_log_on_feature_branch_does_not_touch_file_structure` — sentinel file preserved on `feat/something` branch
  - `test_log_on_default_branch_does_regenerate_file_structure` — fresh content on main
  - `test_aggregate_regenerates_file_structure` — aggregator output includes regen
  - `test_log_stages_modified_agent_files_via_extra_scoped_paths` — dirty AGENTS.md ends up in the same commit
- [x] Full pytest: 474 passed, 1 skipped
- [x] Dogfooded this commit: `logmind log --stage all` left a clean working tree (the v0.1.3 fix catching itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)