### PR TITLE
chore: propagate clud-bug v0.6.22 → v0.6.27 to logmind (Smart Budget self-upgrade)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -23,6 +23,6 @@
       "description": "(bundled baseline)"
     }
   ],
-  "lastUpdate": "2026-05-29T16:29:44.670Z",
-  "lastUpdateVersion": "0.6.22"
+  "lastUpdate": "2026-05-30T13:09:55.697Z",
+  "lastUpdateVersion": "0.6.27"
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.22._
+_Installed at clud-bug v0.6.27._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -1,9 +1,14 @@
-# clud-bug-template-version: v10
+# clud-bug-template-version: v12
 name: Clud Bug 🐛 Crawls Your Code
 
 on:
   pull_request:
     types: [opened, synchronize]
+
+# v0.6.25: workflow-level concurrency — see workflow.yml.tmpl.
+concurrency:
+  group: clud-bug-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Pre-flight (v0.6.14 / 0.0.W + v0.6.15 / 0.0.R) — see workflow.yml.tmpl.
@@ -15,6 +20,13 @@ jobs:
     outputs:
       is_workflow_only: ${{ steps.classify.outputs.is_workflow_only }}
       model: ${{ steps.classify.outputs.model }}
+      max_turns: ${{ steps.classify.outputs.max_turns }}
+      # v0.6.25 / §5.5 Layer 1.5 (calibration) — see workflow.yml.tmpl.
+      turns_estimated: ${{ steps.classify.outputs.turns_estimated }}
+      files_count: ${{ steps.classify.outputs.files_count }}
+      lines_added: ${{ steps.classify.outputs.lines_added }}
+      lines_deleted: ${{ steps.classify.outputs.lines_deleted }}
+      threads_count: ${{ steps.classify.outputs.threads_count }}
     steps:
       - name: Classify PR diff
         id: classify
@@ -27,21 +39,46 @@ jobs:
           CHANGED=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
           MODEL=claude-sonnet-4-6
           if [ -z "$CHANGED" ]; then
-            echo "is_workflow_only=false" >> "$GITHUB_OUTPUT"
-            echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+            # v0.6.23 / §5: max_turns must always be emitted — see workflow.yml.tmpl for design notes.
+            # Grouped redirect (v0.6.24) silences the SC2129 style warning.
+            {
+              echo "is_workflow_only=false"
+              echo "model=$MODEL"
+              echo "max_turns=15"
+              echo "turns_estimated=0"
+              echo "files_count=0"
+              echo "lines_added=0"
+              echo "lines_deleted=0"
+              echo "threads_count=0"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          IS_WORKFLOW_ONLY=true
+          # v0.6.26 / 0.0.W² — see workflow.yml.tmpl for design notes.
+          ALL_IN_ALLOWLIST=true
+          HAS_WORKFLOW_CHANGE=false
           while IFS= read -r f; do
             case "$f" in
-              .github/workflows/clud-bug-*.yml) ;;
-              .github/actions/strict-mode-gate/*) ;;
-              *) IS_WORKFLOW_ONLY=false; break ;;
+              .github/workflows/clud-bug-*.yml) HAS_WORKFLOW_CHANGE=true ;;
+              .github/actions/strict-mode-gate/*) HAS_WORKFLOW_CHANGE=true ;;
+              AGENTS.md) ;;
+              .cursorrules|.clinerules|.windsurfrules|.continuerules) ;;
+              .github/copilot-instructions.md) ;;
+              .claude/skills/.clud-bug.json) ;;
+              .claude/skills/critical-issues-only/SKILL.md) ;;
+              .claude/skills/evidence-based-review/SKILL.md) ;;
+              .claude/skills/respect-existing-conventions/SKILL.md) ;;
+              docs/timeline.md|docs/file-structure.md|docs/decisions.md) ;;
+              docs/decisions-branches/*.md) ;;
+              *) ALL_IN_ALLOWLIST=false; break ;;
             esac
           done <<< "$CHANGED"
+          IS_WORKFLOW_ONLY=false
+          if [ "$ALL_IN_ALLOWLIST" = "true" ] && [ "$HAS_WORKFLOW_CHANGE" = "true" ]; then
+            IS_WORKFLOW_ONLY=true
+          fi
           echo "is_workflow_only=$IS_WORKFLOW_ONLY" >> "$GITHUB_OUTPUT"
           if [ "$IS_WORKFLOW_ONLY" = "true" ]; then
-            echo "::notice title=Clud Bug 🐛::Skipping LLM review — workflow-only PR."
+            echo "::notice title=Clud Bug 🐛::Skipping LLM review — clud-bug update output."
             echo "model=$MODEL" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -75,6 +112,58 @@ jobs:
           fi
           echo "model=$MODEL" >> "$GITHUB_OUTPUT"
 
+          # Smart budget (v0.6.25 / §5.5 Layer 1) — see workflow.yml.tmpl for design notes + formula.
+          FILE_COUNT=$(echo "$CHANGED" | wc -l | tr -d ' ')
+          THREAD_COUNT=$(gh api graphql -f query='{repository(owner:"'"$(echo "$REPO" | cut -d/ -f1)"'",name:"'"$(echo "$REPO" | cut -d/ -f2)"'"){pullRequest(number:'"$PR_NUMBER"'){reviewThreads(first:50){nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and (.comments.nodes[0].author.login == "claude" or .comments.nodes[0].author.login == "claude[bot]"))] | length' 2>/dev/null || echo 0)
+          THREAD_COUNT=${THREAD_COUNT:-0}
+
+          if [ "$IS_TRIVIAL" = "true" ]; then
+            MAX_TURNS=10
+            TURNS_ESTIMATED=10
+            LINES_ADDED=0
+            LINES_DELETED=0
+            echo "::notice title=Clud Bug 🐛::Trivial (Haiku) budget: max_turns=10."
+          else
+            FILES_JSON=$(gh pr view "$PR_NUMBER" -R "$REPO" --json files --jq '.files' 2>/dev/null || echo '[]')
+            LINES_ADDED=$(echo "$FILES_JSON" | jq '[.[].additions] | add // 0' 2>/dev/null || echo 0)
+            LINES_DELETED=$(echo "$FILES_JSON" | jq '[.[].deletions] | add // 0' 2>/dev/null || echo 0)
+            LINES_ADDED=${LINES_ADDED:-0}
+            LINES_DELETED=${LINES_DELETED:-0}
+
+            # jq implements the §5.5 Layer 1 formula — see workflow.yml.tmpl.
+            TURNS_ESTIMATED=$(echo "$FILES_JSON" | jq --argjson threads "$THREAD_COUNT" '
+              def per_line(path):
+                if (path | test("\\.(test|spec)\\.|__tests__|^tests?/")) then 0.01
+                elif (path | test("\\.(md|txt|rst|adoc|mdx)$")) then 0.00666667
+                elif (path | test("\\.(yml|yaml|toml|json|cfg|ini|conf|tmpl)$")) then 0.01
+                elif (path | test("\\.(ts|tsx|py|js|jsx|mjs|cjs|go|rs|java|kt|rb|php|cs|c|cpp|h|hpp|swift|scala)$")) then 0.02
+                else 0.0125 end;
+              map(
+                select(.path != "docs/timeline.md"
+                       and .path != "docs/file-structure.md"
+                       and .path != "docs/decisions.md")
+                | (.additions) as $add | (.deletions) as $del
+                | (if $add < $del then $add else $del end) as $mod
+                | ($add - $mod) as $pa | ($del - $mod) as $pd
+                | per_line(.path) as $tw
+                | 0.3 + ($pa * $tw) + ($mod * 1.5 * $tw) + ($pd * 0.1 * $tw)
+              ) | (add // 0) + 10 + ($threads * 1.5) | (. + 0.9999999) | floor
+            ' 2>/dev/null || echo 15)
+            TURNS_ESTIMATED=${TURNS_ESTIMATED:-15}
+            MAX_TURNS=$(( (TURNS_ESTIMATED * 12 + 9) / 10 ))
+            [ "$MAX_TURNS" -lt 15 ] && MAX_TURNS=15
+            [ "$MAX_TURNS" -gt 60 ] && MAX_TURNS=60
+            echo "::notice title=Clud Bug 🐛::Smart budget: estimated $TURNS_ESTIMATED turns → max_turns=$MAX_TURNS ($FILE_COUNT files, +$LINES_ADDED/-$LINES_DELETED lines, $THREAD_COUNT prior threads)."
+          fi
+          {
+            echo "max_turns=$MAX_TURNS"
+            echo "turns_estimated=$TURNS_ESTIMATED"
+            echo "files_count=$FILE_COUNT"
+            echo "lines_added=$LINES_ADDED"
+            echo "lines_deleted=$LINES_DELETED"
+            echo "threads_count=$THREAD_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
   clud-bug-review:
     needs: paths-check
     if: needs.paths-check.outputs.is_workflow_only != 'true'
@@ -85,6 +174,9 @@ jobs:
       id-token: write
       # checks: write — composite emits per-skill check-runs (BB.3).
       checks: write
+      # v0.6.24: `actions: read` (added in v0.6.23) backed out — broke
+      # `pull_request` trigger firing on private consumer repos. See
+      # workflow.yml.tmpl for the diagnosis.
 
     steps:
       - uses: actions/checkout@v6
@@ -274,6 +366,60 @@ jobs:
             Not a hard cap (SDK doesn't expose max_tokens); brevity compounds
             across the org on every review.
 
+            Turn budget self-rationing (v0.6.25 / §5.5 Layer 2):
+            You are run with a finite `--max-turns` cap. The exact value, plus
+            the pre-flight estimate for this PR, lands in the per-PR prompt
+            section below as `max_turns=N, estimated=M, files=F, +A/-D lines, threads=T`.
+            Treat that as your budget, not a ceiling to test.
+
+            Rules:
+              - Reserve the LAST 5 turns for structured-output emit. It is
+                non-skippable; if you run out before emitting, the workflow
+                falls back to a synthetic summary scraped from your inline
+                findings (v0.6.26+ Layer 6) — strictly worse than a real one.
+              - Rough rates: ~1 turn per 50 lines of code, ~1 turn per 150 lines
+                of docs, ~1 turn per 100 lines of tests or config. Each prior
+                unresolved thread is ~1.5 turns to walk + decide.
+              - Every line of the diff MUST be in your scan. Never silently skip
+                a file. If you must shorten coverage to fit budget, switch from
+                deep-dive analysis to one-sentence per-file verdicts — but every
+                file gets a verdict, even if it's "no issues found".
+              - If you're falling behind pace (files_reviewed/files_total
+                materially less than turns_used/max_turns), broaden+shallow over
+                deep+narrow. Audit visibility lives in `per_skill_scan` — list
+                every file's verdict so a maintainer can verify nothing was
+                skipped.
+
+            Mid-review self-check-in (v0.6.27 / §5.5 Layer 3):
+            After every 5 tool_uses, write a single-line budget heartbeat as a
+            free-text "thinking" message (not a tool call — these don't cost a
+            turn) of the form:
+
+              [budget] files_reviewed=X/N, turns_used=Y/M, pace=ok|behind
+
+            Where:
+              - X / N is the count of files you've meaningfully looked at so far
+                over the total in this PR's diff.
+              - Y / M is your current turn count over max_turns.
+              - pace = "ok" when X / N >= Y / (M - 5). The denominator subtracts the
+                5-turn emit reservation: over the (M - 5) turns available for file
+                review, your file-coverage rate must match where you actually are
+                in the budget. (Don't subtract from Y — that would be saying "I've
+                used Y minus 5 turns" which double-counts the reservation.)
+                pace = "behind" otherwise.
+
+            When pace = "behind", immediately pivot strategy:
+              1. Stop deep-dive analysis on the current file.
+              2. Switch to one-sentence verdicts for every remaining file.
+              3. Keep going through the whole diff — silent skipping is
+                 non-negotiable. Cover everything, even if some files only get
+                 "no issues found in this file" as their verdict.
+
+            The heartbeat serves two purposes: (a) forces internal pacing — you
+            can't drift past budget without noticing; (b) lands in the action's
+            streaming output for post-hoc calibration of the per-line cost
+            coefficients used by paths-check's Layer 1 estimator.
+
             Incremental-diff handshake (v0.6.10+) — emit the SHA marker:
             At the very end of the summary (after the Skills-referenced footer,
             on its own line), append:
@@ -450,50 +596,107 @@ jobs:
           # structured output; post-step renders + posts. See workflow.yml.tmpl for design notes.
           claude_args: |
             --model ${{ needs.paths-check.outputs.model }}
-            --max-turns 15
+            --max-turns ${{ needs.paths-check.outputs.max_turns }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*),Bash(gh api repos/:*),Bash(git show:*),Bash(git diff:*),Bash(git merge-base:*),Bash(cat .claude/skills/.clud-bug.json),Bash(cat .claude/skills/*/SKILL.md),Bash(head:*)"
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"status_header":{"type":"string","enum":["critical findings","clean","bare"],"description":"Strict-mode opt-in repos: `critical findings` when ANY 🔴 finding exists, otherwise `clean`. Non-strict-mode repos (the default): emit `bare` — the renderer produces a `## 🐛 Clud Bug review` H2 with no suffix, matching the v0.6.21- behaviour. Check .claude/skills/.clud-bug.json for `strictMode: true` to pick critical/clean vs bare."},"summary_counts":{"type":"object","additionalProperties":false,"properties":{"critical":{"type":"integer","minimum":0},"minor":{"type":"integer","minimum":0},"preexisting":{"type":"integer","minimum":0},"resolved_from_prior":{"type":"integer","minimum":0},"still_open":{"type":"integer","minimum":0}},"required":["critical","minor","preexisting","resolved_from_prior","still_open"]},"per_skill_scan":{"type":"array","description":"One entry per LOADED skill — even silent ones. Empty when no skills are installed.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string"},"outcome":{"type":"string","description":"One sentence describing what the skill found. Max ~15 words. Examples: \"scanned all paths. 2 critical findings below.\", \"0 findings.\", \"not applicable to this diff.\""}},"required":["skill","outcome"]}},"critical_findings":{"type":"array","description":"NEW 🔴 findings (bugs, security, perf, missing test coverage). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"minor_findings":{"type":"array","description":"NEW 🟡 findings (nits, style, observations). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"preexisting_findings":{"type":"array","description":"NEW 🟣 findings (issues that pre-date this PR). May be empty.","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}},"dedicated_sections":{"type":"array","description":"Per-dedicated-mode-skill section blocks. Each item carries the section header text and its findings.","items":{"type":"object","additionalProperties":false,"properties":{"section_name":{"type":"string","description":"Human-readable section title, e.g. \"Brand voice\"."},"skill":{"type":"string","description":"The dedicated skill name."},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"skill":{"type":"string","description":"The skill name in brackets, e.g. \"critical-issues-only\". Must match a loaded skill or \"(none)\"."},"file":{"type":"string","description":"Path of the affected file relative to repo root. Optional when the finding is cross-cutting."},"line":{"type":"integer","minimum":1,"description":"Line number in the affected file. Required when `file` is set."},"summary":{"type":"string","description":"One sentence stating the claim. Max ~20 words; no trailing period (the renderer adds one)."},"reasoning":{"type":"string","description":"Evidence anchor + suggested fix. Max ~80 words. Rendered inside <details> block; can be omitted for self-evident findings."}},"required":["skill","summary"]}}},"required":["section_name","skill","findings"]}},"diagnostics":{"type":"array","description":"0.0.T tee-hint diagnostics. One line per `head -c` cap that fired during fetch. Empty when no truncation occurred.","items":{"type":"string"}},"skills_referenced":{"type":"array","description":"Names of every skill cited in any finding. Empty list (or [\"(none)\"]) when no skill applied.","items":{"type":"string"}},"last_reviewed_sha":{"type":"string","description":"The HEAD SHA at review time, used by the incremental-diff handshake. Set to the literal value of the workflow env var $HEAD_SHA."}},"required":["status_header","summary_counts","per_skill_scan","critical_findings","minor_findings","preexisting_findings","skills_referenced","last_reviewed_sha"]}'
           prompt: |
             Review this pull request following the discipline in your
             system prompt — every rule about skill routing, comment
             format, the strict-mode header, the two-surface review
-            shape, and the FIX-PUSH FLOW applies.
+            shape, the FIX-PUSH FLOW, and (v0.6.25+) turn-budget
+            self-rationing applies.
+
+            ## Your turn budget for this PR (v0.6.25 / §5.5 Layer 2)
+
+            max_turns=${{ needs.paths-check.outputs.max_turns }},
+            estimated=${{ needs.paths-check.outputs.turns_estimated }},
+            files=${{ needs.paths-check.outputs.files_count }},
+            +${{ needs.paths-check.outputs.lines_added }}/-${{ needs.paths-check.outputs.lines_deleted }} lines,
+            prior_threads=${{ needs.paths-check.outputs.threads_count }}.
+
+            Plan accordingly per the "Turn budget self-rationing"
+            section in your system prompt. Reserve 5 turns for emit.
         id: clud-bug-review
 
       # v0.6.22 / 0.0.O: render structured output → post via gh pr comment.
+      # v0.6.25 / §5.5 Layer 1.5: append calibration marker.
       - name: Render + post structured review
         if: success() && steps.clud-bug-review.outputs.structured_output != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+          TURNS_ESTIMATED: ${{ needs.paths-check.outputs.turns_estimated }}
+          MAX_TURNS: ${{ needs.paths-check.outputs.max_turns }}
+          FILES_COUNT: ${{ needs.paths-check.outputs.files_count }}
+          LINES_ADDED: ${{ needs.paths-check.outputs.lines_added }}
+          LINES_DELETED: ${{ needs.paths-check.outputs.lines_deleted }}
+          THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.22 render --stdin)
-          gh pr comment "$PR_NUMBER" --body "$BODY"
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.27 render --stdin)
+          CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
+          gh pr comment "$PR_NUMBER" --body "$BODY
 
-      # Fallback when structured_output is empty (max-retries hit).
+          $CALIBRATION"
+
+      # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
         if: success() && steps.clud-bug-review.outputs.structured_output == ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TURNS_ESTIMATED: ${{ needs.paths-check.outputs.turns_estimated }}
+          MAX_TURNS: ${{ needs.paths-check.outputs.max_turns }}
+          FILES_COUNT: ${{ needs.paths-check.outputs.files_count }}
+          LINES_ADDED: ${{ needs.paths-check.outputs.lines_added }}
+          LINES_DELETED: ${{ needs.paths-check.outputs.lines_deleted }}
+          THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
+          INLINES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\")]")
+          INLINE_COUNT=$(echo "$INLINES" | jq 'length')
+          CRITICAL=$(echo "$INLINES" | jq '[.[] | select(.body | test("🔴"))] | length')
+          MINOR=$(echo "$INLINES" | jq '[.[] | select(.body | test("🟡"))] | length')
+          PREEXISTING=$(echo "$INLINES" | jq '[.[] | select(.body | test("🟣"))] | length')
+          CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT, structured_output=empty, inline_findings=$INLINE_COUNT -->"
+          if [ "$INLINE_COUNT" -gt 0 ]; then
+            STATUS=""
+            [ "$CRITICAL" -gt 0 ] && STATUS=" — critical findings"
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review${STATUS}
+
+          **This round:** $CRITICAL critical · $MINOR minor · 0 resolved from prior · 0 still open
+
+          Found: $CRITICAL 🔴 / $MINOR 🟡 / $PREEXISTING 🟣
+
+          ⚠️ **Synthetic summary** (v0.6.26 §5.5 Layer 6 fallback). Inline findings above ARE the substantive review.
+
+          <!-- last-reviewed-sha: $HEAD_SHA -->
+
+          $CALIBRATION"
+          else
+            gh pr comment "$PR_NUMBER" --body "## 🐛 Clud Bug review
 
           **This round:** 0 critical · 0 minor · 0 resolved from prior · 0 still open
 
           Found: 0 🔴 / 0 🟡 / 0 🟣
 
-          ⚠️ Structured output (\`--json-schema\`) returned empty — likely max-retries hit on schema validation. Investigate the action logs.
+          ⚠️ Structured output (\`--json-schema\`) returned empty AND no inline findings posted. Investigate run logs.
 
-          Skills referenced: [none]"
+          Skills referenced: [none]
+
+          <!-- last-reviewed-sha: $HEAD_SHA -->
+
+          $CALIBRATION"
+          fi
 
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.22
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.27
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,5 +123,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.22._
+_Installed at clud-bug v0.6.27._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.27-self-upgrade.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.27-self-upgrade.md
@@ -1,0 +1,13 @@
+## 2026-05-30 09:10 - chore: propagate clud-bug v0.6.22 → v0.6.27 to logmind (Smart Budget self-upgrade)
+
+**Reasoning:** logmind's own .github/workflows/clud-bug-review.yml was at template v10 (clud-bug v0.6.22-era), missing Smart Budget Phases 1/2a/3: Layer 1 line-based estimator + Layer 1.5 calibration outputs (turns_estimated/files/+A/-D/threads) + Layer 2 in-prompt budget awareness + Layer 3 mid-review check-in + Layer 6 fallback render-from-inlines + 0.0.W² widened skip allowlist + concurrency-group cancel-in-progress. All 4 consumers (agent-skills/reporulez/rezgen/tokenomics) already on v0.6.27. User directive (2026-05-30): 'i do want clud bug propagated so bugs are better caught more efficiently — efficiency gainer.'
+
+**Alternatives considered:** wait until next quality batch — rejected, calibration data accumulates faster with logmind itself feeding markers, manual workflow file edit — rejected, structural-fix path; idempotent clud-bug update is what consumers run
+
+**Implications:**
+- logmind's PR reviews now emit Layer 1.5 calibration markers — feeds the same 30-day window used to gate clud-bug v0.6.28 (L5 auto-retry). One more data point per logmind PR.
+- 0.0.W² auto-skip widens to the allowlist (AGENTS.md, .cursorrules, .clud-bug.json, derived docs) — future workflow-only or doc-only propagation PRs to logmind itself skip the LLM review and save tokens.
+- Concurrency-group cancel-in-progress means duplicate triggers (e.g., synchronize on rapid pushes) no longer pile up two concurrent reviews — matches the v0.6.25 fix that hit tokenomics #21.
+- This PR may trigger the App-side workflow-self-modification guard (claude-code-action refuses on PRs that modify its own workflow file) — admin-bypass once expected per the documented per-PR-checklist structural exception. Next workflow-only PR in logmind will auto-skip via 0.0.W².
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (74 decisions)
+## 2026-05 (75 decisions)
 
-- **2026-05-30** — feat(v0.5.10): warn loudly when --stage scoped leaves tracked modifications unstaged (#59) *(fix/v0.5.10-stage-scoped-warn-issue-59)* — [decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md](decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md)
-- *... 72 more decisions ...*
+- **2026-05-30** — chore: propagate clud-bug v0.6.22 → v0.6.27 to logmind (Smart Budget self-upgrade) *(chore/clud-bug-v0.6.27-self-upgrade)* — [decisions-branches/chore__clud-bug-v0.6.27-self-upgrade.md](decisions-branches/chore__clud-bug-v0.6.27-self-upgrade.md)
+- *... 73 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)


### PR DESCRIPTION
## Summary

logmind's own `.github/workflows/clud-bug-review.yml` was at template **v10** (clud-bug v0.6.22-era), missing the Smart Budget System Phases 1, 2a, and 3 that already ship to all 4 consumers (agent-skills, reporulez, rezgen, tokenomics).

User directive (2026-05-30): _"i do want clud bug propagated so bugs are better caught more efficiently — efficiency gainer."_

## What v10 → v12 brings

- **Layer 1** — `paths-check` jq-driven line-based budget estimator (code 1/50, docs 1/150, tests/config 1/100, modified ×1.5, deleted ×0.1, prior threads ×1.5). Replaces v0.6.23's 4-bucket if-elif.
- **Layer 1.5** — calibration markers emitted via `<!-- clud-bug-calibration: turns_estimated=N, max_turns=M, files=F, lines_added=A, lines_deleted=D, threads=T -->` on every review summary. Feeds the 30-day window used to gate clud-bug v0.6.28.
- **Layer 2** — in-prompt budget awareness with per-PR injection of live values (`max_turns/estimated/files/+A/-D/threads`).
- **Layer 3** — mid-review `[budget]` heartbeat every 5 tool_uses + pace-behind pivot strategy.
- **Layer 6** — fallback render-from-inlines: when `structured_output` is empty BUT inline findings exist, scrape via `gh api pulls/N/comments` and synthesize a labeled "Synthetic summary."
- **0.0.W²** — widened skip allowlist (AGENTS.md, .cursorrules, .clud-bug.json, derived docs, branch-decisions). HAS_WORKFLOW_CHANGE signature preserves prompt-injection-via-AGENTS.md guard.
- **Concurrency group** with `cancel-in-progress: true` — duplicate triggers on rapid pushes no longer pile up two concurrent reviews.

## Diff scope

- `.github/workflows/clud-bug-review.yml` — 237 lines re-rendered against v12 template.
- `AGENTS.md` — `_Installed at clud-bug v0.6.22._` → `v0.6.27`.
- `.claude/skills/.clud-bug.json` — `lastUpdateVersion` bump + timestamp.
- `.cursorrules` — analogous version bump.

logmind block-version (`v6-pointer`) is current — no `logmind agents update` needed.

## Why this is high-priority

- Calibration data accumulates faster: logmind PR reviews now feed Layer 1.5 markers into the 30-day window gating clud-bug v0.6.28 (L5 auto-retry).
- 0.0.W² means future workflow-only and doc-only propagation PRs to logmind itself auto-skip the LLM review — saved tokens compound.

## Test plan

- [x] `npx --yes clud-bug@0.6.27 update --quiet` — clean idempotent re-render.
- [x] `logmind agents update --apply` — block is current.
- [ ] CI: paths-check fires + Layer 1 estimator computes a budget for this very PR (workflow-self-modification likely fires App-guard; admin-bypass per per-PR-checklist exception).
- [ ] After merge: next workflow-only PR to logmind auto-skips via 0.0.W².

## Admin-bypass expectation

This PR modifies `.github/workflows/clud-bug-review.yml` itself → App-side workflow-self-modification guard expected to fire once (per Anthropic policy, not configurable). Documented per-PR-checklist structural exception. Future workflow-only PRs in logmind will auto-skip via 0.0.W² without admin-bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)