### PR TITLE
v0.3.0: custom git merge driver for derived files + post-merge hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
+### Added — custom git merge driver for derived files
+- **`logmind init` registers a custom merge driver for `docs/timeline.md` and `docs/file-structure.md`.** Closes the parallel-PR conflict class: previously, two PRs that both ran `logmind log` produced textual merge conflicts on rebase because git did three-way merge on the derived snapshot. Now git delegates conflict resolution on these files to logmind, which regenerates them from the per-branch decision files (which never collide). Clean rebases on parallel work.
+  - **`.gitattributes` block** added by `logmind init` (idempotent, marker-bracketed, preserves user edits) — registers `merge=logmind-timeline` and `merge=logmind-file-structure` for the two derived files.
+  - **Per-clone `git config`** also set by `logmind init` — defines the merge drivers themselves (`merge.logmind-timeline.driver = 'logmind timeline --write %A'`, similar for file-structure). Lives in `.git/config`, not committed (git refuses to auto-run a merge driver that wasn't explicitly configured locally — security guard against untrusted repos).
+  - **`logmind init` refresh-mode** re-runs `configure_merge_drivers()` every invocation, so fresh clones get the per-clone config after a single `logmind init` even if the committed `.gitattributes` was already in place.
+- **New `logmind file-structure --write <path>` CLI command** — mirror of `logmind timeline --write`. The merge driver invokes it as `logmind file-structure --write %A` where git passes the resolved-content target path.
+- **`.git/hooks/post-merge` installed by `logmind init`** — re-regenerates `docs/timeline.md` and `docs/file-structure.md` from the FULL post-merge working tree. Belt + suspenders with the merge driver: the driver runs per-file during conflict resolution, before other merged-in files (e.g. the merged-in branch's `docs/decisions-branches/<branch>.md`) are checked out, so its output can miss decisions. The hook runs once at end-of-merge and sweeps any incomplete regen. Verified end-to-end: two branches both running `logmind log`, merge succeeds without conflict, resulting timeline contains both decisions.
+- **`logmind doctor` reports merge-driver drift** as three new rows: `.gitattributes (merge driver)`, `git config (merge driver)`, and `post-merge hook`. Each shows `current`/`missing`. Missing rows do NOT count as drift (they're "not yet installed for this logmind version", not "wrong") — the next `logmind init` resolves them silently.
+
+### Why a minor version bump (0.2.x → 0.3.0)
+The previous v0.2.x line accumulated feature-grade additions under patch bumps (`logmind doctor` in v0.2.4, `--stage all` default in v0.2.7, changelog-on-upgrade in v0.2.10). v0.3.0 introduces a new install-time surface (git config setup, `.gitattributes` ownership) that's clearly minor-grade, and marks a clean reset of the under-bumping pattern.
+
+### Migration from v0.2.10
+Run `logmind init` in each logmind-installed repo to get the merge driver. v0.2.5+'s refresh-mode handles the workflow updates automatically; the `.gitattributes` block is added; `git config` is set per-clone. `logmind doctor` reports two new STALE rows until you do.
+
+**CI runners** (fresh-clone, no `logmind init`) don't get the per-clone config and won't use the driver — but `regen-timeline.yml` already regenerates derived files in CI as a separate safety net (the existing `check-derived-docs` gate). Belt + suspenders.
+
 ## [0.2.10] - 2026-05-26
 
 ### Added

--- a/docs/decisions-branches/feat__v0.3.0-merge-driver.md
+++ b/docs/decisions-branches/feat__v0.3.0-merge-driver.md
@@ -1,0 +1,12 @@
+## 2026-05-26 17:46 - feat: v0.3.0 — custom git merge driver for derived files + post-merge hook
+
+**Reasoning:** Parallel-PR conflict class: two PRs both running logmind log → textual merge conflict on docs/timeline.md when one rebases onto the other (hit twice in 30 minutes earlier today). v0.3.0 ships a custom git merge driver that delegates conflict resolution to logmind, which regenerates from the per-branch decision files (which never collide). Three install-time pieces: (1) .gitattributes block (committed) registers merge=logmind-timeline for the two derived files, (2) per-clone git config defines the drivers (lives in .git/config, not committed, security guard), (3) .git/hooks/post-merge sweeps the regen after merge completes (the driver fires per-file during conflict resolution, before other merged-in files are checked out — hook ensures the final state reflects the FULL post-merge tree). Smoke-tested end-to-end: two branches both run logmind log, merge succeeds without conflict, resulting timeline shows both decisions.
+
+**Alternatives considered:** Merge driver alone (no post-merge hook) — driver fires before sibling non-conflicted files are checked out; smoke test showed regenerated timeline missed the merged-in branch's decision. Hook is the belt + suspenders., Post-merge hook alone (no merge driver) — git would still produce a textual conflict and halt the merge; hook never runs. Driver IS needed to avoid the conflict; hook is needed for correctness afterward., Patch bump to v0.2.11 — under-bumps the change. Strict semver: new install-time surface (gitattributes + git config + hook) is minor-grade. Also marks a clean reset of the v0.2.x under-bumping pattern (doctor, --stage all default, changelog-on-upgrade all shipped as patches and arguably should have been minor too).
+
+**Implications:**
+- logmind init in any v0.3.0+ repo installs the merge driver + post-merge hook; refresh-mode runs them every invocation (idempotent) so fresh checkouts get the per-clone config automatically after one init
+- Three new doctor rows surface drift: .gitattributes block, git config drivers, post-merge hook. drift=missing (not stale) when absent — doesn't false-positive fresh repos or test fixtures
+- Phase 0 of the thrillmade org migration plan; every logmind init we run in Phase B repos installs the conflict-resistant config from day one
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-26** — feat: v0.3.0 — custom git merge driver for derived files + post-merge hook *(feat/v0.3.0-merge-driver)* — [decisions-branches/feat__v0.3.0-merge-driver.md](decisions-branches/feat__v0.3.0-merge-driver.md)
 - **2026-05-26** — feat: v0.2.10 changelog-on-upgrade + escape backticks in self-update notice *(feat/v0.2.10-changelog-on-upgrade)* — [decisions-branches/feat__v0.2.10-changelog-on-upgrade.md](decisions-branches/feat__v0.2.10-changelog-on-upgrade.md)
 - **2026-05-26** — feat: v0.2.9 propagation-gap follow-up — visible notice in logmind log + AGENTS.md drift check in doctor *(chore/v0.2.9-action-bumps-and-vercel-skip)* — [decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md](decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md)
 - **2026-05-26** — chore: v0.2.9 — bump actions to v6 across templates + dogfood; add vercel.json skip-on-non-site *(chore/v0.2.9-action-bumps-and-vercel-skip)* — [decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md](decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.2.10"
+version = "0.3.0"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.2.10"
+__version__ = "0.3.0"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -10,6 +10,11 @@ import click
 
 from logmind.core.config import load_config
 from logmind.core.git_handler import commit_and_push, is_git_repo
+from logmind.core.gitattributes import (
+    configure_merge_drivers,
+    ensure_block as ensure_gitattributes_block,
+    install_post_merge_hook,
+)
 from logmind.core.gitignore import ensure_block as ensure_gitignore_block
 from logmind.core.skill_install import (
     DEFAULT_SKILL_NAME,
@@ -40,7 +45,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.2.10", prog_name="logmind")
+@click.version_option(version="0.3.0", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass
@@ -325,6 +330,20 @@ def init(
         sync_messages = sync_agent_files_from_config(root_path)
         for msg in sync_messages:
             click.echo(msg)
+
+        # v0.3.0: ensure the .gitattributes block + git config merge
+        # drivers are present. Both are idempotent — `.gitattributes`
+        # already in place is a no-op, and `git config` no-ops when the
+        # value already matches. Setting them every refresh covers the
+        # common case where someone freshly cloned a repo that already
+        # has .gitattributes committed but no .git/config driver entries.
+        gitattributes_path = root_path / ".gitattributes"
+        gitattributes_changed = ensure_gitattributes_block(gitattributes_path)
+        if gitattributes_changed:
+            click.echo("✓ Added logmind block to .gitattributes")
+        configure_merge_drivers(root_path)
+        install_post_merge_hook(root_path)
+
         click.echo()
         click.secho("Done. docs/ and .logmind/ left untouched.", fg="green")
 
@@ -434,6 +453,21 @@ def init(
     if gitignore_changed:
         click.echo("✓ Added logmind block to .gitignore")
 
+    # v0.3.0: register the custom merge driver for derived files
+    # (docs/timeline.md + docs/file-structure.md). Two parts:
+    #   1) .gitattributes block (committed) telling git which files
+    #      use the driver
+    #   2) git config (per-clone) defining what the driver does
+    # Without (2), git refuses to invoke the driver — security guard
+    # against untrusted repos running arbitrary commands.
+    gitattributes_path = root_path / ".gitattributes"
+    gitattributes_changed = ensure_gitattributes_block(gitattributes_path)
+    if gitattributes_changed:
+        click.echo("✓ Added logmind block to .gitattributes")
+    if not no_git:
+        configure_merge_drivers(root_path)
+        install_post_merge_hook(root_path)
+
     # Log first decision
     log_first_decision(docs_path)
     click.echo("✓ Logged first decision: \"Initialize logmind decision tracking\"")
@@ -468,6 +502,10 @@ def init(
             # .gitignore (if logmind block was added)
             if gitignore_changed:
                 files_to_commit.append(".gitignore")
+
+            # .gitattributes (if logmind merge-driver block was added)
+            if gitattributes_changed:
+                files_to_commit.append(".gitattributes")
 
             commit_and_push(
                 files_to_commit,
@@ -1656,6 +1694,41 @@ def tree_cmd():
         sys.exit(1)
     update_file_structure(docs_path)
     click.secho("✓ Updated docs/file-structure.md", fg="green")
+
+
+@main.command("file-structure")
+@click.option(
+    "--write",
+    "write_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the rendered tree to PATH (typically docs/file-structure.md). "
+    "Without this flag, prints to stdout.",
+)
+def file_structure_cmd(write_path: Optional[Path]):
+    """
+    Print or regenerate the derived docs/file-structure.md tree snapshot.
+
+    Mirror of ``logmind timeline`` for the file-structure derived doc.
+    The v0.3.0 git merge driver invokes this as
+    ``logmind file-structure --write %A`` to resolve conflicts on
+    parallel-PR rebases without falling through to textual three-way merge.
+
+    Examples:
+        logmind file-structure                                # print to stdout
+        logmind file-structure --write docs/file-structure.md # regenerate file
+    """
+    from logmind.core.tree_gen import generate_file_structure, write_file_structure
+
+    repo_root = Path.cwd()
+    if write_path is None:
+        click.echo(generate_file_structure(repo_root), nl=False)
+        return
+    changed = write_file_structure(write_path)
+    if changed:
+        click.secho(f"✓ Regenerated {write_path}", fg="green")
+    else:
+        click.echo(f"  {write_path} already up to date")
 
 
 @main.command("check-links")

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -264,6 +264,80 @@ def _probe_agents_md(project_root: Path) -> WorkflowStatus:
     )
 
 
+def _probe_merge_driver_attrs(project_root: Path) -> WorkflowStatus:
+    """v0.3.0: .gitattributes contains the logmind merge-driver block.
+
+    Reports `current` when present, `missing` when absent. We never
+    return `stale` here — the block is binary present/absent, and
+    treating absence as drift would false-positive every repo that
+    hasn't yet run `logmind init` post-v0.3.0 (or every test fixture).
+    The next `logmind init` writes the block; that's the signal flow.
+    """
+    from logmind.core.gitattributes import has_block
+
+    gitattrs = project_root / ".gitattributes"
+    if has_block(gitattrs):
+        return WorkflowStatus(
+            name=".gitattributes (merge driver)", installed=True,
+            marker="present", bundled_marker="present", drift="current",
+        )
+    return WorkflowStatus(
+        name=".gitattributes (merge driver)", installed=False,
+        marker=None, bundled_marker="present", drift="missing",
+    )
+
+
+def _probe_merge_driver_config(project_root: Path) -> WorkflowStatus:
+    """v0.3.0: per-clone git config has the merge driver definitions.
+
+    Per-clone state (lives in .git/config, not committed) — a fresh
+    checkout starts without it; `logmind init` sets it. If unset, the
+    `.gitattributes` directive does nothing because git refuses to
+    invoke an undefined driver. Reports `current` when configured,
+    `missing` otherwise (never `stale` — binary).
+    """
+    from logmind.core.gitattributes import driver_configured
+
+    if not (project_root / ".git").exists():
+        return WorkflowStatus(
+            name="git config (merge driver)", installed=False,
+            marker=None, bundled_marker=None, drift="missing",
+        )
+    if driver_configured(project_root):
+        return WorkflowStatus(
+            name="git config (merge driver)", installed=True,
+            marker="configured", bundled_marker="configured", drift="current",
+        )
+    return WorkflowStatus(
+        name="git config (merge driver)", installed=False,
+        marker=None, bundled_marker="configured", drift="missing",
+    )
+
+
+def _probe_post_merge_hook(project_root: Path) -> WorkflowStatus:
+    """v0.3.0: .git/hooks/post-merge installed by logmind. Companion to
+    the merge driver — re-regenerates derived files with the full
+    post-merge tree (the driver alone can fire before all merged-in
+    files are checked out, producing an incomplete regen).
+    """
+    from logmind.core.gitattributes import post_merge_hook_installed
+
+    if not (project_root / ".git").exists():
+        return WorkflowStatus(
+            name="post-merge hook", installed=False,
+            marker=None, bundled_marker=None, drift="missing",
+        )
+    if post_merge_hook_installed(project_root):
+        return WorkflowStatus(
+            name="post-merge hook", installed=True,
+            marker="installed", bundled_marker="installed", drift="current",
+        )
+    return WorkflowStatus(
+        name="post-merge hook", installed=False,
+        marker=None, bundled_marker="installed", drift="missing",
+    )
+
+
 def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     installed = _logmind_installed_version(project_root)
     latest: Optional[str] = None
@@ -279,6 +353,13 @@ def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     # AGENTS.md block-version is reported in the same workflows list so
     # downstream rendering / drift aggregation treats it uniformly.
     workflows.append(_probe_agents_md(project_root))
+    # v0.3.0: merge-driver config drift. Two signals:
+    #   .gitattributes block missing → committed config absent (would
+    #     reappear on next logmind init, but worth surfacing)
+    #   per-clone git config unset → driver won't fire on local rebase
+    workflows.append(_probe_merge_driver_attrs(project_root))
+    workflows.append(_probe_merge_driver_config(project_root))
+    workflows.append(_probe_post_merge_hook(project_root))
 
     # Drift = any installed workflow with a marker that's stale,
     # OR installed version != latest version (when both known).

--- a/src/logmind/core/gitattributes.py
+++ b/src/logmind/core/gitattributes.py
@@ -1,0 +1,211 @@
+"""Idempotent management of a marker-bracketed block in ``.gitattributes``.
+
+The block registers custom merge drivers for logmind's derived files
+(docs/timeline.md, docs/file-structure.md). Without them, parallel PRs
+that both ran ``logmind log`` produce textual merge conflicts when one
+rebases onto the other — git can't tell that the right resolution is
+"regenerate from the per-branch decision files" rather than "interleave
+the diffs textually."
+
+The driver definitions themselves live in ``.git/config`` (per-clone,
+not committed — git refuses to invoke a merge driver that wasn't
+explicitly configured locally as a security guard). ``logmind init``
+runs the matching ``git config`` calls every time it runs; see
+``configure_merge_drivers`` in this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+LOGMIND_GITATTRIBUTES_START = "# >>> logmind >>>"
+LOGMIND_GITATTRIBUTES_END = "# <<< logmind <<<"
+
+# Lines that go inside the managed block. Each registers a merge driver
+# for one of logmind's derived files. The driver names match what
+# configure_merge_drivers() sets in .git/config.
+DEFAULT_GITATTRIBUTES_LINES = (
+    "docs/timeline.md          merge=logmind-timeline",
+    "docs/file-structure.md    merge=logmind-file-structure",
+)
+
+
+def ensure_block(
+    path: Path,
+    lines: Iterable[str] = DEFAULT_GITATTRIBUTES_LINES,
+) -> bool:
+    """Ensure ``path`` (a .gitattributes) contains the logmind-managed block.
+
+    Returns True if the file was created or modified, False if the block
+    was already present (manual edits inside it preserved).
+    """
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if LOGMIND_GITATTRIBUTES_START in existing:
+        return False
+
+    block_parts = [LOGMIND_GITATTRIBUTES_START]
+    for line in lines:
+        block_parts.append(line)
+    block_parts.append(LOGMIND_GITATTRIBUTES_END)
+    block = "\n".join(block_parts) + "\n"
+
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    if existing and not existing.endswith("\n\n"):
+        existing += "\n"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(existing + block, encoding="utf-8")
+    return True
+
+
+def has_block(path: Path) -> bool:
+    if not path.exists():
+        return False
+    return LOGMIND_GITATTRIBUTES_START in path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Per-clone git config — the driver definitions themselves live in .git/config
+# ---------------------------------------------------------------------------
+
+
+# Each entry is (config_key, value). Set every time `logmind init` runs;
+# git config is idempotent (no-op when the value already matches).
+MERGE_DRIVER_CONFIG = (
+    ("merge.logmind-timeline.driver", "logmind timeline --write %A"),
+    ("merge.logmind-timeline.name", "Regenerate logmind timeline"),
+    ("merge.logmind-file-structure.driver", "logmind file-structure --write %A"),
+    ("merge.logmind-file-structure.name", "Regenerate logmind file structure"),
+)
+
+
+def configure_merge_drivers(repo_root: Path) -> bool:
+    """Set the per-clone git config keys that define the logmind merge drivers.
+
+    Returns True if any config key was changed, False if all keys already
+    held the expected value. Silently no-ops outside a git repo.
+    """
+    import subprocess
+
+    if not (repo_root / ".git").exists():
+        # Not a git checkout; caller decides whether that's an error.
+        return False
+
+    changed = False
+    for key, value in MERGE_DRIVER_CONFIG:
+        try:
+            current = subprocess.run(
+                ["git", "-C", str(repo_root), "config", "--get", key],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if current.returncode == 0 and current.stdout.strip() == value:
+                continue
+            subprocess.run(
+                ["git", "-C", str(repo_root), "config", key, value],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            changed = True
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            # Don't break logmind init for a git config hiccup — the driver
+            # is a "merge time" optimization, not a "commit time" requirement.
+            # logmind doctor surfaces the drift on the next invocation.
+            continue
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# post-merge hook — re-regenerates derived files with the FULL post-merge
+# tree (the merge driver fires before all non-conflicted files are in the
+# working tree, so its output may miss decisions from the merged-in branch).
+# ---------------------------------------------------------------------------
+
+_POST_MERGE_HOOK_MARKER = "# logmind post-merge hook"
+_POST_MERGE_HOOK_BODY = """#!/bin/sh
+# logmind post-merge hook
+# Installed by `logmind init` (v0.3.0+). After every merge, regenerate
+# derived docs from the FULL post-merge working tree. Belt + suspenders
+# with the merge driver in .gitattributes — the driver fires per-file
+# during conflict resolution, before sibling non-conflicted files (e.g.
+# the merged-in branch's docs/decisions-branches/<branch>.md) are
+# checked out. This hook runs once at the end and sweeps any incomplete
+# regenerations.
+
+if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
+  if [ -d docs ]; then
+    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
+    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
+    # Stage the regens if they changed anything; user can `git commit --amend`
+    # or include in their next commit.
+    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true
+  fi
+fi
+"""
+
+
+def install_post_merge_hook(repo_root: Path) -> bool:
+    """Write `.git/hooks/post-merge` to re-regenerate derived files after
+    every merge. Returns True if the hook was created or updated, False
+    if logmind's version was already present.
+
+    Refuses to overwrite a non-logmind hook (someone may have custom
+    hook content; we leave it alone and let `logmind doctor` flag the
+    state instead).
+    """
+    hooks_dir = repo_root / ".git" / "hooks"
+    if not hooks_dir.exists():
+        return False
+    hook = hooks_dir / "post-merge"
+    if hook.exists():
+        existing = hook.read_text(encoding="utf-8", errors="ignore")
+        if _POST_MERGE_HOOK_MARKER in existing:
+            # Our hook already present (or some legacy version of it).
+            # Rewrite to current canonical contents; same idempotency
+            # contract as the merge-driver git config.
+            if existing == _POST_MERGE_HOOK_BODY:
+                return False
+            hook.write_text(_POST_MERGE_HOOK_BODY, encoding="utf-8")
+            hook.chmod(0o755)
+            return True
+        # Foreign hook — don't trample.
+        return False
+    hook.write_text(_POST_MERGE_HOOK_BODY, encoding="utf-8")
+    hook.chmod(0o755)
+    return True
+
+
+def post_merge_hook_installed(repo_root: Path) -> bool:
+    hook = repo_root / ".git" / "hooks" / "post-merge"
+    if not hook.exists():
+        return False
+    try:
+        return _POST_MERGE_HOOK_MARKER in hook.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def driver_configured(repo_root: Path) -> bool:
+    """Return True iff every key in MERGE_DRIVER_CONFIG is set to its
+    expected value in the repo's local git config."""
+    import subprocess
+
+    if not (repo_root / ".git").exists():
+        return False
+    for key, value in MERGE_DRIVER_CONFIG:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_root), "config", "--get", key],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return False
+        if result.returncode != 0 or result.stdout.strip() != value:
+            return False
+    return True

--- a/src/logmind/core/tree_gen.py
+++ b/src/logmind/core/tree_gen.py
@@ -273,6 +273,50 @@ def _generate_fallback_tree(
     return "\n".join(line for line in lines if line)
 
 
+def generate_file_structure(repo_root: Path) -> str:
+    """Render the file-structure.md content for ``repo_root`` and return it
+    as a string (no file is written). Useful when the caller wants to
+    direct the output somewhere other than the canonical
+    ``<repo_root>/docs/file-structure.md`` — e.g. v0.3.0's custom merge
+    driver, which receives the target path from git as ``%A``.
+    """
+    tree_output = generate_tree(repo_root)
+    template_path = Path(__file__).parent.parent / "templates" / "file-structure.md.template"
+    template = template_path.read_text(encoding="utf-8")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return template.format(timestamp=timestamp, tree_output=tree_output)
+
+
+def write_file_structure(target_path: Path, repo_root: Optional[Path] = None) -> bool:
+    """Write rendered file-structure to ``target_path`` atomically. Returns
+    True if the file's content changed, False if it was already up to date.
+    Mirrors the shape of ``logmind.core.timeline.write_timeline()``.
+
+    Args:
+        target_path: where to write (e.g. docs/file-structure.md, or %A
+            when invoked by the v0.3.0 git merge driver).
+        repo_root: project root. Defaults to ``target_path.parent.parent``
+            (assumes docs/file-structure.md layout), then falls back to cwd.
+    """
+    from logmind.core.atomic_io import atomic_write_text
+
+    if repo_root is None:
+        # Heuristic: assume target_path is <repo>/docs/file-structure.md
+        # so repo_root is two levels up. Git's merge driver passes an
+        # absolute path under the worktree, which satisfies this.
+        repo_root = target_path.resolve().parent.parent
+        if not (repo_root / ".git").exists():
+            repo_root = Path.cwd()
+
+    rendered = generate_file_structure(repo_root)
+    existing = target_path.read_text(encoding="utf-8") if target_path.exists() else ""
+    if existing == rendered:
+        return False
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(target_path, rendered)
+    return True
+
+
 def update_file_structure(docs_path: Optional[Path] = None) -> None:
     """
     Update the file-structure.md file with current project tree.
@@ -286,25 +330,5 @@ def update_file_structure(docs_path: Optional[Path] = None) -> None:
     """
     if docs_path is None:
         docs_path = Path.cwd() / "docs"
-
     docs_path.mkdir(parents=True, exist_ok=True)
-
-    # Project root is the parent of docs/
-    repo_root = docs_path.parent
-
-    # Generate tree rooted at repo, not the caller's cwd
-    tree_output = generate_tree(repo_root)
-
-    # Read template
-    template_path = Path(__file__).parent.parent / "templates" / "file-structure.md.template"
-    template = template_path.read_text(encoding="utf-8")
-
-    # Fill template
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    content = template.format(timestamp=timestamp, tree_output=tree_output)
-
-    # Write file (atomic so concurrent regens can't truncate)
-    from logmind.core.atomic_io import atomic_write_text
-
-    file_structure_path = docs_path / "file-structure.md"
-    atomic_write_text(file_structure_path, content)
+    write_file_structure(docs_path / "file-structure.md", docs_path.parent)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -43,9 +43,16 @@ def test_offline_no_workflows_reports_clean_unknown_versions(project: Path):
     assert logmind.name == "logmind"
     assert logmind.installed_version is None
     assert logmind.latest_version is None
-    # Every shipped workflow + AGENTS.md is reported as missing
+    # Every shipped workflow + AGENTS.md + the two merge-driver probes
+    # (v0.3.0) are reported as missing. None should be `stale` — that
+    # would false-positive every fresh fixture.
     names = {w.name for w in logmind.workflows}
-    assert names == set(doctor.LOGMIND_WORKFLOWS) | {"AGENTS.md"}
+    expected = (
+        set(doctor.LOGMIND_WORKFLOWS)
+        | {"AGENTS.md"}
+        | {".gitattributes (merge driver)", "git config (merge driver)", "post-merge hook"}
+    )
+    assert names == expected
     assert all(w.drift == "missing" for w in logmind.workflows)
 
 

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -1,0 +1,256 @@
+"""Tests for v0.3.0's git merge driver for derived files."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from logmind.cli import init, main as cli_main
+from logmind.core import doctor
+from logmind.core.gitattributes import (
+    LOGMIND_GITATTRIBUTES_START,
+    MERGE_DRIVER_CONFIG,
+    configure_merge_drivers,
+    driver_configured,
+    ensure_block,
+    has_block,
+    install_post_merge_hook,
+    post_merge_hook_installed,
+)
+
+
+# ---------------------------------------------------------------------------
+# .gitattributes block (committed)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_block_creates_file_with_marker(tmp_path: Path):
+    gitattrs = tmp_path / ".gitattributes"
+    changed = ensure_block(gitattrs)
+    assert changed is True
+    assert gitattrs.exists()
+    text = gitattrs.read_text(encoding="utf-8")
+    assert LOGMIND_GITATTRIBUTES_START in text
+    assert "docs/timeline.md" in text
+    assert "merge=logmind-timeline" in text
+
+
+def test_ensure_block_is_idempotent(tmp_path: Path):
+    gitattrs = tmp_path / ".gitattributes"
+    ensure_block(gitattrs)
+    second = ensure_block(gitattrs)
+    assert second is False  # no-op on second run
+
+
+def test_ensure_block_appends_to_existing_file(tmp_path: Path):
+    gitattrs = tmp_path / ".gitattributes"
+    gitattrs.write_text("*.lock binary\n", encoding="utf-8")
+    changed = ensure_block(gitattrs)
+    assert changed is True
+    text = gitattrs.read_text(encoding="utf-8")
+    assert "*.lock binary" in text  # preserved
+    assert LOGMIND_GITATTRIBUTES_START in text
+
+
+# ---------------------------------------------------------------------------
+# git config per-clone driver setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Bare git repo for testing per-clone config interactions."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def test_configure_merge_drivers_sets_all_keys(git_repo: Path):
+    changed = configure_merge_drivers(git_repo)
+    assert changed is True
+    # Verify every expected key was set
+    for key, expected_value in MERGE_DRIVER_CONFIG:
+        result = subprocess.run(
+            ["git", "-C", str(git_repo), "config", "--get", key],
+            capture_output=True, text=True, check=True,
+        )
+        assert result.stdout.strip() == expected_value
+
+
+def test_configure_merge_drivers_is_idempotent(git_repo: Path):
+    configure_merge_drivers(git_repo)
+    second = configure_merge_drivers(git_repo)
+    assert second is False  # no-op when values already match
+
+
+def test_configure_merge_drivers_noop_outside_git_repo(tmp_path: Path):
+    """Not a git checkout (no .git dir) — silent no-op, no crash."""
+    assert configure_merge_drivers(tmp_path) is False
+
+
+def test_driver_configured_returns_false_when_unset(git_repo: Path):
+    assert driver_configured(git_repo) is False
+
+
+def test_driver_configured_returns_true_after_configure(git_repo: Path):
+    configure_merge_drivers(git_repo)
+    assert driver_configured(git_repo) is True
+
+
+# ---------------------------------------------------------------------------
+# logmind init wires up both
+# ---------------------------------------------------------------------------
+
+
+def test_init_writes_gitattributes_and_configures_drivers(git_repo: Path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        cwd = Path.cwd()
+        subprocess.run(["git", "init", "-q"], cwd=cwd, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=cwd, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=cwd, check=True)
+        # Initial commit so git considers it a real repo
+        (cwd / "README.md").write_text("x", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=cwd, check=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "init"], cwd=cwd, check=True
+        )
+
+        result = runner.invoke(init, ["--no-skill-install"])
+        assert result.exit_code == 0, result.output
+
+        # .gitattributes carries the block
+        assert has_block(cwd / ".gitattributes")
+        # Per-clone config has the driver definitions
+        assert driver_configured(cwd)
+
+
+# ---------------------------------------------------------------------------
+# logmind file-structure --write CLI (mirror of timeline --write)
+# ---------------------------------------------------------------------------
+
+
+def test_file_structure_write_creates_output_at_arbitrary_path(git_repo: Path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        cwd = Path.cwd()
+        (cwd / "some_file.txt").write_text("x", encoding="utf-8")
+        target = cwd / "scratch" / "tree.md"
+        result = runner.invoke(cli_main, ["file-structure", "--write", str(target)])
+        assert result.exit_code == 0, result.output
+        assert target.exists()
+        content = target.read_text(encoding="utf-8")
+        assert "some_file.txt" in content
+
+
+def test_file_structure_write_creates_output_when_missing(git_repo: Path):
+    """The merge driver calls file-structure --write %A on a path git
+    chose. The command must create the file even when the parent dir
+    doesn't exist yet — git's merge target path is in the worktree,
+    parent dirs are guaranteed, but we're defensive."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        cwd = Path.cwd()
+        (cwd / "some_file.txt").write_text("x", encoding="utf-8")
+        target = cwd / "nested" / "deeper" / "tree.md"
+        result = runner.invoke(cli_main, ["file-structure", "--write", str(target)])
+        assert result.exit_code == 0, result.output
+        assert target.exists()
+        assert "Regenerated" in result.output
+
+    # NB: file-structure.md content includes a timestamp, so we don't
+    # assert byte-stable idempotency — `write_file_structure` returns
+    # True every call because the timestamp moves. That's fine for the
+    # merge-driver path: git already detected a conflict and accepts
+    # whatever the driver writes.
+
+
+# ---------------------------------------------------------------------------
+# doctor surfaces the new merge-driver drift signals
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_reports_missing_gitattributes_block(tmp_path: Path):
+    """Fresh dir with no .gitattributes: doctor reports MISSING (not
+    stale — binary present/absent, absence isn't drift, just 'not yet
+    installed for this version of logmind')."""
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    report = doctor.collect_status(tmp_path, offline=True)
+    ga_row = next(
+        w for w in report.tools[0].workflows if "merge driver" in w.name and ".gitattributes" in w.name
+    )
+    assert ga_row.drift == "missing"
+
+
+def test_doctor_reports_missing_git_config(tmp_path: Path):
+    """In a git repo without merge-driver config: doctor reports MISSING."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    report = doctor.collect_status(tmp_path, offline=True)
+    cfg_row = next(
+        w for w in report.tools[0].workflows if "git config" in w.name
+    )
+    assert cfg_row.drift == "missing"
+
+
+def test_doctor_reports_current_after_full_install(tmp_path: Path):
+    """Both .gitattributes and git config set → both rows show current."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    ensure_block(tmp_path / ".gitattributes")
+    configure_merge_drivers(tmp_path)
+    install_post_merge_hook(tmp_path)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    report = doctor.collect_status(tmp_path, offline=True)
+    ga = next(w for w in report.tools[0].workflows if ".gitattributes" in w.name)
+    cfg = next(w for w in report.tools[0].workflows if "git config" in w.name)
+    hook = next(w for w in report.tools[0].workflows if "post-merge" in w.name)
+    assert ga.drift == "current"
+    assert cfg.drift == "current"
+    assert hook.drift == "current"
+
+
+# ---------------------------------------------------------------------------
+# post-merge hook
+# ---------------------------------------------------------------------------
+
+
+def test_install_post_merge_hook_creates_executable_hook(git_repo: Path):
+    """Hook is written under .git/hooks/ and is executable."""
+    changed = install_post_merge_hook(git_repo)
+    assert changed is True
+    hook = git_repo / ".git" / "hooks" / "post-merge"
+    assert hook.exists()
+    assert hook.stat().st_mode & 0o111  # any execute bit set
+    body = hook.read_text(encoding="utf-8")
+    assert "logmind timeline --write" in body
+    assert "logmind file-structure --write" in body
+
+
+def test_install_post_merge_hook_does_not_overwrite_foreign_hook(git_repo: Path):
+    """If a non-logmind hook is already in place, leave it. The user's
+    custom hook isn't our problem to inherit."""
+    hook = git_repo / ".git" / "hooks" / "post-merge"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho 'custom user hook'\n", encoding="utf-8")
+    hook.chmod(0o755)
+    changed = install_post_merge_hook(git_repo)
+    assert changed is False
+    assert "custom user hook" in hook.read_text(encoding="utf-8")
+
+
+def test_post_merge_hook_installed_detects_logmind_hook(git_repo: Path):
+    install_post_merge_hook(git_repo)
+    assert post_merge_hook_installed(git_repo) is True
+
+
+def test_post_merge_hook_installed_returns_false_for_foreign_hook(git_repo: Path):
+    hook = git_repo / ".git" / "hooks" / "post-merge"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho 'custom'\n", encoding="utf-8")
+    assert post_merge_hook_installed(git_repo) is False


### PR DESCRIPTION
## Summary
The parallel-PR conflict class on \`docs/timeline.md\` (hit twice in a 30-min window earlier) is now fixed at the git layer. v0.3.0 ships a custom git merge driver + a post-merge hook installed by \`logmind init\`. Two PRs both running \`logmind log\` can now rebase against each other without conflict, and the resulting timeline contains both decisions.

## What ships

1. **\`.gitattributes\` block** (committed by \`logmind init\`) — registers \`merge=logmind-timeline\` for \`docs/timeline.md\` and \`merge=logmind-file-structure\` for \`docs/file-structure.md\`.

2. **Per-clone git config** (set by \`logmind init\` every invocation, idempotent) — defines the drivers themselves:
   - \`merge.logmind-timeline.driver = 'logmind timeline --write %A'\`
   - \`merge.logmind-file-structure.driver = 'logmind file-structure --write %A'\`
   - Lives in \`.git/config\`, not committed (git refuses to invoke an undefined driver — security guard against untrusted repos).

3. **\`.git/hooks/post-merge\`** (installed by \`logmind init\`, executable) — re-regenerates both derived files from the FULL post-merge working tree. Belt + suspenders: the merge driver fires per-file during conflict resolution, before sibling non-conflicted files (e.g. the merged-in branch's \`docs/decisions-branches/<branch>.md\`) are checked out. The hook sweeps the regen at end-of-merge so the final state is correct.

4. **New \`logmind file-structure --write <path>\` CLI** — mirror of \`logmind timeline --write\`; what the merge driver invokes.

5. **\`logmind doctor\` extended** with three new rows: \`.gitattributes (merge driver)\`, \`git config (merge driver)\`, \`post-merge hook\`. Each is \`current\` or \`missing\`. Missing rows don't count as drift (they're "not yet installed for this version", not "wrong") — the next \`logmind init\` resolves them silently.

## Why a minor bump (v0.2.10 → v0.3.0)
Previous v0.2.x line accumulated feature-grade additions under patch bumps (\`logmind doctor\` in v0.2.4, \`--stage all\` default in v0.2.7, changelog-on-upgrade in v0.2.10). v0.3.0 introduces a new install-time surface (git config + hooks) that's clearly minor-grade. Clean reset of the under-bumping pattern.

## End-to-end smoke test
\`\`\`
# Two branches both run logmind log on the same parent
git checkout -b feat-a && logmind log "Decision A"
git checkout main && git checkout -b feat-b && logmind log "Decision B"

# Without v0.3.0: CONFLICT on docs/timeline.md.
# With v0.3.0: clean merge, timeline.md auto-regenerated from both decision files.
git merge feat-a --no-edit
grep -E "(Decision A|Decision B)" docs/timeline.md
# Both decisions present ✓
\`\`\`

## Test plan
- [x] 17 new tests in \`tests/test_merge_driver.py\` covering \`.gitattributes\` block (idempotent + creation + append), git config setup (idempotent + outside-git no-op), post-merge hook (executable + leaves foreign hooks alone), file-structure --write CLI (arbitrary path + missing parents), doctor probes (current/missing for each row)
- [x] Existing \`tests/test_doctor.py\` updated for the 3 new rows
- [x] Full suite: 549 passed, 1 skipped (was 531 in v0.2.10 + 18 new = 549)
- [x] End-to-end smoke (two-branch merge) reproduces the conflict pre-v0.3.0, resolves cleanly post-v0.3.0

## Migration from v0.2.10
Run \`logmind init\` in each installed repo. v0.2.5+ refresh-mode handles the rest:
- \`.gitattributes\` block added (committed)
- \`git config\` driver entries set (per-clone)
- \`.git/hooks/post-merge\` installed (per-clone, refuses to clobber foreign hooks)

\`logmind doctor\` reports the three new STALE-as-missing rows until you do; once init runs they all show \`current\`.

CI runners do fresh clones and don't run \`logmind init\`, so the driver/hook aren't configured there — but that's fine, the existing \`check-derived-docs\` workflow already regenerates derived files in CI as a separate safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)