### PR TITLE
v0.2.8: replace PyYAML+Python pinVersion detection with grep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-05-26
+
+### Fixed
+- **`logmind-self-update.yml.template`: replace PyYAML+Python pinVersion detection with `grep`.** The previous block called `python3 -c "import yaml, sys; try: ..."` with `import yaml` OUTSIDE the try, so if the workflow runner lacked PyYAML the import raised before the try could catch it. The surrounding `2>/dev/null || echo ""` then swallowed the failure into empty pin — silently breaking opt-out via `pinVersion` whenever the runner shipped without PyYAML. Reported by clud-bug-review across multiple repos (it kept flagging the pattern on every propagation PR even when the bug was dormant on that specific install).
+
+  Replacement uses `grep -E '^[[:space:]]*pinVersion:[[:space:]]*' .logmind/config.yml` plus `sed` to strip optional quotes/whitespace. Tested against 8 input variants (quoted, unquoted, indented, trailing whitespace, absent key, key-as-substring, etc.). No Python, no YAML lib, works on every runner.
+
+- **Template marker bumped `v1 → v2`** so v0.2.7's idempotent refresh logic rewrites `logmind-self-update.yml` on the next `logmind init`.
+
+### Migration from v0.2.7
+Run `logmind init` in each logmind-installed repo to pick up the corrected template. v0.2.1+'s refresh mode auto-detects the stale v1 marker and rewrites the workflow — no manual edits needed. Doctor will report the stale marker if you forget.
+
 ## [0.2.7] - 2026-05-26
 
 ### Changed (default behavior — backwards-compatible flag still works)

--- a/docs/decisions-branches/fix__v0.2.8-pinversion-grep.md
+++ b/docs/decisions-branches/fix__v0.2.8-pinversion-grep.md
@@ -1,0 +1,12 @@
+## 2026-05-26 16:24 - fix: v0.2.8 — replace PyYAML+Python pinVersion detection with grep
+
+**Reasoning:** Bug caught by clud-bug-review across multiple repos: logmind-self-update.yml.template's pinVersion block called python3 -c 'import yaml, sys' with the import OUTSIDE the try block. If the runner lacked PyYAML, the import raised, the surrounding 2>/dev/null || echo '' swallowed the failure into empty pin, and opt-out via pinVersion silently broke. Fix uses grep+sed on the flat top-level scalar — no Python, no YAML lib, works on every runner. Tested against 8 input variants (quoted/unquoted/indented/trailing-ws/absent/substring-only/etc.). Template marker bumped v1→v2 so refresh fires on next logmind init.
+
+**Alternatives considered:** Move import yaml inside try — still requires PyYAML on runner; ubuntu-latest may have it but minimal images don't, Add pip install pyyaml step — slows the workflow and adds a dep just for one field read, Wait for the bug to re-surface on real users — already surfaced via clud-bug-review on multiple repos; fix shouldn't keep slipping
+
+**Implications:**
+- Downstream logmind-installed repos pick up the fix on next logmind init (v0.2.5+ refresh-mode auto-detects stale v1 marker)
+- logmind doctor will report logmind-self-update.yml as STALE (v1, latest v2) for any repo that hasn't refreshed
+- The agent in clud-bug can now ship its propagation PR without the bot re-flagging the same bug
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — fix: v0.2.8 — replace PyYAML+Python pinVersion detection with grep *(fix/v0.2.8-pinversion-grep)* — [decisions-branches/fix__v0.2.8-pinversion-grep.md](decisions-branches/fix__v0.2.8-pinversion-grep.md)
 - **2026-05-26** — feat: v0.2.7 — --stage all becomes the default; logmind log is the commit primitive *(feat/v0.2.7-stage-all-default)* — [decisions-branches/feat__v0.2.7-stage-all-default.md](decisions-branches/feat__v0.2.7-stage-all-default.md)
 - **2026-05-26** — feat: v0.2.6 — notify-agent-skills workflow closes the release→skill update gap *(feat/v0.2.6-notify-agent-skills)* — [decisions-branches/feat__v0.2.6-notify-agent-skills.md](decisions-branches/feat__v0.2.6-notify-agent-skills.md)
 - **2026-05-26** — fix: v0.2.5 — refresh-mode also updates stale version pins *(fix/v0.2.5-pin-refresh)* — [decisions-branches/fix__v0.2.5-pin-refresh.md](decisions-branches/fix__v0.2.5-pin-refresh.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.7"
+version = "0.2.8"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.7", prog_name="logmind")
+@click.version_option(version="0.2.8", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass

--- a/src/logmind/templates/github/logmind-self-update.yml.template
+++ b/src/logmind/templates/github/logmind-self-update.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v1
+# logmind-template-version: v2
 name: logmind self-update
 
 # Weekly check for a newer published logmind. If one exists, runs
@@ -52,17 +52,21 @@ jobs:
             exit 0
           fi
 
-          # Optional pin override from .logmind/config.yml.
+          # Optional pin override from .logmind/config.yml. Parsed with
+          # grep — the field is a flat top-level scalar and the workflow
+          # runner can't be relied on to have any third-party Python
+          # library available. v0.2.7 and earlier invoked a python3
+          # one-liner that depended on a third-party YAML lib being
+          # importable; when the runner lacked it the import failed
+          # before the try block could catch it, and the surrounding
+          # `2>/dev/null || echo ""` swallowed the failure into empty
+          # pin — silently breaking opt-out.
           PIN=""
           if [ -f ".logmind/config.yml" ]; then
-            PIN=$(python3 -c "
-          import yaml, sys
-          try:
-              with open('.logmind/config.yml') as f:
-                  print((yaml.safe_load(f) or {}).get('pinVersion', '') or '')
-          except Exception:
-              print('')
-          " 2>/dev/null || echo "")
+            PIN=$(grep -E '^[[:space:]]*pinVersion:[[:space:]]*' .logmind/config.yml \
+              | head -1 \
+              | sed -E 's/^[[:space:]]*pinVersion:[[:space:]]*//; s/^["'\''](.*)["'\'']$/\1/; s/[[:space:]]*$//' \
+              || echo "")
           fi
 
           LATEST=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -166,6 +166,35 @@ def test_init_refresh_mode_regenerates_missing_workflow(temp_dir):
             "refresh mode must regenerate missing workflow files"
 
 
+def test_self_update_template_uses_grep_not_pyyaml():
+    """v0.2.8 fix: the shipped logmind-self-update.yml.template must NOT
+    have `import yaml` in its pinVersion detection block. The prior
+    template called `python3 -c 'import yaml, sys; try: ...'` with the
+    import OUTSIDE the try — a missing PyYAML on the runner would raise
+    before the try could catch it, the surrounding `|| echo ""` swallowed
+    the failure into empty pin, and opt-out via pinVersion silently
+    broke on any runner without PyYAML. Replaced with grep.
+
+    Also pins template-version marker = v2 so downstream refresh fires."""
+    template = (
+        Path(__file__).parent.parent
+        / "src"
+        / "logmind"
+        / "templates"
+        / "github"
+        / "logmind-self-update.yml.template"
+    ).read_text(encoding="utf-8")
+
+    assert "import yaml" not in template, (
+        "v0.2.8: logmind-self-update.yml.template must not call `import yaml` "
+        "in shell. The pinVersion detection should use grep instead."
+    )
+    # Marker must be v2 (bumped from v1)
+    assert "# logmind-template-version: v2" in template
+    # grep-based detection must be present
+    assert "grep -E '^[[:space:]]*pinVersion:" in template
+
+
 def test_init_refresh_mode_updates_stale_pin_with_current_marker(temp_dir):
     """v0.2.5 fix: when a workflow's template-version marker matches the
     bundled template (so body refresh would skip), but its


### PR DESCRIPTION
## Summary
\`logmind-self-update.yml.template\`'s pinVersion detection block called \`python3 -c "import yaml, sys; try: ..."\` with \`import yaml\` OUTSIDE the try. On runners without PyYAML, the import raised before the try could catch it, the surrounding \`2>/dev/null || echo ""\` swallowed the failure into empty pin, and opt-out via \`pinVersion\` silently broke.

Replaced with \`grep -E '^[[:space:]]*pinVersion:[[:space:]]*'\` + \`sed\` to strip optional quotes/whitespace. No Python, no YAML lib, works on every runner.

## Reported by
An agent working in \`thrillmot/clud-bug\` whose clud-bug-review kept flagging this pattern on every logmind propagation PR (PR #68, then again on the v0.2.6 re-propagation), even when dormant on the install. Bug had been in every release since v0.2.2.

## Local smoke test
8 input variants — all pass:
- \`pinVersion: "0.2.5"\` (double-quoted) → \`0.2.5\`
- \`pinVersion: '0.2.5'\` (single-quoted) → \`0.2.5\`
- \`pinVersion: 0.2.5\` (unquoted) → \`0.2.5\`
- \`  pinVersion: 0.2.5\` (indented) → \`0.2.5\`
- \`pinVersion: 0.2.5   \` (trailing space) → \`0.2.5\`
- absent key (other YAML present) → \`\` (empty, correct)
- multi-key file with pinVersion middle → \`0.2.6\`
- substring-only mention in comment → \`\` (empty, correct — anchored at line start)

## Template marker
\`v1 → v2\`. v0.2.5+ refresh-mode auto-detects the stale marker and rewrites the workflow on next \`logmind init\`. \`logmind doctor\` reports STALE for any installed repo until refresh runs.

## Test plan
- [x] New regression test in \`tests/test_v0_2_1_audit_fixes.py\` (\`test_self_update_template_uses_grep_not_pyyaml\`) — asserts no \`import yaml\`, marker is v2, grep block is present
- [x] Full suite: 514 passed, 1 skipped (was 513 in v0.2.7 + 1 new = 514)
- [x] Single \`logmind log\` shipped the entire PR (one commit, working tree clean — v0.2.7 default-stage-all proven again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)