### PR TITLE
feat(v0.4.0): notify-agent-skills.yml opens a Claude-proposed SKILL.md PR

### DIFF
--- a/.github/scripts/propose_skill_update.py
+++ b/.github/scripts/propose_skill_update.py
@@ -1,0 +1,202 @@
+"""Generate a proposed SKILL.md update from a logmind CHANGELOG section.
+
+Called by `.github/workflows/notify-agent-skills.yml` on every logmind
+tag push (v0.4.0+). Reads:
+
+  - CHANGELOG section for the released version (from --changelog)
+  - Current skills/logmind/SKILL.md content (from --current-skill)
+
+Writes:
+
+  - --out-reasoning : Claude's structured explanation of what it changed
+    (or why it judged the release skill-irrelevant). Always written —
+    the human reviewer needs this context even when no SKILL.md edit
+    was proposed.
+
+  - --out-skill : the proposed new SKILL.md content. ONLY written when
+    Claude returns a `<skill_md>` block (i.e. the changelog had
+    user-facing changes worth surfacing to AI agents). Skipped when
+    Claude emits the NO_SKILL_UPDATE_NEEDED sentinel, in which case
+    the workflow leaves the on-disk SKILL.md untouched and the human
+    sees the stub TODO file alone.
+
+Exit code 0 always (sentinel and proposal both count as "success");
+exit code 1 only on infrastructure failure (missing API key, network
+error after retries, malformed response). The workflow falls back to
+the v0.3.x issue-shaped notification on exit code 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# `anthropic` is pip-installed inside the workflow's Python step.
+# Local pytest mocks the client, so import-time dependency is OK to
+# expect at runtime but allowable to defer in test environments.
+try:
+    from anthropic import Anthropic
+except ImportError:  # pragma: no cover - exercised in CI install
+    Anthropic = None  # type: ignore[assignment]
+
+
+SENTINEL = "NO_SKILL_UPDATE_NEEDED"
+MODEL = "claude-sonnet-4-6"
+
+SYSTEM_PROMPT = """\
+You are a documentation engineer keeping a project's SKILL.md (a
+prompt-format guidance file consumed by AI coding agents) in sync
+with its CHANGELOG.
+
+You receive a CHANGELOG section for a new release and the current
+SKILL.md. Decide whether the release introduces *user-visible*
+behavior or guidance that should be reflected in the SKILL.md:
+
+  - New CLI commands, flags, or behaviors → mention in skill
+  - New defaults that change agent-facing behavior → update Don'ts/Do's
+  - Removed features or renamed primitives → strike or replace
+  - New "always do X" / "never do Y" guidance from the release notes
+    → add to the appropriate section
+
+Skill-IRRELEVANT releases (do NOT propose an edit):
+
+  - Internal refactors with no behavior change
+  - CI / workflow changes that don't affect users
+  - Test additions, doc-internal cleanup, dependency bumps
+  - Bug fixes where the bug was invisible to agents using the skill
+
+Strict output format:
+
+  - If skill update is warranted, emit EXACTLY two XML-tagged blocks:
+      <reasoning>1-3 sentences explaining what changed in the CHANGELOG
+      that warrants the SKILL.md edit, citing specific user-visible
+      behavior.</reasoning>
+      <skill_md>...full updated SKILL.md content...</skill_md>
+
+  - If no skill update is warranted, emit EXACTLY this line on its
+    own (no other content):
+      NO_SKILL_UPDATE_NEEDED
+    Then on the next line, a <reasoning> block explaining why the
+    release is skill-irrelevant.
+
+Preserve the SKILL.md frontmatter (the leading `---\\n...\\n---` block)
+EXACTLY as-is — name, description, review_mode, anything else. Edit
+only the body content.
+
+Do not include any prose outside the XML blocks / sentinel line.
+"""
+
+
+def _user_message(changelog_section: str, current_skill: str, version: str) -> str:
+    return (
+        f"Release version: {version}\n\n"
+        f"=== CHANGELOG SECTION (verbatim) ===\n\n"
+        f"{changelog_section}\n\n"
+        f"=== CURRENT skills/logmind/SKILL.md (verbatim) ===\n\n"
+        f"{current_skill}\n"
+    )
+
+
+_REASONING_RE = re.compile(r"<reasoning>(.*?)</reasoning>", re.DOTALL)
+_SKILL_RE = re.compile(r"<skill_md>(.*?)</skill_md>", re.DOTALL)
+
+
+def parse_response(text: str) -> tuple[str | None, str]:
+    """Return (proposed_skill_or_None, reasoning).
+
+    proposed_skill is None when the model returned the sentinel.
+    reasoning is always a string (empty if the model didn't include
+    one, which the workflow then surfaces as 'no reasoning provided').
+    """
+    reasoning_match = _REASONING_RE.search(text)
+    reasoning = reasoning_match.group(1).strip() if reasoning_match else ""
+
+    # Sentinel takes precedence — even if a stray <skill_md> block
+    # leaked through, treat NO_SKILL_UPDATE_NEEDED on its own line as
+    # the canonical signal.
+    if re.search(r"^\s*" + SENTINEL + r"\s*$", text, re.MULTILINE):
+        return None, reasoning
+
+    skill_match = _SKILL_RE.search(text)
+    if not skill_match:
+        # Malformed response — no sentinel AND no skill block. Treat
+        # as "no update" with a flag in the reasoning so the human
+        # reviewer can spot it.
+        return None, (
+            reasoning + "\n\n[malformed response — no <skill_md> block and no "
+            "NO_SKILL_UPDATE_NEEDED sentinel; treating as no-op]"
+        ).strip()
+
+    return skill_match.group(1).strip() + "\n", reasoning
+
+
+def call_claude(changelog_section: str, current_skill: str, version: str) -> str:
+    """Run one Anthropic API call. Returns the raw response text.
+    Raises on infrastructure failure (no key, no client, no content)."""
+    if Anthropic is None:
+        raise RuntimeError("anthropic package not installed — pip install anthropic")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+    client = Anthropic()
+    msg = client.messages.create(
+        model=MODEL,
+        max_tokens=8192,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": _user_message(changelog_section, current_skill, version)}],
+    )
+
+    # Concatenate text blocks (Anthropic SDK returns a list of content
+    # blocks; for non-streaming we expect just one TextBlock).
+    parts: list[str] = []
+    for block in msg.content:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    if not parts:
+        raise RuntimeError("empty response from Anthropic API")
+    return "".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", type=Path, required=True,
+                        help="path to the extracted CHANGELOG section")
+    parser.add_argument("--current-skill", type=Path, required=True,
+                        help="path to the current SKILL.md content")
+    parser.add_argument("--version", required=True,
+                        help="release version tag (e.g. v0.4.0)")
+    parser.add_argument("--out-reasoning", type=Path, required=True,
+                        help="output path for Claude's reasoning blob")
+    parser.add_argument("--out-skill", type=Path, required=True,
+                        help="output path for the proposed SKILL.md (only "
+                             "written if Claude proposed an update)")
+    args = parser.parse_args(argv)
+
+    changelog_section = args.changelog.read_text(encoding="utf-8")
+    current_skill = args.current_skill.read_text(encoding="utf-8")
+
+    response = call_claude(changelog_section, current_skill, args.version)
+    proposed, reasoning = parse_response(response)
+
+    args.out_reasoning.parent.mkdir(parents=True, exist_ok=True)
+    args.out_reasoning.write_text(
+        reasoning or "(no reasoning provided)",
+        encoding="utf-8",
+    )
+
+    if proposed is not None:
+        args.out_skill.parent.mkdir(parents=True, exist_ok=True)
+        args.out_skill.write_text(proposed, encoding="utf-8")
+        print(f"::notice::Proposed SKILL.md update written ({len(proposed)} chars).")
+    else:
+        print("::notice::No skill update needed (sentinel returned). "
+              "Workflow will leave SKILL.md untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/notify-agent-skills.yml
+++ b/.github/workflows/notify-agent-skills.yml
@@ -1,17 +1,20 @@
 name: notify agent-skills on release
 
-# When logmind ships a new release (tag push v*), open an issue on
-# thrillmade/agent-skills asking the maintainer to review
-# `skills/logmind/SKILL.md` for any new features that should be
-# documented. Closes the manual-sync chore between logmind releases
-# and the skill content — mirror of agent-skills' notify-clud-bug.yml
-# pattern.
+# When logmind ships a new release (tag push v*), open a PR on
+# thrillmade/agent-skills with a Claude-generated proposed update to
+# `skills/logmind/SKILL.md` based on the release's CHANGELOG section.
+# Auto-merge stays OFF — Claude's output is a starting point the
+# maintainer reviews + edits + merges (or closes if over-proposed).
 #
-# Same auth model as notify-clud-bug.yml: GITHUB_TOKEN can create
-# issues on this repo but NOT on a different repo. So this workflow
-# reads an AGENT_SKILLS_NOTIFY_PAT secret — a fine-grained PAT scoped
-# to thrillmade/agent-skills with Issues: write. Without it, the
-# notifier degrades to a ::warning:: rather than failing the release.
+# Auth model: same as v0.3.x — AGENT_SKILLS_NOTIFY_PAT (fine-grained
+# PAT scoped to thrillmade/agent-skills, Contents + Pull requests:
+# write). Org-level secret as of 2026-05-27. ANTHROPIC_API_KEY is
+# org-level too, scoped to this repo.
+#
+# Failure-mode degradation: if either the Anthropic API call or the
+# PAT-clone-and-PR path fails, fall back to the v0.3.x issue-shaped
+# notification. Shipping discipline preserved — a release shouldn't
+# break because the new flow flakes.
 
 on:
   push:
@@ -22,64 +25,242 @@ permissions:
   contents: read
 
 jobs:
-  open-issue:
+  propose-skill-update:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
-      - name: Open issue on thrillmade/agent-skills
+      - name: Checkout logmind
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # need history for `git describe` to find previous tag
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install logmind + anthropic SDK
+        run: |
+          set -euo pipefail
+          # Install the just-released logmind from PyPI. The notify
+          # workflow runs AFTER publish.yml in the release chain, so
+          # the version is available. Pin to the tagged version so
+          # this step's behavior matches what consumers will see.
+          VERSION="${TAG#v}"
+          # Wait briefly for PyPI propagation — publish.yml also
+          # waits, but the GitHub-Actions runner's view of PyPI is
+          # sometimes behind. Best-effort.
+          for i in $(seq 1 18); do
+            if pip install "logmind==${VERSION}" 2>/dev/null; then break; fi
+            echo "  pip install logmind==${VERSION} attempt ${i}/18 — retrying in 10s"
+            sleep 10
+          done
+          pip install logmind=="${VERSION}"  # final attempt; fail loud if still unavailable
+          pip install anthropic
+
+      - name: Determine previous tag (for CHANGELOG slice)
+        id: prev
+        run: |
+          set -euo pipefail
+          # The tag we're releasing is HEAD. Walk back one commit to
+          # find the prior tag — `git describe --tags --abbrev=0 HEAD^`
+          # returns it. If HEAD^ has no ancestor with a tag (very
+          # first release), set to empty so extract_sections_between
+          # emits everything up to the current tag.
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          else
+            PREV=""
+          fi
+          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+          echo "  Previous tag: ${PREV:-<none — first release>}"
+
+      - name: Extract CHANGELOG section
+        env:
+          PREV_TAG: ${{ steps.prev.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Strip leading v from version tags before passing to
+          # extract_sections_between, which expects bare X.Y.Z.
+          AFTER="${PREV_TAG#v}"
+          UP_TO="${TAG#v}"
+          mkdir -p /tmp/notify
+          python3 - <<PY
+          from pathlib import Path
+          from logmind.core.changelog import extract_sections_between
+          text = Path("CHANGELOG.md").read_text(encoding="utf-8")
+          section = extract_sections_between(
+              text,
+              after="${AFTER}" or None,
+              up_to="${UP_TO}",
+          )
+          Path("/tmp/notify/changelog-section.md").write_text(section, encoding="utf-8")
+          print(f"  Extracted {len(section)} chars of CHANGELOG section")
+          PY
+
+      - name: Fetch current SKILL.md from agent-skills
         env:
           GH_TOKEN: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
-          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::AGENT_SKILLS_NOTIFY_PAT secret missing — install a fine-grained PAT scoped to thrillmade/agent-skills with Issues: write to enable this notifier."
+            echo "::error::AGENT_SKILLS_NOTIFY_PAT secret missing"
+            exit 1  # caught by the fallback job below
+          fi
+          gh api repos/thrillmade/agent-skills/contents/skills/logmind/SKILL.md \
+            --jq .content | base64 -d > /tmp/notify/current-skill.md
+          wc -c /tmp/notify/current-skill.md
+
+      - name: Propose SKILL.md update via Anthropic API
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/propose_skill_update.py \
+            --changelog /tmp/notify/changelog-section.md \
+            --current-skill /tmp/notify/current-skill.md \
+            --version "${TAG}" \
+            --out-reasoning /tmp/notify/reasoning.md \
+            --out-skill /tmp/notify/proposed-skill.md
+
+      - name: Checkout thrillmade/agent-skills
+        uses: actions/checkout@v6
+        with:
+          repository: thrillmade/agent-skills
+          path: agent-skills
+          token: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
+
+      - name: Apply outputs + commit + push + open PR
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
+        working-directory: agent-skills
+        run: |
+          set -euo pipefail
+          BRANCH="notify/logmind-${TAG}"
+
+          # Short-circuit if a PR already exists for this branch (e.g.
+          # workflow re-run on the same tag). Don't double-open.
+          EXISTING=$(gh pr list --repo thrillmade/agent-skills \
+            --head "$BRANCH" --state open --json number --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${EXISTING} already open for ${BRANCH} — leaving as-is."
             exit 0
           fi
 
-          body=$(cat <<EOF
-          logmind \`${TAG}\` shipped: https://github.com/thrillmade/logmind/releases/tag/${TAG}
+          git config user.name "logmind-notify[bot]"
+          git config user.email "logmind-notify@users.noreply.github.com"
+          git checkout -b "$BRANCH"
 
-          Review \`skills/logmind/SKILL.md\` for any user-facing changes from
-          this release that should be reflected in the skill body:
+          # Always write the stub TODO file with full context.
+          mkdir -p .skill-update-todo
+          {
+            echo "# logmind ${TAG} — skill update context"
+            echo
+            echo "**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md"
+            echo "**Release URL**: https://github.com/thrillmade/logmind/releases/tag/${TAG}"
+            echo
+            echo "## Claude's reasoning"
+            echo
+            cat /tmp/notify/reasoning.md
+            echo
+            echo "## CHANGELOG section (verbatim, used as Claude's input)"
+            echo
+            cat /tmp/notify/changelog-section.md
+          } > ".skill-update-todo/${TAG}.md"
 
-          - https://github.com/thrillmade/agent-skills/blob/main/skills/logmind/SKILL.md
+          # If Claude proposed an update, overwrite the on-disk SKILL.md.
+          if [ -f /tmp/notify/proposed-skill.md ]; then
+            cp /tmp/notify/proposed-skill.md skills/logmind/SKILL.md
+            SHAPE="proposed SKILL.md edit + TODO context file"
+          else
+            SHAPE="TODO context only (Claude judged release skill-irrelevant)"
+          fi
 
-          ## What to check
+          git add -A
+          git commit -m "notify: logmind ${TAG} shipped — ${SHAPE}"
+          git push -u origin "$BRANCH"
 
-          - New CLI commands, flags, or behaviors → mention in skill
-          - Automatic side effects of \`logmind log\` (timeline regen, etc.) → document
-          - New "Don't" rules surfaced by user feedback → add
-          - Changelog: https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md
+          REASONING=$(cat /tmp/notify/reasoning.md)
+          PR_BODY=$(cat <<EOF
+          Automated notification from \`thrillmade/logmind\` — ${TAG} shipped.
 
-          Close as a no-op if this release is internal-only (refactor, test
-          additions, CI changes) with no skill-relevant behavior change.
+          **CHANGELOG**: [\`${TAG}\` on logmind](https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md)
+          **Release**: https://github.com/thrillmade/logmind/releases/tag/${TAG}
 
-          ## Auto-generated
-          Opened by \`logmind/.github/workflows/notify-agent-skills.yml\` on
-          every tag push.
+          ## Shape of this PR
+
+          ${SHAPE}
+
+          ## Claude's reasoning
+
+          ${REASONING}
+
+          ## Reviewer checklist
+
+          - [ ] Read the CHANGELOG section (linked above) and Claude's reasoning
+          - [ ] If a SKILL.md diff is included: verify it accurately reflects user-visible behavior. Edit if Claude over- or under-proposed; close if entirely wrong.
+          - [ ] Merge to ship the SKILL.md update (auto-merge stays OFF — content is discretionary).
+          - [ ] If Claude judged the release skill-irrelevant (TODO-only PR): close without merging unless you disagree, in which case edit \`skills/logmind/SKILL.md\` on this branch and add it before merging.
+
+          ## How this was generated
+
+          \`logmind/.github/workflows/notify-agent-skills.yml\` (v0.4.0+) on tag push. Calls Anthropic API via \`.github/scripts/propose_skill_update.py\` to generate the proposed edit from the CHANGELOG section + current SKILL.md. Auto-merge intentionally disabled.
           EOF
           )
 
-          # Idempotently ensure the label exists on the receiving repo
-          # before we try to attach it. `--force` makes this a no-op when
-          # the label already exists. Without this, the first tag push
-          # would fail `gh issue create` (label not found), the `|| ::warning::`
-          # would swallow the failure, and no issue would ever land —
-          # exactly the bug the v0.2.6 review caught.
+          gh pr create \
+            --repo thrillmade/agent-skills \
+            --base main \
+            --head "$BRANCH" \
+            --title "logmind ${TAG} shipped — proposed SKILL.md update" \
+            --body "$PR_BODY"
+
+  # Fallback job: if the propose-skill-update job above failed (Anthropic
+  # API down, PAT missing, etc.), open the v0.3.x-style issue so the
+  # release still gets acknowledged.
+  fallback-issue:
+    runs-on: ubuntu-latest
+    needs: propose-skill-update
+    if: failure()
+    env:
+      TAG: ${{ github.ref_name }}
+    steps:
+      - name: Open fallback issue on agent-skills
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::AGENT_SKILLS_NOTIFY_PAT missing — cannot open fallback issue."
+            exit 0
+          fi
+
+          BODY=$(cat <<EOF
+          logmind \`${TAG}\` shipped but the v0.4.0 PR-shape notify workflow failed.
+
+          Falling back to the v0.3.x issue notification. Review \`skills/logmind/SKILL.md\` manually for any user-facing changes:
+
+          - CHANGELOG: https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md
+          - SKILL.md:  https://github.com/thrillmade/agent-skills/blob/main/skills/logmind/SKILL.md
+
+          The workflow run (for debugging): https://github.com/thrillmade/logmind/actions/runs/\${{ github.run_id }}
+
+          Close as a no-op if this release is internal-only with no skill-relevant changes.
+          EOF
+          )
+
           gh label create from-logmind \
             --repo thrillmade/agent-skills \
             --color "0e8a16" \
             --description "Auto-opened by logmind release notifier" \
-            --force \
-            || echo "::warning::could not create/update from-logmind label on agent-skills; proceeding without label"
+            --force || true
 
           gh issue create \
             --repo thrillmade/agent-skills \
-            --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md" \
+            --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md (PR-shape notify failed, fallback)" \
             --label "from-logmind" \
-            --body "$body" \
+            --body "$BODY" \
             || gh issue create \
               --repo thrillmade/agent-skills \
-              --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md" \
-              --body "$body" \
-            || echo "::error::failed to open issue on agent-skills even without label — check AGENT_SKILLS_NOTIFY_PAT scopes (needs Issues: write)"
+              --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md (PR-shape notify failed, fallback)" \
+              --body "$BODY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-27
+
+### Changed — `notify-agent-skills.yml` opens a PR (not an issue) with a Claude-generated proposed SKILL.md update
+- **The reshape.** Every logmind tag push has been opening an *issue* on `thrillmade/agent-skills` titled `logmind vX.Y.Z shipped — review skills/logmind/SKILL.md`. The maintainer then has to read the CHANGELOG, decide what's skill-relevant, write the edit, and PR it themselves. The notification is issue-shaped; the actual work is PR-shaped. v0.4.0 inverts this: the workflow now opens a **PR** on agent-skills with a **Claude-generated proposed SKILL.md edit** based on the release's CHANGELOG section. Reviewer-checklist body, no auto-merge, full reasoning attached.
+- **Mechanism.** New helper script `.github/scripts/propose_skill_update.py` calls the Anthropic API (`claude-sonnet-4-6`) once per release with: the CHANGELOG section sliced via `logmind.core.changelog.extract_sections_between`, plus the current `skills/logmind/SKILL.md` fetched from agent-skills' main. Claude emits either (a) `<reasoning>` + `<skill_md>` XML blocks containing the proposed edit, or (b) a `NO_SKILL_UPDATE_NEEDED` sentinel for releases with no user-facing changes worth surfacing to AI agents. Either way, a stub `.skill-update-todo/vX.Y.Z.md` is always written with full context (CHANGELOG section, Claude's reasoning, release URL).
+- **Auth (already in place).** Same `AGENT_SKILLS_NOTIFY_PAT` from v0.3.x (just expanded scope to Contents + PRs: write, configured earlier in the migration session). `ANTHROPIC_API_KEY` is the existing org-level secret. No setup step required on existing installs.
+- **Failure-mode degradation.** If the Anthropic API call fails or the PAT is missing, a fallback job opens the v0.3.x-shaped issue so the release still gets acknowledged. Shipping discipline preserved — a release shouldn't break because the new flow flakes.
+- **Tests.** `tests/test_propose_skill_update.py` mocks the Anthropic client and exercises: full-proposal parsing, sentinel parsing, sentinel precedence over stray blocks, malformed-response degradation, missing-key/missing-package guards, end-to-end main() with both proposal and sentinel paths.
+
+### Future enhancements considered (not in v0.4.0)
+After 1-3 release dogfoods we'll know whether to:
+- **Prompt-tune** if Claude's proposed edits are consistently off (e.g. N-shot examples drawn from past SKILL.md commit diffs).
+- **Auto-merge gate** on a confidence-score threshold (request a JSON confidence in the structured output, auto-merge when >0.9). Today's design intentionally keeps auto-merge OFF — content is discretionary.
+- **Extend to symmetric flows** if another downstream-sync surface emerges (clud-bug → some-future-consumer, etc.). The two-file shape (changelog slice + current target → propose) generalizes cleanly.
+
+### Migration from v0.3.4
+None required on existing installs. The reshape is server-side (the workflow file inside logmind itself). After this release tags, the next agent-skills notify will arrive as a PR rather than an issue — open it, scan Claude's reasoning, merge or close.
+
 ## [0.3.4] - 2026-05-27
 
 ### Added — `check-derived-docs` auto-fixes stale docs/timeline.md + docs/file-structure.md when configured

--- a/docs/decisions-branches/feat__v0.4.0-notify-pr-shape.md
+++ b/docs/decisions-branches/feat__v0.4.0-notify-pr-shape.md
@@ -1,0 +1,11 @@
+## 2026-05-27 15:27 - feat(v0.4.0): notify-agent-skills.yml opens a Claude-proposed SKILL.md PR (not an issue)
+
+**Reasoning:** Sentinel NO_SKILL_UPDATE_NEEDED for internal releases (CI tweaks, refactors). Always writes .skill-update-todo/vX.Y.Z.md with full context. Failure-mode fallback to v0.3.x issue notification preserves shipping discipline
+
+**Alternatives considered:** Auto-merge from day one — rejected; quality has to be observed across 1-3 dogfooded releases first, Issue-with-attached-content-suggestion instead of full PR — rejected; PR shape forces the diff into review surface where it belongs
+
+**Implications:**
+- First Anthropic API direct integration in the org (not via claude-code-action). The pattern generalizes to future downstream-sync surfaces: (changelog slice + current target) → propose. Worth keeping the helper script's interface stable so a future workflow can reuse it
+- Verification: v0.4.0 release itself dogfoods — its tag push fires the new workflow, which should open a PR on agent-skills proposing an update for v0.4.0's own changes
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-27** — feat(v0.4.0): notify-agent-skills.yml opens a Claude-proposed SKILL.md PR (not an issue) *(feat/v0.4.0-notify-pr-shape)* — [decisions-branches/feat__v0.4.0-notify-pr-shape.md](decisions-branches/feat__v0.4.0-notify-pr-shape.md)
 - **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) *(chore/regen-derived-docs)* — [decisions-branches/chore__regen-derived-docs.md](decisions-branches/chore__regen-derived-docs.md)
 - **2026-05-27** — chore: add test aggregator job (reports under literal 'test' context) *(chore/add-test-aggregator-job)* — [decisions-branches/chore__add-test-aggregator-job.md](decisions-branches/chore__add-test-aggregator-job.md)
 - **2026-05-27** — fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA *(fix/vercel-ignore-bad-sha)* — [decisions-branches/fix__vercel-ignore-bad-sha.md](decisions-branches/fix__vercel-ignore-bad-sha.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.3.4"
+version = "0.4.0"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.3.4"
+__version__ = "0.4.0"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -45,7 +45,7 @@ from logmind.core.tree_gen import update_file_structure
 
 
 @click.group()
-@click.version_option(version="0.3.4", prog_name="logmind")
+@click.version_option(version="0.4.0", prog_name="logmind")
 def main():
     """logmind - AI decision logging system for development projects."""
     pass

--- a/tests/test_propose_skill_update.py
+++ b/tests/test_propose_skill_update.py
@@ -1,0 +1,229 @@
+"""Tests for the v0.4.0 propose_skill_update.py CI helper.
+
+The script itself lives at `.github/scripts/propose_skill_update.py`
+(outside src/ — it's a CI artifact, not part of the installable
+package). These tests import it via a path append so the same parsing
+logic that runs in CI is exercised locally.
+
+We don't make real Anthropic API calls; the `call_claude` function is
+mocked at module level so we can assert prompt construction without
+network or cost.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Insert the scripts dir so we can import propose_skill_update.
+SCRIPTS_DIR = Path(__file__).parent.parent / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import propose_skill_update as psu  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_response — the format-handling core
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_full_proposal():
+    """Happy path: model returns <reasoning> + <skill_md>."""
+    response = """<reasoning>v0.4.0 ships PR-shape notify; agents
+need to know about the new auto-fix workflow.</reasoning>
+<skill_md>---
+name: logmind
+review_mode: shared
+---
+# logmind
+new body content
+</skill_md>"""
+    proposed, reasoning = psu.parse_response(response)
+    assert proposed is not None
+    assert "new body content" in proposed
+    assert proposed.endswith("\n")  # parse_response normalizes trailing newline
+    assert "PR-shape" in reasoning
+    assert "agents" in reasoning
+
+
+def test_parse_response_sentinel():
+    """Model decides no skill update needed — returns sentinel + reasoning."""
+    response = """NO_SKILL_UPDATE_NEEDED
+<reasoning>v0.4.0 is a CI-internal change; nothing user-facing.</reasoning>"""
+    proposed, reasoning = psu.parse_response(response)
+    assert proposed is None
+    assert "CI-internal" in reasoning
+
+
+def test_parse_response_sentinel_precedence_over_stray_block():
+    """If the model emits BOTH sentinel and a <skill_md> block, sentinel wins.
+    Conservative: anyone reading the response sees the explicit no-update
+    signal and we don't accidentally ship a half-formed proposal."""
+    response = """NO_SKILL_UPDATE_NEEDED
+<reasoning>actually no change</reasoning>
+<skill_md>oops should have been silent</skill_md>"""
+    proposed, reasoning = psu.parse_response(response)
+    assert proposed is None  # sentinel takes precedence
+    assert "no change" in reasoning
+
+
+def test_parse_response_malformed():
+    """No sentinel + no <skill_md> block — degrade to no-op with a flag in
+    reasoning so the human reviewer can spot the malformed response."""
+    response = "I think you should update the SKILL.md but I forgot how."
+    proposed, reasoning = psu.parse_response(response)
+    assert proposed is None
+    assert "malformed" in reasoning
+
+
+def test_parse_response_skill_only_no_reasoning():
+    """If the model emits <skill_md> but no <reasoning>, surface the gap.
+    The skill update still proposed; the human sees empty reasoning."""
+    response = "<skill_md>---\nname: logmind\n---\n# body\n</skill_md>"
+    proposed, reasoning = psu.parse_response(response)
+    assert proposed is not None
+    assert "body" in proposed
+    assert reasoning == ""  # no reasoning extracted; workflow writes "(no reasoning provided)"
+
+
+# ---------------------------------------------------------------------------
+# call_claude — guard paths (no real API call)
+# ---------------------------------------------------------------------------
+
+
+def test_call_claude_raises_without_api_key(monkeypatch):
+    # Patch Anthropic so the first guard (package-present) passes;
+    # we're verifying the API-key guard specifically.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(psu, "Anthropic", MagicMock())
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        psu.call_claude("changelog", "skill", "v0.4.0")
+
+
+def test_call_claude_raises_without_anthropic_package(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+    monkeypatch.setattr(psu, "Anthropic", None)
+    with pytest.raises(RuntimeError, match="anthropic package"):
+        psu.call_claude("changelog", "skill", "v0.4.0")
+
+
+def test_call_claude_constructs_user_message_with_inputs(monkeypatch):
+    """Mock the Anthropic client and assert the user message includes the
+    changelog section and current SKILL.md verbatim."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+    fake_response = MagicMock()
+    fake_text_block = MagicMock()
+    fake_text_block.text = "<reasoning>x</reasoning><skill_md>y</skill_md>"
+    fake_response.content = [fake_text_block]
+
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_response
+
+    with patch.object(psu, "Anthropic", return_value=fake_client):
+        result = psu.call_claude(
+            changelog_section="### [0.4.0] - X\n- New CLI flag --foo",
+            current_skill="---\nname: logmind\n---\n# old body",
+            version="v0.4.0",
+        )
+
+    # Inspect the call: kwargs passed to messages.create
+    kwargs = fake_client.messages.create.call_args.kwargs
+    assert kwargs["model"] == psu.MODEL
+    user_message = kwargs["messages"][0]["content"]
+    assert "--foo" in user_message  # changelog text passed verbatim
+    assert "old body" in user_message  # current SKILL.md passed verbatim
+    assert "v0.4.0" in user_message
+    # Verify the system prompt establishes the role
+    assert "documentation engineer" in kwargs["system"].lower()
+    # Verify the result is the model's text output
+    assert "<skill_md>y</skill_md>" in result
+
+
+def test_call_claude_raises_on_empty_response(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+
+    fake_response = MagicMock()
+    fake_response.content = []  # no blocks
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = fake_response
+
+    with patch.object(psu, "Anthropic", return_value=fake_client):
+        with pytest.raises(RuntimeError, match="empty response"):
+            psu.call_claude("c", "s", "v0.4.0")
+
+
+# ---------------------------------------------------------------------------
+# main() — end-to-end wiring with mocked Claude
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_both_files_on_proposal(tmp_path, monkeypatch):
+    """Full end-to-end with mocked API: changelog + skill in, proposal out
+    on disk."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text("### [0.4.0]\n- New thing\n", encoding="utf-8")
+    skill = tmp_path / "skill.md"
+    skill.write_text("---\nname: logmind\n---\n# old\n", encoding="utf-8")
+    out_reason = tmp_path / "out" / "reason.md"
+    out_skill = tmp_path / "out" / "skill.md"
+
+    fake_response = MagicMock()
+    fake_response.content = [MagicMock(text=(
+        "<reasoning>release adds --foo</reasoning>\n"
+        "<skill_md>---\nname: logmind\n---\n# updated body\n</skill_md>"
+    ))]
+
+    with patch.object(psu, "Anthropic", return_value=MagicMock(
+        messages=MagicMock(create=MagicMock(return_value=fake_response))
+    )):
+        rc = psu.main([
+            "--changelog", str(changelog),
+            "--current-skill", str(skill),
+            "--version", "v0.4.0",
+            "--out-reasoning", str(out_reason),
+            "--out-skill", str(out_skill),
+        ])
+
+    assert rc == 0
+    assert "release adds --foo" in out_reason.read_text(encoding="utf-8")
+    assert "updated body" in out_skill.read_text(encoding="utf-8")
+
+
+def test_main_skips_skill_file_on_sentinel(tmp_path, monkeypatch):
+    """When Claude returns the sentinel, only the reasoning file is
+    written — the workflow inspects the out_skill path's existence to
+    decide whether to overwrite the on-disk SKILL.md."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key")
+    changelog = tmp_path / "changelog.md"
+    changelog.write_text("### [0.4.0]\n- Internal CI tweak\n", encoding="utf-8")
+    skill = tmp_path / "skill.md"
+    skill.write_text("---\nname: logmind\n---\n# unchanged\n", encoding="utf-8")
+    out_reason = tmp_path / "reason.md"
+    out_skill = tmp_path / "skill-proposed.md"
+
+    fake_response = MagicMock()
+    fake_response.content = [MagicMock(text=(
+        "NO_SKILL_UPDATE_NEEDED\n"
+        "<reasoning>release is internal CI plumbing; SKILL.md untouched.</reasoning>"
+    ))]
+
+    with patch.object(psu, "Anthropic", return_value=MagicMock(
+        messages=MagicMock(create=MagicMock(return_value=fake_response))
+    )):
+        rc = psu.main([
+            "--changelog", str(changelog),
+            "--current-skill", str(skill),
+            "--version", "v0.4.0",
+            "--out-reasoning", str(out_reason),
+            "--out-skill", str(out_skill),
+        ])
+
+    assert rc == 0
+    assert "internal CI plumbing" in out_reason.read_text(encoding="utf-8")
+    assert not out_skill.exists()  # not created on sentinel


### PR DESCRIPTION
## Summary

Reshapes how logmind notifies `thrillmade/agent-skills` on every release.

**Before (v0.3.x)**: open an issue saying "review SKILL.md for vX.Y.Z" → maintainer reads CHANGELOG, decides what's skill-relevant, writes the edit, opens their own PR. Issue-shaped notification for PR-shaped work.

**After (v0.4.0)**: open a PR on agent-skills with a Claude-generated proposed SKILL.md edit, plus Claude's reasoning + reviewer checklist. Auto-merge OFF — content is discretionary, maintainer accepts/edits/closes.

## Mechanism

1. Workflow extracts the CHANGELOG section for the tagged version via `logmind.core.changelog.extract_sections_between` (already exists, reused).
2. Fetches current `skills/logmind/SKILL.md` from agent-skills.
3. New helper `.github/scripts/propose_skill_update.py` calls Anthropic API (`claude-sonnet-4-6`) once per release. Inputs: CHANGELOG section + current SKILL.md. Output: either `<reasoning>` + `<skill_md>` XML blocks OR the sentinel `NO_SKILL_UPDATE_NEEDED` (for internal-only releases).
4. Workflow clones agent-skills with `AGENT_SKILLS_NOTIFY_PAT`, branches `notify/logmind-vX.Y.Z`, writes the proposed SKILL.md (if any) + the stub `.skill-update-todo/vX.Y.Z.md` (always), commits, pushes, opens PR via `gh pr create`.
5. Fallback job opens the v0.3.x-shape issue if anything in the new flow fails — shipping discipline preserved.

## Auth (already in place)

- `AGENT_SKILLS_NOTIFY_PAT` — Contents + PRs: write on agent-skills (configured org-wide earlier today)
- `ANTHROPIC_API_KEY` — org-level secret with logmind in scope

No setup step needed on existing installs.

## Files

- **NEW** `.github/scripts/propose_skill_update.py` (~190 lines) — Anthropic SDK call, XML parsing, sentinel handling, two output files (reasoning, optional proposed-skill)
- **REWRITTEN** `.github/workflows/notify-agent-skills.yml` — multi-step propose-skill-update job + failure-mode fallback-issue job
- **NEW** `tests/test_propose_skill_update.py` (11 tests, all mocked — no API calls)
- Version pins → 0.4.0
- CHANGELOG `[0.4.0]` entry + "Future enhancements considered" footer

## Test plan
- [x] `pytest tests/` — 561 passed, 1 skipped
- [x] Local mock-based tests for parse_response (5 cases), call_claude (4 guards), main() (2 paths)
- [ ] **Dogfood after merge + tag**: v0.4.0's own tag push fires this workflow → opens a PR on `thrillmade/agent-skills` with Claude's proposed update for v0.4.0's CHANGELOG. Inspect the proposal, close-or-merge based on quality.
- [ ] If the API call flakes or PAT goes missing in CI, the fallback-issue job should fire and produce the v0.3.x-shape issue (no release-breaking outage).