### PR TITLE
v0.2.10: changelog-on-upgrade + escape backticks in self-update notice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Bundle CHANGELOG into package
+        # CHANGELOG.md is canonical at repo root (GitHub auto-renders it,
+        # publish.yml's release-notes step reads from there) but must be
+        # under src/logmind/ for setuptools package-data to bundle it
+        # into the wheel. Copy at build time so the file stays in one
+        # place in source control; editable installs fall back to the
+        # repo-root copy via logmind.core.changelog._changelog_path().
+        run: cp CHANGELOG.md src/logmind/CHANGELOG.md
+
       - name: Build
         run: |
           python -m pip install --upgrade pip build

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ skills-lock.json
 homebrew-logmind/
 homebrew-tap/
 verify_logmind.sh
+src/logmind/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-05-26
+
+### Added
+- **`logmind init` refresh-mode prints CHANGELOG sections between the prior pinned version and the currently installed `__version__`.** Closes the agent-memory propagation gap from the other direction: instead of relying on agents to re-read AGENTS.md or the skill, the actual behavior changes show up inline in the init command output. When agents (or humans) observe `logmind init` after a `pip install --upgrade logmind`, they see "📋 What's new in logmind since vX.Y.Z" followed by every CHANGELOG section between old and new.
+- **`logmind.core.changelog` module** with `extract_sections_between(text, after, up_to)` (slice CHANGELOG by version range, descending) and `render_upgrade_prompt(prior_version, current_version)` (compose the printed block; returns None when no upgrade applies).
+- **CHANGELOG.md bundled in the wheel** via `pyproject.toml` `package-data`. `publish.yml` adds a build-time copy step (`cp CHANGELOG.md src/logmind/CHANGELOG.md`) since the canonical file stays at repo root for GitHub auto-rendering. Editable installs fall back to the repo-root copy via `_changelog_path()`.
+
+### Fixed
+- **`logmind-self-update.yml.template:50` — escape backticks around `pip install`.** Bug hunter caught: the `:notice::` line had ` `pip install` ` (unescaped backticks) in a double-quoted bash string, triggering command substitution. `pip install` (no args) exits non-zero, prints "ERROR: You must give at least one requirement…" to stderr, and the words `pip install` get swallowed from the rendered notice. Only fires on pre-v0.2.1 fresh-install path (no pin in regen-timeline.yml). One-character fix: `` `pip install` `` → `` \`pip install\` ``. Template marker bumped `v3 → v4` so the refresh sweeps it into downstream repos automatically.
+
+### Migration from v0.2.9
+Run `logmind init` in each logmind-installed repo. The v0.2.10 init will detect the prior pin (likely v0.2.7–v0.2.9), print the CHANGELOG since then, and refresh `logmind-self-update.yml` to the corrected `v4` marker.
+
 ## [0.2.9] - 2026-05-26
 
 ### Changed

--- a/docs/decisions-branches/feat__v0.2.10-changelog-on-upgrade.md
+++ b/docs/decisions-branches/feat__v0.2.10-changelog-on-upgrade.md
@@ -1,0 +1,12 @@
+## 2026-05-26 17:02 - feat: v0.2.10 changelog-on-upgrade + escape backticks in self-update notice
+
+**Reasoning:** Two changes bundled. (1) Main feature: logmind init refresh-mode prints CHANGELOG sections between the prior pinned version and the currently installed __version__. Closes the agent-memory propagation gap from the inside — when a refresh happens, the agent observing the command output sees every behavior change inline, no AGENTS.md re-read required. New core/changelog.py with extract_sections_between + render_upgrade_prompt; CHANGELOG.md bundled via package-data with build-time copy in publish.yml; editable installs fall back to repo-root copy. Smoke-tested in a fresh repo: simulating a v0.2.6 pin produced a clean 4-section prompt for v0.2.7→v0.2.10. (2) Drive-by fix: bug hunter caught unescaped backticks in logmind-self-update.yml.template line 50; pip install (no args) triggered command-substitution and corrupted the pre-v0.2.1 notice. One-char fix. Template marker bumped v3 → v4 so refresh sweeps it downstream automatically.
+
+**Alternatives considered:** Fetch CHANGELOG from PyPI at runtime instead of bundling — adds network dep + slows init; bundling is simpler, Move CHANGELOG.md into src/logmind/ as canonical — breaks GitHub repo-page auto-rendering + publish.yml's release-notes step that reads from root, Ship the backtick fix as a separate v0.2.11 — adds another release cycle for a one-char fix that's right here
+
+**Implications:**
+- logmind init in any repo with a stale workflow pin will now show the full changelog inline; agents whose memory predates the upgrade see actual behavior changes
+- publish.yml gains a one-line copy step (cp CHANGELOG.md src/logmind/CHANGELOG.md) before python -m build; src/logmind/CHANGELOG.md is gitignored
+- 9 new tests in tests/test_changelog.py covering version parse + range extraction + missing-changelog graceful fallback; pin test in test_v0_2_1_audit_fixes.py updated to v4 marker for logmind-self-update
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — feat: v0.2.10 changelog-on-upgrade + escape backticks in self-update notice *(feat/v0.2.10-changelog-on-upgrade)* — [decisions-branches/feat__v0.2.10-changelog-on-upgrade.md](decisions-branches/feat__v0.2.10-changelog-on-upgrade.md)
 - **2026-05-26** — feat: v0.2.9 propagation-gap follow-up — visible notice in logmind log + AGENTS.md drift check in doctor *(chore/v0.2.9-action-bumps-and-vercel-skip)* — [decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md](decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md)
 - **2026-05-26** — chore: v0.2.9 — bump actions to v6 across templates + dogfood; add vercel.json skip-on-non-site *(chore/v0.2.9-action-bumps-and-vercel-skip)* — [decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md](decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md)
 - **2026-05-26** — fix: v0.2.8 — replace PyYAML+Python pinVersion detection with grep *(fix/v0.2.8-pinversion-grep)* — [decisions-branches/fix__v0.2.8-pinversion-grep.md](decisions-branches/fix__v0.2.8-pinversion-grep.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.9"
+version = "0.2.10"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -69,6 +69,7 @@ logmind = [
     "templates/*.template",
     "templates/*.md",
     "templates/github/*.template",
+    "CHANGELOG.md",
 ]
 
 [tool.black]

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -40,7 +40,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.9", prog_name="logmind")
+@click.version_option(version="0.2.10", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
@@ -293,6 +293,15 @@ def init(
         and (root_path / ".logmind" / "config.yml").exists()
     )
     if already_initialized:
+        # v0.2.10: detect the prior pinned logmind version BEFORE refresh
+        # rewrites the workflow files. The pin lives in regen-timeline.yml's
+        # `pip install "logmind==X.Y.Z"` line. We use it to decide whether
+        # there's an upgrade-relevant CHANGELOG to print after the refresh.
+        from logmind import __version__ as current_version
+        from logmind.core.doctor import _logmind_installed_version
+
+        prior_version = _logmind_installed_version(root_path)
+
         click.secho(
             "logmind is already initialized — running in refresh mode.",
             fg="yellow",
@@ -318,6 +327,20 @@ def init(
             click.echo(msg)
         click.echo()
         click.secho("Done. docs/ and .logmind/ left untouched.", fg="green")
+
+        # v0.2.10: print the CHANGELOG sections between prior pinned and
+        # current installed version. Closes the propagation gap where
+        # agents' session memory keeps using pre-upgrade patterns even
+        # though `logmind init` refreshed the repo's instructions on disk.
+        if prior_version and prior_version != current_version:
+            from logmind.core.changelog import render_upgrade_prompt
+
+            prompt = render_upgrade_prompt(
+                prior_version=prior_version,
+                current_version=current_version,
+            )
+            if prompt:
+                click.echo(prompt)
         return
 
     # Surface the skill recommendation prominently BEFORE we write any files,

--- a/src/logmind/core/changelog.py
+++ b/src/logmind/core/changelog.py
@@ -1,0 +1,123 @@
+"""CHANGELOG parsing — extract sections between two versions for upgrade
+prompts.
+
+When logmind init refreshes a repo's workflows from an older pinned
+version to the current installed logmind, agents need to see what
+changed. The repo's AGENTS.md gets refreshed in place; agent session
+memory does not. Printing the CHANGELOG entries between old and new
+version puts the actual behavior changes into command output, where
+agents observing the init invocation will see them inline.
+
+The CHANGELOG.md file is at repo root in the source tree. For installed
+wheels it's bundled at package root via pyproject.toml package-data.
+The lookup falls back to the repo-root copy for editable installs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import logmind
+
+
+_VERSION_HEADER_RE = re.compile(r"^##\s*\[(\d+\.\d+\.\d+(?:[\w.+\-]*)?)\]")
+
+
+def _changelog_path() -> Optional[Path]:
+    """Find the CHANGELOG.md file. Prefer the bundled package copy
+    (wheel installs); fall back to the repo-root copy for editable
+    installs from source.
+    """
+    pkg_dir = Path(logmind.__file__).resolve().parent
+    bundled = pkg_dir / "CHANGELOG.md"
+    if bundled.exists():
+        return bundled
+    # Editable install: src/logmind/ → repo root is two levels up.
+    repo_root = pkg_dir.parent.parent
+    dev = repo_root / "CHANGELOG.md"
+    if dev.exists():
+        return dev
+    return None
+
+
+def _parse_version(v: str) -> Tuple[int, ...]:
+    """Parse a semver-ish string into a comparable tuple. Non-numeric
+    components sort lowest (so e.g. 0.2.10-rc1 < 0.2.10)."""
+    parts: List[int] = []
+    for chunk in v.split("."):
+        try:
+            parts.append(int(chunk))
+        except ValueError:
+            # First non-int chunk → stop comparing numerically; treat
+            # this as a pre-release suffix that sorts before the stable.
+            return tuple(parts) + (-1,)
+    return tuple(parts)
+
+
+def extract_sections_between(
+    changelog_text: str, *, after: Optional[str], up_to: str
+) -> str:
+    """Return the substring of CHANGELOG.md containing every `## [X.Y.Z]`
+    section S such that ``after < S.version <= up_to``.
+
+    ``after=None`` means "everything up to and including up_to".
+
+    Sections are emitted in source order (most recent first, as the
+    canonical CHANGELOG is laid out). The trailing newline / blank line
+    of the last included section is preserved.
+    """
+    if after is not None and _parse_version(up_to) <= _parse_version(after):
+        return ""  # caller is on or ahead of the target
+
+    lines = changelog_text.splitlines(keepends=True)
+    out: List[str] = []
+    in_section = False
+    for line in lines:
+        m = _VERSION_HEADER_RE.match(line)
+        if m:
+            version = m.group(1)
+            v_tuple = _parse_version(version)
+            include = v_tuple <= _parse_version(up_to) and (
+                after is None or v_tuple > _parse_version(after)
+            )
+            if include:
+                in_section = True
+                out.append(line)
+                continue
+            # If we encounter a section we don't want AFTER having
+            # already collected some, we're done — sections are in
+            # descending version order.
+            if out:
+                break
+            in_section = False
+            continue
+        if in_section:
+            out.append(line)
+    return "".join(out).rstrip() + "\n" if out else ""
+
+
+def render_upgrade_prompt(
+    *, prior_version: Optional[str], current_version: str
+) -> Optional[str]:
+    """Compose the printed block for an upgrade prompt. Returns None if
+    no upgrade applies (e.g. same version, or CHANGELOG not findable)."""
+    if prior_version == current_version:
+        return None
+    path = _changelog_path()
+    if path is None:
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    body = extract_sections_between(text, after=prior_version, up_to=current_version)
+    if not body.strip():
+        return None
+    header_prior = prior_version if prior_version else "first install"
+    return (
+        f"\n📋 What's new in logmind since v{header_prior} "
+        f"(currently installed: v{current_version}):\n\n"
+        f"{body}"
+    )

--- a/src/logmind/templates/github/logmind-self-update.yml.template
+++ b/src/logmind/templates/github/logmind-self-update.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v3
+# logmind-template-version: v4
 name: logmind self-update
 
 # Weekly check for a newer published logmind. If one exists, runs
@@ -47,7 +47,7 @@ jobs:
             INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$REGEN_FILE" | head -1 | sed 's/logmind==//') || true
           fi
           if [ -z "$INSTALLED" ]; then
-            echo "::notice::Installed logmind version not detected (no pinned `pip install` in regen-timeline.yml). Re-run \`logmind init\` once locally to upgrade past pre-v0.2.1 installs, then self-update will work from then on."
+            echo "::notice::Installed logmind version not detected (no pinned \`pip install\` in regen-timeline.yml). Re-run \`logmind init\` once locally to upgrade past pre-v0.2.1 installs, then self-update will work from then on."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,123 @@
+"""Tests for the CHANGELOG section extractor used by upgrade prompts."""
+
+from __future__ import annotations
+
+from logmind.core.changelog import (
+    _parse_version,
+    extract_sections_between,
+    render_upgrade_prompt,
+)
+
+
+SAMPLE = """# Changelog
+
+## [Unreleased]
+
+## [0.2.10] - 2026-05-26
+
+### Added
+- Upgrade-prompt printing in `logmind init`.
+
+## [0.2.9] - 2026-05-26
+
+### Changed
+- actions/checkout@v4 → @v6.
+
+## [0.2.8] - 2026-05-26
+
+### Fixed
+- pinVersion detection uses grep.
+
+## [0.2.7] - 2026-05-26
+
+### Changed
+- logmind log defaults to --stage all.
+"""
+
+
+def test_parse_version_orders_numerically():
+    assert _parse_version("0.2.7") < _parse_version("0.2.10")
+    assert _parse_version("0.2.10") < _parse_version("0.3.0")
+    assert _parse_version("0.2.7") < _parse_version("0.2.8")
+
+
+def test_parse_version_pre_release_sorts_before_stable():
+    assert _parse_version("0.2.10-rc1") < _parse_version("0.2.10")
+
+
+def test_extract_two_consecutive_versions():
+    """Slice between 0.2.8 (exclusive) and 0.2.10 (inclusive) — should
+    grab 0.2.10 and 0.2.9 sections only.
+    """
+    out = extract_sections_between(SAMPLE, after="0.2.8", up_to="0.2.10")
+    assert "## [0.2.10]" in out
+    assert "## [0.2.9]" in out
+    assert "## [0.2.8]" not in out
+    assert "## [0.2.7]" not in out
+    assert "## [Unreleased]" not in out
+
+
+def test_extract_single_version():
+    out = extract_sections_between(SAMPLE, after="0.2.9", up_to="0.2.10")
+    assert "## [0.2.10]" in out
+    assert "## [0.2.9]" not in out
+
+
+def test_extract_returns_empty_when_already_current():
+    out = extract_sections_between(SAMPLE, after="0.2.10", up_to="0.2.10")
+    assert out == ""
+
+
+def test_extract_returns_empty_when_prior_ahead():
+    out = extract_sections_between(SAMPLE, after="0.3.0", up_to="0.2.10")
+    assert out == ""
+
+
+def test_extract_excludes_unreleased():
+    """[Unreleased] header doesn't parse as a semver and should never
+    appear in the prompt body."""
+    out = extract_sections_between(SAMPLE, after="0.2.7", up_to="0.2.10")
+    assert "## [Unreleased]" not in out
+    assert "## [0.2.10]" in out
+
+
+def test_extract_handles_none_as_after():
+    """after=None means 'include everything up to up_to'."""
+    out = extract_sections_between(SAMPLE, after=None, up_to="0.2.8")
+    assert "## [0.2.8]" in out
+    assert "## [0.2.7]" in out
+    assert "## [0.2.9]" not in out
+
+
+def test_render_upgrade_prompt_returns_none_on_same_version():
+    assert render_upgrade_prompt(prior_version="0.2.10", current_version="0.2.10") is None
+
+
+def test_render_upgrade_prompt_returns_block_on_real_upgrade(tmp_path, monkeypatch):
+    """End-to-end: with a CHANGELOG findable on disk, the prompt is
+    non-empty and contains the version delta."""
+    from logmind.core import changelog as cl
+
+    # Point the loader at an in-memory CHANGELOG
+    sample_path = tmp_path / "CHANGELOG.md"
+    sample_path.write_text(SAMPLE, encoding="utf-8")
+    monkeypatch.setattr(cl, "_changelog_path", lambda: sample_path)
+
+    prompt = render_upgrade_prompt(prior_version="0.2.8", current_version="0.2.10")
+    assert prompt is not None
+    # Section headers for 0.2.10 and 0.2.9 must appear; 0.2.8's section
+    # must NOT (it's the prior version, exclusive lower bound). The "since
+    # v0.2.8" appears in the prompt's intro line — that's expected — so
+    # we check for the section header form `## [X.Y.Z]` specifically.
+    assert "## [0.2.10]" in prompt
+    assert "## [0.2.9]" in prompt
+    assert "## [0.2.8]" not in prompt
+    assert "What's new" in prompt
+    assert "since v0.2.8" in prompt  # header references the prior version
+
+
+def test_render_upgrade_prompt_handles_missing_changelog(monkeypatch):
+    from logmind.core import changelog as cl
+
+    monkeypatch.setattr(cl, "_changelog_path", lambda: None)
+    assert render_upgrade_prompt(prior_version="0.2.8", current_version="0.2.10") is None

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -196,7 +196,7 @@ def test_shipped_template_markers_match_expected():
         "regen-timeline.yml.template": "v2",
         "check-decisions.yml.template": "v2",
         "check-doc-links.yml.template": "v3",
-        "logmind-self-update.yml.template": "v3",
+        "logmind-self-update.yml.template": "v4",
     }
     templates_dir = (
         Path(__file__).parent.parent / "src" / "logmind" / "templates" / "github"
@@ -207,6 +207,42 @@ def test_shipped_template_markers_match_expected():
         assert first_line == f"# logmind-template-version: {version}", (
             f"{name}: expected marker '{version}', got first line {first_line!r}"
         )
+
+
+def test_self_update_template_no_unescaped_backticks_in_notice():
+    """v0.2.10 fix: the 'no pinned pip install' notice on the
+    pre-v0.2.1-fresh-install path had unescaped backticks around
+    `pip install`, which bash treats as command substitution. That
+    runs `pip install` (no args), prints an error to stderr, and
+    swallows the words 'pip install' from the rendered notice.
+
+    Every backtick-quoted code reference in the shell here-string must
+    be escaped (\\\\`...\\\\`) or the workflow log gets junk on the
+    older-install branch."""
+    template = (
+        Path(__file__).parent.parent
+        / "src"
+        / "logmind"
+        / "templates"
+        / "github"
+        / "logmind-self-update.yml.template"
+    ).read_text(encoding="utf-8")
+
+    # Find the notice line (only one in the file) and assert its
+    # backticks are all properly escaped.
+    notice_lines = [
+        ln for ln in template.splitlines()
+        if "Installed logmind version not detected" in ln
+    ]
+    assert len(notice_lines) == 1, "expected exactly one such notice line"
+    line = notice_lines[0]
+    # Every literal backtick in the line must be preceded by a backslash.
+    # Walk char by char and check.
+    for i, ch in enumerate(line):
+        if ch == "`":
+            assert i > 0 and line[i - 1] == "\\", (
+                f"unescaped backtick at column {i}: {line!r}"
+            )
 
 
 def test_self_update_template_uses_grep_not_pyyaml():


### PR DESCRIPTION
## Summary
**Main feature:** \`logmind init\` refresh-mode now prints the CHANGELOG sections between the prior pinned version and the currently installed \`__version__\`. Closes the agent-memory propagation gap from inside the init flow — when refresh fires, the agent observing the command output sees every behavior change inline. No AGENTS.md re-read required, no skill cache sync required.

**Drive-by fix:** Bug hunter caught unescaped backticks in \`logmind-self-update.yml.template:50\`. \`\`pip install\`\` (unescaped) triggered bash command substitution → ran \`pip install\` with no args → exited non-zero → corrupted the pre-v0.2.1 notice. One-character fix. Template marker bumped \`v3 → v4\`.

## Sample output (refresh after upgrade from v0.2.6 to v0.2.10)
\`\`\`
logmind is already initialized — running in refresh mode.

↻ Refreshed .github/workflows/logmind-self-update.yml to current template
↻ Refreshed .github/workflows/check-doc-links.yml to current template
↻ Refreshed .github/workflows/regen-timeline.yml to current template
↻ Refreshed .github/workflows/check-decisions.yml to current template

Done. docs/ and .logmind/ left untouched.

📋 What's new in logmind since v0.2.6 (currently installed: v0.2.10):

## [0.2.10] - 2026-05-26
### Added
- logmind init refresh-mode prints CHANGELOG sections...

## [0.2.9] - 2026-05-26
### Changed
- Bump shipped workflow templates from actions/checkout@v4...

## [0.2.8] - 2026-05-26
### Fixed
- logmind-self-update.yml.template: replace PyYAML+Python pinVersion...

## [0.2.7] - 2026-05-26
### Changed (default behavior — backwards-compatible flag still works)
- logmind log now defaults to --stage all...
\`\`\`

## Architecture
- **\`logmind.core.changelog\`** new module: \`extract_sections_between(text, after, up_to)\` slices by version range; \`render_upgrade_prompt(prior, current)\` composes the printed block.
- **\`CHANGELOG.md\` bundled in the wheel** via \`pyproject.toml\` package-data. Canonical file stays at repo root (GitHub auto-rendering + publish.yml's release-notes step). \`publish.yml\` adds \`cp CHANGELOG.md src/logmind/CHANGELOG.md\` before \`python -m build\`. Editable installs fall back to repo-root copy via \`_changelog_path()\`.
- **Skipped on first install**, only fires when prior pinned version differs from current.

## Test plan
- [x] 9 new tests in \`tests/test_changelog.py\` (version parsing, range extraction, edge cases like Unreleased section and prior > current)
- [x] 1 new test in \`tests/test_v0_2_1_audit_fixes.py\` asserts every backtick in the self-update notice line is escaped
- [x] Existing test pinning marker values updated for \`logmind-self-update.yml: v3 → v4\`
- [x] Full suite: 531 passed, 1 skipped (was 519 in v0.2.9 + 12 new = 531)
- [x] Smoke-tested in a fresh \`/tmp\` repo: pin tampered to v0.2.6 → init refresh produced the full v0.2.7–v0.2.10 prompt inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)