### PR TITLE
v0.2.7: --stage all becomes default; logmind log is the commit primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,41 +7,52 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v3-slim -->
-## Decision logging — see the `logmind` skill
+<!-- logmind-block-version: v4-slim -->
+## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). The full procedure
-(when to log, how to log, what counts as a decision, branch routing) lives
-in the **`logmind` agent skill** which your runtime should auto-load.
+This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
 
-If the skill isn't loaded for some reason, install it once:
+```bash
+logmind log "decision summary" -r "why" -a "alternative" -i "implication"
+```
+
+That single command:
+
+1. Writes the decision file (default branch → `docs/decisions.md`, feature branch → `docs/decisions-branches/<branch>.md`).
+2. Regenerates `docs/timeline.md` (and `file-structure.md` on the default branch).
+3. **`git add`** every change in the working tree (default `--stage all` since v0.2.7).
+4. **`git commit`** with message `logmind: <decision>`.
+5. **`git push`** to remote.
+
+That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git push`, no follow-up `logmind timeline --write`.
+
+### When NOT to use `logmind log`
+
+- **The change has no decision worth recording** (typo fix, formatting, dependency-only patch bump) — use plain `git commit` then.
+- **You have unrelated WIP in the working tree** you don't want to commit — pass `--stage scoped` to stage only the decision files (rare for automated agents; they should be working on one thing at a time).
+
+### The full skill
+
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmot/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
 
 ```bash
 npx skills add https://github.com/thrillmot/agent-skills --skill logmind
 ```
 
-### Project-specific paths
+### Required reading before non-trivial work
 
-- **[docs/timeline.md](docs/timeline.md)** — auto-generated chronological overview across all branches; start here.
-- Recent decisions on the default branch: **[docs/decisions.md](docs/decisions.md)**
-- Per-branch decisions (in-flight feature work): **docs/decisions-branches/**
-- Archived decisions: **[docs/decisions-archive.md](docs/decisions-archive.md)**
-- Project tree (regenerated on main-branch logs + post-PR-merge): **[docs/file-structure.md](docs/file-structure.md)**
-
-### Quick reference
+1. **[docs/timeline.md](docs/timeline.md)** — chronological overview across all branches; start here.
+2. **[docs/decisions.md](docs/decisions.md)** — recent decisions on the default branch.
+3. **`docs/decisions-branches/<your-branch>.md`** if present — earlier decisions on this branch.
+4. **[docs/file-structure.md](docs/file-structure.md)** — current project tree.
 
 ```bash
-logmind log "decision summary" -r "why" -a "alternative" -i "implication"
 logmind show               # recent decisions on the current branch
 logmind search "keyword"   # full-text across recent + archive
+logmind doctor             # check installed version + workflow template drift
 ```
 
-**Use `logmind log` for the commit, not `git add` + `git commit`.** The
-`log` command writes the decision file, stages the decision log + its
-companion files, and creates the commit in one step. Use
-`--stage all` to also stage the rest of the working tree.
-
-**Read `docs/decisions.md` and the matching `docs/decisions-branches/<branch>.md` (if any) before starting any non-trivial task.** The team has likely already decided things you'd otherwise re-litigate.
+The team has likely already decided things you'd otherwise re-litigate.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-05-26
+
+### Changed (default behavior — backwards-compatible flag still works)
+- **`logmind log` now defaults to `--stage all`**, staging every change in the working tree alongside the decision rather than just the decision log + companion files. The whole point of `logmind log` is to be a single add+commit+push primitive for automated agents — the previous `--stage scoped` default forced agents into the same two-step pattern (`git add` + `git commit`) that `logmind log` exists to replace.
+
+  The previous default (`scoped`) is still available via `--stage scoped` — useful when you have unrelated WIP in the working tree you don't want to commit. But for the common case (an agent making a focused change + logging the decision for it), one `logmind log "summary" -r "why"` invocation now does everything: writes the decision file, regenerates the derived docs, stages every change in the working tree, commits, pushes.
+
+### Added (documentation clarity — propagates to AGENTS.md via `logmind init` refresh)
+- **AGENTS.md.slim.template + AGENTS.md.template rewritten to lead with the single-command model.** Was: "Use `logmind log` for the commit, not `git add` + `git commit`. Use `--stage all` to also stage the rest of the working tree." Now: `logmind log` IS the commit primitive that handles `git add`, `git commit`, and `git push` together; manual git commands are explicitly off-script for any change that carries a decision.
+
+### Migration from v0.2.6
+**No `logmind init` required** for the CLI default change — that takes effect as soon as the new logmind is installed. Optional: run `logmind init` in installed repos to pick up the refreshed AGENTS.md block.
+
+**If you have scripts that relied on the old scoped default** (i.e. they ran `logmind log "..."` expecting unrelated working-tree changes to stay unstaged), pass `--stage scoped` explicitly to preserve the old behavior.
+
 ## [0.2.6] - 2026-05-26
 
 ### Added

--- a/docs/decisions-branches/feat__v0.2.7-stage-all-default.md
+++ b/docs/decisions-branches/feat__v0.2.7-stage-all-default.md
@@ -1,0 +1,13 @@
+## 2026-05-26 16:06 - feat: v0.2.7 — --stage all becomes the default; logmind log is the commit primitive
+
+**Reasoning:** logmind exists to be ONE command that handles add+commit+push for automated agents. The previous default (--stage scoped) forced agents into a manual two-step git workflow that defeated the design intent — users (correctly) kept asking 'why isn't logmind log doing this already?'. Default flip closes that gap; explicit --stage scoped remains as escape hatch for users with unrelated WIP.
+
+**Alternatives considered:** Drop --stage flag entirely — too restrictive; some users genuinely want decision-only commits when staging a long-running refactor separately, Major version bump to v0.3.0 — not strictly breaking; --stage scoped opt-in preserves prior behavior, and the new default is more aligned with the README/skill intent than the prior 'feature'
+
+**Implications:**
+- Same logmind log command now produces a single commit with decision + code + any working-tree changes; downstream agent workflows simplify from add+commit→log to just log
+- AGENTS.md.slim.template (v3-slim → v4-slim) and AGENTS.md.template (v3 → v4) rewritten to lead with 'logmind log is the commit primitive that replaces git add + git commit + git push'. Refresh fires automatically on next logmind init in installed repos
+- Two regression tests pin the new default behavior; explicit --stage scoped test pins backwards-compatibility
+- Companion update to canonical skill on agent-skills follows in a separate PR (notify-agent-skills.yml shipped in v0.2.6 will fire on this tag and open the prompt automatically)
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — feat: v0.2.7 — --stage all becomes the default; logmind log is the commit primitive *(feat/v0.2.7-stage-all-default)* — [decisions-branches/feat__v0.2.7-stage-all-default.md](decisions-branches/feat__v0.2.7-stage-all-default.md)
 - **2026-05-26** — feat: v0.2.6 — notify-agent-skills workflow closes the release→skill update gap *(feat/v0.2.6-notify-agent-skills)* — [decisions-branches/feat__v0.2.6-notify-agent-skills.md](decisions-branches/feat__v0.2.6-notify-agent-skills.md)
 - **2026-05-26** — fix: v0.2.5 — refresh-mode also updates stale version pins *(fix/v0.2.5-pin-refresh)* — [decisions-branches/fix__v0.2.5-pin-refresh.md](decisions-branches/fix__v0.2.5-pin-refresh.md)
 - **2026-05-26** — feat: v0.2.4 — new logmind doctor stack-status command *(feat/v0.2.4-doctor)* — [decisions-branches/feat__v0.2.4-doctor.md](decisions-branches/feat__v0.2.4-doctor.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.6"
+version = "0.2.7"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.6", prog_name="logmind")
+@click.version_option(version="0.2.7", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
@@ -643,13 +643,15 @@ def _maybe_install_skill(flag: Optional[bool]) -> None:
 )
 @click.option(
     "--stage",
-    type=click.Choice(["scoped", "all"]),
-    default="scoped",
+    type=click.Choice(["all", "scoped"]),
+    default="all",
     show_default=True,
     help=(
-        "What to stage in the decision commit. 'scoped' stages only the "
-        "decision log + file-structure + archive (if rotated) + timeline. "
-        "'all' stages everything in the working tree (pre-v0.1.2 behavior)."
+        "What to stage in the decision commit. Default 'all' stages every "
+        "change in the working tree alongside the decision — the whole "
+        "point of `logmind log` is to be a single add+commit+push primitive. "
+        "Use 'scoped' if you have unrelated WIP you want to keep unstaged "
+        "(rare for automated agents)."
     ),
 )
 def log(

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -226,7 +226,7 @@ def log(
     docs_path: Optional[Path] = None,
     auto_commit: Optional[bool] = None,
     auto_push: Optional[bool] = None,
-    stage: str = "scoped",
+    stage: str = "all",
     extra_scoped_paths: Optional[List[str]] = None,
 ) -> None:
     """
@@ -248,11 +248,13 @@ def log(
         docs_path: Path to docs directory. Defaults to ./docs
         auto_commit: Whether to auto-commit. If None, uses config value.
         auto_push: Whether to auto-push. If None, uses config value.
-        stage: ``"scoped"`` (default) stages only the decision log and its
-            companion files (file-structure.md, decisions-archive.md if
-            rotated, timeline.md if changed). ``"all"`` stages the entire
-            working tree (pre-v0.1.2 behavior, opt-in via
-            ``logmind log ... --stage all``).
+        stage: ``"all"`` (default since v0.2.7) stages every change in the
+            working tree alongside the decision — `logmind log` is the
+            single add+commit+push primitive for automated workflows.
+            ``"scoped"`` stages only the decision log + companion files
+            (file-structure.md, decisions-archive.md if rotated,
+            timeline.md if changed) — opt in when you have unrelated WIP
+            you want to keep unstaged.
 
     Raises:
         FileNotFoundError: If docs/ doesn't exist (run logmind init first)

--- a/src/logmind/templates/AGENTS.md.slim.template
+++ b/src/logmind/templates/AGENTS.md.slim.template
@@ -7,41 +7,52 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v3-slim -->
-## Decision logging — see the `logmind` skill
+<!-- logmind-block-version: v4-slim -->
+## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). The full procedure
-(when to log, how to log, what counts as a decision, branch routing) lives
-in the **`logmind` agent skill** which your runtime should auto-load.
+This project uses [logmind](https://logmind.dev) for decision logging. **`logmind log` replaces `git add`, `git commit`, and `git push`** for any change that carries a decision. Do not run those git commands directly when logging a decision — `logmind log` does all three in one step.
 
-If the skill isn't loaded for some reason, install it once:
+```bash
+logmind log "decision summary" -r "why" -a "alternative" -i "implication"
+```
+
+That single command:
+
+1. Writes the decision file (default branch → `docs/decisions.md`, feature branch → `docs/decisions-branches/<branch>.md`).
+2. Regenerates `docs/timeline.md` (and `file-structure.md` on the default branch).
+3. **`git add`** every change in the working tree (default `--stage all` since v0.2.7).
+4. **`git commit`** with message `logmind: <decision>`.
+5. **`git push`** to remote.
+
+That's it. No follow-up `git add`, no follow-up `git commit`, no follow-up `git push`, no follow-up `logmind timeline --write`.
+
+### When NOT to use `logmind log`
+
+- **The change has no decision worth recording** (typo fix, formatting, dependency-only patch bump) — use plain `git commit` then.
+- **You have unrelated WIP in the working tree** you don't want to commit — pass `--stage scoped` to stage only the decision files (rare for automated agents; they should be working on one thing at a time).
+
+### The full skill
+
+The complete procedure (when something counts as a decision, branch routing, doctor, refresh patterns) lives in the **`logmind` agent skill** at https://github.com/thrillmot/agent-skills/tree/main/skills/logmind. Most agent runtimes auto-load it. If yours doesn't:
 
 ```bash
 npx skills add https://github.com/thrillmot/agent-skills --skill logmind
 ```
 
-### Project-specific paths
+### Required reading before non-trivial work
 
-- **[docs/timeline.md](docs/timeline.md)** — auto-generated chronological overview across all branches; start here.
-- Recent decisions on the default branch: **[docs/decisions.md](docs/decisions.md)**
-- Per-branch decisions (in-flight feature work): **docs/decisions-branches/**
-- Archived decisions: **[docs/decisions-archive.md](docs/decisions-archive.md)**
-- Project tree (regenerated on main-branch logs + post-PR-merge): **[docs/file-structure.md](docs/file-structure.md)**
-
-### Quick reference
+1. **[docs/timeline.md](docs/timeline.md)** — chronological overview across all branches; start here.
+2. **[docs/decisions.md](docs/decisions.md)** — recent decisions on the default branch.
+3. **`docs/decisions-branches/<your-branch>.md`** if present — earlier decisions on this branch.
+4. **[docs/file-structure.md](docs/file-structure.md)** — current project tree.
 
 ```bash
-logmind log "decision summary" -r "why" -a "alternative" -i "implication"
 logmind show               # recent decisions on the current branch
 logmind search "keyword"   # full-text across recent + archive
+logmind doctor             # check installed version + workflow template drift
 ```
 
-**Use `logmind log` for the commit, not `git add` + `git commit`.** The
-`log` command writes the decision file, stages the decision log + its
-companion files, and creates the commit in one step. Use
-`--stage all` to also stage the rest of the working tree.
-
-**Read `docs/decisions.md` and the matching `docs/decisions-branches/<branch>.md` (if any) before starting any non-trivial task.** The team has likely already decided things you'd otherwise re-litigate.
+The team has likely already decided things you'd otherwise re-litigate.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/src/logmind/templates/AGENTS.md.template
+++ b/src/logmind/templates/AGENTS.md.template
@@ -7,10 +7,10 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v3 -->
+<!-- logmind-block-version: v4 -->
 ## Decision Logging (logmind)
 
-**This project uses [logmind](https://logmind.dev). Logging is part of the work, not after it.**
+**This project uses [logmind](https://logmind.dev). `logmind log` is the commit primitive — it replaces `git add`, `git commit`, and `git push` for any change that carries a decision. Do not run those git commands directly when logging a decision.**
 
 > **Tip:** the canonical procedure for *when / how / why* lives in the
 > [`logmind` skill](https://github.com/thrillmot/agent-skills/tree/main/skills/logmind)
@@ -23,6 +23,22 @@ guidance lives in one place.
 >
 > The full procedure is also embedded below as a fallback when the
 > skill isn't available.
+
+### The one rule: `logmind log` does everything
+
+```bash
+logmind log "decision summary" -r "why" -a "alternative" -i "implication"
+```
+
+That single command:
+
+1. Writes the decision file (default branch → `docs/decisions.md`, feature branch → `docs/decisions-branches/<branch>.md`).
+2. Regenerates the derived docs (`docs/timeline.md` always; `docs/file-structure.md` on default branch).
+3. **`git add`** every change in the working tree (default `--stage all` since v0.2.7).
+4. **`git commit`** with message `logmind: <decision>`.
+5. **`git push`** to remote (configurable in `.logmind/config.yml`).
+
+You don't need a follow-up `git add`, `git commit`, `git push`, or `logmind timeline --write`. If you find yourself running any of those after a `logmind log`, stop — something's wrong (most likely a pre-v0.2.7 logmind; check `logmind --version`).
 
 ### When you MUST log (before, not after)
 
@@ -42,14 +58,10 @@ that don't get logged are exactly how teams lose context. If you're
 unsure, log it — a 30-second log is cheap; recovering missing context
 months later is not.
 
-**Use `logmind log` for the commit, not `git add` + `git commit`.** The
-`log` command writes the decision file, stages the decision log + its
-companion files (file-structure, archive if rotated), and creates the
-commit in one step. Use `logmind log ... --stage all` if you want to
-stage everything in the working tree alongside the decision. Bypassing
-`logmind log` (manual `git commit -m "..."`) means the decision either
-isn't logged or gets logged in a separate commit — both of which lose
-the value of having the reasoning attached to the code change.
+### When NOT to use `logmind log`
+
+- **The change has no decision worth recording** (typo fix, formatting, dependency-only patch bump) — plain `git commit` is fine for those.
+- **You have unrelated WIP in the working tree** you don't want to commit alongside the decision — pass `--stage scoped` to stage only the decision files (rare for automated agents; they should be working on one task at a time).
 
 ### How to log
 

--- a/tests/test_agents_consolidation.py
+++ b/tests/test_agents_consolidation.py
@@ -107,8 +107,11 @@ def test_get_agents_md_template_returns_slim_when_skills_available(monkeypatch):
 
     monkeypatch.setattr(skill_install, "is_skills_available", lambda: True)
     slim = get_agents_md_template()
-    assert "logmind-block-version: v3-slim" in slim
-    assert "see the `logmind` skill" in slim
+    assert "logmind-block-version: v4-slim" in slim
+    # v4 leads with the single-command framing; "logmind log is the commit
+    # primitive" is the new headline. Either marker should anchor the slim
+    # variant.
+    assert "logmind log` is the commit primitive" in slim or "logmind` skill" in slim
 
 
 def test_get_agents_md_template_returns_full_when_skills_absent(monkeypatch):
@@ -117,7 +120,10 @@ def test_get_agents_md_template_returns_full_when_skills_absent(monkeypatch):
 
     monkeypatch.setattr(skill_install, "is_skills_available", lambda: False)
     full = get_agents_md_template()
-    assert "logmind-block-version: v3" in full
+    # Match exact marker (v4 — not v4-slim, which is a different file). Use
+    # the line-exact match so a future v4-extended variant wouldn't also
+    # satisfy this assertion accidentally.
+    assert "logmind-block-version: v4 " in full or "logmind-block-version: v4\n" in full
     # Full template carries the inline procedure
     assert "When you MUST log" in full or "REQUIREMENT" in full or "skill is also embedded" in full
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,77 @@ def test_log_command_basic(git_repo):
         assert "Test decision" in content
 
 
+def test_log_command_default_stage_is_all(git_repo):
+    """v0.2.7: default --stage is 'all', not 'scoped'. An unrelated
+    working-tree change made between `logmind init` and `logmind log`
+    must end up in the decision commit by default. The previous scoped
+    default forced agents into a two-step git add + git commit + push
+    pattern that defeated the whole point of `logmind log` being a
+    single primitive.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        runner.invoke(init)
+        # Make an unrelated working-tree change (simulates the agent's
+        # actual code change that prompted the decision).
+        rogue = Path.cwd() / "rogue_change.py"
+        rogue.write_text("# unrelated edit\n", encoding="utf-8")
+
+        result = runner.invoke(log, ["Test decision"])
+        assert result.exit_code == 0, result.output
+
+        # The rogue change must be in the resulting commit AND no longer
+        # dirty in the working tree.
+        out = subprocess.run(
+            ["git", "log", "-1", "--name-only", "--format="],
+            capture_output=True, text=True, check=True,
+        )
+        # Paths in the commit may carry a tmp-fs prefix; substring match.
+        assert "rogue_change.py" in out.stdout, (
+            f"v0.2.7 default --stage all must sweep working-tree changes "
+            f"into the decision commit; commit listed:\n{out.stdout}"
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        )
+        assert status.stdout.strip() == "", (
+            f"working tree must be clean after `logmind log` (default "
+            f"--stage all); leftover: {status.stdout!r}"
+        )
+
+
+def test_log_command_scoped_stage_keeps_rogue_unstaged(git_repo):
+    """v0.2.7: explicit --stage scoped preserves the old behavior —
+    unrelated working-tree changes stay unstaged. Backwards-compat
+    escape hatch for users who relied on the previous default."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        runner.invoke(init)
+        rogue = Path.cwd() / "rogue_change.py"
+        rogue.write_text("# unrelated edit\n", encoding="utf-8")
+
+        result = runner.invoke(log, ["Test decision", "--stage", "scoped"])
+        assert result.exit_code == 0, result.output
+
+        out = subprocess.run(
+            ["git", "log", "-1", "--name-only", "--format="],
+            capture_output=True, text=True, check=True,
+        )
+        assert "rogue_change.py" not in out.stdout, (
+            f"explicit --stage scoped must leave rogue_change.py unstaged; "
+            f"commit listed:\n{out.stdout}"
+        )
+        # And it must still be dirty
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        )
+        assert "rogue_change.py" in status.stdout, (
+            "rogue_change.py must remain unstaged after --stage scoped"
+        )
+
+
 def test_log_command_regenerates_timeline(git_repo):
     """v0.2.3: logmind log must regenerate + stage docs/timeline.md so
     derived-docs CI doesn't catch authors out. Regression: PR #42 stalled


### PR DESCRIPTION
## Summary
- **\`logmind log\` now defaults to \`--stage all\`** instead of \`--stage scoped\`. The whole point of \`logmind log\` is to be a single \`git add\` + \`git commit\` + \`git push\` primitive for automated agents; the prior scoped default forced them into a two-step pattern that defeated that design intent.
- **AGENTS.md.slim.template + AGENTS.md.template rewritten** to lead with the single-command framing. Was: "Use \`logmind log\` for the commit". Now: \`logmind log\` IS the commit primitive that replaces \`git add\` + \`git commit\` + \`git push\`; manual git commands are explicitly off-script when a change carries a decision.
- Marker bumps: \`v3 → v4\` (full) and \`v3-slim → v4-slim\` (slim) — refresh fires automatically on next \`logmind init\` in installed repos.

## Dogfood proof
This PR was committed with a single \`logmind log\` invocation. One command, one commit. 12 files swept into the decision commit (code + tests + templates + CHANGELOG + version bumps + auto-refreshed AGENTS.md + decision file + timeline). Working tree clean immediately after.

## Backwards-compat
- \`--stage scoped\` still works as an explicit opt-in for users who want to keep unrelated WIP unstaged.
- New regression test \`test_log_command_scoped_stage_keeps_rogue_unstaged\` pins that behavior.

## Test plan
- [x] 2 new regression tests in \`tests/test_cli.py\` (default-stage-all + explicit-scoped-still-works)
- [x] 2 updated tests in \`tests/test_agents_consolidation.py\` (v3 → v4 marker assertions)
- [x] Full suite: 513 passed, 1 skipped (was 511 + 2 new = 513)
- [ ] \`check-derived-docs\` CI passes (timeline auto-regen handles it)
- [ ] After tag v0.2.7: notify-agent-skills.yml (v0.2.6, just shipped) auto-opens an issue prompting a skill refresh on agent-skills

## Follow-up (separate PR)
Refresh \`skills/logmind/SKILL.md\` on \`thrillmot/agent-skills\` to reflect the new default. The notify-agent-skills workflow will surface this automatically when v0.2.7 tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)