### PR TITLE
ci: add Homebrew tap auto-bump workflow

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,74 @@
+name: homebrew tap bump
+
+# Fires after a PyPI release tag is pushed and opens a bump PR on
+# thrillmot/homebrew-logmind. Uses dawidd6/action-homebrew-bump-formula,
+# which knows how to compute the new tarball SHA from the URL and edit the
+# formula in place.
+#
+# Requires a repo secret HOMEBREW_TAP_PAT — a fine-grained PAT scoped to
+# thrillmot/homebrew-logmind with these permissions:
+#   - Contents: Read and write
+#   - Pull requests: Read and write
+# (GITHUB_TOKEN from this repo cannot write to a different repo, so a PAT
+# is required. A GitHub App token would also work.)
+#
+# Manual override: trigger via "Run workflow" with a specific tag.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to bump to (e.g. v0.1.3). Defaults to the latest release."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  homebrew-bump:
+    name: open bump PR on tap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve target tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF##*/}"
+          fi
+          # Strip leading v if present, so {0.1.3, v0.1.3} both work.
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for PyPI to surface the new release
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS "https://pypi.org/pypi/logmind/${VERSION}/json" > /dev/null; then
+              echo "PyPI has logmind ${VERSION}."
+              exit 0
+            fi
+            echo "Waiting for PyPI propagation (attempt ${i}/30)..."
+            sleep 10
+          done
+          echo "::error::PyPI did not surface logmind ${VERSION} within 5 minutes."
+          exit 1
+
+      - name: Open bump PR on homebrew-logmind
+        uses: dawidd6/action-homebrew-bump-formula@v5
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_PAT }}
+          tap: thrillmot/homebrew-logmind
+          formula: logmind
+          tag: ${{ steps.tag.outputs.tag }}
+          revision: ""   # let the action resolve to the tag's commit
+          force: false   # don't overwrite an existing open PR
+          livecheck: false


### PR DESCRIPTION
## Summary
Wires the missing piece you flagged: every \`v*\` tag now fires a workflow that opens a bump PR on \`thrillmot/homebrew-logmind\` so the formula tracks the latest release without manual intervention.

## How it works
1. Triggered by tag push matching \`v[0-9]+.[0-9]+.[0-9]+\` (same shape as \`publish.yml\`)
2. Waits up to 5 min for PyPI to surface the new release (so the bump doesn't race with the publish workflow)
3. Uses \`dawidd6/action-homebrew-bump-formula@v5\` (widely-used Homebrew bumper) to compute the new SHA, edit the formula, push a branch, and open the PR

## One-time setup required
Create a **fine-grained PAT** scoped to \`thrillmot/homebrew-logmind\` with:
- **Contents:** Read and write
- **Pull requests:** Read and write

Add as \`HOMEBREW_TAP_PAT\` in this repo's secrets. (\`GITHUB_TOKEN\` can't write to a different repo, hence the PAT requirement.)

A GitHub App token works too if you'd rather avoid PATs.

## Manual override
\`workflow_dispatch\` accepts a \`tag\` input so you can retroactively bump if a release ever ships without the auto-bump having fired.

## Why now
v0.1.2 and v0.1.3 both required hand-bumping the formula. With this in place, v0.1.4 onward is one tag away from PyPI + Homebrew both being live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)