### PR TITLE
feat(v0.5.2): show --brief / --limit / --json (Phase B.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-28
+
+### Added — `logmind show --brief` / `--limit` / `--json` (Phase B.2)
+
+Agent-friendly views on the `show` command. Pure additive — existing
+`logmind show` and `logmind show --all` behavior unchanged.
+
+- `--brief`: one-line summary per decision (`YYYY-MM-DD HH:MM — title [source]`). Cheap recall for agents that need context but don't need full prose. Uses `iter_decisions` from `logmind.core.parser` (already exists).
+- `--limit N` / `-n N`: cap to N most-recent entries (newest-first). Matches the `logmind aggregate --limit` convention. Combinable with `--brief` and `--json`.
+- `--json`: stable structured output for downstream tools. Array of `{date: ISO8601, title: str, source: "main" | "archive"}`. Bypasses the `--quiet` patch so JSON is always emitted to stdout (it's primary output, not progress).
+- All three combine: `logmind show --brief --limit 5` for quick last-5 recall, `logmind show --json --limit 10 --all` for parsed access across main + archive.
+
+### Tests
+
+- `tests/test_cli.py` (+3): brief shape (newest-first), `--limit 2` caps correctly, `--json` produces a valid parseable array.
+
 ## [0.5.1] - 2026-05-27
 
 ### Added — `--quiet/-q` flag + `LOGMIND_QUIET=1` env var (Phase B.3)

--- a/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
+++ b/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
@@ -8,3 +8,8 @@
 **Reasoning:** clud-bug findings: (1) --json stdout was polluted by sync_messages + ok line — downstream parsers couldn't jq it. (2) Missing test coverage for --quiet --json + --json --all. Fixed: suppress sync chatter when as_json=True, route ok line to stderr via _ok(err=True). +3 tests.
 
 ---
+## 2026-05-28 00:30 - PR #70 fixes: limit-only output bug + py3.8 Click compat + JSON-wins-over-brief test
+
+**Reasoning:** clud-bug findings + py3.8 CI failures: (1) 🔴 show --limit N alone produced no output — parsed-view path only handled as_json/brief, control-flow hole. Fixed: brief-style rendering for limit-only (we only have date+title from parser, brief is the natural answer). (2) py3.8 CI failed 3 JSON tests with JSONDecodeError — Click 8.1.x defaults mix_stderr=True so the _ok(err=True) line landed in result.stdout. Added _separate_streams_runner() helper with try/TypeError fallback. (3) Added test_show_json_wins_over_brief for the help-text precedence contract. (4) Added test_show_limit_only_emits_decisions as regression.
+
+---

--- a/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
+++ b/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
@@ -3,3 +3,8 @@
 **Reasoning:** Phase B.2. Reuses iter_decisions from logmind.core.parser. Default behavior unchanged. --json bypasses quiet patch (primary output). Tests cover all three flags + combinations.
 
 ---
+## 2026-05-28 00:17 - B.2 PR #70 fixes: JSON stdout cleanliness + test coverage gaps
+
+**Reasoning:** clud-bug findings: (1) --json stdout was polluted by sync_messages + ok line — downstream parsers couldn't jq it. (2) Missing test coverage for --quiet --json + --json --all. Fixed: suppress sync chatter when as_json=True, route ok line to stderr via _ok(err=True). +3 tests.
+
+---

--- a/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
+++ b/docs/decisions-branches/feat__0.B.2-show-brief-limit-json.md
@@ -1,0 +1,5 @@
+## 2026-05-28 00:09 - B.2: show --brief / --limit / --json (v0.5.2)
+
+**Reasoning:** Phase B.2. Reuses iter_decisions from logmind.core.parser. Default behavior unchanged. --json bypasses quiet patch (primary output). Tests cover all three flags + combinations.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — PR #70 fixes: limit-only output bug + py3.8 Click compat + JSON-wins-over-brief test *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — B.2 PR #70 fixes: JSON stdout cleanliness + test coverage gaps *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — B.2: show --brief / --limit / --json (v0.5.2) *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — Fix B.3 PR #69 review threads: cwd leak, missing end-to-end test, state reset, byte counts *(feat/0.B.3-quiet-ok-output)* — [decisions-branches/feat__0.B.3-quiet-ok-output.md](decisions-branches/feat__0.B.3-quiet-ok-output.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — B.2: show --brief / --limit / --json (v0.5.2) *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — Fix B.3 PR #69 review threads: cwd leak, missing end-to-end test, state reset, byte counts *(feat/0.B.3-quiet-ok-output)* — [decisions-branches/feat__0.B.3-quiet-ok-output.md](decisions-branches/feat__0.B.3-quiet-ok-output.md)
 - **2026-05-27** — B.3: logmind --quiet / LOGMIND_QUIET=1 with ok output (v0.5.1) *(feat/0.B.3-quiet-ok-output)* — [decisions-branches/feat__0.B.3-quiet-ok-output.md](decisions-branches/feat__0.B.3-quiet-ok-output.md)
 - **2026-05-27** — Fix tree(1) -L off-by-one + --help docstring (clud-bug PR #68 findings) *(feat/0.B.1-file-structure-max-depth)* — [decisions-branches/feat__0.B.1-file-structure-max-depth.md](decisions-branches/feat__0.B.1-file-structure-max-depth.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — B.2 PR #70 fixes: JSON stdout cleanliness + test coverage gaps *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — B.2: show --brief / --limit / --json (v0.5.2) *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — Fix B.3 PR #69 review threads: cwd leak, missing end-to-end test, state reset, byte counts *(feat/0.B.3-quiet-ok-output)* — [decisions-branches/feat__0.B.3-quiet-ok-output.md](decisions-branches/feat__0.B.3-quiet-ok-output.md)
 - **2026-05-27** — B.3: logmind --quiet / LOGMIND_QUIET=1 with ok output (v0.5.1) *(feat/0.B.3-quiet-ok-output)* — [decisions-branches/feat__0.B.3-quiet-ok-output.md](decisions-branches/feat__0.B.3-quiet-ok-output.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.1"
+version = "0.5.2"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -87,7 +87,7 @@ def _ok(msg: str) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.1", prog_name="logmind")
+@click.version_option(version="0.5.2", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -909,8 +909,45 @@ def log(
     is_flag=True,
     help="Show all decisions including archived",
 )
-def show(show_all: bool):
-    """Show recent decisions."""
+@click.option(
+    "--brief",
+    is_flag=True,
+    help="One-line summary per decision (date + title) instead of "
+    "full markdown. Reduces ingest cost when agents read prior context.",
+)
+@click.option(
+    "--limit",
+    "-n",
+    "limit",
+    type=int,
+    default=None,
+    help="Show at most N most-recent decisions. Matches `logmind aggregate "
+    "--limit` convention. Default: no limit (full file when --brief absent; "
+    "all parsed entries when --brief set).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a JSON array of {date, title, source} objects. Stable schema "
+    "for downstream tools. Mutually exclusive with --brief (JSON wins).",
+)
+def show(show_all: bool, brief: bool, limit: Optional[int], as_json: bool):
+    """Show recent decisions.
+
+    Default: streams docs/decisions.md verbatim (the current 20 most-recent
+    entries; older are in decisions-archive.md, surface via --all).
+
+    Agent-friendly views (v0.5.2+):
+
+      --brief                one-line summary per entry
+      --limit N              cap to N most-recent
+      --json                 structured array for parsing
+
+    Combinations are allowed: `logmind show --brief --limit 5` for a quick
+    last-5 recall, `logmind show --json --limit 10 --all` for parsed access
+    across main + archive.
+    """
     docs_path = Path.cwd() / "docs"
 
     if not docs_path.exists():
@@ -928,24 +965,74 @@ def show(show_all: bool):
     decisions_path = docs_path / "decisions.md"
 
     if not decisions_path.exists():
-        click.secho("No decisions logged yet.", fg="yellow")
+        if as_json:
+            _orig_click_echo("[]")
+        else:
+            click.secho("No decisions logged yet.", fg="yellow")
         _ok("show: 0 decisions (none logged yet)")
         return
 
-    click.echo(decisions_path.read_text(encoding="utf-8"))
+    # Default verbatim view (preserves pre-v0.5.2 behavior).
+    if not (brief or as_json or limit is not None):
+        click.echo(decisions_path.read_text(encoding="utf-8"))
 
-    archive_shown = False
+        archive_shown = False
+        if show_all:
+            archive_path = docs_path / "decisions-archive.md"
+            if archive_path.exists():
+                click.echo("\n" + "=" * 80)
+                click.echo("ARCHIVED DECISIONS")
+                click.echo("=" * 80 + "\n")
+                click.echo(archive_path.read_text(encoding="utf-8"))
+                archive_shown = True
+        decisions_bytes = decisions_path.stat().st_size
+        suffix = " + archive" if archive_shown else ""
+        _ok(f"show: docs/decisions.md ({decisions_bytes} bytes{suffix})")
+        return
+
+    # Parsed-view paths (brief / limit / json). Load entries with provenance.
+    from logmind.core.parser import iter_decisions
+
+    entries = []
+    for dt, title in iter_decisions(decisions_path):
+        entries.append({"date": dt, "title": title, "source": "main"})
     if show_all:
         archive_path = docs_path / "decisions-archive.md"
         if archive_path.exists():
-            click.echo("\n" + "=" * 80)
-            click.echo("ARCHIVED DECISIONS")
-            click.echo("=" * 80 + "\n")
-            click.echo(archive_path.read_text(encoding="utf-8"))
-            archive_shown = True
-    decisions_bytes = decisions_path.stat().st_size
-    suffix = " + archive" if archive_shown else ""
-    _ok(f"show: docs/decisions.md ({decisions_bytes} bytes{suffix})")
+            for dt, title in iter_decisions(archive_path):
+                entries.append({"date": dt, "title": title, "source": "archive"})
+
+    # Sort newest-first so --limit N picks the latest entries.
+    entries.sort(key=lambda e: e["date"], reverse=True)
+    if limit is not None:
+        entries = entries[:limit]
+
+    if as_json:
+        import json
+        # ALWAYS emit JSON to stdout (bypass quiet patch — JSON is the
+        # primary output for downstream parsers, not progress chatter).
+        _orig_click_echo(
+            json.dumps(
+                [
+                    {
+                        "date": e["date"].isoformat(),
+                        "title": e["title"],
+                        "source": e["source"],
+                    }
+                    for e in entries
+                ],
+                indent=2,
+            )
+        )
+    elif brief:
+        # Use _orig_click_echo so brief output isn't suppressed by --quiet.
+        for e in entries:
+            _orig_click_echo(f"{e['date'].strftime('%Y-%m-%d %H:%M')} — {e['title']} [{e['source']}]")
+
+    _ok(
+        f"show: {len(entries)} decisions "
+        f"({'json' if as_json else 'brief' if brief else 'verbatim'})"
+    )
 
 
 @main.command()

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -1032,15 +1032,17 @@ def show(show_all: bool, brief: bool, limit: Optional[int], as_json: bool):
                 indent=2,
             )
         )
-    elif brief:
-        # Use _orig_click_echo so brief output isn't suppressed by --quiet.
+    else:
+        # brief OR limit-only: render one-line-per-entry. limit-only falls
+        # here because we only carry (date, title) from the parser (no body
+        # for verbatim) — one-line-per-entry is the natural "N most recent"
+        # answer. Use _orig_click_echo so output isn't suppressed by --quiet.
         for e in entries:
             _orig_click_echo(f"{e['date'].strftime('%Y-%m-%d %H:%M')} — {e['title']} [{e['source']}]")
 
     # Route the ok line to stderr in JSON mode so stdout is parseable JSON.
     _ok(
-        f"show: {len(entries)} decisions "
-        f"({'json' if as_json else 'brief' if brief else 'verbatim'})",
+        f"show: {len(entries)} decisions ({'json' if as_json else 'brief'})",
         err=as_json,
     )
 

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -79,11 +79,16 @@ def _set_quiet(flag: bool) -> None:
     _QUIET = bool(flag)
 
 
-def _ok(msg: str) -> None:
+def _ok(msg: str, *, err: bool = False) -> None:
     """Single-line success summary — ALWAYS emits, even with --quiet.
     Format: `ok <key-value>` so agents can parse it for chaining
-    (commit SHA / file count / depth)."""
-    _orig_click_echo(f"ok {msg}")
+    (commit SHA / file count / depth).
+
+    Pass `err=True` to route the line to stderr (used when stdout is
+    reserved for parseable primary output, e.g. `show --json`). Agents
+    still see the ok line; pipeline consumers (jq, etc.) get a clean
+    stdout."""
+    _orig_click_echo(f"ok {msg}", err=err)
 
 
 @click.group()
@@ -957,10 +962,13 @@ def show(show_all: bool, brief: bool, limit: Optional[int], as_json: bool):
         )
         sys.exit(1)
 
-    # Sync agent files from config
+    # Sync agent files from config. In --json mode, suppress sync chatter
+    # entirely (it's not the primary output and would corrupt `... | jq`
+    # pipelines by printing non-JSON before the array). Sync still runs.
     sync_messages = sync_agent_files_from_config()
-    for msg in sync_messages:
-        click.echo(msg)
+    if not as_json:
+        for msg in sync_messages:
+            click.echo(msg)
 
     decisions_path = docs_path / "decisions.md"
 
@@ -969,7 +977,7 @@ def show(show_all: bool, brief: bool, limit: Optional[int], as_json: bool):
             _orig_click_echo("[]")
         else:
             click.secho("No decisions logged yet.", fg="yellow")
-        _ok("show: 0 decisions (none logged yet)")
+        _ok("show: 0 decisions (none logged yet)", err=as_json)
         return
 
     # Default verbatim view (preserves pre-v0.5.2 behavior).
@@ -1029,9 +1037,11 @@ def show(show_all: bool, brief: bool, limit: Optional[int], as_json: bool):
         for e in entries:
             _orig_click_echo(f"{e['date'].strftime('%Y-%m-%d %H:%M')} — {e['title']} [{e['source']}]")
 
+    # Route the ok line to stderr in JSON mode so stdout is parseable JSON.
     _ok(
         f"show: {len(entries)} decisions "
-        f"({'json' if as_json else 'brief' if brief else 'verbatim'})"
+        f"({'json' if as_json else 'brief' if brief else 'verbatim'})",
+        err=as_json,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,21 @@ from click.testing import CliRunner
 from logmind.cli import agents, config, init, log, main, show, update, check_decisions, install_hook
 
 
+def _separate_streams_runner():
+    """CliRunner that keeps stdout/stderr separate across Click versions.
+
+    Click <8.4 (py3.8 ships Click 8.1.x) defaults to mix_stderr=True, which
+    merges stderr into stdout and breaks tests that parse `result.stdout`
+    as JSON when an `ok` line is routed to stderr. Click 8.4 removed the
+    kwarg but separates streams by default — so try the kwarg first, fall
+    back to the no-arg constructor.
+    """
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
 def test_cli_help():
     """Test main CLI help."""
     runner = CliRunner()
@@ -1311,7 +1326,7 @@ def test_show_json_stdout_is_parseable_no_chatter(git_repo, docs_dir, monkeypatc
         "# Decision Log\n\n## 2026-01-01 10:00 - Decision\n\n", encoding="utf-8"
     )
     monkeypatch.chdir(git_repo)
-    runner = CliRunner()
+    runner = _separate_streams_runner()
     result = runner.invoke(main, ["show", "--json"])
     assert result.exit_code == 0
     # stdout should be parseable JSON top-to-bottom (no extra chatter
@@ -1332,7 +1347,7 @@ def test_show_json_with_quiet_still_emits_json(git_repo, docs_dir, monkeypatch):
         "# Decision Log\n\n## 2026-01-01 10:00 - Decision\n\n", encoding="utf-8"
     )
     monkeypatch.chdir(git_repo)
-    runner = CliRunner()
+    runner = _separate_streams_runner()
     result = runner.invoke(main, ["--quiet", "show", "--json"])
     assert result.exit_code == 0
     parsed = json.loads(result.stdout)
@@ -1350,7 +1365,7 @@ def test_show_json_with_all_includes_archive(git_repo, docs_dir, monkeypatch):
         "# DA\n\n## 2025-12-01 09:00 - Older\n\n", encoding="utf-8"
     )
     monkeypatch.chdir(git_repo)
-    runner = CliRunner()
+    runner = _separate_streams_runner()
     result = runner.invoke(main, ["show", "--json", "--all"])
     assert result.exit_code == 0
     parsed = json.loads(result.stdout)
@@ -1358,3 +1373,46 @@ def test_show_json_with_all_includes_archive(git_repo, docs_dir, monkeypatch):
     assert sources == {"main", "archive"}, (
         f"--json --all should span both sources; got: {sources}"
     )
+
+
+def test_show_json_wins_over_brief(git_repo, docs_dir, monkeypatch):
+    """`--json --brief`: JSON precedence per help text contract.
+
+    Help on `--json` says: "Mutually exclusive with --brief (JSON wins)".
+    Verifies stdout is parseable JSON, not brief one-liners.
+    """
+    import json
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - Decision\n\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = _separate_streams_runner()
+    result = runner.invoke(main, ["show", "--json", "--brief"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+
+
+def test_show_limit_only_emits_decisions(git_repo, docs_dir, monkeypatch):
+    """`--limit N` alone (no --brief/--json) must emit decisions.
+
+    Regression for PR #70 review finding: the parsed-view path only
+    handled `as_json` and `brief`, leaving `--limit N` with no output
+    branch — user saw zero decisions followed by a misleading `ok` line.
+    """
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n"
+        "## 2026-01-01 10:00 - One\n\n"
+        "## 2026-01-02 11:00 - Two\n\n"
+        "## 2026-01-03 12:00 - Three\n\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--limit", "2"])
+    assert result.exit_code == 0
+    # Newest 2 entries present (Three + Two); oldest (One) capped out.
+    assert "Three" in result.output, f"expected newest in --limit 2; got: {result.output!r}"
+    assert "Two" in result.output
+    assert "One" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1299,3 +1299,62 @@ def test_show_json_emits_valid_array(git_repo, docs_dir, monkeypatch):
     assert parsed[0]["title"] == "First decision"
     assert parsed[0]["source"] == "main"
     assert "date" in parsed[0]
+
+
+def test_show_json_stdout_is_parseable_no_chatter(git_repo, docs_dir, monkeypatch):
+    """v0.5.2 PR #70 review: stdout under --json must be ONLY the JSON
+    array — no sync_messages, no `ok ...` line. Verifies the pipeline
+    contract for `logmind show --json | jq`.
+    """
+    import json
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - Decision\n\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--json"])
+    assert result.exit_code == 0
+    # stdout should be parseable JSON top-to-bottom (no extra chatter
+    # before or after the array).
+    parsed = json.loads(result.stdout)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+    # The ok line MUST go to stderr (agent-visible, pipeline-clean).
+    assert "ok show:" in result.stderr, (
+        f"--json should route the ok line to stderr; got stderr: {result.stderr!r}"
+    )
+
+
+def test_show_json_with_quiet_still_emits_json(git_repo, docs_dir, monkeypatch):
+    """--json bypasses the --quiet suppression — JSON is primary output."""
+    import json
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - Decision\n\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--quiet", "show", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+
+
+def test_show_json_with_all_includes_archive(git_repo, docs_dir, monkeypatch):
+    """--json --all spans main + archive sources."""
+    import json
+    (docs_dir / "decisions.md").write_text(
+        "# DL\n\n## 2026-02-01 10:00 - Recent\n\n", encoding="utf-8"
+    )
+    (docs_dir / "decisions-archive.md").write_text(
+        "# DA\n\n## 2025-12-01 09:00 - Older\n\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--json", "--all"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout)
+    sources = {e["source"] for e in parsed}
+    assert sources == {"main", "archive"}, (
+        f"--json --all should span both sources; got: {sources}"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1234,3 +1234,68 @@ def test_env_var_LOGMIND_QUIET_suppresses_progress_end_to_end(
     assert "✓" not in result.output, (
         f"LOGMIND_QUIET=1 should suppress ✓-prefixed progress lines; got: {result.output!r}"
     )
+
+
+# --- 0.B.2 (v0.5.2): show --brief / --limit / --json ---
+
+def test_show_brief_emits_one_line_per_entry(git_repo, docs_dir, monkeypatch):
+    """--brief: one line per decision (date + title + source)."""
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - First decision\n\nBody.\n\n"
+        "## 2026-01-02 11:00 - Second decision\n\nBody.\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--brief"])
+    assert result.exit_code == 0, result.output
+    lines = [l for l in result.output.splitlines() if not l.startswith("ok ")]
+    # Two decisions, two non-ok lines (verbatim markdown not emitted in brief mode).
+    summary_lines = [l for l in lines if l.strip() and "—" in l]
+    assert len(summary_lines) == 2, f"expected 2 brief lines; got: {result.output!r}"
+    # Newest-first: 2026-01-02 should come before 2026-01-01.
+    assert "2026-01-02" in summary_lines[0]
+    assert "2026-01-01" in summary_lines[1]
+    # Source tag present.
+    assert "[main]" in summary_lines[0]
+
+
+def test_show_limit_caps_to_n_most_recent(git_repo, docs_dir, monkeypatch):
+    """--limit N: keeps N most-recent (newest-first)."""
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n"
+        "## 2026-01-01 10:00 - One\n\n"
+        "## 2026-01-02 11:00 - Two\n\n"
+        "## 2026-01-03 12:00 - Three\n\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--brief", "--limit", "2"])
+    assert result.exit_code == 0
+    assert "Three" in result.output
+    assert "Two" in result.output
+    assert "One" not in result.output  # capped out
+
+
+def test_show_json_emits_valid_array(git_repo, docs_dir, monkeypatch):
+    """--json: stable structured output for downstream tools."""
+    import json
+    (docs_dir / "decisions.md").write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - First decision\n\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(git_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["show", "--json"])
+    assert result.exit_code == 0
+    # Pull out the JSON array from result.output (sync_messages may precede).
+    # JSON starts at first '[' and ends at matching ']'.
+    output = result.output
+    start = output.find("[")
+    end = output.rfind("]") + 1
+    assert start >= 0 and end > start, f"no JSON found: {output!r}"
+    parsed = json.loads(output[start:end])
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+    assert parsed[0]["title"] == "First decision"
+    assert parsed[0]["source"] == "main"
+    assert "date" in parsed[0]


### PR DESCRIPTION
Agent-friendly views on `logmind show`. Pure additive — existing behavior unchanged. Reuses `iter_decisions` from `logmind.core.parser`.

- `--brief`: one line per decision
- `--limit N` / `-n N`: cap to N newest
- `--json`: structured array (bypasses --quiet — JSON is primary output)
- Combinable

572/572 pass (+3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)