### PR TITLE
site: size thrllmt logo proportionally to marginalia (h-[0.85em])

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -309,12 +309,15 @@ export default function Home() {
                 aria-label="thrllmt (thrillmot.com)"
                 className="opacity-60 hover:opacity-100 transition-opacity inline-flex items-center"
               >
+                {/* Sized relative to the surrounding text's em so the logo
+                    scales proportionally with the marginalia at every
+                    viewport. 0.85em matches the cap-height of the adjacent
+                    uppercase glyphs. w-auto preserves SVG aspect ratio. */}
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src="/thrllmt.svg"
                   alt="thrllmt"
-                  height={12}
-                  className="block h-[12px] w-auto"
+                  className="block h-[0.85em] w-auto"
                 />
               </a>
             </div>


### PR DESCRIPTION
Follow-up to PR #32. User flagged the footer logo as visually off — the previous fixes used fixed pixel heights (12px, then 9px) that broke the visual link with the surrounding text.

Switching to \`h-[0.85em] w-auto\` makes the logo scale automatically with whatever font-size the marginalia inherits. 0.85em matches the cap-height of the adjacent uppercase glyphs (V0.1.4 · MIT LICENSED · BY), so they read at matched visual weight at every viewport without per-breakpoint tuning.

## Test plan
- [x] Measured at 720px viewport: logo height 8.84px, marginalia font-size 10.4px → ratio 0.85
- [x] Measured at 1440px viewport: logo height 8.84px (font-size also 10.4px in this section)
- [ ] Live verify after Vercel deploy