### PR TITLE
fix(v0.5.3): LOGMIND_QUIET=1 now suppresses click.secho progress chatter too (Phase 0.B.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-05-28
+
+### Fixed — `LOGMIND_QUIET=1` now also suppresses `click.secho` progress chatter
+
+v0.5.1 monkey-patched `click.echo` but intentionally left `click.secho`
+untouched on the rationale "errors via secho(fg='red'/'yellow') still
+print." Side effect: progress lines that also use secho (the `ℹ Default
+--stage all` cyan notice, `✓ Logged decision` green success) slipped
+through unsuppressed — visibly defeating the token-frugal mode for the
+most common command (`logmind log`).
+
+Fix: monkey-patch `click.secho` too, with a small wrapper that
+suppresses when `_QUIET` UNLESS `fg` is one of `_LOUD_COLORS` =
+`{red, yellow, bright_red, bright_yellow}`. Errors and warnings still
+print; progress chatter goes away.
+
+Concrete user-visible change with `LOGMIND_QUIET=1 logmind log "..."`:
+
+```
+# Before (v0.5.1, v0.5.2):                 # After (v0.5.3):
+ℹ Default --stage all (v0.2.7+): ...       ok logged: <sha> "..."
+✓ Logged decision: "..."
+ok logged: <sha> "..."
+```
+
+3 lines → 1 line. ~67% reduction on the most common quiet-mode call.
+
+### Tests
+
+- `tests/test_cli.py`: assert `LOGMIND_QUIET=1 logmind log` emits only
+  the single `ok logged:` line (no `ℹ`, no `✓`); assert error/warning
+  secho paths still print under quiet mode.
+
 ## [0.5.2] - 2026-05-28
 
 ### Added — `logmind show --brief` / `--limit` / `--json` (Phase B.2)

--- a/docs/decisions-branches/feat__0.B.3.1-secho-quiet-fix.md
+++ b/docs/decisions-branches/feat__0.B.3.1-secho-quiet-fix.md
@@ -1,0 +1,8 @@
+## 2026-05-28 00:48 - v0.5.3: patch click.secho for LOGMIND_QUIET=1 (progress vs error fg)
+
+**Reasoning:** v0.5.1 only patched click.echo, intentionally leaving secho untouched so red/yellow errors print. Side effect: progress lines using secho(fg=cyan) for ℹ notice and secho(fg=green) for ✓ success leaked through unsuppressed. User flagged 2026-05-28 that LOGMIND_QUIET=1 logmind log still emits 3 lines (ℹ, ✓, ok) instead of 1 (just ok). Fix: monkey-patch click.secho with a wrapper that suppresses when _QUIET unless fg in {red, yellow, bright_red, bright_yellow}. +2 tests: end-to-end log emits one ok line; direct-call regression guard asserts loud-color secho still prints under quiet mode. Smoke-tested: LOGMIND_QUIET=1 logmind log now emits exactly 'ok logged: <sha> "..."' — single line.
+
+**Implications:**
+- Future secho call sites adding NEW loud-color semantics should use red/yellow; using cyan/green for warnings would silently disappear under quiet mode.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05
 
+- **2026-05-28** — v0.5.3: patch click.secho for LOGMIND_QUIET=1 (progress vs error fg) *(feat/0.B.3.1-secho-quiet-fix)* — [decisions-branches/feat__0.B.3.1-secho-quiet-fix.md](decisions-branches/feat__0.B.3.1-secho-quiet-fix.md)
 - **2026-05-28** — PR #70 fixes: limit-only output bug + py3.8 Click compat + JSON-wins-over-brief test *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — B.2 PR #70 fixes: JSON stdout cleanliness + test coverage gaps *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
 - **2026-05-28** — B.2: show --brief / --limit / --json (v0.5.2) *(feat/0.B.2-show-brief-limit-json)* — [decisions-branches/feat__0.B.2-show-brief-limit-json.md](decisions-branches/feat__0.B.2-show-brief-limit-json.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.2"
+version = "0.5.3"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -46,32 +46,47 @@ from logmind.core.tree_gen import update_file_structure
 
 import os
 
-# Quiet-mode mechanism (v0.5.1+, mirrors clud-bug v0.6.7's pattern).
+# Quiet-mode mechanism (v0.5.1+, extended in v0.5.3 to also patch secho).
 #
-# Strategy: monkey-patch click.echo at module load so EVERY existing
-# call site (185 of them) becomes quiet-aware without touching each
-# one. Errors via click.secho(fg="red"/"yellow") still print because
-# we only filter the colorless click.echo path. ok() uses the
-# UNPATCHED echo so its single-line summary always emits.
+# Strategy: monkey-patch BOTH click.echo and click.secho at module load
+# so progress chatter is suppressed without touching 250+ call sites.
+# secho needs special handling — it carries semantic color: red/yellow
+# mean error/warning and MUST still print when LOGMIND_QUIET=1, while
+# green/cyan/blue/default are progress chatter and get suppressed.
+# ok() uses the UNPATCHED echo so its single-line summary always emits.
 #
 # Activation: LOGMIND_QUIET=1 env var OR --quiet/-q on the group.
 _QUIET = os.environ.get("LOGMIND_QUIET") == "1"
 _orig_click_echo = click.echo
+_orig_click_secho = click.secho
+
+# Colors that always print regardless of quiet mode — these carry
+# error/warning semantics agents need to see. Everything else (green
+# success, cyan info, default/none) is progress chatter and suppressed.
+_LOUD_COLORS = frozenset({"red", "yellow", "bright_red", "bright_yellow"})
 
 
 def _quiet_aware_echo(*args, **kwargs):
-    """Drop-in for click.echo that no-ops when _QUIET. Error paths use
-    click.secho(fg=...) which calls _orig_secho — secho is left
-    untouched, so warnings + errors still print."""
+    """Drop-in for click.echo that no-ops when _QUIET."""
     if _QUIET:
         return
     return _orig_click_echo(*args, **kwargs)
 
 
-# Install the patch immediately so subcommand functions captured at
-# import time pick it up. _QUIET is re-read on every call so the
+def _quiet_aware_secho(*args, **kwargs):
+    """Drop-in for click.secho. Suppresses when _QUIET unless fg is one
+    of the loud colors (red/yellow) — those carry error/warning
+    semantics and must still print in quiet mode."""
+    if _QUIET and kwargs.get("fg") not in _LOUD_COLORS:
+        return
+    return _orig_click_secho(*args, **kwargs)
+
+
+# Install the patches immediately so subcommand functions captured at
+# import time pick them up. _QUIET is re-read on every call so the
 # group-level --quiet flag can flip it mid-run.
 click.echo = _quiet_aware_echo
+click.secho = _quiet_aware_secho
 
 
 def _set_quiet(flag: bool) -> None:
@@ -92,7 +107,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.2", prog_name="logmind")
+@click.version_option(version="0.5.3", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1251,6 +1251,82 @@ def test_env_var_LOGMIND_QUIET_suppresses_progress_end_to_end(
     )
 
 
+# --- 0.B.3.1 (v0.5.3): click.secho also suppressed under LOGMIND_QUIET ---
+
+def test_quiet_suppresses_secho_progress_in_log(git_repo, monkeypatch):
+    """v0.5.3 fix: LOGMIND_QUIET=1 logmind log must NOT emit the
+    `ℹ Default --stage all` cyan notice or the `✓ Logged decision`
+    green-success line. Pre-v0.5.3 only click.echo was patched; secho
+    leaked through. After: only the `ok logged: ...` line prints."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=git_repo):
+        # Init first (uses default — not quiet — to set up docs/).
+        init_result = runner.invoke(init)
+        assert init_result.exit_code == 0
+
+        # Now flip LOGMIND_QUIET on and exercise log.
+        monkeypatch.setenv("LOGMIND_QUIET", "1")
+        result = runner.invoke(
+            main, ["log", "test secho quiet fix", "--no-push"]
+        )
+        assert result.exit_code == 0, f"log should succeed: {result.output!r}"
+        # Exactly one ok line.
+        ok_lines = [l for l in result.output.splitlines() if l.startswith("ok ")]
+        assert len(ok_lines) == 1, (
+            f"LOGMIND_QUIET=1 log must emit exactly one ok line; got: {result.output!r}"
+        )
+        # Neither secho-emitted progress glyph appears.
+        assert "ℹ" not in result.output, (
+            f"v0.5.3: LOGMIND_QUIET=1 should suppress ℹ-prefixed secho notice; got: {result.output!r}"
+        )
+        assert "✓" not in result.output, (
+            f"v0.5.3: LOGMIND_QUIET=1 should suppress ✓-prefixed secho success; got: {result.output!r}"
+        )
+
+
+def test_quiet_still_prints_error_warning_secho(monkeypatch):
+    """Loud-color secho (fg=red, fg=yellow) MUST still print even under
+    LOGMIND_QUIET — agents need to see errors and warnings. Regression
+    guard against over-suppression in v0.5.3."""
+    from logmind.cli import _quiet_aware_secho, _set_quiet
+    import click as click_mod
+
+    # Capture by patching the underlying _orig_click_secho via a buffer.
+    captured = []
+    orig = click_mod.secho
+
+    def capture(*args, **kwargs):
+        captured.append((args, kwargs))
+
+    # Activate quiet mode and exercise the wrapper directly.
+    _set_quiet(True)
+    try:
+        # Monkey-patch the original-secho the wrapper delegates to so we
+        # don't actually emit ANSI sequences in the test.
+        import logmind.cli as cli_mod
+        monkeypatch.setattr(cli_mod, "_orig_click_secho", capture)
+
+        # Loud colors must pass through.
+        _quiet_aware_secho("err msg", fg="red")
+        _quiet_aware_secho("warn msg", fg="yellow")
+        _quiet_aware_secho("err bright", fg="bright_red")
+        _quiet_aware_secho("warn bright", fg="bright_yellow")
+
+        # Quiet colors must be suppressed.
+        _quiet_aware_secho("info msg", fg="cyan")
+        _quiet_aware_secho("success msg", fg="green")
+        _quiet_aware_secho("default fg", )  # no fg at all
+    finally:
+        _set_quiet(False)
+
+    # 4 loud colors should have passed through; 3 quiet calls suppressed.
+    assert len(captured) == 4, (
+        f"loud-color secho calls must print under quiet mode; captured: {captured!r}"
+    )
+    bodies = [args[0] for args, _ in captured]
+    assert bodies == ["err msg", "warn msg", "err bright", "warn bright"]
+
+
 # --- 0.B.2 (v0.5.2): show --brief / --limit / --json ---
 
 def test_show_brief_emits_one_line_per_entry(git_repo, docs_dir, monkeypatch):


### PR DESCRIPTION
## Summary

- v0.5.1 patched `click.echo` but intentionally left `click.secho` unpatched (rationale: keep error/warning prints). Side effect: progress lines that use secho — the `ℹ Default --stage all` cyan notice + `✓ Logged decision` green-success — leaked through, visibly defeating quiet mode on the most common command.
- Fix: also patch `click.secho` with a wrapper that suppresses when `_QUIET` UNLESS `fg in {red, yellow, bright_red, bright_yellow}` (loud colors carry error/warning semantics).
- Before vs after on `LOGMIND_QUIET=1 logmind log "..."`: 3 lines → 1 line (~67% reduction).

## Test plan

- [x] Local pytest: 579 pass + 1 skipped (was 577; +2 new tests).
- [x] New end-to-end test: `LOGMIND_QUIET=1 logmind log` emits exactly one `ok logged:` line (no ℹ, no ✓).
- [x] New regression guard: loud-color (red/yellow/bright_red/bright_yellow) secho calls still print under quiet mode.
- [x] Manual smoke: `LOGMIND_QUIET=1 logmind log "smoke test" --no-push` → single `ok logged: 15d0160 "smoke test"` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)