### PR TITLE
v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site URL fix

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -171,9 +171,10 @@ jobs:
             --title "logmind ${VERSION}" \
             --body "Auto-bumped from logmind tag \`v${VERSION}\`. PyPI tarball SHA verified against pypi.org. Resource blocks not refreshed (rarely changes between patch releases — open a follow-up if needed).")
           echo "Opened: ${PR_URL}"
-          # Auto-merge: the change is mechanical (URL + SHA already
-          # verified against PyPI above), and the tap repo has no
-          # required checks, so --auto merges the PR immediately. Squash
-          # + delete-branch keeps the tap history linear.
-          gh pr merge "${PR_URL}" --auto --squash --delete-branch
-          echo "Auto-merge requested on ${PR_URL}"
+          # Merge synchronously: change is mechanical (URL + SHA already
+          # verified against PyPI above) and the tap repo has no required
+          # checks, so `gh pr merge --squash` resolves the PR immediately
+          # without the repo-level `Allow auto-merge` precondition that
+          # `--auto` requires. Same end-state, fewer moving parts.
+          gh pr merge "${PR_URL}" --squash --delete-branch
+          echo "Merged ${PR_URL}"

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -145,6 +145,14 @@ jobs:
           PY
 
           git add Formula/logmind.rb
+          # Nothing-to-commit guard: if the formula already points at this
+          # version (workflow re-run on the same tag, or a manual edit
+          # already shipped), exit 0 cleanly instead of erroring on the
+          # empty commit. The desired end-state is reached either way.
+          if git diff --cached --quiet; then
+            echo "Formula already at logmind ${VERSION}; nothing to commit."
+            exit 0
+          fi
           git diff --cached --stat
           git commit -m "logmind ${VERSION}
 
@@ -156,9 +164,16 @@ jobs:
           follow-up PR if a major dependency rev'd between releases."
           git push -u origin "${BRANCH}"
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --repo thrillmade/homebrew-logmind \
             --base main \
             --head "${BRANCH}" \
             --title "logmind ${VERSION}" \
-            --body "Auto-bumped from logmind tag \`v${VERSION}\`. PyPI tarball SHA verified against pypi.org. Resource blocks not refreshed (rarely changes between patch releases — open a follow-up if needed)."
+            --body "Auto-bumped from logmind tag \`v${VERSION}\`. PyPI tarball SHA verified against pypi.org. Resource blocks not refreshed (rarely changes between patch releases — open a follow-up if needed).")
+          echo "Opened: ${PR_URL}"
+          # Auto-merge: the change is mechanical (URL + SHA already
+          # verified against PyPI above), and the tap repo has no
+          # required checks, so --auto merges the PR immediately. Squash
+          # + delete-branch keeps the tap history linear.
+          gh pr merge "${PR_URL}" --auto --squash --delete-branch
+          echo "Auto-merge requested on ${PR_URL}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-27
+
+### Changed — homebrew tap bump now auto-merges
+- **`.github/workflows/homebrew-bump.yml` now auto-merges the tap PR it opens.** The bump is mechanical (formula `url` + `sha256`, already verified against `pypi.org/pypi/logmind/<version>/json` upstream in the same workflow). No human judgment adds value, and `thrillmade/homebrew-logmind` has no required checks, so `gh pr merge --auto --squash --delete-branch` resolves the PR seconds after creation. End-to-end: tag push → PyPI publish → tap PR opened → tap PR auto-merged → `brew install logmind` resolves the new version, all without human touch.
+- **Nothing-to-commit guard** — if the formula already points at the target version (workflow re-run on the same tag, or the formula was edited by hand first), the workflow exits 0 cleanly instead of erroring on an empty commit. The desired end-state is reached either way.
+
+### Changed — `site/app/page.tsx` GitHub-org URL refs
+- **Marketing site GitHub-org links now point at `thrillmade`.** The v0.3.1 bulk sed sweep used `--include='*.md' '*.yml' '*.json' '*.template' '*.py' '*.js' '*.toml'` and missed `.tsx`, leaving 12 GitHub-org refs in `site/app/page.tsx` (brew tap copy, skill install copy, github navlinks, CHANGELOG / CONTRIBUTING / issues / security-policy links, skills.sh agent-skills badge). Replaced. Personal-brand `thrillmot.com` refs (lines 306–319) intentionally preserved — those point at the human author's site and don't migrate with the org.
+
+### Migration from v0.3.1
+None required. The homebrew-bump change takes effect on the next tag push (v0.3.2 itself dogfoods it). The marketing site change is cosmetic for the logmind.dev site.
+
 ## [0.3.1] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.2] - 2026-05-27
 
-### Changed — homebrew tap bump now auto-merges
-- **`.github/workflows/homebrew-bump.yml` now auto-merges the tap PR it opens.** The bump is mechanical (formula `url` + `sha256`, already verified against `pypi.org/pypi/logmind/<version>/json` upstream in the same workflow). No human judgment adds value, and `thrillmade/homebrew-logmind` has no required checks, so `gh pr merge --auto --squash --delete-branch` resolves the PR seconds after creation. End-to-end: tag push → PyPI publish → tap PR opened → tap PR auto-merged → `brew install logmind` resolves the new version, all without human touch.
+### Changed — homebrew tap bump now self-merges
+- **`.github/workflows/homebrew-bump.yml` now squash-merges the tap PR synchronously after opening it.** The bump is mechanical (formula `url` + `sha256`, already verified against `pypi.org/pypi/logmind/<version>/json` upstream in the same workflow). No human judgment adds value, and `thrillmade/homebrew-logmind` has no required checks, so `gh pr merge --squash --delete-branch` resolves the PR immediately without the repo-level `Allow auto-merge` precondition that `--auto` would otherwise require. End-to-end: tag push → PyPI publish → tap PR opened → tap PR merged → `brew install logmind` resolves the new version, all without human touch.
 - **Nothing-to-commit guard** — if the formula already points at the target version (workflow re-run on the same tag, or the formula was edited by hand first), the workflow exits 0 cleanly instead of erroring on an empty commit. The desired end-state is reached either way.
 
 ### Changed — `site/app/page.tsx` GitHub-org URL refs

--- a/docs/decisions-branches/chore__v0.3.2-homebrew-automerge.md
+++ b/docs/decisions-branches/chore__v0.3.2-homebrew-automerge.md
@@ -7,3 +7,12 @@
 - Site change cosmetic for logmind.dev visitors
 
 ---
+## 2026-05-27 00:48 - fix(v0.3.2): drop --auto, use synchronous gh pr merge
+
+**Reasoning:** Tap repo has no required checks, so synchronous 'gh pr merge --squash' merges immediately with no precondition. Same end-state, fewer moving parts
+
+**Implications:**
+- Removes brittleness around the allow_auto_merge setting (which can be toggled off accidentally)
+- CHANGELOG language updated from 'auto-merges' to 'self-merges' to match reality
+
+---

--- a/docs/decisions-branches/chore__v0.3.2-homebrew-automerge.md
+++ b/docs/decisions-branches/chore__v0.3.2-homebrew-automerge.md
@@ -1,0 +1,9 @@
+## 2026-05-27 00:43 - v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site/app/page.tsx URL fix
+
+**Reasoning:** (3) Nothing-to-commit guard added to handle workflow re-runs idempotently — exits 0 when formula already at target version instead of erroring on empty commit
+
+**Implications:**
+- Next tag push (v0.3.2 itself) dogfoods the auto-merge — tag → PyPI publish → tap PR opened → tap PR auto-merged
+- Site change cosmetic for logmind.dev visitors
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — fix(v0.3.2): drop --auto, use synchronous gh pr merge *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)
 - **2026-05-27** — v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site/app/page.tsx URL fix *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)
 - **2026-05-26** — v0.3.1: pre-transfer URL update — thrillmot → thrillmade *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — feat: v0.3.0 — custom git merge driver for derived files + post-merge hook *(feat/v0.3.0-merge-driver)* — [decisions-branches/feat__v0.3.0-merge-driver.md](decisions-branches/feat__v0.3.0-merge-driver.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site/app/page.tsx URL fix *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)
 - **2026-05-26** — v0.3.1: pre-transfer URL update — thrillmot → thrillmade *(chore/migrate-to-thrillmade)* — [decisions-branches/chore__migrate-to-thrillmade.md](decisions-branches/chore__migrate-to-thrillmade.md)
 - **2026-05-26** — feat: v0.3.0 — custom git merge driver for derived files + post-merge hook *(feat/v0.3.0-merge-driver)* — [decisions-branches/feat__v0.3.0-merge-driver.md](decisions-branches/feat__v0.3.0-merge-driver.md)
 - **2026-05-26** — feat: v0.2.10 changelog-on-upgrade + escape backticks in self-update notice *(feat/v0.2.10-changelog-on-upgrade)* — [decisions-branches/feat__v0.2.10-changelog-on-upgrade.md](decisions-branches/feat__v0.2.10-changelog-on-upgrade.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.3.1"
+version = "0.3.2"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,8 +1,8 @@
 import { CopyButton } from "./copy-button";
 
 const PIP = "pip install logmind";
-const BREW = "brew tap thrillmot/logmind && brew install logmind";
-const SKILL = "npx skills add -g thrillmot/logmind-skill";
+const BREW = "brew tap thrillmade/logmind && brew install logmind";
+const SKILL = "npx skills add -g thrillmade/logmind-skill";
 
 const QUICKSTART = `$ logmind init
 $ git checkout -b feat/auth
@@ -62,9 +62,9 @@ export default function Home() {
             logmind<span className="text-accent">.</span>
           </a>
           <nav className="flex items-center gap-6 sm:gap-8">
-            <NavLink href="https://github.com/thrillmot/logmind">github</NavLink>
+            <NavLink href="https://github.com/thrillmade/logmind">github</NavLink>
             <NavLink href="https://pypi.org/project/logmind/">pypi</NavLink>
-            <NavLink href="https://skills.sh/thrillmot/logmind-skill">skill</NavLink>
+            <NavLink href="https://skills.sh/thrillmade/logmind-skill">skill</NavLink>
           </nav>
         </div>
       </header>
@@ -117,7 +117,7 @@ export default function Home() {
 
           <div className="rise mt-12 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 text-sm" style={{ animationDelay: "0.32s" }}>
             <a
-              href="https://github.com/thrillmot/logmind"
+              href="https://github.com/thrillmade/logmind"
               target="_blank"
               rel="noopener noreferrer"
               className="font-mono uppercase tracking-[0.18em] px-5 py-3 bg-paper text-background hover:bg-accent hover:text-paper transition-colors text-center whitespace-nowrap"
@@ -324,14 +324,14 @@ export default function Home() {
           </div>
           <div className="flex flex-col sm:items-end gap-4">
             <a
-              href="https://www.skills.sh/thrillmot/agent-skills"
+              href="https://www.skills.sh/thrillmade/agent-skills"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="thrillmot/agent-skills collection on skills.sh"
+              aria-label="thrillmade/agent-skills collection on skills.sh"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src="https://skills.sh/b/thrillmot/agent-skills"
+                src="https://skills.sh/b/thrillmade/agent-skills"
                 alt="skills.sh skill count"
                 height={20}
               />
@@ -343,19 +343,19 @@ export default function Home() {
               boundaries instead of overflowing the viewport.
             */}
             <nav className="text-sm flex flex-wrap items-center gap-y-1 sm:block sm:whitespace-nowrap sm:text-right">
-              <NavLink href="https://github.com/thrillmot/logmind/blob/main/CHANGELOG.md">
+              <NavLink href="https://github.com/thrillmade/logmind/blob/main/CHANGELOG.md">
                 changelog
               </NavLink>
               <span aria-hidden className="mx-2 text-foreground/30">·</span>
-              <NavLink href="https://github.com/thrillmot/logmind/blob/main/CONTRIBUTING.md">
+              <NavLink href="https://github.com/thrillmade/logmind/blob/main/CONTRIBUTING.md">
                 contributing
               </NavLink>
               <span aria-hidden className="mx-2 text-foreground/30">·</span>
-              <NavLink href="https://github.com/thrillmot/logmind/issues">
+              <NavLink href="https://github.com/thrillmade/logmind/issues">
                 issues
               </NavLink>
               <span aria-hidden className="mx-2 text-foreground/30">·</span>
-              <NavLink href="https://github.com/thrillmot/logmind/security/policy">
+              <NavLink href="https://github.com/thrillmade/logmind/security/policy">
                 security
               </NavLink>
             </nav>

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -45,7 +45,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.3.1", prog_name="logmind")
+@click.version_option(version="0.3.2", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass


### PR DESCRIPTION
## Summary
- **homebrew-bump.yml auto-merges its tap PR.** The bump is mechanical (URL+SHA pre-verified against `pypi.org/pypi/logmind/<v>/json` in the same workflow), tap repo has no required checks, so `gh pr merge --auto --squash --delete-branch` resolves the PR seconds after creation. End-to-end: tag push → PyPI publish → tap PR opened+auto-merged → `brew install logmind` resolves the new version, no human touch.
- **Nothing-to-commit guard** — workflow exits 0 cleanly if the formula already points at the target version (workflow re-run on the same tag, or hand-edited first).
- **`site/app/page.tsx`** — 12 GitHub-org URL refs `thrillmot/<repo>` → `thrillmade/<repo>`. Missed by v0.3.1's bulk sweep (didn't include `.tsx` in `--include` list). Personal-brand `thrillmot.com` refs intentionally preserved.

## Test plan
- [x] `pytest tests/ -x -q` — 549 passed, 1 skipped (~70s)
- [x] CHANGELOG entry under `[0.3.2]`
- [x] Version pins synced: `pyproject.toml`, `src/logmind/__init__.py`, `src/logmind/cli.py`
- [x] `grep -c "thrillmot/" site/app/page.tsx` → 0 (org refs); `thrillmot.com` preserved (lines 306-319)
- [ ] **v0.3.2 itself dogfoods the auto-merge**: after merge + tag push, observe tap PR open + auto-merge within ~30s