### PR TITLE
v0.2.2: fix paths-filter bug in check-doc-links.yml.template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-18
+
+### Fixed
+- **`check-doc-links.yml.template`: removed paths filter that silently blocked merges.** The shipped template had `paths: ["**/*.md", ".logmind/config.yml"]` on both `pull_request:` and `push:` triggers. When a PR doesn't change any markdown, GitHub Actions skips the workflow — no status report. But if `check-links` is in the ruleset's `required_status_checks` list (like reporulez's `clud-bug-logmind` variant ships it), GitHub treats the missing report as **"expected but never reported"** and blocks the merge forever. Logmind's own dogfood copy fixed this months ago; the shipped template never got the backport. Bit clud-bug PR #52 today — the template-marker PR had no markdown changes and sat blocked until a CHANGELOG entry was added as a fake-trigger.
+- **Template marker bumped `v1 → v2`.** v0.2.1's idempotent refresh logic will rewrite the workflow on the next `logmind init` because the version marker differs.
+
+### Migration from v0.2.1
+Run `logmind init` in each logmind-installed repo to pick up the corrected template. v0.2.1's refresh mode auto-detects the stale v1 marker and rewrites the workflow — no manual edits needed.
+
 ## [0.2.1] - 2026-05-18
 
 ### Fixed (audit-driven)

--- a/docs/decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md
+++ b/docs/decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md
@@ -1,0 +1,12 @@
+## 2026-05-18 15:08 - v0.2.2: fix paths-filter bug in check-doc-links.yml.template
+
+**Reasoning:** The shipped check-doc-links.yml.template had  filters on pull_request + push triggers. When a PR doesn't touch markdown, GitHub Actions skips the workflow — no status report. But if check-links is in required_status_checks (as reporulez's clud-bug-logmind variant ships it), GitHub treats the missing report as 'expected but never reported' and blocks merge forever. Bit clud-bug PR #52 directly (template-marker PR had no markdown changes; sat blocked until a CHANGELOG entry was added as a fake-trigger). The fix has been in logmind's OWN dogfood workflow for months but never backported to the shipped template. Bumping template marker to v2 so v0.2.1's idempotent refresh auto-rewrites downstream installs.
+
+**Alternatives considered:** Document the bug in a release note and tell users to add CHANGELOG-style fake-trigger markdown changes — terrible UX, Add a fallback null-check step that always reports success — defeats the purpose of the check, Leave paths filter but add docs telling users to NOT make check-links required — fights against reporulez's clud-bug-logmind variant which ships check-links as required
+
+**Implications:**
+- Workflow now runs unconditionally on every PR + main push. ~15s end-to-end, predictable gate behavior
+- Template marker bumped v1→v2; v0.2.1+ idempotent refresh auto-rewrites the workflow on next logmind init in downstream repos
+- clud-bug + reporulez + any repo using the canonical clud-bug-logmind ruleset no longer needs paths:-triggered fake-changes to unblock merges
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,8 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-18** — v0.2.2: fix paths-filter bug in check-doc-links.yml.template *(fix/check-doc-links-paths-filter-v0.2.2)* — [decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md](decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md)
+- **2026-05-18** — feat: ship logmind-self-update.yml workflow template *(feat/logmind-self-update)* — [decisions-branches/feat__logmind-self-update.md](decisions-branches/feat__logmind-self-update.md)
 - **2026-05-18** — docs: fix stale skills.sh badge URL in README *(docs/fix-skills-badge-url)* — [decisions-branches/docs__fix-skills-badge-url.md](decisions-branches/docs__fix-skills-badge-url.md)
 - **2026-05-18** — v0.2.1: audit-driven fixes — version pinning, idempotent init, atomic writes, hardened git helpers *(feat/v0.2.1-audit-fixes)* — [decisions-branches/feat__v0.2.1-audit-fixes.md](decisions-branches/feat__v0.2.1-audit-fixes.md)
 - **2026-05-18** — docs: correct README required-repo-settings for v0.2 + add reporulez one-command *(docs/readme-v0.2-corrections)* — [decisions-branches/docs__readme-v0.2-corrections.md](decisions-branches/docs__readme-v0.2-corrections.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.1"
+version = "0.2.2"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.1", prog_name="logmind")
+@click.version_option(version="0.2.2", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass

--- a/src/logmind/templates/github/check-doc-links.yml.template
+++ b/src/logmind/templates/github/check-doc-links.yml.template
@@ -1,19 +1,20 @@
-# logmind-template-version: v1
+# logmind-template-version: v2
 name: doc link integrity
 
 # Fail PRs that introduce broken or orphaned markdown links so agents stay
 # in context when they follow [link](path.md) references between docs.
 # Installed by `logmind init`.
 
+# Runs unconditionally on every PR / main push — no `paths:` filter.
+# Filtered runs interact badly with `required_status_checks` rules:
+# GitHub treats a filter-skipped check as "expected but missing" and
+# blocks the merge forever. Running unconditionally is cheap (~15s
+# end-to-end) and keeps the gate predictable.
+
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".logmind/config.yml"
   push:
     branches: [main, master]
-    paths:
-      - "**/*.md"
 
 jobs:
   check-links:

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -48,6 +48,40 @@ def test_install_github_action_templates_pins_logmind_version(temp_dir):
             assert "__LOGMIND_VERSION__" not in content
 
 
+def test_check_doc_links_template_has_no_paths_filter():
+    """v0.2.2 fix: shipped check-doc-links.yml.template must NOT have a
+    `paths:` filter. The filter (which v0.2.0/v0.2.1 shipped) causes
+    GitHub to skip the workflow on non-markdown PRs, which silently
+    blocks merges when the check is in required_status_checks (treated
+    as 'expected but never reported'). Bit clud-bug PR #52.
+
+    The fix lifts the no-filter behavior from logmind's own dogfood copy
+    into the shipped template + bumps the template marker to v2."""
+    template = (
+        Path(__file__).parent.parent
+        / "src"
+        / "logmind"
+        / "templates"
+        / "github"
+        / "check-doc-links.yml.template"
+    ).read_text(encoding="utf-8")
+
+    # The on: block must NOT contain `paths:` filter.
+    # Use a narrow check: any `paths:` line in the file means regression.
+    paths_lines = [
+        line for line in template.splitlines()
+        if line.strip().startswith("paths:")
+    ]
+    assert not paths_lines, (
+        "check-doc-links.yml.template ships a paths: filter again; this "
+        "silently blocks merges when check-links is a required status check. "
+        f"Found: {paths_lines!r}"
+    )
+
+    # Template marker must be v2 (bumped from v1)
+    assert "# logmind-template-version: v2" in template
+
+
 def test_self_update_template_is_shipped(temp_dir):
     """v0.2.x+: logmind init must install the logmind-self-update workflow
     so downstream repos get the Monday-cron PR for new releases without


### PR DESCRIPTION
## Summary
Remove the \`paths:\` filter from the shipped \`check-doc-links.yml.template\`. The filter caused GitHub Actions to skip the workflow on non-markdown PRs, which silently blocked merges when \`check-links\` was a required status check (treated as "expected but never reported"). Bit clud-bug PR #52 today.

## What changed
- \`src/logmind/templates/github/check-doc-links.yml.template\`:
  - Removed \`paths:\` filter from both \`pull_request:\` and \`push:\` triggers
  - Lifted the explanatory comment from logmind's own dogfood copy (was already discovered there months ago but never backported)
  - Bumped \`# logmind-template-version: v1\` → \`v2\` so v0.2.1's idempotent refresh mode auto-rewrites downstream installs

## Why this bug existed
The fix was in logmind's OWN \`.github/workflows/check-doc-links.yml\` for months, but the shipped template (`src/logmind/templates/github/`) never got the backport. Symptom: every downstream \`logmind init\` shipped the bug.

## Test plan
- [x] New regression test asserts the template has no \`paths:\` lines
- [x] Full pytest: 495 passed, 1 skipped
- [x] Template marker bump verified (v2)

## Migration
Downstream repos: \`logmind init\` (idempotent refresh) rewrites the workflow automatically on next run because the v1→v2 marker mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)