### PR TITLE
feat: RTK-inspired fail-safe patterns — warn-not-silent + orphan-tmp cleanup (Phase 0.5 / 0.0.T, logmind side)

### DIFF
--- a/docs/decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md
+++ b/docs/decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md
@@ -1,0 +1,8 @@
+## 2026-05-29 09:18 - 0.0.T (logmind side): RTK-inspired fail-safe → warn-not-silent on parser; orphan-cleanup on atomic_write
+
+**Reasoning:** Two RTK-inspired patterns applied to logmind. (1) src/logmind/core/parser.py iter_decisions: previously caught ValueError on malformed date/time in headers (regex matched but date impossible like '2026-13-45 25:99 - title') and silent-passed. Now emits stderr warning naming file + lineno + the parse error before skipping the entry. The Phase 0 hindsight bug — Phase B's brief-elision test on PR #72 wouldn't have caught this if the input were corrupt. (2) src/logmind/core/atomic_io.py atomic_write_text: previously left an orphaned .tmp sibling behind if Path.write_text raised mid-write. Now catches BaseException (covers KeyboardInterrupt), unlinks the orphan with missing_ok=True, then re-raises. Cleanup is best-effort — if unlink ALSO fails, the original exception still propagates (cleanup never masks the load-bearing error). +6 tests in tests/test_fail_safe_0_0_T.py: warns on malformed date, no warning on clean file, no warning on missing file; cleans up tmp on write failure, never masks original exception, happy path unchanged. 608 pass (full suite).
+
+**Implications:**
+- Pattern shape ports cleanly to clud-bug — same try/except/best-effort-cleanup applies to lib/skills.js GraphQL parse fallbacks. Will ship clud-bug side as a separate PR (different repo) after PR #109 (golden gate) lands so the prompt-changes are gated.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (62 decisions)
+## 2026-05 (63 decisions)
 
-- **2026-05-29** — chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I) *(chore/agents-md-import)* — [decisions-branches/chore__agents-md-import.md](decisions-branches/chore__agents-md-import.md)
-- *... 60 more decisions ...*
+- **2026-05-29** — 0.0.T (logmind side): RTK-inspired fail-safe → warn-not-silent on parser; orphan-cleanup on atomic_write *(feat/0.0.T-rtk-inspired-fail-safe)* — [decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md](decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md)
+- *... 61 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/src/logmind/core/atomic_io.py
+++ b/src/logmind/core/atomic_io.py
@@ -39,8 +39,24 @@ def atomic_write_text(
     The tmp file lives next to ``path`` (not in ``/tmp``) so the rename
     is guaranteed atomic — ``os.replace`` is atomic only within a single
     filesystem.
+
+    Fail-safe (0.0.T, RTK-inspired): if either step raises, the original
+    file is untouched AND we make a best-effort attempt to remove the
+    orphaned tmp sibling so the next write doesn't trip on it. The
+    original exception still propagates — cleanup never masks the real
+    error.
     """
     path = Path(path)
     tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(content, encoding=encoding)
-    os.replace(tmp, path)
+    try:
+        tmp.write_text(content, encoding=encoding)
+        os.replace(tmp, path)
+    except BaseException:
+        # On any failure (encoding error, disk full, KeyboardInterrupt
+        # mid-write), remove the orphaned tmp sibling. Best-effort:
+        # never mask the underlying exception with a cleanup failure.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise

--- a/src/logmind/core/parser.py
+++ b/src/logmind/core/parser.py
@@ -1,6 +1,7 @@
 """Shared decision file parsing utilities."""
 
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Generator, Tuple
@@ -9,14 +10,32 @@ DECISION_HEADER = re.compile(r"^## (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}) - (.+)$")
 
 
 def iter_decisions(path: Path) -> Generator[Tuple[datetime, str], None, None]:
-    """Yield (datetime, title) tuples from a decision markdown file."""
+    """Yield (datetime, title) tuples from a decision markdown file.
+
+    Headers that match the structure but carry a malformed date/time
+    (e.g. "2026-13-45 25:99 - title") are SKIPPED with a stderr warning
+    rather than silently dropped. Pattern: RTK-inspired (0.0.T) —
+    fail-safe → loud rather than silent on parse failure.
+
+    Missing files return empty (this is expected when iterating
+    optional decision-branch files).
+    """
     if not path.exists():
         return
-    for line in path.read_text(encoding="utf-8").splitlines():
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
         m = DECISION_HEADER.match(line)
-        if m:
-            try:
-                dt = datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M")
-                yield dt, m.group(3)
-            except ValueError:
-                pass
+        if not m:
+            continue
+        try:
+            dt = datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M")
+        except ValueError as e:
+            # Header matched the structure but the date/time is
+            # malformed. Warn loudly so the user can fix the source
+            # file; do NOT yield anything for this entry.
+            print(
+                f"  ! logmind: skipping malformed decision header at {path}:{lineno}: {e}",
+                file=sys.stderr,
+            )
+            continue
+        yield dt, m.group(3)

--- a/tests/test_fail_safe_0_0_T.py
+++ b/tests/test_fail_safe_0_0_T.py
@@ -1,0 +1,161 @@
+"""Tests for 0.0.T (RTK-inspired fail-safe patterns).
+
+Two surfaces audited:
+
+1. ``iter_decisions`` in ``src/logmind/core/parser.py`` — previously
+   silent-dropped malformed decision headers (regex matched but the
+   date/time failed to parse). Now emits a stderr warning naming the
+   file + lineno + parse error before skipping.
+
+2. ``atomic_write_text`` in ``src/logmind/core/atomic_io.py`` —
+   previously left an orphaned ``.tmp`` sibling behind if the write
+   failed partway. Now cleans up the orphan on any exception, while
+   still propagating the original exception (cleanup never masks it).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+
+# --- iter_decisions: warn on malformed header instead of silent-drop ---
+
+def test_iter_decisions_warns_on_malformed_date(tmp_path, capsys):
+    """Header structure matches but the date is impossible. The parser
+    must skip the entry AND warn on stderr — silent drops were the
+    Phase 0 hindsight bug 0.0.T fixes."""
+    from logmind.core.parser import iter_decisions
+
+    path = tmp_path / "decisions.md"
+    path.write_text(
+        "# Decision Log\n\n"
+        "## 2026-01-01 10:00 - valid entry\n\n"
+        "## 2026-13-45 25:99 - malformed date\n\n"   # impossible date
+        "## 2026-02-02 11:00 - another valid entry\n\n",
+        encoding="utf-8",
+    )
+
+    entries = list(iter_decisions(path))
+    # Both valid entries yielded; malformed one skipped.
+    assert len(entries) == 2
+    assert entries[0][1] == "valid entry"
+    assert entries[1][1] == "another valid entry"
+
+    # And — critically — the malformed entry generated a stderr warning
+    # naming the file, line number, and the parse error.
+    captured = capsys.readouterr()
+    assert "logmind: skipping malformed decision header" in captured.err
+    assert str(path) in captured.err
+    # The malformed entry is at line 5 (1-indexed, after 4 lines of
+    # prelude/valid entry/blank).
+    assert ":5:" in captured.err
+
+
+def test_iter_decisions_no_warning_on_well_formed_file(tmp_path, capsys):
+    """No spurious warnings on a clean file — only the malformed-header
+    path emits to stderr."""
+    from logmind.core.parser import iter_decisions
+
+    path = tmp_path / "decisions.md"
+    path.write_text(
+        "# Decision Log\n\n## 2026-01-01 10:00 - clean entry\n\n",
+        encoding="utf-8",
+    )
+    entries = list(iter_decisions(path))
+    assert len(entries) == 1
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_iter_decisions_missing_file_returns_empty_no_warning(tmp_path, capsys):
+    """Missing file is expected (optional decision-branch files); do
+    not warn. Only malformed-header detection warns."""
+    from logmind.core.parser import iter_decisions
+
+    entries = list(iter_decisions(tmp_path / "does-not-exist.md"))
+    assert entries == []
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# --- atomic_write_text: clean up orphan tmp file on failure ---
+
+def test_atomic_write_cleans_up_tmp_on_write_failure(tmp_path, monkeypatch):
+    """If Path.write_text raises mid-write, the orphaned .tmp sibling
+    must be removed. Otherwise the next write would either trip on the
+    stale file or have to ignore it."""
+    from logmind.core import atomic_io
+
+    target = tmp_path / "out.md"
+    tmp_sibling = tmp_path / "out.md.tmp"
+
+    # Monkey-patch Path.write_text to fail AFTER creating the tmp file
+    # (simulating a disk-full or interrupt scenario where bytes started
+    # to land but the write didn't complete).
+    real_write_text = Path.write_text
+    calls = {"n": 0}
+
+    def failing_write_text(self, content, encoding="utf-8"):
+        # Create a partial file first, then fail.
+        real_write_text(self, "PARTIAL", encoding=encoding)
+        calls["n"] += 1
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        atomic_io.atomic_write_text(target, "new content")
+
+    # Original target untouched (it never existed in this test, so
+    # absent is the right state).
+    assert not target.exists()
+    # CRITICAL: the orphaned tmp must have been cleaned up.
+    assert not tmp_sibling.exists(), (
+        "atomic_write_text must clean up the .tmp sibling on failure — "
+        "leaving it behind would trip the next write"
+    )
+    # And the failure path ran exactly once (no retry / hidden swallow).
+    assert calls["n"] == 1
+
+
+def test_atomic_write_cleanup_never_masks_original_exception(tmp_path, monkeypatch):
+    """If both the write AND the cleanup fail, the ORIGINAL exception
+    must propagate — never replaced by the cleanup's exception. RTK
+    pattern: cleanup is best-effort, never load-bearing."""
+    from logmind.core import atomic_io
+
+    target = tmp_path / "out.md"
+
+    # Force the write to fail first.
+    def failing_write_text(self, content, encoding="utf-8"):
+        raise OSError("PRIMARY: write failed")
+
+    # Force the cleanup (tmp.unlink) to also fail.
+    real_unlink = Path.unlink
+
+    def failing_unlink(self, missing_ok=False):
+        raise OSError("SECONDARY: unlink failed (should not propagate)")
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+    monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+    # The PRIMARY exception is what surfaces; the SECONDARY (cleanup)
+    # is swallowed.
+    with pytest.raises(OSError, match="PRIMARY: write failed"):
+        atomic_io.atomic_write_text(target, "x")
+
+
+def test_atomic_write_success_path_unchanged(tmp_path):
+    """Sanity: the happy path still works (no regression from adding
+    the try/except)."""
+    from logmind.core.atomic_io import atomic_write_text
+
+    target = tmp_path / "out.md"
+    atomic_write_text(target, "content\n")
+    assert target.read_text(encoding="utf-8") == "content\n"
+    # No orphan tmp sibling left behind.
+    assert not (tmp_path / "out.md.tmp").exists()


### PR DESCRIPTION
## Summary

Two RTK-inspired fail-safe patterns applied to logmind. This is the **logmind side** of 0.0.T; the clud-bug side (tee-hint when caps fire + lib/skills.js parse fallback) ships as a separate PR after clud-bug PR #109 (golden gate) lands.

## What changed

| File | Pattern | Before | After |
|---|---|---|---|
| `src/logmind/core/parser.py` | warn-not-silent | `except ValueError: pass` silently dropped malformed headers | Emits stderr warning naming file + lineno + parse error; skips entry |
| `src/logmind/core/atomic_io.py` | best-effort cleanup | Orphan `.tmp` sibling left behind on write failure | Cleans up orphan with `missing_ok=True`; re-raises original exception. Cleanup never masks the load-bearing error |

## Why

RTK's `skip_filter_on_failure` (in `src/core/runner.rs:71-133`) inspired the second pattern — best-effort recovery without losing the original signal. The first pattern is the Phase 0 hindsight bug: silent drops on malformed parses hide corruption rather than surface it.

## Test plan

- [x] `pytest -q` — 608 passed, 1 skipped (+6 new in `tests/test_fail_safe_0_0_T.py`).
- [x] Tests cover: malformed-date warning, no warning on clean / missing files, tmp cleanup on write failure, original exception propagated when cleanup also fails, happy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)