### PR TITLE
ci: homebrew-bump — wire git credentials so push works

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -96,6 +96,9 @@ jobs:
           # if a major dependency bumps.
           git config --global user.name "homebrew-bump"
           git config --global user.email "homebrew-bump@users.noreply.github.com"
+          # Configure git to use GH_TOKEN for all github.com HTTPS auth so
+          # `git push` against the tap remote works without prompting.
+          gh auth setup-git
 
           gh repo clone thrillmot/homebrew-logmind tap -- --quiet
           cd tap


### PR DESCRIPTION
PR #30 fixed the brew-bump-formula-pr 24h-old-package issue but exposed the next layer: \`git push\` failed because \`gh repo clone\` doesn't set up a credential helper. One-line fix: \`gh auth setup-git\`.