### PR TITLE
v0.2.5: refresh-mode also updates stale version pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-26
+
+### Fixed
+- **`logmind init` refresh-mode now updates stale `pip install "logmind==X.Y.Z"` pins** in installed workflow templates even when the template-version marker hasn't moved. Pin drift is independent of body drift — versions like 0.2.2 → 0.2.4 didn't change any templates, so refresh-mode left the pin at 0.2.1 across multiple releases. Now: if the installed file's body is current (or markerless) but its `==X.Y.Z` doesn't match the running logmind's `__version__`, the pin line is surgically rewritten in place. One line touched; user body customizations preserved. Caught by an agent working in clud-bug whose `regen-timeline.yml` was still pinned to 0.2.1 after we shipped 0.2.4.
+
+### Migration from v0.2.4
+None — behavior-only refinement of refresh-mode. Run `logmind init` in any repo whose `logmind doctor` reports a stale `installed_version` to pick up the fresh pin.
+
 ## [0.2.4] - 2026-05-26
 
 ### Added

--- a/docs/decisions-branches/fix__v0.2.5-pin-refresh.md
+++ b/docs/decisions-branches/fix__v0.2.5-pin-refresh.md
@@ -1,0 +1,12 @@
+## 2026-05-26 15:20 - fix: v0.2.5 — refresh-mode also updates stale version pins
+
+**Reasoning:** Bug caught by another agent in clud-bug: regen-timeline.yml still pinned to logmind==0.2.1 after we shipped 0.2.4. Cause: refresh-mode only re-renders a workflow when the template-version marker differs, but the pip install pin can drift independently — releases like 0.2.3 and 0.2.4 didn't touch any template body, so refresh-mode left old pins behind. Fix: when marker matches AND a pin line exists, surgically rewrite ONLY the pin line if its version != current __version__. Markerless workflows (dogfood/customized) still left alone, respecting the same v0.2.1 heuristic.
+
+**Alternatives considered:** Always re-render when pin is stale — would clobber legitimate body customizations users kept alongside a current marker, Bump every template marker on every release — defeats the idempotent-refresh design and over-refreshes
+
+**Implications:**
+- logmind init in any repo with stale pin will pick up the current version on next run, even when no template body changed
+- Two regression tests added: stale-pin-with-current-marker (refreshes) and markerless-stale-pin (left alone)
+- Net effect: logmind doctor's 'STALE installed version' suggestion now actually heals via the printed command
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — fix: v0.2.5 — refresh-mode also updates stale version pins *(fix/v0.2.5-pin-refresh)* — [decisions-branches/fix__v0.2.5-pin-refresh.md](decisions-branches/fix__v0.2.5-pin-refresh.md)
 - **2026-05-26** — feat: v0.2.4 — new logmind doctor stack-status command *(feat/v0.2.4-doctor)* — [decisions-branches/feat__v0.2.4-doctor.md](decisions-branches/feat__v0.2.4-doctor.md)
 - **2026-05-26** — feat: v0.2.3 — logmind log auto-regenerates docs/timeline.md *(feat/v0.2.3-auto-regen-timeline)* — [decisions-branches/feat__v0.2.3-auto-regen-timeline.md](decisions-branches/feat__v0.2.3-auto-regen-timeline.md)
 - **2026-05-18** — v0.2.2: fix paths-filter bug in check-doc-links.yml.template *(fix/check-doc-links-paths-filter-v0.2.2)* — [decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md](decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.4"
+version = "0.2.5"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.4", prog_name="logmind")
+@click.version_option(version="0.2.5", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
@@ -121,6 +121,37 @@ def _extract_template_version(text: str) -> Optional[str]:
     return m.group(1) if m else None
 
 
+# Matches the install pin line in a rendered workflow, e.g.
+#   `pip install "logmind==0.2.1"`  or  `pip install 'logmind==0.2.1'`
+# Capture groups: 1 = prefix up through `==`, 2 = version string, 3 = trailing quote.
+_LOGMIND_PIN_RE = re.compile(r'(pip install\s+["\']?logmind==)([\d][\w.+\-]*)(["\']?)')
+
+
+def _maybe_refresh_pin(installed_text: str) -> Tuple[str, Optional[str]]:
+    """Surgically update the `pip install "logmind==X.Y.Z"` line if X.Y.Z
+    doesn't match the running logmind's ``__version__``.
+
+    Returns ``(new_text, previous_version_or_None)``. ``previous_version`` is
+    the old pin string when a rewrite happened, or ``None`` when nothing
+    changed (no pin line, or pin already matched). Touches one line —
+    preserves any other body customizations the user kept.
+    """
+    from logmind import __version__ as logmind_version
+
+    m = _LOGMIND_PIN_RE.search(installed_text)
+    if m is None:
+        return installed_text, None  # no pin line (dogfood / unpinned)
+    found_version = m.group(2)
+    if found_version == logmind_version:
+        return installed_text, None  # already current
+    new_text = _LOGMIND_PIN_RE.sub(
+        lambda mo: f"{mo.group(1)}{logmind_version}{mo.group(3)}",
+        installed_text,
+        count=1,
+    )
+    return new_text, found_version
+
+
 def _install_github_action_templates(
     root_path: Path,
     refresh_stale: bool = False,
@@ -137,6 +168,11 @@ def _install_github_action_templates(
         ``# logmind-template-version:`` marker is older than the
         template's, overwrite it. User-customised workflows that have
         had their version marker stripped are still left alone.
+        Additionally (v0.2.5+), the `pip install "logmind==X.Y.Z"` pin
+        is surgically refreshed to the current ``__version__`` even when
+        the template marker hasn't moved — pin drift is independent of
+        body drift, and the previous behaviour left stale pins in place
+        across versions like 0.2.1 → 0.2.4 that didn't touch templates.
 
     Returns ``(created, refreshed)`` — two lists of relative paths.
     """
@@ -162,7 +198,7 @@ def _install_github_action_templates(
         installed = target.read_text(encoding="utf-8")
         installed_version = _extract_template_version(installed)
         template_version = _extract_template_version(rendered)
-        # Only refresh if BOTH have a marker AND they differ. A missing
+        # Body refresh: only if BOTH have a marker AND they differ. A missing
         # installed marker means the user stripped it — treat as customised
         # and leave alone. A missing template marker means a logmind bug;
         # skip silently rather than break user installs.
@@ -173,6 +209,15 @@ def _install_github_action_templates(
         ):
             target.write_text(rendered, encoding="utf-8")
             refreshed.append(str(target.relative_to(root_path)))
+            continue
+        # Body is current (or markerless = user-canonical). Still check the
+        # pin line — it can drift independently of body content across
+        # logmind releases that don't touch the template.
+        if installed_version is not None:
+            new_text, prev = _maybe_refresh_pin(installed)
+            if prev is not None:
+                target.write_text(new_text, encoding="utf-8")
+                refreshed.append(str(target.relative_to(root_path)))
     return created, refreshed
 
 

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -166,6 +166,73 @@ def test_init_refresh_mode_regenerates_missing_workflow(temp_dir):
             "refresh mode must regenerate missing workflow files"
 
 
+def test_init_refresh_mode_updates_stale_pin_with_current_marker(temp_dir):
+    """v0.2.5 fix: when a workflow's template-version marker matches the
+    bundled template (so body refresh would skip), but its
+    `pip install "logmind==X.Y.Z"` pin is stale, refresh mode must
+    surgically update the pin line in place. Before this fix, releases
+    that didn't touch any template (0.2.3, 0.2.4) left old pins behind
+    across `logmind init` invocations.
+
+    Regression: caught by an agent on clud-bug whose regen-timeline.yml
+    still said `logmind==0.2.1` after the v0.2.4 release."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=temp_dir):
+        runner.invoke(init, ["--no-git", "--no-skill-install"])
+        regen = Path(".github/workflows/regen-timeline.yml")
+        original = regen.read_text(encoding="utf-8")
+        assert f'pip install "logmind=={__version__}"' in original
+
+        # Simulate a stale-pin install: same body marker, older version pin.
+        tampered = original.replace(
+            f'pip install "logmind=={__version__}"',
+            'pip install "logmind==0.2.1"',
+            1,
+        )
+        regen.write_text(tampered, encoding="utf-8")
+        assert '"logmind==0.2.1"' in regen.read_text(encoding="utf-8")
+
+        result = runner.invoke(init, ["--no-git", "--no-skill-install"])
+        assert result.exit_code == 0
+        after = regen.read_text(encoding="utf-8")
+        # Pin must be refreshed to the running version; old pin must be gone.
+        assert f'pip install "logmind=={__version__}"' in after
+        assert '"logmind==0.2.1"' not in after
+
+
+def test_init_refresh_mode_leaves_markerless_pin_alone(temp_dir):
+    """v0.2.5: a markerless workflow (dogfood / heavily customized) keeps
+    whatever pin the user wrote, even if it doesn't match the running
+    logmind. Pin-refresh respects the same no-marker-leave-alone heuristic
+    as body-refresh."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=temp_dir):
+        runner.invoke(init, ["--no-git", "--no-skill-install"])
+        regen = Path(".github/workflows/regen-timeline.yml")
+        original = regen.read_text(encoding="utf-8")
+
+        # Strip the marker line entirely (simulates user customization)
+        # and set a stale pin.
+        markerless = re.sub(
+            r"^# logmind-template-version:.*\n",
+            "",
+            original,
+            count=1,
+            flags=re.MULTILINE,
+        ).replace(
+            f'pip install "logmind=={__version__}"',
+            'pip install "logmind==0.0.99"',
+            1,
+        )
+        regen.write_text(markerless, encoding="utf-8")
+        assert "logmind-template-version" not in regen.read_text(encoding="utf-8")
+
+        result = runner.invoke(init, ["--no-git", "--no-skill-install"])
+        assert result.exit_code == 0
+        # Pin still says 0.0.99 — markerless = user-canonical, don't touch.
+        assert '"logmind==0.0.99"' in regen.read_text(encoding="utf-8")
+
+
 def test_init_refresh_mode_refreshes_stale_workflow_by_template_version(temp_dir):
     """If a workflow has an OLDER `# logmind-template-version:` marker,
     refresh mode replaces it. If markers match, leaves it alone."""


### PR DESCRIPTION
## Summary
- Refresh-mode (\`logmind init\` on an already-initialized repo) now also refreshes stale \`pip install "logmind==X.Y.Z"\` pin lines, not just stale template bodies.
- Surgical line-level rewrite — touches one line, preserves any other body customizations.
- Markerless workflows still left alone (same no-marker-leave-alone heuristic as body-refresh).

## Why
Releases that don't touch any template body (0.2.3, 0.2.4) leave downstream pins stale because refresh-mode skips re-rendering when template-version markers match. So an install at v0.2.1 stays pinned to \`logmind==0.2.1\` even after \`pip install --upgrade logmind && logmind init\` to v0.2.4.

Reported by an agent working in clud-bug whose \`regen-timeline.yml\` was still pinned to \`logmind==0.2.1\` after v0.2.4 shipped, despite running \`logmind init\` afterwards.

## Design
- Body refresh: marker stale → full re-render (unchanged from v0.2.1)
- Pin refresh (new): marker current + pin stale → surgically rewrite the pin line, leave everything else alone
- Markerless: leave entirely alone (user-customized)

## Test plan
- [x] Two new regression tests in \`tests/test_v0_2_1_audit_fixes.py\`:
  - \`test_init_refresh_mode_updates_stale_pin_with_current_marker\` — installs workflow with current marker but pin set to "0.2.1", verifies refresh rewrites the pin
  - \`test_init_refresh_mode_leaves_markerless_pin_alone\` — installs markerless workflow with pin "0.0.99", verifies refresh leaves it alone
- [x] Full suite green: 511 passed, 1 skipped (was 509 in v0.2.4 + 2 new = 511)
- [x] Dogfooded on this PR — decision commit auto-staged timeline.md via v0.2.3 feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)