### PR TITLE
feat(v0.3.4): check-derived-docs auto-fixes derived docs when LOGMIND_AUTO_REGEN_PAT configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-05-27
+
+### Added — `check-derived-docs` auto-fixes stale docs/timeline.md + docs/file-structure.md when configured
+- **The pain.** v0.2+'s derived-doc model treats `docs/timeline.md` + `docs/file-structure.md` as artifacts that must always be in sync with sources. Today's `check-derived-docs` workflow VERIFIES sync — if stale, it fails red and tells the author to regenerate locally. That works, but it makes merging harder: every rebase, every concurrent PR, every multi-commit branch push hits the same papercut. We were burning multiple cycles per session on "regen, add, commit, push" sequences that shouldn't need a human.
+- **The shape.** The shipped `regen-timeline.yml` template now runs in two modes. When the repo (or its org) has a `LOGMIND_AUTO_REGEN_PAT` secret configured, the workflow regenerates stale derived docs and pushes the fix back to the PR branch using the PAT — downstream CI re-runs naturally, the merge gate clears on its own. When no PAT is configured, falls back to today's fail-fast behavior (the warning explains how to opt in). Forked PRs always run in fail-fast mode (can't push to forks).
+- **Why a PAT.** GitHub deliberately blocks `GITHUB_TOKEN`-pushed commits from re-triggering required-status workflows (anti-recursion safety). Auto-commit via `GITHUB_TOKEN` would leave the merge gate stuck on "Expected — Waiting for status to be reported" forever. The PAT path is the documented escape hatch.
+- **Setup (one-time per repo or per org).** Create a fine-grained PAT scoped to the target repo(s) with `Contents: write`. Add it as `LOGMIND_AUTO_REGEN_PAT` under Settings → Secrets and variables → Actions. Already-installed `logmind init` repos pick up the new behavior on the next `logmind init` invocation (refresh-mode bumps the workflow's template-version marker from v2 → v3 and rewrites the file).
+- **Same context name.** The workflow still reports under the `check-derived-docs` status check — required-status rulesets and existing branch protection keep working without changes.
+
+### Migration from v0.3.3
+Run `logmind init` in each installed repo to pull the new `regen-timeline.yml` body. The behavior is backwards-compatible without setup — fail-fast mode is identical to v0.3.3's behavior. Opt into auto-fix by adding the `LOGMIND_AUTO_REGEN_PAT` secret.
+
 ## [0.3.3] - 2026-05-27
 
 ### Fixed — post-merge hook no longer re-stages `docs/file-structure.md` on every `git pull`

--- a/docs/decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md
+++ b/docs/decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md
@@ -1,0 +1,11 @@
+## 2026-05-27 07:52 - feat(v0.3.4): check-derived-docs auto-fixes when LOGMIND_AUTO_REGEN_PAT configured
+
+**Reasoning:** Forked PRs ALWAYS run in fail-fast mode — can't push to a fork's head ref. Three-way branching: internal+PAT → auto-fix; internal+no-PAT → fail-fast with opt-in hint; fork → fail-fast
+
+**Alternatives considered:** Auto-commit via GITHUB_TOKEN — rejected because it doesn't re-trigger downstream checks; merge gate stays stuck on 'Expected', Bot-PR-opener instead of push-back — more ceremony, same UX cost as today's manual path. The push-back is the happy path
+
+**Implications:**
+- Workflow template-version bumped v2 → v3. logmind init refresh-mode rewrites existing installs on next invocation. Backwards-compatible without setup: identical to v0.3.3's behavior until LOGMIND_AUTO_REGEN_PAT is added
+- Required permission bumped from contents:read to contents:write (needed for the auto-push path)
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — feat(v0.3.4): check-derived-docs auto-fixes when LOGMIND_AUTO_REGEN_PAT configured *(feat/v0.3.4-auto-regen-derived-docs)* — [decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md](decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md)
 - **2026-05-27** — fix(v0.3.3): drop wall-clock timestamp from docs/file-structure.md *(fix/v0.3.3-file-structure-determinism)* — [decisions-branches/fix__v0.3.3-file-structure-determinism.md](decisions-branches/fix__v0.3.3-file-structure-determinism.md)
 - **2026-05-27** — fix(v0.3.2): drop --auto, use synchronous gh pr merge *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)
 - **2026-05-27** — v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site/app/page.tsx URL fix *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.3.3"
+version = "0.3.4"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -45,7 +45,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.3.3", prog_name="logmind")
+@click.version_option(version="0.3.4", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass

--- a/src/logmind/templates/github/regen-timeline.yml.template
+++ b/src/logmind/templates/github/regen-timeline.yml.template
@@ -1,19 +1,35 @@
-# logmind-template-version: v2
+# logmind-template-version: v3
 name: check derived docs
 
-# Derived-file architecture (v0.2+): docs/timeline.md is a derived
-# artifact, deterministically computed from sources (per-branch logs +
-# decisions.md + archive). This workflow VERIFIES that docs/timeline.md
-# on the PR matches what `logmind timeline` would produce — same
-# pattern as Prettier/ESLint/Black checks. If stale, the build fails
-# red with a clear message and the user regenerates locally + pushes.
+# Derived-file architecture (v0.2+): docs/timeline.md + docs/file-structure.md
+# are derived artifacts, deterministically computed from sources (per-branch
+# logs + decisions.md + archive for timeline; tree walk for file-structure).
 #
-# Why fail-fast instead of auto-commit: GitHub deliberately blocks
-# GITHUB_TOKEN-pushed commits from triggering downstream workflows
-# (anti-recursion safety). An auto-commit approach leaves required
-# status checks stuck on "Expected — Waiting for status to be reported"
-# forever, because the new commit never gets pytest runs. Fail-fast
-# avoids this entire class of problem — no PAT, no token games.
+# Two modes (v0.3.4+):
+#
+# 1. AUTO-FIX mode (preferred — happy path).
+#    Triggered when `LOGMIND_AUTO_REGEN_PAT` secret is configured on the repo
+#    (or inherited from the org). When derived docs are stale, the workflow
+#    regenerates them and pushes the fix back to the PR branch using the PAT.
+#    Downstream CI re-runs naturally (PAT-pushed commits DO trigger workflows,
+#    unlike GITHUB_TOKEN-pushed ones). Author sees one extra commit with a
+#    clear `[bot]` author; nothing else changes about their PR.
+#
+# 2. FAIL-FAST mode (fallback — when no PAT configured).
+#    Without the PAT, the workflow falls back to the v0.2 behavior: fails red
+#    with the regenerate-locally message. Required because GITHUB_TOKEN
+#    commits don't re-trigger required status checks (anti-recursion safety),
+#    so auto-commit via GITHUB_TOKEN would leave the merge gate stuck on
+#    "Expected — Waiting for status to be reported" forever.
+#
+# Forked PRs always run in fail-fast mode (can't push back to the fork's
+# head ref). Internal PRs use auto-fix when the PAT is available.
+#
+# Setup for the PAT path:
+#   1. Create a fine-grained PAT scoped to this repo with Contents: write.
+#   2. Add it as `LOGMIND_AUTO_REGEN_PAT` under
+#      Settings → Secrets and variables → Actions (or at the org level if
+#      multiple repos use logmind).
 #
 # Replaces the v0.1.x `logmind-aggregate.yml` workflow.
 
@@ -22,7 +38,8 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write   # needed for the auto-fix push when PAT is configured
+  pull-requests: read
 
 jobs:
   check-derived-docs:
@@ -31,7 +48,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # For internal PRs, check out the PR's head ref so we can push
+          # back to it. For forks, github.head_ref is set but we can't
+          # push to forks — handled below.
+          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
+          # Use PAT if available so the push triggers downstream checks.
+          # Falls through to GITHUB_TOKEN when absent (still allows checkout).
+          token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -43,7 +67,7 @@ jobs:
         # locally. Bump after running `logmind init` against a new release.
         run: pip install "logmind==__LOGMIND_VERSION__"
 
-      - name: Verify docs/timeline.md is current
+      - name: Regenerate derived docs
         run: |
           set -euo pipefail
           if [ ! -f docs/timeline.md ]; then
@@ -51,9 +75,55 @@ jobs:
             exit 1
           fi
           logmind timeline --write docs/timeline.md
-          if ! git diff --quiet docs/timeline.md; then
-            echo "::error::docs/timeline.md is stale. Run \`logmind timeline --write docs/timeline.md\` locally and commit the regenerated file."
-            git --no-pager diff docs/timeline.md | head -50
+          logmind file-structure --write docs/file-structure.md
+
+      - name: Auto-fix or fail fast
+        env:
+          PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          # No diff → already current. Nothing to do.
+          if git diff --quiet docs/timeline.md docs/file-structure.md 2>/dev/null; then
+            echo "docs/timeline.md + docs/file-structure.md are up to date."
+            exit 0
+          fi
+
+          echo "Derived docs are stale on this PR."
+
+          # Forked PR — can't push back to the fork's head ref.
+          # Fall back to fail-fast (today's behaviour).
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error title=Stale derived docs::PR is from a fork ($HEAD_REPO). Auto-fix cannot push back. Run \`logmind timeline --write docs/timeline.md && logmind file-structure --write docs/file-structure.md\` locally and commit the regenerated files."
+            git --no-pager diff docs/timeline.md docs/file-structure.md | head -80
             exit 1
           fi
-          echo "docs/timeline.md is up to date."
+
+          # No PAT configured — fail-fast mode. GITHUB_TOKEN-pushed commits
+          # don't re-trigger required checks, so auto-commit would brick
+          # the merge gate. See workflow header comment for rationale.
+          if [ -z "${PAT:-}" ]; then
+            echo "::warning title=Stale derived docs::No \`LOGMIND_AUTO_REGEN_PAT\` configured — falling back to fail-fast."
+            echo "::warning::To enable auto-fix: create a fine-grained PAT with Contents: write on this repo, add it as \`LOGMIND_AUTO_REGEN_PAT\` secret. logmind will then push regenerated derived docs back to the PR branch on stale."
+            echo "::error title=Stale derived docs::Run \`logmind timeline --write docs/timeline.md && logmind file-structure --write docs/file-structure.md\` locally and commit the regenerated files."
+            git --no-pager diff docs/timeline.md docs/file-structure.md | head -80
+            exit 1
+          fi
+
+          # Auto-fix mode: commit + push back. The checkout step above
+          # already authenticated with the PAT, so `git push` here uses
+          # the PAT credentials and the push triggers downstream CI.
+          echo "::notice title=Auto-fixing stale derived docs::Regenerating and pushing back to ${HEAD_REF}."
+          git config user.name "logmind-auto-regen[bot]"
+          git config user.email "logmind-auto-regen@users.noreply.github.com"
+          git add docs/timeline.md docs/file-structure.md
+          git commit -m "chore: regen derived docs
+
+          Auto-fix by logmind's check-derived-docs workflow (v0.3.4+).
+          The PR's docs/timeline.md or docs/file-structure.md was stale
+          after a code change. Regenerated from the per-branch decision
+          files (timeline) and current tree (file-structure)."
+          git push origin "HEAD:${HEAD_REF}"
+          echo "::notice::Derived docs regenerated and pushed. CI will re-run on the new commit."

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -269,12 +269,15 @@ def test_aggregator_template_no_longer_shipped():
     assert (template_root / "regen-timeline.yml.template").exists()
 
 
-def test_regen_timeline_template_is_fail_fast_not_autocommit():
-    """v0.2 final design: the workflow VERIFIES timeline.md is current and
-    fails red if not — it does NOT auto-commit. Auto-committing via
-    GITHUB_TOKEN doesn't trigger downstream workflows (GitHub anti-recursion
-    safety), which leaves required status checks stuck on "Expected" forever.
-    The fail-fast pattern (same as Prettier/ESLint) avoids the entire issue."""
+def test_regen_timeline_template_supports_auto_fix_with_failfast_fallback():
+    """v0.3.4 design: the workflow auto-fixes when LOGMIND_AUTO_REGEN_PAT is
+    configured (pushes a regenerated derived-doc commit back to the PR branch
+    so downstream CI re-runs naturally), and falls back to v0.2's fail-fast
+    behavior when no PAT is configured. The fail-fast fallback exists because
+    GITHUB_TOKEN-pushed commits don't re-trigger required status checks,
+    which would leave the merge gate stuck on "Expected" forever — so the
+    PAT path is the documented opt-in for the happy-path UX. Forked PRs
+    always run in fail-fast mode (can't push to a fork's head ref)."""
     template = (
         Path(__file__).parent.parent
         / "src"
@@ -283,12 +286,20 @@ def test_regen_timeline_template_is_fail_fast_not_autocommit():
         / "github"
         / "regen-timeline.yml.template"
     ).read_text(encoding="utf-8")
-    # Must NOT depend on LOGMIND_BOT_PAT
+    # Auto-fix path: opt-in via LOGMIND_AUTO_REGEN_PAT. The legacy
+    # LOGMIND_BOT_PAT name from the v0.1.x aggregator is NOT reused.
     assert "secrets.LOGMIND_BOT_PAT" not in template
-    # Must NOT push a commit back to the branch (the failure mode we're
-    # avoiding). The previous auto-commit design used `git push` here.
-    assert "git push" not in template
-    # Must use `::error::` to surface the failure clearly
-    assert "::error::" in template
-    # Must guide the user to the fix command
+    assert "secrets.LOGMIND_AUTO_REGEN_PAT" in template
+    # The push back to the PR branch IS shipped now (auto-fix mode).
+    assert "git push origin" in template
+    # But the push must be gated — fork PRs and no-PAT cases fail fast,
+    # never auto-commit via GITHUB_TOKEN. The gate is the explicit empty
+    # PAT check.
+    assert '[ -z "${PAT:-}" ]' in template
+    # Fail-fast fallback must still surface a clear ::error:: and guide
+    # the user to the regenerate-locally command.
+    assert "::error" in template
     assert "logmind timeline --write docs/timeline.md" in template
+    # Fork PRs always fall back to fail-fast (the head repo != base repo
+    # branch in the env block proves the workflow is checking).
+    assert "HEAD_REPO" in template and "BASE_REPO" in template

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -193,7 +193,7 @@ def test_shipped_template_markers_match_expected():
     future marker change is intentional + accompanied by a test
     update."""
     expected = {
-        "regen-timeline.yml.template": "v2",
+        "regen-timeline.yml.template": "v3",  # v0.3.4: auto-fix-with-PAT + fail-fast fallback
         "check-decisions.yml.template": "v2",
         "check-doc-links.yml.template": "v3",
         "logmind-self-update.yml.template": "v4",


### PR DESCRIPTION
## Summary

Fixes the merge-friction pain that surfaced repeatedly in the 2026-05-27 thrillmade session: every rebase / multi-commit push / concurrent-PR scenario eventually hits `check-derived-docs: FAIL — stale docs/timeline.md, regenerate locally` and someone has to manually `logmind timeline --write && git add && git commit && git push`. We hit this 4+ times today.

User feedback (paraphrased): "logmind shouldn't make merging harder — strong happy path."

## The shape

`regen-timeline.yml` (the workflow producing the `check-derived-docs` status check) now runs in two modes:

1. **Auto-fix mode (preferred — happy path).** Triggered when `LOGMIND_AUTO_REGEN_PAT` is configured on the repo (or inherited from the org). When derived docs are stale, the workflow regenerates them and **pushes the fix back to the PR branch** using the PAT. Downstream CI re-runs naturally (PAT-pushed commits DO trigger workflows, unlike `GITHUB_TOKEN`-pushed ones). Author sees one extra commit by `logmind-auto-regen[bot]` and the merge gate clears.

2. **Fail-fast mode (fallback — when no PAT configured).** Backwards-compatible with v0.3.3 — fails red with the regenerate-locally message. Includes a `::warning::` line explaining how to opt in.

Forked PRs always run in fail-fast mode (can't push to a fork's head ref).

## Why a PAT (one-time setup, not built-in)

GitHub deliberately blocks `GITHUB_TOKEN`-pushed commits from re-triggering required-status workflows (anti-recursion safety). Auto-commit via `GITHUB_TOKEN` would leave the merge gate stuck on "Expected — Waiting for status to be reported" forever. The PAT path is the documented escape hatch — fine-grained PAT with `Contents: write` scope, one secret per repo (or org-level for all repos).

## Files
- `src/logmind/templates/github/regen-timeline.yml.template` — major rewrite; template-version v2 → v3; permissions `contents: read` → `contents: write`
- `pyproject.toml`, `src/logmind/__init__.py`, `src/logmind/cli.py` — bump to 0.3.4
- `CHANGELOG.md` — `[0.3.4]` entry with full migration notes
- `tests/test_timeline.py` — updated `test_regen_timeline_template_is_fail_fast_not_autocommit` to `_supports_auto_fix_with_failfast_fallback` reflecting the new architecture
- `tests/test_v0_2_1_audit_fixes.py` — expected template marker v2 → v3

## Test plan
- [x] `pytest tests/` — 550 passed, 1 skipped
- [x] Workflow YAML parses (validates as YAML with `__LOGMIND_VERSION__` substituted)
- [x] All three guard paths covered (internal+PAT, internal+no-PAT, fork) in the test assertions
- [ ] After merge + tag v0.3.4: `logmind init` in a downstream repo refreshes the workflow body; without configuring `LOGMIND_AUTO_REGEN_PAT`, behavior is identical to today
- [ ] After PAT setup on a sample repo: stale derived docs on a PR get auto-pushed; downstream CI re-runs; merge gate clears

## Migration
None forced. v0.3.3 → v0.3.4 is backwards-compatible without setup (fail-fast mode is identical). Opt into auto-fix by adding the `LOGMIND_AUTO_REGEN_PAT` secret per the CHANGELOG.