### PR TITLE
feat: ship logmind-self-update.yml workflow template

### DIFF
--- a/docs/decisions-branches/feat__logmind-self-update.md
+++ b/docs/decisions-branches/feat__logmind-self-update.md
@@ -1,0 +1,10 @@
+## 2026-05-18 14:18 - feat: ship logmind-self-update.yml workflow template
+
+**Reasoning:** Mirrors clud-bug's self-update.yml.tmpl pattern (Monday 12:00 UTC cron, opens PR on bump). Closes architectural gap F from the 5-repo seamless-updates plan: previously repos with logmind installed had to manually  to pick up new releases. Now they get a weekly auto-PR. Reads installed version from the v0.2.1+ workflow pin ( in regen-timeline.yml). Opt-out via pinVersion in .logmind/config.yml.
+
+**Implications:**
+- Future logmind releases auto-propagate to all repos that have logmind installed and have the workflow active
+- Pre-v0.2.1 installs (no pin marker) get a clear notice telling them to re-run init once manually
+- Pinning to a specific version is a one-line addition to .logmind/config.yml — same UX as clud-bug's manifest
+
+---

--- a/src/logmind/templates/github/logmind-self-update.yml.template
+++ b/src/logmind/templates/github/logmind-self-update.yml.template
@@ -1,0 +1,123 @@
+# logmind-template-version: v1
+name: logmind self-update
+
+# Weekly check for a newer published logmind. If one exists, runs
+# `pip install --upgrade logmind && logmind init` (refresh mode — leaves
+# docs/ and .logmind/config.yml alone, refreshes stale workflow
+# templates) and opens a PR titled "logmind self-update: X.Y.Z → A.B.C".
+#
+# Reads the currently installed version from this repo's pinned
+# workflow line (`pip install "logmind==X.Y.Z"` in regen-timeline.yml,
+# shipped since logmind v0.2.1). Pre-v0.2.1 installs aren't pinned and
+# self-update will skip with a notice — re-run `logmind init` once
+# manually to upgrade past that.
+#
+# To pin to a specific logmind version and stop self-updates, add a
+# `pinVersion: "X.Y.Z"` field to `.logmind/config.yml`. The cron will
+# skip when that field is present.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1'   # Mondays 12:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compare installed vs PyPI latest
+        id: compare
+        run: |
+          set -euo pipefail
+          # Installed version: parsed from the workflow pin line shipped
+          # since v0.2.1. If absent, skip with a clear notice.
+          REGEN_FILE=".github/workflows/regen-timeline.yml"
+          INSTALLED=""
+          if [ -f "$REGEN_FILE" ]; then
+            INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$REGEN_FILE" | head -1 | sed 's/logmind==//') || true
+          fi
+          if [ -z "$INSTALLED" ]; then
+            echo "::notice::Installed logmind version not detected (no pinned `pip install` in regen-timeline.yml). Re-run \`logmind init\` once locally to upgrade past pre-v0.2.1 installs, then self-update will work from then on."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Optional pin override from .logmind/config.yml.
+          PIN=""
+          if [ -f ".logmind/config.yml" ]; then
+            PIN=$(python3 -c "
+          import yaml, sys
+          try:
+              with open('.logmind/config.yml') as f:
+                  print((yaml.safe_load(f) or {}).get('pinVersion', '') or '')
+          except Exception:
+              print('')
+          " 2>/dev/null || echo "")
+          fi
+
+          LATEST=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true
+          if [ -z "$LATEST" ]; then
+            # Fallback: PyPI JSON API
+            LATEST=$(curl -fsSL https://pypi.org/pypi/logmind/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])")
+          fi
+
+          echo "installed=$INSTALLED" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST"       >> "$GITHUB_OUTPUT"
+          echo "pin=$PIN"              >> "$GITHUB_OUTPUT"
+          echo "Installed: $INSTALLED  Latest: $LATEST  Pin: ${PIN:-(none)}"
+
+          if [ -n "$PIN" ]; then
+            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$INSTALLED" = "$LATEST" ]; then
+            echo "Already on latest ($INSTALLED). Nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run logmind init + open PR
+        if: steps.compare.outputs.skip == 'false'
+        env:
+          INSTALLED: ${{ steps.compare.outputs.installed }}
+          LATEST:    ${{ steps.compare.outputs.latest }}
+          GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="logmind/self-update-${LATEST}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          pip install --upgrade "logmind==${LATEST}"
+          # Refresh mode (v0.2.1+) rewrites stale workflow templates by
+          # `# logmind-template-version:` marker, leaves docs/ + .logmind/
+          # + agent files untouched. Idempotent.
+          logmind init --no-git --no-skill-install || logmind init
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::No file changes after logmind init — nothing to PR."
+            exit 0
+          fi
+          git commit -m "logmind self-update: ${INSTALLED} → ${LATEST}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "logmind self-update: ${INSTALLED} → ${LATEST}" \
+            --body "Automated upgrade from logmind ${INSTALLED} → ${LATEST}.
+
+          Refresh mode (v0.2.1+) only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.
+
+          Review the diff. To stop self-updates after this, add \`pinVersion: \"${LATEST}\"\` to \`.logmind/config.yml\` before merging."

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -48,6 +48,25 @@ def test_install_github_action_templates_pins_logmind_version(temp_dir):
             assert "__LOGMIND_VERSION__" not in content
 
 
+def test_self_update_template_is_shipped(temp_dir):
+    """v0.2.x+: logmind init must install the logmind-self-update workflow
+    so downstream repos get the Monday-cron PR for new releases without
+    manual `pip install --upgrade logmind && logmind init` each cycle."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=temp_dir):
+        result = runner.invoke(init, ["--no-git", "--no-skill-install"])
+        assert result.exit_code == 0, result.output
+        wf = Path(".github/workflows/logmind-self-update.yml")
+        assert wf.exists(), "logmind init must install logmind-self-update.yml"
+        content = wf.read_text(encoding="utf-8")
+        # cron schedule on Mondays at noon UTC (mirror of clud-bug self-update)
+        assert "cron: '0 12 * * 1'" in content
+        # Reads the workflow pin to detect installed version
+        assert "regen-timeline.yml" in content
+        # Opt-out via pinVersion in .logmind/config.yml
+        assert "pinVersion" in content
+
+
 def test_install_templates_substitution_does_not_break_yaml_braces(temp_dir):
     """Confirm the placeholder substitution uses str.replace (not str.format),
     so YAML's `${{ ... }}` expressions in workflow templates survive intact.


### PR DESCRIPTION
## Summary
New \`src/logmind/templates/github/logmind-self-update.yml.template\` installed by \`logmind init\`. Mondays 12:00 UTC cron compares installed logmind version (parsed from \`regen-timeline.yml\`'s \`pip install "logmind==X.Y.Z"\` pin) against PyPI's latest; opens a PR with the upgrade if newer.

## Why
Mirror of clud-bug's \`self-update.yml.tmpl\` pattern. Pre-v0.2.1 logmind had no equivalent — users had to remember \`pip install --upgrade logmind && logmind init\` manually. Now downstream repos get a weekly auto-PR.

## Opt-out
Add \`pinVersion: "X.Y.Z"\` to \`.logmind/config.yml\` and the workflow skips with a notice.

## Test plan
- [x] New \`test_self_update_template_is_shipped\` passes
- [x] Full pytest: 494 passed, 1 skipped
- [ ] After merge: \`logmind init\` on a fresh repo creates \`logmind-self-update.yml\` alongside the existing three workflows

## Closes
Architectural gap F from the 5-repo seamless-updates plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)