### PR TITLE
release: v0.5.5 — RTK-inspired fail-safe patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-05-29
+
+### Added — RTK-inspired fail-safe patterns (Phase 0.5 / 0.0.T, logmind side)
+
+Two surgical patterns lifted from RTK (MIT-licensed) into logmind's
+parser + atomic-write paths. RTK is not adopted as a dependency; only
+the patterns ship.
+
+**Parser warn-not-silent** (`src/logmind/core/parser.py`):
+`iter_decisions` previously caught `ValueError` on malformed decision
+header dates (e.g. `"## 2026-13-45 25:99 - title"` — regex matches but
+the date doesn't parse) and silently dropped the entry. Now emits a
+stderr warning naming the file + lineno + parse error, then skips.
+Silent drops were the Phase 0 hindsight bug this addresses.
+
+```
+  ! logmind: skipping malformed decision header at
+  docs/decisions-branches/foo.md:14: month must be in 1..12
+```
+
+**Atomic-write orphan cleanup** (`src/logmind/core/atomic_io.py`):
+`atomic_write_text` previously left an orphaned `.tmp` sibling behind
+if the write failed mid-flight. Now catches `BaseException` (covers
+`KeyboardInterrupt`), unlinks the orphan with `missing_ok=True`, then
+re-raises the original exception. Cleanup is best-effort: if the
+unlink ALSO fails, the original exception still propagates so the
+real error is never masked.
+
+### Tests
+
++6 tests in `tests/test_fail_safe_0_0_T.py`: malformed-date warning,
+no warning on clean / missing files, tmp cleanup on write failure,
+original exception preserved when cleanup also fails, happy path
+unchanged. Full suite: 614 passed, 1 skipped.
+
+### Impact
+
+Quality boost (Q6 — never silent-drop warnings). No measurable token
+cost change.
+
 ## [0.5.4] - 2026-05-28
 
 ### Added — `docs/timeline.md` ships brief format on disk (Phase 0.B.4)

--- a/docs/decisions-branches/release__v0.5.5.md
+++ b/docs/decisions-branches/release__v0.5.5.md
@@ -1,0 +1,8 @@
+## 2026-05-29 09:24 - Release logmind v0.5.5 — RTK-inspired fail-safe (0.0.T logmind side)
+
+**Reasoning:** Version bump packaging PR after #76 merged. pyproject.toml + __init__.py + cli.py click.version_option bumped to 0.5.5. CHANGELOG.md gets a [0.5.5] - 2026-05-29 section documenting both fail-safe patterns (parser warn-not-silent + atomic_io orphan cleanup) with code-shape examples and impact notes.
+
+**Implications:**
+- Once merged + tagged, the GitHub release workflow uploads to PyPI; agent-skills can then bump logmind in its dev requirements pin if it has one (audit). clud-bug consumes logmind via subprocess so no version-pin churn there.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (63 decisions)
+## 2026-05 (64 decisions)
 
-- **2026-05-29** — 0.0.T (logmind side): RTK-inspired fail-safe → warn-not-silent on parser; orphan-cleanup on atomic_write *(feat/0.0.T-rtk-inspired-fail-safe)* — [decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md](decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md)
-- *... 61 more decisions ...*
+- **2026-05-29** — Release logmind v0.5.5 — RTK-inspired fail-safe (0.0.T logmind side) *(release/v0.5.5)* — [decisions-branches/release__v0.5.5.md](decisions-branches/release__v0.5.5.md)
+- *... 62 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.4"
+version = "0.5.5"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -107,7 +107,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.4", prog_name="logmind")
+@click.version_option(version="0.5.5", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",


### PR DESCRIPTION
## Summary

Version bump from 0.5.4 to 0.5.5 to ship the changes from #76 (0.0.T logmind side: parser warn-not-silent + atomic_io orphan-tmp cleanup) on PyPI.

## Files touched

- `pyproject.toml` — `version = "0.5.5"`
- `src/logmind/__init__.py` — `__version__ = "0.5.5"`
- `src/logmind/cli.py` — `@click.version_option(version="0.5.5", …)`
- `CHANGELOG.md` — adds `[0.5.5] - 2026-05-29` section
- `docs/timeline.md` — auto-regen
- `docs/decisions-branches/release__v0.5.5.md` — logmind decision entry

## Test plan

- [x] `pytest tests/test_fail_safe_0_0_T.py` — 6/6 pass
- [x] `logmind --version` reports `0.5.5`
- [ ] CI green
- [ ] After merge: tag `v0.5.5`, GitHub release uploads to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)