### PR TITLE
v0.2.6: notify-agent-skills.yml on tag push

### DIFF
--- a/.github/workflows/notify-agent-skills.yml
+++ b/.github/workflows/notify-agent-skills.yml
@@ -60,9 +60,26 @@ jobs:
           EOF
           )
 
+          # Idempotently ensure the label exists on the receiving repo
+          # before we try to attach it. `--force` makes this a no-op when
+          # the label already exists. Without this, the first tag push
+          # would fail `gh issue create` (label not found), the `|| ::warning::`
+          # would swallow the failure, and no issue would ever land —
+          # exactly the bug the v0.2.6 review caught.
+          gh label create from-logmind \
+            --repo thrillmot/agent-skills \
+            --color "0e8a16" \
+            --description "Auto-opened by logmind release notifier" \
+            --force \
+            || echo "::warning::could not create/update from-logmind label on agent-skills; proceeding without label"
+
           gh issue create \
             --repo thrillmot/agent-skills \
             --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md" \
             --label "from-logmind" \
             --body "$body" \
-            || echo "::warning::failed to open issue on agent-skills (label may not exist — re-run after creating the 'from-logmind' label on agent-skills, or remove the --label flag)"
+            || gh issue create \
+              --repo thrillmot/agent-skills \
+              --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md" \
+              --body "$body" \
+            || echo "::error::failed to open issue on agent-skills even without label — check AGENT_SKILLS_NOTIFY_PAT scopes (needs Issues: write)"

--- a/.github/workflows/notify-agent-skills.yml
+++ b/.github/workflows/notify-agent-skills.yml
@@ -1,0 +1,68 @@
+name: notify agent-skills on release
+
+# When logmind ships a new release (tag push v*), open an issue on
+# thrillmot/agent-skills asking the maintainer to review
+# `skills/logmind/SKILL.md` for any new features that should be
+# documented. Closes the manual-sync chore between logmind releases
+# and the skill content — mirror of agent-skills' notify-clud-bug.yml
+# pattern.
+#
+# Same auth model as notify-clud-bug.yml: GITHUB_TOKEN can create
+# issues on this repo but NOT on a different repo. So this workflow
+# reads an AGENT_SKILLS_NOTIFY_PAT secret — a fine-grained PAT scoped
+# to thrillmot/agent-skills with Issues: write. Without it, the
+# notifier degrades to a ::warning:: rather than failing the release.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  open-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue on thrillmot/agent-skills
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::AGENT_SKILLS_NOTIFY_PAT secret missing — install a fine-grained PAT scoped to thrillmot/agent-skills with Issues: write to enable this notifier."
+            exit 0
+          fi
+
+          body=$(cat <<EOF
+          logmind \`${TAG}\` shipped: https://github.com/thrillmot/logmind/releases/tag/${TAG}
+
+          Review \`skills/logmind/SKILL.md\` for any user-facing changes from
+          this release that should be reflected in the skill body:
+
+          - https://github.com/thrillmot/agent-skills/blob/main/skills/logmind/SKILL.md
+
+          ## What to check
+
+          - New CLI commands, flags, or behaviors → mention in skill
+          - Automatic side effects of \`logmind log\` (timeline regen, etc.) → document
+          - New "Don't" rules surfaced by user feedback → add
+          - Changelog: https://github.com/thrillmot/logmind/blob/${TAG}/CHANGELOG.md
+
+          Close as a no-op if this release is internal-only (refactor, test
+          additions, CI changes) with no skill-relevant behavior change.
+
+          ## Auto-generated
+          Opened by \`logmind/.github/workflows/notify-agent-skills.yml\` on
+          every tag push.
+          EOF
+          )
+
+          gh issue create \
+            --repo thrillmot/agent-skills \
+            --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md" \
+            --label "from-logmind" \
+            --body "$body" \
+            || echo "::warning::failed to open issue on agent-skills (label may not exist — re-run after creating the 'from-logmind' label on agent-skills, or remove the --label flag)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-26
+
+### Added
+- **`notify-agent-skills.yml` workflow** on this repo. Mirrors the `notify-clud-bug.yml` pattern shipped on `thrillmot/agent-skills`: on every tag push (`v*`), opens an issue on `thrillmot/agent-skills` titled `logmind <tag> shipped — review skills/logmind/SKILL.md`. Closes the manual-sync gap that left the skill out of date with v0.2.3 → v0.2.5 features until someone (an agent, in this case) noticed and shipped a batch update.
+
+  - Same auth model as the agent-skills→clud-bug notifier: needs `AGENT_SKILLS_NOTIFY_PAT` repo secret (fine-grained PAT scoped to `thrillmot/agent-skills` with `Issues: write`). Without it, the notifier degrades to a `::warning::` and the release itself succeeds.
+  - Internal-only releases (refactor / CI / test additions) can close the issue as no-op; the prompt is the value.
+
+### Migration from v0.2.5
+None — this is a logmind-repo-internal workflow, not a downstream template. No `logmind init` needed in installed repos.
+
 ## [0.2.5] - 2026-05-26
 
 ### Fixed

--- a/docs/decisions-branches/feat__v0.2.6-notify-agent-skills.md
+++ b/docs/decisions-branches/feat__v0.2.6-notify-agent-skills.md
@@ -1,0 +1,12 @@
+## 2026-05-26 15:43 - feat: v0.2.6 — notify-agent-skills workflow closes the release→skill update gap
+
+**Reasoning:** Until today, every logmind release left the canonical skill on agent-skills out of date until someone manually noticed and opened a PR. Mirror the agent-skills→clud-bug notify pattern: on every tag push, open an issue on thrillmot/agent-skills prompting a SKILL.md review. Closes the structural gap that produced today's batch update covering v0.2.3→v0.2.5.
+
+**Alternatives considered:** Move SKILL.md into logmind repo and auto-push to agent-skills on release — couples the two repos too tightly; agent-skills is a multi-skill collection with its own release cadence, Bundle SKILL.md content INTO logmind package and have logmind init copy it locally — wouldn't help skills.sh consumers who fetch from the canonical repo
+
+**Implications:**
+- Future logmind releases will auto-open an issue on agent-skills; maintainer reviews and either updates SKILL.md or closes as no-op
+- Requires AGENT_SKILLS_NOTIFY_PAT repo secret on logmind (fine-grained PAT, Issues:write on agent-skills). Without it, degrades to ::warning:: rather than failing the release
+- Reusable pattern: same shape as notify-clud-bug.yml on agent-skills; both close manual-sync chores between paired repos
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — feat: v0.2.6 — notify-agent-skills workflow closes the release→skill update gap *(feat/v0.2.6-notify-agent-skills)* — [decisions-branches/feat__v0.2.6-notify-agent-skills.md](decisions-branches/feat__v0.2.6-notify-agent-skills.md)
 - **2026-05-26** — fix: v0.2.5 — refresh-mode also updates stale version pins *(fix/v0.2.5-pin-refresh)* — [decisions-branches/fix__v0.2.5-pin-refresh.md](decisions-branches/fix__v0.2.5-pin-refresh.md)
 - **2026-05-26** — feat: v0.2.4 — new logmind doctor stack-status command *(feat/v0.2.4-doctor)* — [decisions-branches/feat__v0.2.4-doctor.md](decisions-branches/feat__v0.2.4-doctor.md)
 - **2026-05-26** — feat: v0.2.3 — logmind log auto-regenerates docs/timeline.md *(feat/v0.2.3-auto-regen-timeline)* — [decisions-branches/feat__v0.2.3-auto-regen-timeline.md](decisions-branches/feat__v0.2.3-auto-regen-timeline.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.5"
+version = "0.2.6"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.5", prog_name="logmind")
+@click.version_option(version="0.2.6", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass


### PR DESCRIPTION
## Summary
New \`.github/workflows/notify-agent-skills.yml\` fires on every tag push (\`v*\`) and opens an issue on \`thrillmot/agent-skills\` titled \`logmind <tag> shipped — review skills/logmind/SKILL.md\`. Closes the structural manual-sync gap that left the skill out of date with v0.2.3 → v0.2.5 until I shipped a batch PR earlier this session.

Mirror of the agent-skills→clud-bug notify pattern.

## Why
Until today, every logmind release left the canonical skill on agent-skills stale until someone (an agent, in this case) noticed and shipped a refresh. The notify pattern moves that from "remember to do it" to "the CI opens an issue, maintainer reviews, ships or closes as no-op."

## Setup (one-time)
Repo admin needs to create \`AGENT_SKILLS_NOTIFY_PAT\` secret on this repo:
- Fine-grained PAT scoped to \`thrillmot/agent-skills\` with **Issues: write**
- Without it, the workflow runs but emits a \`::warning::\` and skips the issue-open call (release itself still succeeds)

Same auth model as the existing \`CLUD_BUG_NOTIFY_PAT\` on agent-skills.

## Test plan
- [x] YAML parses (\`yaml.safe_load\` clean)
- [x] Mirrors notify-clud-bug.yml structure (PAT env, gh issue create, graceful-degrade on missing secret)
- [ ] First real test: when v0.2.6 itself tags, the workflow fires and opens an issue (assuming PAT is set; otherwise warns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)