### PR TITLE
docs: fix stale skills.sh badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/logmind.svg)](https://pypi.org/project/logmind/)
 [![Python versions](https://img.shields.io/pypi/pyversions/logmind.svg)](https://pypi.org/project/logmind/)
 [![CI](https://github.com/thrillmot/logmind/actions/workflows/test.yml/badge.svg)](https://github.com/thrillmot/logmind/actions/workflows/test.yml)
-[![skills.sh](https://skills.sh/b/thrillmot/logmind-skill)](https://skills.sh/thrillmot/logmind-skill)
+[![skills.sh](https://skills.sh/b/thrillmot/agent-skills)](https://www.skills.sh/thrillmot/agent-skills/logmind)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 AI decision logging for development projects — branch-aware by default.

--- a/docs/decisions-branches/docs__fix-skills-badge-url.md
+++ b/docs/decisions-branches/docs__fix-skills-badge-url.md
@@ -1,0 +1,9 @@
+## 2026-05-18 14:02 - docs: fix stale skills.sh badge URL in README
+
+**Reasoning:** The skills.sh badge in README.md line 6 still pointed at thrillmot/logmind-skill — that repo was renamed to thrillmot/agent-skills in v0.1.2 and reorganized into a collection layout. Badge image was 404'ing or showing 'custom badge invalid'. Updated to the collection badge URL (thrillmot/agent-skills) and the link to the logmind skill's page within the collection.
+
+**Implications:**
+- README badge resolves to the collection's Skills count badge
+- Click-through lands on the logmind skill's skills.sh page within the agent-skills collection
+
+---


### PR DESCRIPTION
The skills.sh badge in README line 6 still pointed at \`thrillmot/logmind-skill\` — that repo was renamed to \`thrillmot/agent-skills\` weeks ago and reorganized into the collection layout. Badge was 404'ing.

Updated to the collection badge (`skills.sh/b/thrillmot/agent-skills` → "Skills: 5") with the link to the logmind skill's page within the collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)