### PR TITLE
docs: correct README for v0.2 fail-fast architecture + add reporulez one-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,33 @@ pip install logmind
 
 ## Required repo settings
 
-`logmind init` ships GitHub Actions workflows that regenerate
-`docs/timeline.md` and `docs/file-structure.md` on every PR. For those
-to land cleanly, your repo needs:
+`logmind init` ships a GitHub Action (`regen-timeline.yml`) that VERIFIES
+`docs/timeline.md` is up to date on every PR — fail-fast if stale, no
+auto-commit. For the derived-file architecture to stay conflict-free
+between concurrent PRs, your repo needs:
 
-1. **Workflow write permissions** —
-   `Settings → Actions → General → Workflow permissions = Read and write permissions`.
-   The regen workflow needs to push its commit back to the PR branch via
-   `GITHUB_TOKEN`. Default on new repos may be read-only; flip it once.
+- **Strict required status checks on `main`** —
+  `Settings → Branches → Branch protection rule (or Ruleset)` →
+  *"Require branches to be up to date before merging"*. This forces a
+  PR to be rebased on latest `main` before merge, which is what makes
+  `docs/timeline.md` (and any other derived file) conflict-free across
+  concurrent PRs.
 
-2. **Strict required status checks on `main`** —
-   `Settings → Branches → Branch protection rule (or Ruleset)` →
-   *"Require branches to be up to date before merging"*. This forces a
-   PR to be rebased on latest `main` before merge, which is what makes
-   the derived files (`docs/timeline.md`, `docs/file-structure.md`)
-   conflict-free between concurrent PRs.
+Without that toggle, two PRs in flight can both regenerate against
+different base commits and merge-conflict on the derived file.
 
-Without (1), the regen step fails to push and your `docs/timeline.md`
-stays stale. Without (2), two concurrent PRs editing `docs/timeline.md`
-can produce a merge conflict the bot can't resolve. Both settings are
-one-time toggles per repo.
+### One-command setup via reporulez
+
+If you'd rather not click through the GitHub UI, the
+[`clud-bug-logmind`](https://github.com/thrillmot/reporulez) variant of
+`reporulez` ships the canonical ruleset for repos using both logmind
+and clud-bug — strict status checks pinned to logmind's check names,
+required thread resolution, squash-only, the works:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thrillmot/reporulez/main/bin/apply.sh \
+  | bash -s -- owner/your-repo clud-bug-logmind
+```
 
 ## Quick Start
 

--- a/docs/decisions-branches/docs__readme-v0.2-corrections.md
+++ b/docs/decisions-branches/docs__readme-v0.2-corrections.md
@@ -1,0 +1,8 @@
+## 2026-05-18 12:36 - docs: correct README required-repo-settings for v0.2 + add reporulez one-command
+
+**Reasoning:** v0.2 switched regen-timeline.yml from auto-commit to fail-fast (workflow permissions: contents:read only, no write). README still claimed workflow write permissions were required — that's outdated. Removed. Also added a reporulez clud-bug-logmind variant link as the one-command setup path, since reporulez just shipped that bundle.
+
+**Implications:**
+- Bonus: this PR triggers a fresh Vercel production deploy (rate-limit expired 3 days ago, last attempt failed red)
+
+---


### PR DESCRIPTION
## Summary
- v0.2 switched `regen-timeline.yml` to fail-fast (no auto-commit). The README's "workflow write permissions" item is no longer needed and was misleading users.
- Added a reporulez `clud-bug-logmind` one-command setup as the alternative to clicking through the GitHub UI.

## Why
README accuracy. Setting up the recommended ruleset is one curl-pipe-bash now thanks to the new reporulez variant.

## Test plan
- [x] `logmind log` regenerated docs/timeline.md cleanly
- [ ] CI green (check-derived-docs verifies timeline.md is current)
- [ ] After merge, Vercel auto-deploy fires on push to main (rate-limit expired 3 days ago)

🤖 Generated with [Claude Code](https://claude.com/claude-code)