### PR TITLE
chore: refresh clud-bug to v0.5.6 templates

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -22,5 +22,7 @@
       "kind": "baseline",
       "description": "(bundled baseline)"
     }
-  ]
+  ],
+  "lastUpdate": "2026-05-18T18:10:14.042Z",
+  "lastUpdateVersion": "0.5.6"
 }

--- a/.claude/skills/clud-bug-collaboration/SKILL.md
+++ b/.claude/skills/clud-bug-collaboration/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: clud-bug-collaboration
+description: How Claude Code agents working in a clud-bug-installed repo should interact with the bot's review threads, strict-mode gate, and skill set. Use this skill whenever you're about to push a commit, address a clud-bug PR review comment, edit anything under .claude/skills/, modify .github/workflows/clud-bug-*.yml, or wonder why a PR check is red. Also use when planning work in a repo that has a `clud-bug-review` workflow installed — even if the user didn't mention clud-bug by name.
+---
+
+# Working in a clud-bug-installed repo
+
+Clud Bug reviews every PR via `anthropics/claude-code-action`. As another
+Claude Code agent working alongside it, here's what to know — these aren't
+arbitrary rules, they're the consequences of how the gate is wired.
+
+## When you push fixes to a clud-bug-reviewed PR
+
+The bot reviews on `pull_request: synchronize` (every push). When you push
+a commit that addresses an issue Clud Bug flagged in a prior review, the bot
+will re-review the PR within ~2 minutes and **resolve its own prior
+unresolved inline review threads** where the flagged issue is verifiably
+fixed in the current diff. You don't have to resolve threads manually.
+
+If a thread it left isn't auto-resolved after your fix:
+- The bot judged the issue still open (read its latest comment for why).
+- Or the resolution call hit a transient API issue (re-push to retry).
+
+Don't manually resolve clud-bug threads on its behalf. The check
+(`required_conversation_resolution` branch protection) will block merge if
+unresolved threads remain — and the right fix is usually "fix the actual
+issue and re-push," not "mark the conversation resolved."
+
+## When you read the PR's `clud-bug-review` check status
+
+- **Green** = Clud Bug ran and either found no critical issues OR strict
+  mode is off (advisory).
+- **Red** = either the action errored OR strict mode is on AND Clud Bug
+  flagged a critical issue. Read the latest `## 🐛 Clud Bug review` comment
+  on the PR — the body indicates "critical findings" or "clean."
+- **Skipped/green-with-comment** = bot- or fork-authored PR (Dependabot,
+  Renovate, fork contributor). GitHub deliberately doesn't pass repo
+  secrets to those workflows. The bot posts a one-line "Clud Bug skipped"
+  comment and exits 0. Review the diff manually.
+
+## Strict mode
+
+Read `.claude/skills/.clud-bug.json` to check this repo's setting.
+`strictMode: true` means the workflow check fails on critical findings.
+The setting is read from the **base ref**, so a PR cannot disable strict
+mode on itself by editing the manifest. Changes take effect for PRs opened
+after the change merges to the base branch.
+
+To disable strict mode for a repo, edit the manifest on the base branch:
+
+```json
+{ "strictMode": false, ... }
+```
+
+## When you modify a clud-bug skill
+
+Skills live in `.claude/skills/<slug>/SKILL.md`. Three groups:
+
+- **Baseline** (`critical-issues-only`, `evidence-based-review`,
+  `respect-existing-conventions`) — managed by clud-bug; if you edit them
+  in-place they'll be overwritten on the next `clud-bug update`. To
+  customize behavior for this repo, write a NEW skill rather than mutating
+  a baseline.
+- **From skills.sh** — installed via `clud-bug add <source/name>`. Tracked
+  in `.claude/skills/.clud-bug.json`. Use `clud-bug refresh` to sync.
+- **Custom** (anything not in the manifest) — yours, never touched by any
+  clud-bug command. Drop a new `.md` here and it auto-loads on the next PR.
+
+When you write a custom skill, follow the SKILL.md frontmatter format
+(`name`, `description`) and write specific, evidence-anchored guidance.
+Generic advice gets ignored; rules with examples and quoted-line evidence
+move the bot's behavior.
+
+## When you edit `.github/workflows/clud-bug-*.yml`
+
+`anthropics/claude-code-action` **refuses to run on PRs that modify its
+own workflow file** (App token exchange fails with 401, "Workflow
+validation failed"). This is a security guard against PRs that try to
+neuter the reviewer or exfiltrate secrets.
+
+Consequence: if you bundle a workflow tweak with other work, the
+`clud-bug-review` check on that PR will fail and not actually review your
+other changes either.
+
+The fix: split workflow edits into their own PR. The CLI helps:
+
+```bash
+# After editing .github/workflows/clud-bug-*.yml locally:
+clud-bug edit-workflow
+```
+
+It refuses to run if your working tree has non-workflow changes, so the
+isolation guarantee is enforced. Branches from `origin/main`, not HEAD —
+unrelated commits on a feature branch can't leak in.
+
+## When the secret is missing
+
+`ANTHROPIC_API_KEY` must be set in the repo's Actions secrets. Without it,
+the workflow's guard step fails loudly with an `::error::` annotation
+explaining how to set it. (For bot/fork PRs where the secret legitimately
+isn't passed, the guard posts a one-line advisory comment and exits 0
+instead of failing red.)
+
+## Updating clud-bug itself
+
+`clud-bug-self-update.yml` runs weekly (Mondays 12:00 UTC) and opens a PR
+when a newer clud-bug version is published to npm. Pin to a specific
+version by adding `pinVersion: "x.y.z"` to `.claude/skills/.clud-bug.json`.
+
+To trigger an update on demand:
+
+```bash
+clud-bug update
+```
+
+Re-renders workflow templates and refreshes baseline skills from the
+currently-installed clud-bug version. Custom and skills.sh-installed
+skills are left untouched.
+
+## Where to find more
+
+- Site: https://cludbug.dev
+- Repo: https://github.com/thrillmot/clud-bug
+- Skill catalog: https://github.com/thrillmot/agent-skills

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,3 +1,48 @@
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.6._
+<!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -6,11 +6,6 @@ on:
 
 jobs:
   clud-bug-review:
-    # clud-bug always runs. Even on Dependabot/Renovate PRs that lack
-    # secrets — the action gracefully degrades to a no-comment exit, and
-    # the upside (catching real bugs in dependency-graph changes that
-    # downstream maintainers DO want eyes on) outweighs the occasional
-    # silent run.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,16 +13,49 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # strict-mode gate reads base ref's manifest
+
+      # Three-way guard — see workflow.yml.tmpl for full design notes.
+      - name: Guard — require ANTHROPIC_API_KEY
+        id: guard
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then echo "skip=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          IS_FORK=false; [ "$HEAD_REPO" != "$BASE_REPO" ] && IS_FORK=true
+          IS_BOT=false; case "$PR_AUTHOR" in *\[bot\]) IS_BOT=true ;; esac
+          if $IS_FORK || $IS_BOT; then
+            REASON=$($IS_BOT && echo "bot author ($PR_AUTHOR)" || echo "fork ($HEAD_REPO)")
+            EXISTING=$(gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug skipped")))] | length')
+            if [ "${EXISTING:-0}" = "0" ]; then
+              BODY=$(printf '## 🐛 Clud Bug skipped\n\nThis PR is from a %s. GitHub deliberately does not pass repository secrets to such workflows, so Clud Bug could not authenticate against Anthropic. Review the diff manually.' "$REASON")
+              gh pr comment "$PR_NUMBER" --body "$BODY" || true
+            fi
+            echo "::warning title=Clud Bug 🐛::Skipped — $REASON cannot access repository secrets."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error title=Clud Bug 🐛::ANTHROPIC_API_KEY secret is not set on this repository."
+          echo "::error::Set it: Settings → Secrets and variables → Actions → New repository secret."
+          exit 1
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.guard.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api graphql:*),Bash(gh api repos/:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(cat .claude/skills/.clud-bug.json)"
           prompt: |
             This project is "logmind". Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents. It's primarily python using click, pytest.
 
@@ -45,8 +73,38 @@ jobs:
             Skip style suggestions, minor naming issues, or anything that
             doesn't affect correctness, security, or performance.
 
-            Any project-specific skills loaded from .claude/skills/ should
-            shape your review — defer to their guidance over generic advice.
+            Skills are not background context — they are review rules with
+            authority. Before flagging any finding, scan the loaded skills in
+            .claude/skills/ for relevant guidance. If a skill applies, your
+            review MUST reference it by name in the finding (e.g. "[evidence-
+            based-review]: this claim isn't anchored to a line"). Generic
+            advice that contradicts a project skill is wrong by definition.
+
+            At the end of every review, append a single-line footer:
+              Skills referenced: [skill-name-1, skill-name-2, ...]
+            If you genuinely cited none, list "[none]" and explain why no
+            installed skill applied to this diff.
+
+            Strict-mode header (opt-in): if .claude/skills/.clud-bug.json
+            contains { "strictMode": true }, the comment header you post
+            MUST signal whether you flagged a critical issue:
+              IF you flagged any critical issue (bug, security,
+                  performance, missing test coverage):
+                  ## 🐛 Clud Bug review — critical findings
+              OTHERWISE:
+                  ## 🐛 Clud Bug review — clean
+            A post-step in this workflow greps your posted comment for
+            that header and fails the check on "critical findings." The
+            gate is deterministic on top of your judgment.
+
+            If strictMode is NOT set (or absent), keep the existing
+            "## 🐛 Clud Bug review" header — strict mode is opt-in and
+            other repos use the plain header.
+
+            Tone: address the author conversationally. A concise field-naturalist
+            voice is welcome (you are Clud Bug, examining specimens of code) but
+            never at the cost of clarity, evidence, or the critical-issues-only
+            discipline. Don't perform the bit; let the precision speak.
 
             When you finish, post your review as a single PR comment.
             The comment body MUST start with this exact line so the
@@ -54,6 +112,40 @@ jobs:
             claude[bot], but the comment header brands it as Clud Bug):
 
               ## 🐛 Clud Bug review
+
+            Immediately after the H2 header — on the next non-empty
+            line — emit a status block in this exact format:
+
+              **This round:** N critical · N minor · N resolved from prior · N still open
+
+            This applies to BOTH the bare "## 🐛 Clud Bug review" header
+            and the strict-mode variants ("— critical findings" /
+            "— clean"). The status line goes on the next non-empty line
+            regardless of which header you used. Do not omit the H2
+            header variant in strict mode just to fit the status line —
+            the strict-mode gate reads the H2 line and would break.
+
+            The four counters (always include all four, even when 0 —
+            fixed format is grep-able and lets agents reading the
+            comment parse it deterministically):
+              • critical            — count of NEW critical findings
+                                      in this review (the ones strict
+                                      mode gates on)
+              • minor               — count of non-critical findings
+                                      (suggestions / nits / observations)
+              • resolved from prior — count of prior unresolved threads
+                                      YOU (claude[bot]) just resolved on
+                                      this pass via resolveReviewThread
+                                      (the loop-closing signal — this
+                                      tells the author the bot read
+                                      their fixes)
+              • still open          — count of prior unresolved threads
+                                      whose issue still stands AFTER
+                                      this pass
+
+            On a first-time review, "resolved from prior" and "still
+            open" are both 0. On follow-up reviews after a fix-push,
+            "resolved from prior" should typically be positive.
 
             Post it via:
               gh pr comment "$PR_NUMBER" --body "<your review>"
@@ -75,3 +167,24 @@ jobs:
             For line-specific issues, use the github_inline_comment MCP tool
             with confirmed: true.
             If there are no critical issues, post a one-line comment saying so.
+
+      # Strict-mode gate — see workflow.yml.tmpl for full design notes.
+      - name: Strict mode — fail check on critical findings
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BASE_MANIFEST=$(git show "origin/${{ github.base_ref }}:.claude/skills/.clud-bug.json" 2>&1) || {
+            echo "::warning::Base manifest not found on ${{ github.base_ref }} — strict mode disabled for this run."
+            exit 0
+          }
+          STRICT=$(echo "$BASE_MANIFEST" | node -e "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(s).strictMode===true)}catch(e){console.log('false')}})")
+          [ "$STRICT" = "true" ] || exit 0
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments?sort=created&direction=desc&per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]" and (.body | startswith("## 🐛 Clud Bug review")))][0].body // ""')
+          if echo "$LATEST" | head -n1 | grep -q "Clud Bug review — critical findings"; then
+            echo "::error title=Clud Bug 🐛::Critical issues found and strictMode is enabled — failing this check."
+            echo "::error::See the latest Clud Bug review comment for details. Push a fix and the gate will clear on the next run."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,48 @@ See [docs/plan.md](docs/plan.md) for complete roadmap.
 ## Project Rules
 
 [Add your Cursor rules here]
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.6._
+<!-- clud-bug-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,48 @@
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
 See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
+
+<!-- clud-bug-start -->
+<!-- clud-bug-block-version: v1 -->
+## clud-bug — Claude PR review
+
+This repository uses [clud-bug](https://cludbug.dev) to review pull requests
+automatically. Three things matter when other agents (or future-you) work
+in this repo:
+
+### When you push fixes addressing prior Clud Bug review threads
+
+The bot resolves its own prior review threads on the next pass when it can
+verify the fix in the diff. You don't need to manually resolve threads it
+opened — push the fix, wait ~2 minutes, and check the PR. If a thread it
+left isn't auto-resolved after a fix, the bot judged the issue still open;
+read its latest review comment for what it's still flagging.
+
+### Strict mode
+
+Strict mode is **off** in this repo (advisory only). Toggle by editing `.claude/skills/.clud-bug.json`:
+
+```json
+{ "strictMode": true | false, ... }
+```
+
+The setting is read from the **base ref** of any open PR, so PRs cannot
+disable strict mode on themselves. Changes take effect on PRs opened after
+they merge to the base branch.
+
+### Where the skills live
+
+Project-aware review rules live in `.claude/skills/<name>/SKILL.md`. A
+small baseline kit ships with every install — see
+`.claude/skills/.clud-bug.json` for the current set. Add more via
+`clud-bug add <source/name>` (from skills.sh) or by dropping your own
+`.md` files there. They auto-load into the reviewer.
+
+### Editing the workflow
+
+Anthropic's `claude-code-action` refuses to run on PRs that modify its own
+workflow file. Use `clud-bug edit-workflow` to bundle workflow tweaks into
+their own isolated PR — see [README](https://github.com/thrillmot/clud-bug#when-you-edit-the-workflow).
+
+_Installed at clud-bug v0.5.6._
+<!-- clud-bug-end -->

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,9 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — docs: fix stale skills.sh badge URL in README *(docs/fix-skills-badge-url)* — [decisions-branches/docs__fix-skills-badge-url.md](decisions-branches/docs__fix-skills-badge-url.md)
+- **2026-05-18** — v0.2.1: audit-driven fixes — version pinning, idempotent init, atomic writes, hardened git helpers *(feat/v0.2.1-audit-fixes)* — [decisions-branches/feat__v0.2.1-audit-fixes.md](decisions-branches/feat__v0.2.1-audit-fixes.md)
+- **2026-05-18** — docs: correct README required-repo-settings for v0.2 + add reporulez one-command *(docs/readme-v0.2-corrections)* — [decisions-branches/docs__readme-v0.2-corrections.md](decisions-branches/docs__readme-v0.2-corrections.md)
 - **2026-05-15** — Merged: footer-polish (#32) *(main)* — [decisions.md](decisions.md)
 - **2026-05-15** — v0.2.0: derived-file architecture replaces per-merge aggregator *(feat/v0.2-derived-decisions-md)* — [decisions-branches/feat__v0.2-derived-decisions-md.md](decisions-branches/feat__v0.2-derived-decisions-md.md)
 - **2026-05-15** — site: footer polish — version, skill URL, breathing room, single-line nav *(footer-polish)* — [decisions-branches/footer-polish.md](decisions-branches/footer-polish.md)


### PR DESCRIPTION
## Summary
\`npx clud-bug update\` refreshes:
- \`clud-bug-review.yml\`: \`actions/checkout@v4\` → \`@v6\` + \`Bash(git show:*)\` allowlist entry
- \`.claude/skills/clud-bug-collaboration/SKILL.md\` to current agent-skills SHA
- Agent docs blocks in AGENTS.md / CLAUDE.md / .cursorrules
- Manifest \`lastUpdateVersion\` → 0.5.6

## Self-mod note
\`clud-bug-review\` WILL fail red on this PR by design — claude-code-action refuses to run when the PR modifies its own workflow file (401 security guard). The check is not in this repo's required_status_checks list right now, so it doesn't block merge. Phase 1D will add it later via reporulez.

## Test plan
- [x] All other CI green (pytest matrix, check-links, check-derived-docs, check-decisions)
- [x] timeline.md regenerated (AGENTS.md changes flowed through)
- [ ] After merge: clud-bug-review on the next PR runs cleanly under v0.5.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)