### PR TITLE
feat(v0.5.7): bench/org_cumulative real impl — closes last Q7-logmind stub (Phase 0.5 §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-05-29
+
+### Added — `bench/org_cumulative.py` real impl (Phase 0.5 §2)
+
+Closes the last Q7-logmind bench stub. The 4-angle frame is now
+fully populated: `per-call` ✅, `worst-case` ✅, `per-session` ✅
+(v0.5.6), `org-cumulative` ✅ (this release).
+
+Same data source as `per-session` (real agent session logs at
+`~/.claude/projects/*/*.jsonl`), but rolls up differently: instead
+of averaging `net_pct` across sessions, sums bytes across all
+sessions and all repos to produce one global cumulative `net_pct`
+plus per-repo share.
+
+Same informational-only treatment as `per-session` — both share the
+`git log --oneline -100` baseline which is too thin to interpret
+sign as a quality signal. The load-bearing data:
+
+- `per_repo_share` (dict by cwd) — which consuming repos contribute
+  most of the sampled byte volume. Used by Step 4 validation to
+  spot per-consumer outliers (>2× median share signals a cache-key
+  regression in that consumer's prompt prefix).
+- `repos_sampled`, `total_logmind_bytes`, `total_git_bytes` —
+  cross-checks against `per-session` (informational invariants
+  hold when both populate cleanly).
+
+Sample output on a real dev machine:
+
+```
+org-cumulative +130% bytes amortized (across 7 repos, 90 KB logmind / 39 KB git) ℹ info (Step 4 / 0.B.5 / 0.B.6 inputs)
+```
+
+### Changed
+
+- `bench/__main__.py` informational set: `per-session` AND
+  `org-cumulative` both excluded from exit-gate (both share the
+  thin baseline). Verdict label updated from "gates 0.B.5/0.B.6 via
+  shares" to "Step 4 / 0.B.5 / 0.B.6 inputs" to reflect the dual
+  consumer (org-cumulative feeds Step 4; per-session gates
+  0.B.5/0.B.6).
+- `run_org_cumulative_stub` retained as a back-compat alias that
+  delegates to `run_org_cumulative`; pin-tested by
+  `test_org_cumulative_stub_shim_calls_real_impl` so the alias
+  can't quietly diverge to the old placeholder shape.
+
+### Tests
+
+3 new tests in `tests/test_bench.py`:
+
+- `test_org_cumulative_no_sessions_returns_stub` — stub-invariant.
+- `test_org_cumulative_aggregates_across_sessions_and_repos` —
+  end-to-end fixture: two sessions across two distinct logmind
+  repos, validates global sum aggregation (not per-session
+  averaging) AND `per_repo_share` keys both repos with correct
+  weights.
+- `test_org_cumulative_per_repo_share_isolates_outlier` — 3:1
+  byte ratio across 2 repos, asserts the dominant repo's share
+  matches `3000 / 3500` and small repo's matches `500 / 3500`.
+  This is the metric Step 4 uses to flag per-consumer cache-key
+  regressions.
+
 ## [0.5.6] - 2026-05-29
 
 ### Added — `bench/per_session.py` real impl (Phase 0.5 Step 1)

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -16,14 +16,14 @@ from typing import Any
 from .per_call import run_per_call
 from .worst_case import run_worst_case
 from .per_session import run_per_session
-from .org_cumulative import run_org_cumulative_stub
+from .org_cumulative import run_org_cumulative
 
 
 ANGLES = {
     "per-call": run_per_call,
     "worst-case": run_worst_case,
     "per-session": run_per_session,
-    "org-cumulative": run_org_cumulative_stub,
+    "org-cumulative": run_org_cumulative,
 }
 
 
@@ -72,14 +72,15 @@ def main() -> int:
         print(_format_human(results))
 
     # Exit non-zero if any GATING non-stub angle is a NET SPENDER.
-    # Stubs (net_pct=None) don't gate. Per-session is informational
-    # only — its baseline (``git log --oneline -100``) is conceptually
-    # too thin (agents would not get equivalent context from raw git
-    # log alone in the no-logmind world), so the absolute ``net_pct``
-    # isn't a quality signal. The angle's value is the per-file shares
-    # (``per_file_share``, ``agents_md_block_share``) which gate the
-    # conditional 0.B.5 / 0.B.6 candidates downstream.
-    informational = {"per-session"}
+    # Stubs (net_pct=None) don't gate. Per-session AND org-cumulative
+    # are informational only — they share the ``git log --oneline -100``
+    # baseline, which is conceptually too thin (agents would not get
+    # equivalent context from raw git log alone in the no-logmind world),
+    # so the absolute ``net_pct`` isn't a quality signal. Per-session's
+    # value is per-file shares (``per_file_share``, ``agents_md_block_share``)
+    # which gate 0.B.5 / 0.B.6; org-cumulative's value is ``per_repo_share``
+    # which surfaces per-consumer outliers for Step 4 validation.
+    informational = {"per-session", "org-cumulative"}
     any_spender = any(
         (r.get("net_pct") or 0) > 0
         for name, r in results.items()
@@ -92,7 +93,7 @@ def main() -> int:
 
 def _format_human(results: dict[str, Any]) -> str:
     lines = ["ok: 4-angle Q7-logmind compliance" if not _has_spender(results) else "FAIL: Q7-logmind net-spender detected"]
-    informational = {"per-session"}
+    informational = {"per-session", "org-cumulative"}
     for name, r in results.items():
         if name.startswith("_"):
             continue
@@ -104,10 +105,11 @@ def _format_human(results: dict[str, Any]) -> str:
             lines.append(f"  {name:<14} (stub — not yet implemented)")
             continue
         if name in informational:
-            # Per-session's ``git log --oneline`` baseline is too thin
-            # to interpret pos/neg as quality — the per-file shares in
-            # ``label`` are the load-bearing data.
-            verdict = "ℹ info (gates 0.B.5/0.B.6 via shares)"
+            # Same baseline-thinness concern for both per-session and
+            # org-cumulative — pos/neg net_pct isn't a quality signal.
+            # The load-bearing data is in ``label`` + per-repo / per-file
+            # shares (Step 4 validation + 0.B.5/0.B.6 gating).
+            verdict = "ℹ info (Step 4 / 0.B.5 / 0.B.6 inputs)"
         else:
             verdict = "✅ saver" if pct < 0 else "❌ spender"
         sign = "" if pct < 0 else "+"
@@ -122,9 +124,10 @@ def _format_human(results: dict[str, Any]) -> str:
 
 
 def _has_spender(results: dict[str, Any]) -> bool:
-    """Header verdict — informational angles (per-session) are excluded
-    so the human-readable banner matches the exit-gate logic."""
-    informational = {"per-session"}
+    """Header verdict — informational angles (per-session, org-cumulative)
+    are excluded so the human-readable banner matches the exit-gate
+    logic."""
+    informational = {"per-session", "org-cumulative"}
     return any(
         isinstance(r, dict) and (r.get("net_pct") or 0) > 0
         for name, r in results.items()

--- a/bench/org_cumulative.py
+++ b/bench/org_cumulative.py
@@ -13,8 +13,8 @@ sampled byte volume — used by Step 4 validation to spot per-repo
 outliers (a single misconfigured consumer >2× the median share would
 indicate a cache-key regression).
 
-Closes the last Q7-logmind bench stub. See plan §2 in
-``/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md``.
+Closes the last Q7-logmind bench stub. See the Phase 0.5 §2 entry in
+``CHANGELOG.md`` for the ship/defer rationale.
 """
 
 from __future__ import annotations
@@ -38,7 +38,16 @@ class OrgCumulativeResult:
     label: str
     net_pct: float | None
     stub: bool
+    # All sessions whose cwd is a logmind repo. Matches per_session's
+    # ``sessions_sampled`` semantic so the cross-check invariant
+    # (``org_cumulative.sessions_sampled == per_session.sessions_sampled``
+    # when run against the same home dir) holds.
     sessions_sampled: int = 0
+    # Subset of ``sessions_sampled`` that actually contributed bytes
+    # (>0 decision-doc reads AND non-zero git baseline). Matches
+    # per_session's ``sessions_with_decision_reads``. These are the
+    # sessions whose bytes flow into ``total_logmind_bytes``.
+    sessions_contributing: int = 0
     repos_sampled: int = 0
     total_logmind_bytes: int = 0
     total_git_bytes: int = 0
@@ -62,6 +71,7 @@ def run_org_cumulative(home: Path | None = None) -> OrgCumulativeResult:
         )
 
     sessions_sampled = 0
+    sessions_contributing = 0
     total_logmind_bytes = 0
     total_git_bytes = 0
     repo_bytes: dict[str, int] = {}
@@ -88,6 +98,7 @@ def run_org_cumulative(home: Path | None = None) -> OrgCumulativeResult:
             # Same divide-by-zero defence as per_session: skip the
             # session entirely rather than fake a "free" git baseline.
             continue
+        sessions_contributing += 1
         total_logmind_bytes += session_logmind_bytes
         total_git_bytes += git_bytes
         repo_key = str(cwd)
@@ -128,6 +139,7 @@ def run_org_cumulative(home: Path | None = None) -> OrgCumulativeResult:
         net_pct=net_pct,
         stub=False,
         sessions_sampled=sessions_sampled,
+        sessions_contributing=sessions_contributing,
         repos_sampled=repos_sampled,
         total_logmind_bytes=total_logmind_bytes,
         total_git_bytes=total_git_bytes,

--- a/bench/org_cumulative.py
+++ b/bench/org_cumulative.py
@@ -1,21 +1,36 @@
-"""Org cumulative angle (STUB).
+"""Org-cumulative angle (real impl).
 
-The plan: aggregate per-call + per-session measurements across 5
-consuming repos over 30 days. Total bytes-saved minus total bytes-spent
-must be net negative.
+Same data source as :mod:`bench.per_session` (real agent session logs at
+``~/.claude/projects/*/*.jsonl``), but rolls up DIFFERENTLY: instead of
+averaging ``net_pct`` across sessions, we **sum bytes across all
+sessions and all repos** to produce one global cumulative ``net_pct``.
 
-Initial stub returns null `net_pct`. Real implementation depends on
-per_session.py shipping first (it consumes session-log data) AND on a
-mechanism to walk 5 consuming repos' Git history for logmind-log usage
-frequency.
+The angle is informational (same exclusion from the exit-gate as
+``per-session``): the ``git log --oneline -100`` baseline is too thin
+to interpret pos/neg as a quality signal. The load-bearing data is
+``per_repo_share`` — which consuming repos contribute most of the
+sampled byte volume — used by Step 4 validation to spot per-repo
+outliers (a single misconfigured consumer >2× the median share would
+indicate a cache-key regression).
 
-Ship the stub now so the 4-angle frame is complete in the dashboard;
-real implementation lands as a follow-up PR.
+Closes the last Q7-logmind bench stub. See plan §2 in
+``/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .per_session import (
+    _bucket,
+    _git_equivalent_bytes,
+    _GIT_BASELINE_CACHE,
+    _is_logmind_repo,
+    _session_cwd,
+    _session_paths,
+    _walk_reads,
+)
 
 
 @dataclass
@@ -23,11 +38,105 @@ class OrgCumulativeResult:
     label: str
     net_pct: float | None
     stub: bool
+    sessions_sampled: int = 0
+    repos_sampled: int = 0
+    total_logmind_bytes: int = 0
+    total_git_bytes: int = 0
+    per_repo_share: dict[str, float] = field(default_factory=dict)
+
+
+def run_org_cumulative(home: Path | None = None) -> OrgCumulativeResult:
+    """Walk session logs, sum bytes across all (session, repo) pairs,
+    produce one global cumulative ``net_pct`` + per-repo share.
+
+    ``home`` is injectable for tests (mirrors :func:`per_session.run_per_session`).
+    """
+    _GIT_BASELINE_CACHE.clear()
+
+    paths = _session_paths(home=home)
+    if not paths:
+        return OrgCumulativeResult(
+            label="no sessions found",
+            net_pct=None,
+            stub=True,
+        )
+
+    sessions_sampled = 0
+    total_logmind_bytes = 0
+    total_git_bytes = 0
+    repo_bytes: dict[str, int] = {}
+    repos_with_reads: set[str] = set()
+
+    for path in paths:
+        cwd = _session_cwd(path)
+        if cwd is None or not _is_logmind_repo(cwd):
+            continue
+        sessions_sampled += 1
+        session_logmind_bytes = 0
+        for fp, nbytes in _walk_reads(path):
+            if _bucket(fp, cwd) is None:
+                continue
+            session_logmind_bytes += nbytes
+        if session_logmind_bytes == 0:
+            continue
+        # Each session contributes one git-baseline read (cached per repo
+        # in ``_GIT_BASELINE_CACHE``). For org-cumulative, every session
+        # in the no-logmind world would pay that cost — so we add it on
+        # every contributing session, not just once per repo.
+        git_bytes = _git_equivalent_bytes(cwd)
+        if git_bytes == 0:
+            # Same divide-by-zero defence as per_session: skip the
+            # session entirely rather than fake a "free" git baseline.
+            continue
+        total_logmind_bytes += session_logmind_bytes
+        total_git_bytes += git_bytes
+        repo_key = str(cwd)
+        repo_bytes[repo_key] = repo_bytes.get(repo_key, 0) + session_logmind_bytes
+        repos_with_reads.add(repo_key)
+
+    if sessions_sampled == 0:
+        return OrgCumulativeResult(
+            label="no logmind repos in sampled sessions",
+            net_pct=None,
+            stub=True,
+        )
+    if total_git_bytes == 0:
+        # Every contributing session had a zero baseline — same condition
+        # per_session guards. Without a usable baseline we have no
+        # denominator and reporting any ``net_pct`` would be fake signal.
+        return OrgCumulativeResult(
+            label="no decision-doc reads in sampled sessions",
+            net_pct=None,
+            stub=True,
+            sessions_sampled=sessions_sampled,
+        )
+
+    net_pct = ((total_logmind_bytes - total_git_bytes) / total_git_bytes) * 100.0
+    per_repo_share = {
+        repo: repo_bytes[repo] / total_logmind_bytes
+        for repo in repo_bytes
+    }
+    repos_sampled = len(repos_with_reads)
+    label = (
+        f"bytes amortized (across {repos_sampled} repos, "
+        f"{total_logmind_bytes // 1024} KB logmind / "
+        f"{total_git_bytes // 1024} KB git)"
+    )
+
+    return OrgCumulativeResult(
+        label=label,
+        net_pct=net_pct,
+        stub=False,
+        sessions_sampled=sessions_sampled,
+        repos_sampled=repos_sampled,
+        total_logmind_bytes=total_logmind_bytes,
+        total_git_bytes=total_git_bytes,
+        per_repo_share=per_repo_share,
+    )
 
 
 def run_org_cumulative_stub() -> OrgCumulativeResult:
-    return OrgCumulativeResult(
-        label="net (cumulative, stub)",
-        net_pct=None,
-        stub=True,
-    )
+    """Back-compat shim — kept so callers that imported the stub
+    directly don't break. The registry in ``bench/__main__.py`` has
+    been switched to ``run_org_cumulative``."""
+    return run_org_cumulative()

--- a/bench/per_session.py
+++ b/bench/per_session.py
@@ -12,8 +12,9 @@ equivalent). Positive = spender (P0 fix).
 The output also surfaces per-file shares + an AGENTS.md-logmind-block
 sub-share — these are the load-bearing metrics for the conditional
 0.B.5 (decisions.md per-entry compact) and 0.B.6 (logmind-block trim)
-candidates. See ``/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md``
-Step 3 for the ship/defer rubric that consumes them.
+candidates. The ship/defer rubric that consumes them lives in
+``CHANGELOG.md`` (the per-version entries describe how the per-file
+shares + ``agents_md_block_share`` thresholds gated each decision).
 
 Edge cases all return ``stub=True`` / ``net_pct=None`` so the angle
 reports as "not yet implemented"-shaped (and the exit gate doesn't

--- a/docs/decisions-branches/feat__0.5-S2-org-cumulative-bench.md
+++ b/docs/decisions-branches/feat__0.5-S2-org-cumulative-bench.md
@@ -8,3 +8,11 @@
 - Bumps to v0.5.7. CHANGELOG entry. 3 new tests in tests/test_bench.py (no-sessions stub, fixture aggregation across 2 repos, per-repo outlier detection at 3:1 ratio) + 1 pin-test (stub shim must delegate to real impl, not silently revert to placeholder shape). bench/__main__.py informational set now {per-session, org-cumulative}; verdict label updated to Step 4 / 0.B.5 / 0.B.6 inputs to reflect dual consumer.
 
 ---
+## 2026-05-29 16:46 - fix(0.5 §2): add sessions_contributing counter + strip hardcoded paths (PR #81 review)
+
+**Reasoning:** Two findings from clud-bug-review on #81 — both legit: (1) sessions_sampled semantic ambiguity: it counts logmind-repo sessions (matching per_session) but downstream readers may want the contributing-only count. Added sessions_contributing as a separate field that mirrors per_session.sessions_with_decision_reads, so both invariants are surfaced without renaming the cross-check counter. (2) hardcoded /Users/ludlow/.claude/plans/... path leaked into org_cumulative + per_session docstrings — those references break outside the author's machine. Replaced with CHANGELOG.md pointer (in-repo, stable, follows the repo across machines).
+
+**Implications:**
+- 1 new test pinning the dual-counter semantic (test_org_cumulative_zero_bytes_session_increments_sampled_not_contributing) — a session in a logmind repo with zero decision-doc reads MUST increment sessions_sampled (cross-check) but MUST NOT increment sessions_contributing. Future refactor can't quietly collapse the two.
+
+---

--- a/docs/decisions-branches/feat__0.5-S2-org-cumulative-bench.md
+++ b/docs/decisions-branches/feat__0.5-S2-org-cumulative-bench.md
@@ -1,0 +1,10 @@
+## 2026-05-29 16:31 - Implement bench/org_cumulative real impl (Phase 0.5 §2, v0.5.7)
+
+**Reasoning:** Closes the last Q7-logmind bench stub. The 4-angle frame is now fully populated (per-call ✅, worst-case ✅, per-session ✅ [v0.5.6], org-cumulative ✅ [this]). Walks the same session JSONLs as per_session.py via shared helpers (_session_paths, _session_cwd, _is_logmind_repo, _walk_reads, _bucket, _git_equivalent_bytes), then aggregates DIFFERENTLY — sums bytes across sessions+repos for one global net_pct + per_repo_share, instead of per-session avg. Same informational-only treatment as per-session (shared thin git baseline; sign isn't a quality signal). Load-bearing data is per_repo_share, used by Step 4 validation to spot per-consumer cache-key regressions (>2× median share).
+
+**Alternatives considered:** Different baseline for org-cumulative (e.g., session-aware reconstruction) — deferred: needs a defined no-logmind-world comparator before sign becomes interpretable; informational treatment matches per_session's same constraint, Walk consuming-repo git history for logmind-log frequency — rejected as primary signal: requires multi-repo enumeration + auth; session-log aggregation is the same fidelity at zero infrastructure cost
+
+**Implications:**
+- Bumps to v0.5.7. CHANGELOG entry. 3 new tests in tests/test_bench.py (no-sessions stub, fixture aggregation across 2 repos, per-repo outlier detection at 3:1 ratio) + 1 pin-test (stub shim must delegate to real impl, not silently revert to placeholder shape). bench/__main__.py informational set now {per-session, org-cumulative}; verdict label updated to Step 4 / 0.B.5 / 0.B.6 inputs to reflect dual consumer.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (69 decisions)
+## 2026-05 (70 decisions)
 
-- **2026-05-29** — Defer 0.B.5 (docs/decisions.md per-entry compact) to Phase 3+ — structural overhead too small to be worth a release *(main)* — [decisions.md](decisions.md)
-- *... 67 more decisions ...*
+- **2026-05-29** — Implement bench/org_cumulative real impl (Phase 0.5 §2, v0.5.7) *(feat/0.5-S2-org-cumulative-bench)* — [decisions-branches/feat__0.5-S2-org-cumulative-bench.md](decisions-branches/feat__0.5-S2-org-cumulative-bench.md)
+- *... 68 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (70 decisions)
+## 2026-05 (71 decisions)
 
-- **2026-05-29** — Implement bench/org_cumulative real impl (Phase 0.5 §2, v0.5.7) *(feat/0.5-S2-org-cumulative-bench)* — [decisions-branches/feat__0.5-S2-org-cumulative-bench.md](decisions-branches/feat__0.5-S2-org-cumulative-bench.md)
-- *... 68 more decisions ...*
+- **2026-05-29** — fix(0.5 §2): add sessions_contributing counter + strip hardcoded paths (PR #81 review) *(feat/0.5-S2-org-cumulative-bench)* — [decisions-branches/feat__0.5-S2-org-cumulative-bench.md](decisions-branches/feat__0.5-S2-org-cumulative-bench.md)
+- *... 69 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.6"
+version = "0.5.7"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -107,7 +107,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.6", prog_name="logmind")
+@click.version_option(version="0.5.7", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -362,11 +362,159 @@ def test_per_session_malformed_line_skipped(tmp_path):
     assert result.per_file_share["AGENTS.md"] == pytest.approx(1.0)
 
 
-def test_org_cumulative_returns_stub_with_null_net_pct():
-    from bench.org_cumulative import run_org_cumulative_stub
-    result = run_org_cumulative_stub()
+def test_org_cumulative_no_sessions_returns_stub(tmp_path):
+    """Stub-invariant: when no sessions exist on disk, the angle
+    reports as not-yet-implemented-shaped so the exit gate skips it."""
+    from bench.org_cumulative import run_org_cumulative
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    result = run_org_cumulative(home=fake_home)
     assert result.stub is True
     assert result.net_pct is None
+    assert "no sessions found" in result.label
+
+
+def test_org_cumulative_aggregates_across_sessions_and_repos(tmp_path):
+    """End-to-end: two sessions across two distinct logmind repos.
+    Verifies global sum aggregation (not per-session averaging) AND
+    that ``per_repo_share`` keys both repos. Distinguishes from
+    per_session.py's average-of-percentages rollup."""
+    from bench.org_cumulative import run_org_cumulative
+
+    def _setup_repo(name: str, doc_content: str) -> Path:
+        repo = tmp_path / name
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+        (repo / "README.md").write_text("# t\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        (repo / ".logmind").mkdir()
+        (repo / ".logmind" / "config.yml").write_text("project: t\n", encoding="utf-8")
+        (repo / "docs").mkdir()
+        (repo / "docs" / "decisions.md").write_text(doc_content, encoding="utf-8")
+        return repo
+
+    repo_a = _setup_repo("repo-a", "# A\n")
+    repo_b = _setup_repo("repo-b", "# B\n")
+
+    fake_home = tmp_path / "home"
+
+    def _emit_session(session_name: str, repo: Path, payload_size: int) -> None:
+        projects_dir = fake_home / ".claude" / "projects" / session_name
+        projects_dir.mkdir(parents=True, exist_ok=True)
+        session = projects_dir / "session.jsonl"
+        payload = "x" * payload_size
+        lines = [
+            json.dumps({"cwd": str(repo), "type": "user"}),
+            json.dumps({
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "name": "Read",
+                        "id": f"tu-{session_name}",
+                        "input": {"file_path": str(repo / "docs" / "decisions.md")},
+                    }]
+                }
+            }),
+            json.dumps({
+                "message": {
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": f"tu-{session_name}",
+                        "content": payload,
+                    }]
+                }
+            }),
+        ]
+        session.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    _emit_session("enc-a", repo_a, 3000)
+    _emit_session("enc-b", repo_b, 1000)
+
+    result = run_org_cumulative(home=fake_home)
+    assert result.stub is False
+    assert result.sessions_sampled == 2
+    assert result.repos_sampled == 2
+    # Total logmind bytes = 3000 + 1000 = 4000.
+    assert result.total_logmind_bytes == 4000
+    assert result.total_git_bytes > 0
+    # Global net_pct = (4000 - total_git) / total_git * 100. Sign +/-
+    # depends on baseline size, but the value must be defined.
+    assert result.net_pct is not None
+    # Per-repo share: repo-a contributes 75 %, repo-b 25 %.
+    shares = result.per_repo_share
+    assert sum(shares.values()) == pytest.approx(1.0)
+    assert shares[str(repo_a)] == pytest.approx(0.75)
+    assert shares[str(repo_b)] == pytest.approx(0.25)
+
+
+def test_org_cumulative_per_repo_share_isolates_outlier(tmp_path):
+    """Three sessions in the same repo vs one in another → first repo
+    should carry the dominant share. This is the metric Step 4 uses
+    to spot per-consumer cache-key regressions (>2× median share)."""
+    from bench.org_cumulative import run_org_cumulative
+
+    repos: list[Path] = []
+    for name in ("dominant", "small"):
+        r = tmp_path / name
+        r.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=r, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=r, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=r, check=True)
+        (r / "README.md").write_text("# t\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=r, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=r, check=True)
+        (r / ".logmind").mkdir()
+        (r / ".logmind" / "config.yml").write_text("project: t\n", encoding="utf-8")
+        (r / "docs").mkdir()
+        (r / "docs" / "decisions.md").write_text(f"# {name}\n", encoding="utf-8")
+        repos.append(r)
+
+    fake_home = tmp_path / "home"
+
+    def _emit(slug: str, repo: Path, payload: int) -> None:
+        d = fake_home / ".claude" / "projects" / slug
+        d.mkdir(parents=True, exist_ok=True)
+        s = d / "session.jsonl"
+        lines = [
+            json.dumps({"cwd": str(repo), "type": "user"}),
+            json.dumps({"message": {"content": [{
+                "type": "tool_use", "name": "Read", "id": f"tu-{slug}",
+                "input": {"file_path": str(repo / "docs" / "decisions.md")}
+            }]}}),
+            json.dumps({"message": {"content": [{
+                "type": "tool_result", "tool_use_id": f"tu-{slug}", "content": "x" * payload,
+            }]}}),
+        ]
+        s.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    _emit("d1", repos[0], 1000)
+    _emit("d2", repos[0], 1000)
+    _emit("d3", repos[0], 1000)
+    _emit("s1", repos[1], 500)
+
+    result = run_org_cumulative(home=fake_home)
+    assert result.stub is False
+    assert result.repos_sampled == 2
+    # Dominant repo: 3000 / 3500 ≈ 0.857; small repo: 500 / 3500 ≈ 0.143.
+    assert result.per_repo_share[str(repos[0])] == pytest.approx(3000 / 3500)
+    assert result.per_repo_share[str(repos[1])] == pytest.approx(500 / 3500)
+
+
+def test_org_cumulative_stub_shim_calls_real_impl():
+    """``run_org_cumulative_stub`` is a back-compat alias that just
+    delegates to the real implementation. It MUST NOT return the
+    pre-impl stub shape (would silently keep callers on the old
+    placeholder). Caught at registry-swap time."""
+    from bench.org_cumulative import run_org_cumulative_stub
+    result = run_org_cumulative_stub()
+    # On a real machine this MAY be a stub (no sessions in test env)
+    # but the SHAPE must include the new fields, not the old 3-field
+    # dataclass. ``repos_sampled`` is the canary.
+    assert hasattr(result, "repos_sampled")
+    assert hasattr(result, "per_repo_share")
 
 
 @_skip_on_windows

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -436,6 +436,7 @@ def test_org_cumulative_aggregates_across_sessions_and_repos(tmp_path):
     result = run_org_cumulative(home=fake_home)
     assert result.stub is False
     assert result.sessions_sampled == 2
+    assert result.sessions_contributing == 2  # both sessions contributed bytes
     assert result.repos_sampled == 2
     # Total logmind bytes = 3000 + 1000 = 4000.
     assert result.total_logmind_bytes == 4000
@@ -501,6 +502,54 @@ def test_org_cumulative_per_repo_share_isolates_outlier(tmp_path):
     # Dominant repo: 3000 / 3500 ≈ 0.857; small repo: 500 / 3500 ≈ 0.143.
     assert result.per_repo_share[str(repos[0])] == pytest.approx(3000 / 3500)
     assert result.per_repo_share[str(repos[1])] == pytest.approx(500 / 3500)
+
+
+def test_org_cumulative_zero_bytes_session_increments_sampled_not_contributing(tmp_path):
+    """A session in a logmind repo with zero decision-doc reads MUST
+    increment ``sessions_sampled`` (cross-check against per_session)
+    but MUST NOT increment ``sessions_contributing`` (which counts
+    only sessions whose bytes flow into the totals). Caught by the
+    PR #81 review thread on counter-placement semantics — pinned here
+    so a future refactor can't quietly collapse the two counters."""
+    from bench.org_cumulative import run_org_cumulative
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "README.md").write_text("# t\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    (repo / ".logmind").mkdir()
+    (repo / ".logmind" / "config.yml").write_text("project: t\n", encoding="utf-8")
+
+    fake_home = tmp_path / "home"
+    projects_dir = fake_home / ".claude" / "projects" / "enc"
+    projects_dir.mkdir(parents=True)
+
+    # Session in the logmind repo that reads ONLY a non-bucket file
+    # (e.g., random source) — gets sampled but contributes zero bytes.
+    session = projects_dir / "session.jsonl"
+    lines = [
+        json.dumps({"cwd": str(repo), "type": "user"}),
+        json.dumps({"message": {"content": [{
+            "type": "tool_use", "name": "Read", "id": "tu-1",
+            "input": {"file_path": str(repo / "README.md")}
+        }]}}),
+        json.dumps({"message": {"content": [{
+            "type": "tool_result", "tool_use_id": "tu-1", "content": "x" * 500,
+        }]}}),
+    ]
+    session.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = run_org_cumulative(home=fake_home)
+    # Zero contributing sessions → angle reports stub (no signal),
+    # but the sampled-counter MUST still reflect the visit.
+    assert result.sessions_contributing == 0
+    # Note: returns stub because no contributing sessions; the sampled
+    # counter still surfaces in the result for the cross-check.
+    assert result.sessions_sampled == 1
 
 
 def test_org_cumulative_stub_shim_calls_real_impl():


### PR DESCRIPTION
## Summary

- Real implementation of `bench/org_cumulative.py` (was a 30-line stub returning `net_pct=None`). Closes the last Q7-logmind bench angle.
- Same data source as `per_session.py` (session JSONLs at `~/.claude/projects/*/*.jsonl`) but rolls up DIFFERENTLY — sums bytes across sessions+repos for one global cumulative `net_pct` plus `per_repo_share`.

## Why this is informational only

Same baseline-thinness concern as `per-session`: `git log --oneline -100` would not be the agent's actual no-logmind-world context, so the `net_pct` sign isn't a quality signal. Both angles are excluded from the exit-gate.

The load-bearing data is **`per_repo_share`** — which consuming repos contribute most of the sampled byte volume. Used by Step 4 validation to spot per-consumer cache-key regressions (>2× median share signals a regression in one consumer's prompt prefix).

## Test plan

- [x] `pytest tests/test_bench.py -k org_cumulative -v` — 4/4 pass.
- [x] `python -m bench` runs end-to-end; org-cumulative now produces real output:
  ```
  org-cumulative +130% bytes amortized (across 7 repos, 90 KB logmind / 39 KB git) ℹ info (Step 4 / 0.B.5 / 0.B.6 inputs)
  ```
- [x] `python -m bench --json | jq '.org_cumulative.per_repo_share'` returns a dict keyed by cwd.

## Bench preview (Q7-logmind 4-angle dashboard, this dev machine)

```
ok: 4-angle Q7-logmind compliance
  per-call       (stub — not yet implemented)  ← env-only stub (logmind CLI not in venv); CI runs real
  worst-case     (stub — not yet implemented)  ← env-only stub (same reason); CI runs real
  per-session    +261% bytes amortized (9/14 sessions, AGENTS.md=35%, decisions=38%) ℹ info
  org-cumulative +130% bytes amortized (across 7 repos, 90 KB logmind / 39 KB git) ℹ info
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)