### PR TITLE
v0.2.3: logmind log auto-regenerates docs/timeline.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-26
+
+### Fixed
+- **`logmind log` now regenerates and stages `docs/timeline.md` automatically.** Previously the command wrote the new decision file to `docs/decisions-branches/<branch>.md` but left the derived `docs/timeline.md` index out of date, so every decision PR required an extra `logmind timeline --write docs/timeline.md` + push before `check-derived-docs` would pass. PR #42 was the last one bitten by this — the workflow caught the stale index as designed but the manual heal was friction we shouldn't be paying. Now `logmind log` produces a self-consistent commit: the new decision file, the regenerated tree, archived rotations, and the timeline index are all staged together. Timeline regen runs on every branch (not just default) because the CI gate runs on PR branches and timeline merges three-way-merge trivially.
+
+### Migration from v0.2.2
+None — this is a CLI behavior change with no template change. No `logmind init` needed in installed repos.
+
 ## [0.2.2] - 2026-05-18
 
 ### Fixed

--- a/docs/decisions-branches/feat__v0.2.3-auto-regen-timeline.md
+++ b/docs/decisions-branches/feat__v0.2.3-auto-regen-timeline.md
@@ -1,0 +1,12 @@
+## 2026-05-26 11:21 - feat: v0.2.3 — logmind log auto-regenerates docs/timeline.md
+
+**Reasoning:** PR #42 (v0.2.2 paths-filter fix) stalled because docs/timeline.md was stale. logmind log writes a new decision file but didn't regen the derived timeline.md index, so every decision PR needed an extra 'logmind timeline --write' + push before check-derived-docs would pass. The fix calls write_timeline() in logger.py's log() function after archival and adds timeline.md to the scoped-staging list — mirroring the existing companion-file pattern for file-structure.md and decisions-archive.md. Regen runs on every branch (not just default) because the CI gate runs on PR branches and timeline merges three-way trivially.
+
+**Alternatives considered:** Pre-commit hook, CI auto-commits via PAT
+
+**Implications:**
+- logmind log now produces a self-consistent commit on every branch — no manual timeline regen step needed
+- Behavior-only change; no template change; no logmind init needed in installed repos
+- This commit itself proves the fix: docs/timeline.md should be auto-staged alongside the decision file
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — feat: v0.2.3 — logmind log auto-regenerates docs/timeline.md *(feat/v0.2.3-auto-regen-timeline)* — [decisions-branches/feat__v0.2.3-auto-regen-timeline.md](decisions-branches/feat__v0.2.3-auto-regen-timeline.md)
 - **2026-05-18** — v0.2.2: fix paths-filter bug in check-doc-links.yml.template *(fix/check-doc-links-paths-filter-v0.2.2)* — [decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md](decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md)
 - **2026-05-18** — feat: ship logmind-self-update.yml workflow template *(feat/logmind-self-update)* — [decisions-branches/feat__logmind-self-update.md](decisions-branches/feat__logmind-self-update.md)
 - **2026-05-18** — docs: fix stale skills.sh badge URL in README *(docs/fix-skills-badge-url)* — [decisions-branches/docs__fix-skills-badge-url.md](decisions-branches/docs__fix-skills-badge-url.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.2"
+version = "0.2.3"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.2", prog_name="logmind")
+@click.version_option(version="0.2.3", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
@@ -603,8 +603,8 @@ def _maybe_install_skill(flag: Optional[bool]) -> None:
     show_default=True,
     help=(
         "What to stage in the decision commit. 'scoped' stages only the "
-        "decision log + file-structure + archive (if rotated). 'all' stages "
-        "everything in the working tree (pre-v0.1.2 behavior)."
+        "decision log + file-structure + archive (if rotated) + timeline. "
+        "'all' stages everything in the working tree (pre-v0.1.2 behavior)."
     ),
 )
 def log(

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -18,6 +18,7 @@ from logmind.core.git_handler import (
     git_push,
     is_git_repo,
 )
+from logmind.core.timeline import write_timeline
 from logmind.core.tree_gen import update_file_structure
 
 
@@ -235,7 +236,9 @@ def log(
     1. Appends the decision to docs/decisions.md
     2. Archives oldest decision if > max_recent entries (from config)
     3. Updates docs/file-structure.md with current tree
-    4. Commits and pushes changes (based on config or parameters)
+    4. Regenerates docs/timeline.md so the derived index stays in sync
+       with the decision file it just wrote (v0.2.3+)
+    5. Commits and pushes changes (based on config or parameters)
 
     Args:
         decision: Decision summary (will be used in commit message)
@@ -247,8 +250,9 @@ def log(
         auto_push: Whether to auto-push. If None, uses config value.
         stage: ``"scoped"`` (default) stages only the decision log and its
             companion files (file-structure.md, decisions-archive.md if
-            rotated). ``"all"`` stages the entire working tree (pre-v0.1.2
-            behavior, opt-in via ``logmind log ... --stage all``).
+            rotated, timeline.md if changed). ``"all"`` stages the entire
+            working tree (pre-v0.1.2 behavior, opt-in via
+            ``logmind log ... --stage all``).
 
     Raises:
         FileNotFoundError: If docs/ doesn't exist (run logmind init first)
@@ -323,6 +327,15 @@ def log(
             update_file_structure(docs_path)
             file_structure_updated = True
 
+    # Regenerate docs/timeline.md on every branch — unlike file-structure.md,
+    # timeline conflicts are trivially three-way-mergeable (each branch
+    # appends its own dated row), and the check-derived-docs CI gate runs
+    # on PR branches, so skipping on feature branches would defeat the
+    # auto-heal. write_timeline() returns True only when content actually
+    # changed; we use that to decide whether to stage it.
+    timeline_path = docs_path / "timeline.md"
+    timeline_updated = write_timeline(timeline_path, docs_path)
+
     # Commit and push if requested
     if auto_commit and is_git_repo():
         if stage == "all":
@@ -337,6 +350,8 @@ def log(
                 scoped.append(str(docs_path / "file-structure.md"))
             if archive_rotated:
                 scoped.append(str(docs_path / "decisions-archive.md"))
+            if timeline_updated:
+                scoped.append(str(timeline_path))
             if extra_scoped_paths:
                 scoped.extend(extra_scoped_paths)
             git_add(scoped)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,32 @@ def test_log_command_basic(git_repo):
         assert "Test decision" in content
 
 
+def test_log_command_regenerates_timeline(git_repo):
+    """v0.2.3: logmind log must regenerate + stage docs/timeline.md so
+    derived-docs CI doesn't catch authors out. Regression: PR #42 stalled
+    because the workflow gate caught a stale timeline.md the author hadn't
+    regenerated manually."""
+    from logmind.core.timeline import write_timeline
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        runner.invoke(init)
+        result = runner.invoke(log, ["Test decision"])
+        assert result.exit_code == 0, result.output
+
+        timeline_path = Path.cwd() / "docs" / "timeline.md"
+        assert timeline_path.exists(), "timeline.md should be created by logmind log"
+        assert "Test decision" in timeline_path.read_text(encoding="utf-8"), (
+            "timeline.md should reference the new decision"
+        )
+
+        # Running write_timeline again produces no diff — proves the commit
+        # is self-consistent, which is what check-derived-docs verifies.
+        changed = write_timeline(timeline_path, Path.cwd() / "docs")
+        assert changed is False, "timeline.md should already be current after logmind log"
+
+
 def test_log_command_with_reasoning(git_repo):
     """Test log command with reasoning."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- Root-cause fix for the friction PR #42 hit this afternoon: \`logmind log\` now regenerates and stages \`docs/timeline.md\` automatically, alongside the decision file, file-structure.md, and archive rotations.
- This commit itself demonstrates the fix — the decision commit (\`899f744\`) auto-staged \`docs/timeline.md\` (+1 line referencing the new branch decision file). Before v0.2.3 that would have required a separate \`logmind timeline --write\` + push step.
- Behavior-only change. No template change. No \`logmind init\` needed in installed repos.

## Background
PR #42 (v0.2.2 paths-filter fix) stalled because \`docs/timeline.md\` was stale: \`logmind log\` writes a new decision file at \`docs/decisions-branches/<branch>.md\` but did NOT regenerate the derived \`timeline.md\` index. The \`check-derived-docs\` CI gate catches it correctly but doesn't auto-heal, so every decision PR needed an extra "regen + push" step.

## Design call: regen on every branch
\`update_file_structure\` skips regen on feature branches because the tree snapshot diverges across concurrent PRs (noisy conflicts). Timeline is the opposite case — each branch appends its own dated row, three-way merge handles it trivially, and the CI gate runs on PR branches (where the auto-heal needs to fire). So no \`current_branch != default_branch\` guard for timeline; always run.

## Alternatives considered
- Pre-commit hook installed by \`logmind init\` — bypassed in agent/CI contexts that skip hooks. Rejected.
- CI auto-commits the regen back to the PR branch — requires a PAT (GITHUB_TOKEN-pushed commits can't re-trigger workflows by design), adds ghost commits with bot author. Rejected.
- In-CLI regen (this PR) — universal fix, works regardless of caller context.

## Test plan
- [x] New regression test: \`tests/test_cli.py::test_log_command_regenerates_timeline\` asserts timeline.md exists, references the new decision, and is byte-stable on a re-run of \`write_timeline\`.
- [x] Full suite green (\`pytest\` → 496 passed, 1 skipped).
- [x] Dogfooded on this PR: decision commit auto-staged timeline.md.
- [ ] \`check-derived-docs\` CI passes on first push (no manual regen needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)