### PR TITLE
fix(vercel.json): guard ignoreCommand against missing VERCEL_GIT_PREVIOUS_SHA

### DIFF
--- a/docs/decisions-branches/fix__vercel-ignore-bad-sha.md
+++ b/docs/decisions-branches/fix__vercel-ignore-bad-sha.md
@@ -1,0 +1,8 @@
+## 2026-05-27 11:42 - fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA
+
+**Reasoning:** Fix: gate git diff with 'git cat-file -e $SHA' — if the object exists, do the diff (skip when site/ unchanged); if not, fall through to 'else false' (treat as 'do build'). Same defensive behavior we had for empty SHA, now extended to missing-object
+
+**Implications:**
+- Same change shipped to clud-bug/vercel.json as a separate PR — both had the same bug
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA *(fix/vercel-ignore-bad-sha)* — [decisions-branches/fix__vercel-ignore-bad-sha.md](decisions-branches/fix__vercel-ignore-bad-sha.md)
 - **2026-05-27** — feat(v0.3.4): check-derived-docs auto-fixes when LOGMIND_AUTO_REGEN_PAT configured *(feat/v0.3.4-auto-regen-derived-docs)* — [decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md](decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md)
 - **2026-05-27** — fix(v0.3.3): drop wall-clock timestamp from docs/file-structure.md *(fix/v0.3.3-file-structure-determinism)* — [decisions-branches/fix__v0.3.3-file-structure-determinism.md](decisions-branches/fix__v0.3.3-file-structure-determinism.md)
 - **2026-05-27** — fix(v0.3.2): drop --auto, use synchronous gh pr merge *(chore/v0.3.2-homebrew-automerge)* — [decisions-branches/chore__v0.3.2-homebrew-automerge.md](decisions-branches/chore__v0.3.2-homebrew-automerge.md)

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- site/; else false; fi"
+  "ignoreCommand": "if [ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] && git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null; then git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- site/; else false; fi"
 }


### PR DESCRIPTION
## Repro

Vercel build for logmind.dev failed post org-rename:

```
Command failed with exit code 128: if [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- site/; else false; fi
fatal: bad object 03c92541990ede570eaf7e88e008f1a39bc01430
```

That SHA was a thrillmot-era commit. After Vercel project reconnect to thrillmade/logmind, the shallow clone no longer includes the pre-rename SHA, so `git diff` exits 128 instead of either skipping or building.

## Fix

Wrap the diff in a `git cat-file -e` existence check. If the SHA exists, do the diff (skip when site/ unchanged). If not, fall through to `else false` (treat as "build").

Same defensive shape as the original empty-SHA guard, now extended to missing-object.

## Test plan
- [x] Local syntax check
- [ ] After merge: next Vercel deploy reaches the build step (no exit 128). cludbug.dev gets the same fix in a sibling PR.