### PR TITLE
chore: add test aggregator job (reports under literal 'test' context)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,12 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  pytest:
+    # Per-matrix-cell test runner. Each matrix cell reports as its own
+    # status context (e.g. "pytest (ubuntu-latest / py3.10)") because
+    # matrix-expanded jobs replace the job-id-based context name with
+    # the `name:` template below. So none of these are named exactly
+    # `test` — that's what the aggregator job below covers.
     name: pytest (${{ matrix.os }} / py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -48,3 +53,22 @@ jobs:
       - name: Markdown link integrity (own docs)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: logmind check-links
+
+  test:
+    # Aggregator that reports under the literal `test` context — the
+    # org ruleset's `required_status_checks` rule pins this exact name,
+    # so without an aggregator every matrix-expanded cell's context
+    # (`pytest (…)`) gets ignored by the gate. `needs:` makes this
+    # block until every cell completes; `if: always()` + the inner
+    # `result` check propagates failure correctly when any cell fails.
+    needs: pytest
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Aggregate matrix results
+        run: |
+          if [ "${{ needs.pytest.result }}" != "success" ]; then
+            echo "::error::One or more pytest matrix cells failed (needs.pytest.result=${{ needs.pytest.result }})"
+            exit 1
+          fi
+          echo "All pytest matrix cells passed."

--- a/docs/decisions-branches/chore__add-test-aggregator-job.md
+++ b/docs/decisions-branches/chore__add-test-aggregator-job.md
@@ -1,0 +1,8 @@
+## 2026-05-27 11:47 - chore: add test aggregator job (reports under literal 'test' context)
+
+**Reasoning:** Add an aggregator job named 'test' that needs: pytest. Reports under the 'test' context for the ruleset, propagates failure correctly via needs.pytest.result check
+
+**Implications:**
+- logmind PR #62 was BLOCKED by this gap — had to admin-bypass. Future PRs land cleanly with this aggregator in place
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — chore: add test aggregator job (reports under literal 'test' context) *(chore/add-test-aggregator-job)* — [decisions-branches/chore__add-test-aggregator-job.md](decisions-branches/chore__add-test-aggregator-job.md)
 - **2026-05-27** — fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA *(fix/vercel-ignore-bad-sha)* — [decisions-branches/fix__vercel-ignore-bad-sha.md](decisions-branches/fix__vercel-ignore-bad-sha.md)
 - **2026-05-27** — feat(v0.3.4): check-derived-docs auto-fixes when LOGMIND_AUTO_REGEN_PAT configured *(feat/v0.3.4-auto-regen-derived-docs)* — [decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md](decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md)
 - **2026-05-27** — fix(v0.3.3): drop wall-clock timestamp from docs/file-structure.md *(fix/v0.3.3-file-structure-determinism)* — [decisions-branches/fix__v0.3.3-file-structure-determinism.md](decisions-branches/fix__v0.3.3-file-structure-determinism.md)


### PR DESCRIPTION
## Summary

Adds an aggregator job named `test` to `.github/workflows/test.yml` that `needs: pytest` (the matrix runner) and reports under the literal `test` context. Required because the org ruleset's `required_status_checks` rule pins the exact context name `test`, but logmind's matrix-expanded pytest jobs all report as `pytest (ubuntu-latest / py3.10)` etc. — none produce a `test` context.

Without this aggregator, every logmind PR sits BLOCKED on the ruleset even when every pytest cell passes. PR #62 (the vercel.json fix) had to be admin-bypassed for exactly this reason.

## Files
- `.github/workflows/test.yml` — renamed the matrix job from `test` → `pytest` (job-id matters for `needs:`), added a tiny aggregator job named `test` that propagates the matrix result.

## Test plan
- [x] YAML still valid
- [ ] CI on THIS PR reports a `test` context (the aggregator) alongside the 6 `pytest (…)` matrix cells
- [ ] After merge: future PRs no longer get BLOCKED on missing `test` context