### PR TITLE
feat(v0.5.10): warn when --stage scoped leaves tracked modifications unstaged (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-05-30
+
+### Fixed — issue #59: `--stage scoped` silent-failure on forgotten `git add`
+
+`logmind log "<title>" --stage scoped` stages only logmind-owned
+files (decisions.md, file-structure.md, etc.). When a user forgot
+`git add` before running it — the failure mode that hit clud-bug
+PR #87 and reporulez PR #20 in the 2026-05-27 wrap-up session —
+the commit shipped ONLY the decision-log entry. The intended file
+change stayed unstaged; the PR diff didn't match its description;
+CI reviewed unchanged code; reviewer flagged "PR does not match
+description"; user had to push a follow-up commit.
+
+logmind now detects this case and emits a stderr warning naming
+the unstaged tracked file(s) plus the fix hint
+(`git add <files> && git commit --amend --no-edit`). Warn-not-block
+per the Q6 invariant: the user may legitimately have unrelated
+tracked WIP they want to keep unstaged, so the commit still
+proceeds.
+
+Untracked files (scratch debug artifacts, generated PNGs, etc.) do
+NOT trigger the warning — users opting into `--stage scoped`
+typically have intentional untracked WIP. Only tracked-but-modified
+files surface the warning (i.e., the actual silent-failure
+scenario).
+
+### Added
+
+- `git_handler.unstaged_tracked_modifications(path)` helper —
+  returns the list of tracked files with unstaged modifications.
+  Used by the `--stage scoped` warning code path; reusable for
+  future scoped-stage tooling.
+
+### Tests
+
+4 new tests in `tests/test_logger.py`:
+
+- `test_log_scoped_stage_warns_on_unstaged_tracked_modifications`
+  — the actual silent-failure scenario; warning fires AND commit
+  still proceeds (non-blocking).
+- `test_log_scoped_stage_silent_when_working_tree_clean` —
+  regression guard against warning-spam on clean scoped commits.
+- `test_log_scoped_stage_ignores_untracked_files` — untracked
+  scratch files (the `--stage scoped` raison d'être) do NOT
+  trigger the warning.
+- `test_log_stage_all_never_warns` — `--stage all` sweeps the
+  whole tree so the warning code path must never fire.
+
 ## [0.5.9] - 2026-05-30
 
 ### Fixed — issue #60: check-links parses markdown links inside backticks / code fences

--- a/docs/decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md
+++ b/docs/decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md
@@ -1,0 +1,12 @@
+## 2026-05-30 08:43 - feat(v0.5.10): warn loudly when --stage scoped leaves tracked modifications unstaged (#59)
+
+**Reasoning:** Pre-fix silent-failure: logmind log "<title>" --stage scoped stages only logmind-owned files (decisions.md, file-structure.md, etc.); when a user forgot git add before running it, the commit shipped ONLY the decision-log entry. The intended file change stayed unstaged; PR diff did not match its description; CI reviewed unchanged code; reviewer flagged "PR does not match description"; user had to push a follow-up commit. Hit live in clud-bug PR #87 and reporulez PR #20 in the 2026-05-27 wrap-up session — repeating pattern flagged as a real bug.
+
+**Alternatives considered:** fail loud (error + exit non-zero when unstaged tracked changes present + --stage scoped — rejected because users have legitimate WIP scenarios), interactive prompt (Continue anyway? [y/N] — rejected because logmind is used heavily in agent automation flows that have no stdin), intent-matching heuristic (substring match unstaged filenames against title/reasoning — rejected because too many false positives on common words like fix/update, and filenames don't always appear in commit messages)
+
+**Implications:**
+- Warn-not-block per Q6 invariant: commit still proceeds (the user may legitimately have unrelated tracked WIP they want unstaged); the warning appears on stderr after git_add and before git_commit so the user sees what is about to be left out.
+- Untracked files (scratch/debug artifacts) do NOT trigger the warning — users opting into --stage scoped typically have intentional untracked WIP; only tracked-but-modified files surface the warning (the actual silent-failure scenario).
+- New reusable helper git_handler.unstaged_tracked_modifications(path) — can be used by future scoped-stage tooling without duplicating the git diff --name-only invocation.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (73 decisions)
+## 2026-05 (74 decisions)
 
-- **2026-05-29** — feat(v0.5.9): fix #60 — strip code regions before scanning for links *(feat/v0.5.9-check-links-strip-code)* — [decisions-branches/feat__v0.5.9-check-links-strip-code.md](decisions-branches/feat__v0.5.9-check-links-strip-code.md)
-- *... 71 more decisions ...*
+- **2026-05-30** — feat(v0.5.10): warn loudly when --stage scoped leaves tracked modifications unstaged (#59) *(fix/v0.5.10-stage-scoped-warn-issue-59)* — [decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md](decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md)
+- *... 72 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.9"
+version = "0.5.10"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -107,7 +107,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.9", prog_name="logmind")
+@click.version_option(version="0.5.10", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/git_handler.py
+++ b/src/logmind/core/git_handler.py
@@ -259,6 +259,33 @@ def default_branch(path: Optional[Path] = None) -> str:
     return "main"
 
 
+def unstaged_tracked_modifications(path: Optional[Path] = None) -> List[str]:
+    """
+    Return tracked files that have unstaged modifications.
+
+    Uses ``git diff --name-only`` which lists modifications to tracked
+    files NOT in the index. Untracked files (``git ls-files --others``)
+    are intentionally excluded — users opting into ``--stage scoped``
+    typically have intentional untracked WIP they want to preserve.
+
+    Returns empty list on any git error (including not-a-git-repo).
+    """
+    if path is None:
+        path = Path.cwd()
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only"],
+            cwd=path,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        return [line for line in result.stdout.splitlines() if line]
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return []
+
+
 def commit_and_push(files: List[str], message: str, path: Optional[Path] = None, push: bool = True) -> None:
     """
     Add files, commit, and optionally push in one operation.

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
@@ -17,6 +18,7 @@ from logmind.core.git_handler import (
     git_commit,
     git_push,
     is_git_repo,
+    unstaged_tracked_modifications,
 )
 from logmind.core.timeline import write_timeline
 from logmind.core.tree_gen import update_file_structure
@@ -347,6 +349,34 @@ def log(
             if extra_scoped_paths:
                 scoped.extend(extra_scoped_paths)
             git_add(scoped)
+
+            # v0.5.10 / issue #59: warn loudly when --stage scoped runs
+            # with tracked-but-unstaged modifications still present after
+            # staging logmind's own files. Without this warning, users
+            # who forget `git add` before `logmind log --stage scoped`
+            # silently ship only the decision-log entry — the actual
+            # code change stays unstaged and the PR diff doesn't match
+            # its description. Hit live in clud-bug PR #87 and reporulez
+            # PR #20 in the 2026-05-27 wrap-up session. Q6 invariant:
+            # warnings never silently dropped (warn-not-block, the user
+            # may legitimately have unrelated WIP they want unstaged).
+            leftover = unstaged_tracked_modifications()
+            if leftover:
+                count = len(leftover)
+                sys.stderr.write(
+                    f"\nWarning: --stage scoped committed without "
+                    f"{count} tracked modification"
+                    f"{'s' if count != 1 else ''} "
+                    f"(still unstaged):\n"
+                )
+                for f in leftover:
+                    sys.stderr.write(f"  - {f}\n")
+                sys.stderr.write(
+                    "  Did you mean --stage all (the default since "
+                    "v0.2.7)? If you intended to include the file(s), "
+                    "run `git add <files> && git commit --amend "
+                    "--no-edit` before pushing.\n\n"
+                )
 
         # Use configured commit message template
         commit_message = config.commit_message_template.format(decision=decision)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -335,3 +335,177 @@ def test_log_stage_all_preserves_v011_behavior(tmp_path, monkeypatch):
     committed = {line for line in out.stdout.split() if line}
     assert "docs/decisions.md" in committed
     assert "feature.py" in committed
+
+
+# ---------------------------------------------------------------------------
+# v0.5.10 / issue #59 — --stage scoped warns when tracked files have
+# unstaged modifications. Pre-v0.5.10 silent-failure mode:
+# user runs `logmind log "chore: bump pin X" --stage scoped` having
+# forgotten to `git add` the actual file; --stage scoped stages only
+# logmind-owned files; commit ships ONLY the decision log; PR diff
+# doesn't match its description. Hit live twice (clud-bug PR #87 +
+# reporulez PR #20) in the 2026-05-27 wrap-up session.
+# ---------------------------------------------------------------------------
+
+
+def test_log_scoped_stage_warns_on_unstaged_tracked_modifications(
+    tmp_path, monkeypatch, capsys
+):
+    """v0.5.10 / issue #59: --stage scoped emits a stderr warning when
+    tracked files have unstaged modifications. Commit still proceeds
+    (warn-not-block per Q6 invariant)."""
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    (docs / "decisions-archive.md").write_text("# Archive\n\n---\n", encoding="utf-8")
+
+    # Create + commit a tracked workflow file, then modify it without staging.
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow_file = workflow_dir / "ci.yml"
+    workflow_file.write_text("name: ci\non: push\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", ".github/workflows/ci.yml"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add ci"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+    # The unstaged-tracked-modification — silent-failure scenario.
+    workflow_file.write_text(
+        "name: ci\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+
+    log(
+        "chore: bump CI pin",
+        reasoning="security update",
+        docs_path=docs,
+        auto_commit=True,
+        auto_push=False,
+        stage="scoped",
+    )
+
+    captured = capsys.readouterr()
+    assert ".github/workflows/ci.yml" in captured.err, (
+        f"v0.5.10 / #59: warning must name the unstaged tracked file. "
+        f"Got stderr={captured.err!r}"
+    )
+    assert "--stage scoped" in captured.err, (
+        f"v0.5.10 / #59: warning must mention --stage scoped so users "
+        f"connect the warning to their flag choice. "
+        f"Got stderr={captured.err!r}"
+    )
+
+    # Commit still happened — warn-not-block per Q6 invariant.
+    out = subprocess.run(
+        ["git", "log", "--oneline", "-n", "2"],
+        cwd=tmp_path, check=True, capture_output=True, text=True,
+    )
+    assert "chore: bump CI pin" in out.stdout, (
+        "v0.5.10 / #59: warning must be non-blocking (commit still proceeds). "
+        f"Got log:\n{out.stdout}"
+    )
+
+
+def test_log_scoped_stage_silent_when_working_tree_clean(
+    tmp_path, monkeypatch, capsys
+):
+    """v0.5.10 / issue #59: no warning when --stage scoped runs with no
+    leftover unstaged tracked modifications (happy-path regression
+    guard against warning-spam on legitimate scoped commits)."""
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    (docs / "decisions-archive.md").write_text("# Archive\n\n---\n", encoding="utf-8")
+
+    log(
+        "clean scoped commit",
+        reasoning="happy path",
+        docs_path=docs,
+        auto_commit=True,
+        auto_push=False,
+        stage="scoped",
+    )
+
+    captured = capsys.readouterr()
+    assert "--stage scoped" not in captured.err, (
+        f"v0.5.10 / #59: clean working tree must not produce the "
+        f"stage-scoped warning. Got stderr={captured.err!r}"
+    )
+
+
+def test_log_scoped_stage_ignores_untracked_files(
+    tmp_path, monkeypatch, capsys
+):
+    """v0.5.10 / issue #59: untracked files (e.g. scratch debug files)
+    do NOT trigger the warning — users opting into --stage scoped
+    typically have intentional untracked WIP they want to preserve.
+    Only TRACKED-but-unstaged modifications surface the warning."""
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    (docs / "decisions-archive.md").write_text("# Archive\n\n---\n", encoding="utf-8")
+
+    # Untracked-only working-tree noise — must NOT trigger warning.
+    (tmp_path / "scratch.txt").write_text("draft", encoding="utf-8")
+    (tmp_path / "debug.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    log(
+        "scoped commit with untracked WIP",
+        reasoning="intentional preservation",
+        docs_path=docs,
+        auto_commit=True,
+        auto_push=False,
+        stage="scoped",
+    )
+
+    captured = capsys.readouterr()
+    assert "--stage scoped" not in captured.err, (
+        f"v0.5.10 / #59: untracked files (scratch.txt, debug.png) must "
+        f"NOT trigger the stage-scoped warning. "
+        f"Got stderr={captured.err!r}"
+    )
+
+
+def test_log_stage_all_never_warns(tmp_path, monkeypatch, capsys):
+    """v0.5.10 / issue #59: --stage all sweeps the whole working tree
+    so the scoped-warning code path must never fire under it."""
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+
+    tracked = tmp_path / "feature.py"
+    tracked.write_text("def old(): pass\n", encoding="utf-8")
+    subprocess.run(["git", "add", "feature.py"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add feature"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    tracked.write_text("def new(): pass\n", encoding="utf-8")
+
+    log(
+        "stage-all sweeps everything",
+        reasoning="opt back in",
+        docs_path=docs,
+        auto_commit=True,
+        auto_push=False,
+        stage="all",
+    )
+
+    captured = capsys.readouterr()
+    assert "--stage scoped" not in captured.err


### PR DESCRIPTION
Closes #59.

## Summary

- `logmind log "<title>" --stage scoped` previously committed only logmind-owned files (decisions.md, file-structure.md, …) and silently shipped no real change when the user forgot `git add` first. Hit live in clud-bug PR #87 and reporulez PR #20 in the 2026-05-27 wrap-up session — repeating-pattern bug.
- Now: after staging logmind-owned files, if any tracked file still has unstaged modifications, emit a stderr warning naming the file(s) + the fix hint (`git add <files> && git commit --amend --no-edit`). **Warn-not-block per Q6 invariant** — the user may legitimately have unrelated tracked WIP they want unstaged.
- Untracked files (scratch/debug artifacts) intentionally do NOT trigger the warning — those are exactly the `--stage scoped` raison d'être. Only tracked-but-modified files surface it.
- New reusable helper `git_handler.unstaged_tracked_modifications(path)` — `git diff --name-only` wrapper, safe defaults on git errors.

## Why this design

The issue body sketched two options (interactive prompt vs error). I went with a third — **non-blocking stderr warning** — because:

1. Interactive prompt breaks the agent automation flows where `logmind log` is the commit primitive (no stdin).
2. Hard error blocks the legitimate "unrelated tracked WIP I'm preserving" case the issue itself acknowledges.
3. Warn-on-stderr matches the v0.5.5 `core/parser.py` "skipping malformed decision header" warning pattern (same Q6 invariant).

## Test plan

- [x] `pytest tests/test_logger.py -v` — 23/23 green (4 new + 19 existing).
- [x] `pytest -q` (full suite) — 629 passed, 1 skipped.
- [x] 4 new tests cover: (a) the silent-failure scenario warns + commit still happens, (b) clean working tree stays silent, (c) untracked-only WIP stays silent, (d) `--stage all` never warns.
- [ ] CI: `check-derived-docs`, `check-links`, `clud-bug-review` green.
- [ ] After merge: tag `v0.5.10` → Trusted Publishing OIDC publishes to PyPI → `pip index versions logmind` shows 0.5.10 within ~1 min.

## Files

- `src/logmind/core/git_handler.py` — new `unstaged_tracked_modifications()` helper.
- `src/logmind/core/logger.py` — warning code path in `stage == "scoped"` branch (after `git_add`, before `git_commit`).
- `tests/test_logger.py` — 4 new tests.
- `pyproject.toml`, `src/logmind/__init__.py`, `src/logmind/cli.py` — version bump 0.5.9 → 0.5.10.
- `CHANGELOG.md` — `[0.5.10] - 2026-05-30` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)