### PR TITLE
feat(v0.5.9): fix #60 — strip code regions before scanning for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,50 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.8] - 2026-05-30
+## [0.5.9] - 2026-05-30
 
-### Fixed — issue #57: `logmind agents update` dry-run output
+### Fixed — issue #60: check-links parses markdown links inside backticks / code fences
 
-The pre-fix monolithic "✓ All agent files are current" message conflated
-three distinct cases — no AGENTS.md, AGENTS.md without a logmind marker
-block, AGENTS.md with a current marker — and misled users into thinking
-everything was current when really logmind hadn't been installed at
-all. Split into three case-specific messages:
+Pre-fix, mentioning markdown link syntax inside backticks (a
+documentation-of-the-syntax pattern, e.g. `` `[text](path)` ``) tripped
+the link checker even though the bracket-paren wasn't a live link.
+Recursion: writing a decision-log entry explaining "I fixed broken
+`[text](missing.md)` examples" persisted that very example as plain
+markdown, breaking the next CI run. Hit constantly by agents writing
+decision-log reasoning that needed to discuss link syntax.
 
-- **No AGENTS.md**: `✓ No AGENTS.md in this repo — nothing to update.
-  Run `logmind init` to install one.`
-- **AGENTS.md w/o marker block**: `✓ AGENTS.md exists but has no logmind
-  marker block. Run `logmind init` to install one ...`
-- **AGENTS.md w/ current marker**: `✓ AGENTS.md logmind block is current
-  (no update needed).`
-
-Plus refined the dry-run-with-outdated-files prefix from "Found N file(s)
-..." to "Would update N file(s) ..." so the user knows the action is
-prospective, not retrospective.
-
-### Fixed — issue #66: file-structure.md skipped on feature branches
-
-Pre-v0.5.8, `logmind log` on a feature branch regenerated `timeline.md`
-but skipped `docs/file-structure.md`. The skip self-perpetuated a
-1-entry-stale cycle on main: PR adds `docs/decisions-branches/<branch>.md`
-→ squash-merges without an updated file-structure → main's
-`file-structure.md` is one entry behind reality → next PR catches it via
-check-derived-docs, ships a regen + a new decision file → cycle repeats.
-Hit live on `thrillmade/agent-skills` PRs #37 → #38 → (would-be #39).
-
-The original rationale for the skip (per-branch regen would conflict
-against main on rebase) was made obsolete by v0.3.0's merge driver for
-`file-structure.md`, which resolves conflicts by regenerating from the
-merged tree. Feature branches now regen on every `logmind log` — same
-behaviour as `timeline.md`.
+Other markdown linters (markdown-link-check, lychee, etc.) skip code
+regions because that's specifically where you discuss the syntax.
+logmind now matches that convention via `_strip_code_regions()` which
+substitutes fenced blocks (` ``` ... ``` `) and inline-code spans
+(`` `...` ``) with whitespace of equivalent length before scanning
+for link patterns. Whitespace-replacement (vs. deletion) preserves
+line numbers + byte offsets so any broken-link error messages still
+point at the correct location in the original file.
 
 ### Tests
 
-- 3 new tests in `tests/test_agents_consolidation.py` covering the per-case
-  messaging (no-AGENTS.md / no-marker / dry-run-prefix).
-- `test_log_on_feature_branch_regenerates_file_structure` (renamed +
-  inverted from `_does_not_touch_file_structure`) — pins the v0.5.8
-  behaviour against future regression.
+4 new tests in `tests/test_link_check.py`:
+- `test_links_inside_inline_code_span_are_ignored`
+- `test_links_inside_fenced_code_block_are_ignored`
+- `test_links_outside_code_still_detected_alongside_code_examples`
+  (regression guard against silencing legitimate broken-link detection)
+- `test_strip_code_regions_preserves_line_numbers`
+
+### Note on v0.5.8
+
+This release is v0.5.9 because v0.5.8 (#82) is in parallel review;
+v0.5.9's #60 fix is independent and can ship without depending on
+v0.5.8's changes. Once v0.5.8 lands, v0.5.9 rebases cleanly atop it.
 
 ## [0.5.7] - 2026-05-29
 

--- a/docs/decisions-branches/feat__v0.5.9-check-links-strip-code.md
+++ b/docs/decisions-branches/feat__v0.5.9-check-links-strip-code.md
@@ -1,6 +1,6 @@
 ## 2026-05-29 23:53 - feat(v0.5.9): fix #60 — strip code regions before scanning for links
 
-**Reasoning:** Mentioning markdown link syntax inside backticks (e.g. discussing the [text](path) pattern in prose) used to trip check-links because the link-extraction regex didn't strip code regions first. Recursion: writing a decision-log entry to fix this trips on the same fix-attempting example. Other markdown linters (markdown-link-check, lychee) skip code regions; we now match. _strip_code_regions() replaces fenced blocks and inline-code spans with whitespace of equivalent length so line numbers + byte offsets stay correct for any broken-link error messages.
+**Reasoning:** Mentioning markdown link syntax inside backticks (e.g. discussing the `[text](path)` pattern in prose) used to trip check-links because the link-extraction regex didn't strip code regions first. Recursion: writing a decision-log entry to fix this trips on the same fix-attempting example. Other markdown linters (markdown-link-check, lychee) skip code regions; we now match. `_strip_code_regions()` replaces fenced blocks and inline-code spans with whitespace of equivalent length so line numbers + byte offsets stay correct for any broken-link error messages.
 
 **Implications:**
 - Bumps to v0.5.9. 4 new tests covering inline-code + fenced-block + regression-guard (real broken link in prose alongside code example STILL gets detected) + line-number preservation. 624/624 tests pass. Independent of v0.5.8 which is in parallel review.

--- a/docs/decisions-branches/feat__v0.5.9-check-links-strip-code.md
+++ b/docs/decisions-branches/feat__v0.5.9-check-links-strip-code.md
@@ -1,0 +1,8 @@
+## 2026-05-29 23:53 - feat(v0.5.9): fix #60 — strip code regions before scanning for links
+
+**Reasoning:** Mentioning markdown link syntax inside backticks (e.g. discussing the [text](path) pattern in prose) used to trip check-links because the link-extraction regex didn't strip code regions first. Recursion: writing a decision-log entry to fix this trips on the same fix-attempting example. Other markdown linters (markdown-link-check, lychee) skip code regions; we now match. _strip_code_regions() replaces fenced blocks and inline-code spans with whitespace of equivalent length so line numbers + byte offsets stay correct for any broken-link error messages.
+
+**Implications:**
+- Bumps to v0.5.9. 4 new tests covering inline-code + fenced-block + regression-guard (real broken link in prose alongside code example STILL gets detected) + line-number preservation. 624/624 tests pass. Independent of v0.5.8 which is in parallel review.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,6 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-05 (72 decisions)
 
-- **2026-05-29** — feat(v0.5.8): quality batch — issue #57 dry-run output + issue #66 file-structure on feature branches *(feat/v0.5.8-quality-batch)* — [decisions-branches/feat__v0.5.8-quality-batch.md](decisions-branches/feat__v0.5.8-quality-batch.md)
+- **2026-05-29** — feat(v0.5.9): fix #60 — strip code regions before scanning for links *(feat/v0.5.9-check-links-strip-code)* — [decisions-branches/feat__v0.5.9-check-links-strip-code.md](decisions-branches/feat__v0.5.9-check-links-strip-code.md)
 - *... 70 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (72 decisions)
+## 2026-05 (73 decisions)
 
 - **2026-05-29** — feat(v0.5.9): fix #60 — strip code regions before scanning for links *(feat/v0.5.9-check-links-strip-code)* — [decisions-branches/feat__v0.5.9-check-links-strip-code.md](decisions-branches/feat__v0.5.9-check-links-strip-code.md)
-- *... 70 more decisions ...*
+- *... 71 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.8"
+version = "0.5.9"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/actions/link_check.py
+++ b/src/logmind/actions/link_check.py
@@ -75,7 +75,18 @@ _FENCED_CODE_BLOCK = re.compile(
 # Match 1+ backticks for the delimiter, then non-backtick content, then
 # the same delimiter. Handles ``code with ` inside`` correctly (per
 # CommonMark §6.1 the delimiter length must match).
-_INLINE_CODE_SPAN = re.compile(r"(`+)(?:(?!\1).)+?\1", re.DOTALL)
+#
+# v0.5.9 PR #83 review fix: NO re.DOTALL — an unmatched stray backtick
+# (common in informal prose, e.g. mid-sentence `foo) would otherwise
+# match all the way to the next backtick paragraphs later, consuming
+# real broken links along the way. Restricting to non-newline keeps
+# code spans to a single line, matching CommonMark's common case and
+# leaving cross-line code blocks to the (greedy, intentional) fenced-
+# block regex. The cost: a CommonMark-compliant multi-line code span
+# isn't recognized — but in the docs corpus that's vanishingly rare
+# and the safer failure mode (false positive on a broken link rather
+# than silent suppression of one).
+_INLINE_CODE_SPAN = re.compile(r"(`+)(?:(?!\1)[^\n])+?\1")
 
 
 def _strip_code_regions(text: str) -> str:

--- a/src/logmind/actions/link_check.py
+++ b/src/logmind/actions/link_check.py
@@ -57,12 +57,54 @@ def _collect_md_files(roots: Iterable[Path]) -> Set[Path]:
     return found
 
 
+# v0.5.9 / issue #60 — strip code regions before scanning for links.
+# Pre-v0.5.9, fenced code blocks (``` ... ```) and inline-code spans
+# (`...`) were scanned as live content, so any `[text](path)` example
+# inside backticks tripped the link checker. This made it impossible
+# to *talk about* markdown link syntax in prose or decision-log entries
+# without breaking CI. Every other markdown linter (markdown-link-check,
+# lychee, etc.) skips code regions because that's specifically where
+# you discuss the syntax. Now logmind matches that convention.
+#
+# Order matters: strip FENCED blocks first (they can contain backticks
+# that would confuse the inline-code regex), then inline-code spans.
+_FENCED_CODE_BLOCK = re.compile(
+    r"^```.*?^```",
+    re.DOTALL | re.MULTILINE,
+)
+# Match 1+ backticks for the delimiter, then non-backtick content, then
+# the same delimiter. Handles ``code with ` inside`` correctly (per
+# CommonMark §6.1 the delimiter length must match).
+_INLINE_CODE_SPAN = re.compile(r"(`+)(?:(?!\1).)+?\1", re.DOTALL)
+
+
+def _strip_code_regions(text: str) -> str:
+    """v0.5.9 / issue #60 — return ``text`` with fenced code blocks and
+    inline-code spans replaced by whitespace of equivalent length.
+
+    Whitespace-replacement (vs. deletion) preserves line numbers + byte
+    offsets so error messages still point at the correct location in the
+    original file when the link scanner reports problems.
+    """
+    def _to_whitespace(match: "re.Match[str]") -> str:
+        # Preserve newlines so line numbers stay correct; replace other
+        # chars with spaces.
+        return "".join("\n" if c == "\n" else " " for c in match.group(0))
+
+    # Fenced blocks first (multi-line, can contain inline-code patterns).
+    text = _FENCED_CODE_BLOCK.sub(_to_whitespace, text)
+    # Then inline-code spans.
+    text = _INLINE_CODE_SPAN.sub(_to_whitespace, text)
+    return text
+
+
 def _extract_links(md_path: Path) -> List[Tuple[str, str]]:
     try:
         text = md_path.read_text(errors="ignore")
     except OSError:
         return []
-    return LINK_PATTERN.findall(text)
+    # v0.5.9 / issue #60: strip code regions before link-pattern scan.
+    return LINK_PATTERN.findall(_strip_code_regions(text))
 
 
 def check(

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -1521,10 +1521,45 @@ def agents_update(do_apply: bool, commit: bool):
     outdated = find_outdated_marker_blocks(root_path)
 
     if not outdated:
-        click.secho("✓ All agent files are current.", fg="green")
+        # v0.5.8 / issue #57: "All agent files are current" was misleading
+        # in two distinct cases — AGENTS.md absent, or AGENTS.md present
+        # without a logmind marker block. Split them out so the message
+        # accurately describes WHY no update is needed.
+        agents_path = root_path / "AGENTS.md"
+        if not agents_path.exists():
+            click.secho(
+                "✓ No AGENTS.md in this repo — nothing to update. "
+                "Run `logmind init` to install one.",
+                fg="green",
+            )
+        else:
+            from logmind.core.inserter import _extract_marker_block
+            installed = _extract_marker_block(
+                agents_path.read_text(encoding="utf-8")
+            )
+            if installed is None:
+                click.secho(
+                    "✓ AGENTS.md exists but has no logmind marker block. "
+                    "Run `logmind init` to install one (will preserve "
+                    "existing content above + below the markers).",
+                    fg="green",
+                )
+            else:
+                click.secho(
+                    "✓ AGENTS.md logmind block is current "
+                    "(no update needed).",
+                    fg="green",
+                )
         return
 
-    click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
+    # v0.5.8 / issue #57: surface the version delta on dry-run so the
+    # user knows what `--apply` would actually do.
+    if not do_apply:
+        click.echo(
+            f"Would update {len(outdated)} file(s) with stale logmind block(s):"
+        )
+    else:
+        click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
     for file_path, _old, _new in outdated:
         rel = file_path.relative_to(root_path)
         click.echo(f"  - {rel}")

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -107,7 +107,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.8", prog_name="logmind")
+@click.version_option(version="0.5.9", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -1521,45 +1521,10 @@ def agents_update(do_apply: bool, commit: bool):
     outdated = find_outdated_marker_blocks(root_path)
 
     if not outdated:
-        # v0.5.8 / issue #57: "All agent files are current" was misleading
-        # in two distinct cases — AGENTS.md absent, or AGENTS.md present
-        # without a logmind marker block. Split them out so the message
-        # accurately describes WHY no update is needed.
-        agents_path = root_path / "AGENTS.md"
-        if not agents_path.exists():
-            click.secho(
-                "✓ No AGENTS.md in this repo — nothing to update. "
-                "Run `logmind init` to install one.",
-                fg="green",
-            )
-        else:
-            from logmind.core.inserter import _extract_marker_block
-            installed = _extract_marker_block(
-                agents_path.read_text(encoding="utf-8")
-            )
-            if installed is None:
-                click.secho(
-                    "✓ AGENTS.md exists but has no logmind marker block. "
-                    "Run `logmind init` to install one (will preserve "
-                    "existing content above + below the markers).",
-                    fg="green",
-                )
-            else:
-                click.secho(
-                    "✓ AGENTS.md logmind block is current "
-                    "(no update needed).",
-                    fg="green",
-                )
+        click.secho("✓ All agent files are current.", fg="green")
         return
 
-    # v0.5.8 / issue #57: surface the version delta on dry-run so the
-    # user knows what `--apply` would actually do.
-    if not do_apply:
-        click.echo(
-            f"Would update {len(outdated)} file(s) with stale logmind block(s):"
-        )
-    else:
-        click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
+    click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
     for file_path, _old, _new in outdated:
         rel = file_path.relative_to(root_path)
         click.echo(f"  - {rel}")

--- a/tests/test_link_check.py
+++ b/tests/test_link_check.py
@@ -96,6 +96,90 @@ def test_broken_anchor_to_missing_file(tmp_path):
     assert any("docs/missing.md" in b for b in broken)
 
 
+# v0.5.9 / issue #60 — strip code regions before scanning for links.
+# Pre-v0.5.9, mentioning markdown link syntax inside backticks (a
+# documentation-of-the-syntax pattern) tripped the link checker even
+# though the bracket-paren wasn't a live link. These tests pin the new
+# code-aware behaviour.
+
+def test_links_inside_inline_code_span_are_ignored(tmp_path):
+    """Mentioning `[text](path)` inside backticks is NOT a live link."""
+    _make_clean_tree(tmp_path)
+    (tmp_path / "README.md").write_text(
+        "Discussion: use `[text](docs/this-does-not-exist.md)` syntax for links.\n",
+        encoding="utf-8",
+    )
+    broken, orphans = check(tmp_path)
+    assert broken == [], (
+        f"v0.5.9 / #60: link inside inline-code span must be ignored. "
+        f"Got broken={broken!r}"
+    )
+
+
+def test_links_inside_fenced_code_block_are_ignored(tmp_path):
+    """Mentioning [text](path) inside ``` blocks is NOT a live link."""
+    _make_clean_tree(tmp_path)
+    (tmp_path / "README.md").write_text(
+        "Example:\n\n```markdown\n[broken](docs/nonexistent.md)\n```\n",
+        encoding="utf-8",
+    )
+    broken, orphans = check(tmp_path)
+    assert broken == [], (
+        f"v0.5.9 / #60: link inside fenced code block must be ignored. "
+        f"Got broken={broken!r}"
+    )
+
+
+def test_links_outside_code_still_detected_alongside_code_examples(tmp_path):
+    """Real broken links outside code regions are STILL caught even when
+    the same file mentions the link syntax in prose. Regression guard:
+    the strip-code-regions fix mustn't silence legitimate broken-link
+    detection."""
+    _make_clean_tree(tmp_path)
+    (tmp_path / "README.md").write_text(
+        # Real broken link in prose:
+        "[real-broken](docs/actually-missing.md)\n\n"
+        # Same file mentions the link syntax in code (should be ignored):
+        "We use the `[text](path)` syntax. Avoid `[broken](nope.md)` examples.\n",
+        encoding="utf-8",
+    )
+    broken, orphans = check(tmp_path)
+    # Must detect the real broken link...
+    assert any("docs/actually-missing.md" in b for b in broken), (
+        f"v0.5.9 / #60 regression: legitimate broken link in prose missed. "
+        f"Got broken={broken!r}"
+    )
+    # ...but NOT the in-code examples.
+    assert not any("nope.md" in b for b in broken), (
+        f"v0.5.9 / #60: in-code example `[broken](nope.md)` got flagged. "
+        f"Got broken={broken!r}"
+    )
+
+
+def test_strip_code_regions_preserves_line_numbers(tmp_path):
+    """The strip-code-regions transform replaces code regions with
+    whitespace of equivalent length so byte offsets + line numbers stay
+    correct. Tested indirectly: a broken link AFTER a multi-line fenced
+    block reports correctly."""
+    from logmind.actions.link_check import _strip_code_regions
+    src = (
+        "Line 1\n"
+        "```\n"
+        "code line A\n"
+        "code line B\n"
+        "```\n"
+        "Line 6: [real](missing.md)\n"
+    )
+    stripped = _strip_code_regions(src)
+    # Same number of lines.
+    assert stripped.count("\n") == src.count("\n")
+    # Real link still present in the stripped output.
+    assert "[real](missing.md)" in stripped
+    # Fenced content gone (replaced by whitespace).
+    assert "code line A" not in stripped
+    assert "code line B" not in stripped
+
+
 def test_format_report_clean():
     assert "no orphans" in format_report([], [])
 

--- a/tests/test_link_check.py
+++ b/tests/test_link_check.py
@@ -156,6 +156,33 @@ def test_links_outside_code_still_detected_alongside_code_examples(tmp_path):
     )
 
 
+def test_unmatched_backtick_does_not_suppress_broken_link(tmp_path):
+    """v0.5.9 PR #83 review — `re.DOTALL` on the inline-code regex used to
+    let an unmatched stray backtick on one line pair with another
+    backtick many paragraphs later, consuming all content between them
+    (including real broken links). Concrete case: informal prose with
+    a stray ` mid-sentence followed paragraphs later by a real broken
+    link gets silently passed. Fix removes DOTALL so code spans can't
+    span newlines.
+    """
+    _make_clean_tree(tmp_path)
+    (tmp_path / "README.md").write_text(
+        "Mid-sentence stray backtick: The `foo shortcut works.\n"
+        "\n"
+        "Real broken link in next paragraph:\n"
+        "\n"
+        "[real-broken](docs/actually-missing.md)\n"
+        "\n"
+        "Another stray ` here.\n",
+        encoding="utf-8",
+    )
+    broken, orphans = check(tmp_path)
+    assert any("docs/actually-missing.md" in b for b in broken), (
+        f"v0.5.9 PR #83 review: stray backticks must not consume real broken "
+        f"links across paragraphs (re.DOTALL bug). Got broken={broken!r}"
+    )
+
+
 def test_strip_code_regions_preserves_line_numbers(tmp_path):
     """The strip-code-regions transform replaces code regions with
     whitespace of equivalent length so byte offsets + line numbers stay


### PR DESCRIPTION
## Summary

Fixes #60. Pre-fix, mentioning markdown link syntax inside backticks tripped `check-links` even when the bracket-paren wasn't a live link. Other markdown linters (markdown-link-check, lychee) skip code regions; logmind now matches.

`_strip_code_regions()` substitutes fenced blocks and inline-code spans with whitespace of equivalent length BEFORE the link-pattern scan — preserves line numbers + byte offsets so any broken-link error messages still point at the correct location.

## Test plan

- [x] 624/624 tests pass (4 new tests in `tests/test_link_check.py`).
- [x] Regression guard: real broken links in prose alongside in-code examples STILL get detected.

## Note

This ships as v0.5.9 because v0.5.8 (#82, dry-run + file-structure regen) is in parallel review. v0.5.9 is independent and lands as a separate small ship per the "small changes over and over" cadence. Once #82 merges, this PR rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)