### PR TITLE
feat(v0.5.12): logmind log auto-installs merge driver + hooks (fresh-clone auto-resolve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-05-30
+
+### Fixed — `timeline.md` auto-resolves on fresh clones / CI / throwaway worktrees
+
+Pre-fix, `logmind init` was the only path that installed the
+per-clone git config + hooks needed for `timeline.md` and
+`file-structure.md` to merge cleanly. Fresh clones, CI runners,
+and agents working in throwaway worktrees had the committed
+`.gitattributes` reference to `merge=logmind-timeline` but no
+driver definition registered locally. Git refuses to invoke an
+unconfigured merge driver (security guard against untrusted
+repos), so it silently fell back to the default ort 3-way merge.
+The result was text-valid but semantically incomplete `timeline.md`
+output that `check-derived-docs` later flagged — failing the PR
+gate even though the merge "succeeded."
+
+Hit live on tokenomics #21 when merging main into a branch
+produced `Auto-merging docs/timeline.md / Merge made by the 'ort'
+strategy` instead of the expected `logmind-timeline` driver
+output. User stance (memory `project_timeline_conflict_should_auto_resolve`):
+_"conflicts bugs like this shouldn't happen on our own timeline
+file and logmind should auto resolve."_
+
+v0.5.12 makes `logmind log` self-healing. Every invocation now
+runs the three idempotent installers from `logmind.core.gitattributes`:
+
+- `configure_merge_drivers(repo_root)` — sets `merge.logmind-timeline.driver` + `merge.logmind-file-structure.driver` in `.git/config`.
+- `install_post_merge_hook(repo_root)` — writes the canonical post-merge hook (v0.3.0+).
+- `install_post_rewrite_hook(repo_root)` — writes the post-rewrite hook (v0.5.11+).
+
+All three are silent no-ops outside a git repo (the fresh-clone
+case isn't always in a git checkout — e.g. when an agent works
+in a temp directory). Cost per `logmind log`: ~3 `git config --get`
+calls + 2 file stats. Negligible.
+
+The first `logmind log` in any fresh clone now leaves the clone
+fully configured for future merges, rebases, and amends. No more
+"why isn't the merge driver firing?" mysteries on CI / agents.
+
+### Added
+
+- `logmind.core.logger.log()` — auto-install block at top of
+  function, runs unconditionally (idempotent + git-safe).
+
+### Tests
+
+3 new tests in `tests/test_logger.py`:
+
+- `test_log_auto_installs_merge_driver_on_fresh_clone` — fresh-clone
+  simulation (.gitattributes committed, no per-clone driver). After
+  `logmind log` with `auto_commit=False`, driver + both hooks are
+  configured.
+- `test_log_auto_install_is_silent_noop_outside_git_repo` — non-git-repo
+  invocation doesn't crash. Decision is still recorded.
+- `test_log_auto_install_is_idempotent_across_repeated_invocations`
+  — second `logmind log` doesn't re-write hook files (regression
+  guard against double-install at log() layer).
+
 ## [0.5.11] - 2026-05-30
 
 ### Fixed — issue #58: multi-commit rebases left `docs/timeline.md` stale

--- a/docs/decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md
+++ b/docs/decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md
@@ -1,0 +1,13 @@
+## 2026-05-30 10:12 - feat(v0.5.12): `logmind log` auto-installs merge driver + hooks on every invocation (fresh-clone auto-resolve)
+
+**Reasoning:** Pre-v0.5.12: logmind init was the only path that installed the per-clone git config + hooks for timeline.md / file-structure.md to merge cleanly. Fresh clones / CI runners / agents in throwaway worktrees had the committed .gitattributes reference to merge=logmind-timeline but no driver definition registered locally — git refused to invoke the unconfigured driver (security guard) and silently fell back to ort 3-way merge → text-valid but semantically incomplete timeline.md → check-derived-docs failed downstream. Hit live on tokenomics #21. User stance (memory project_timeline_conflict_should_auto_resolve): 'conflicts bugs like this shouldn't happen on our own timeline file and logmind should auto resolve.'
+
+**Alternatives considered:** logmind doctor exits non-zero + nags — rejected, requires user to run doctor (won't catch agent flows). v0.5.13 will add the doctor-exit anyway for CI gate use, but log() is the load-bearing self-heal path., Commit driver script to repo + reference via .gitattributes wrapper — rejected, git's security model requires .git/config registration regardless of where the script lives., Ship driver as python -m logmind.merge_drivers.timeline — rejected for the same reason; git still needs .git/config to know about the driver name.
+
+**Implications:**
+- Cost per logmind log: ~3 git config --get calls + 2 file stats. Negligible.
+- All three installers are individually idempotent + silent no-ops outside a git repo. The cost is fully amortized — first logmind log in a fresh clone leaves the clone fully configured; subsequent calls are pure no-ops.
+- Closes the auto-resolve gap for fresh clones. Combined with v0.5.11's post-rewrite hook + v0.3.0's post-merge hook + merge driver, the derived-docs self-healing story is now end-to-end complete: clone → log → merge / rebase / amend all work without manual intervention.
+- Stream 4b website messaging ('Your docs stay in sync. Always.') now backed by full implementation across all 3 git operations (merge / rebase / amend) and all clone states (fresh / configured).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (76 decisions)
+## 2026-05 (77 decisions)
 
-- **2026-05-30** — feat(v0.5.11): post-rewrite hook so multi-commit rebases don't leave timeline.md stale (#58) *(fix/v0.5.11-post-rewrite-hook-issue-58)* — [decisions-branches/fix__v0.5.11-post-rewrite-hook-issue-58.md](decisions-branches/fix__v0.5.11-post-rewrite-hook-issue-58.md)
-- *... 74 more decisions ...*
+- **2026-05-30** — feat(v0.5.12): `logmind log` auto-installs merge driver + hooks on every invocation (fresh-clone auto-resolve) *(fix/v0.5.12-auto-install-merge-driver-on-log)* — [decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md](decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md)
+- *... 75 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.11"
+version = "0.5.12"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -108,7 +108,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.11", prog_name="logmind")
+@click.version_option(version="0.5.12", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -20,6 +20,11 @@ from logmind.core.git_handler import (
     is_git_repo,
     unstaged_tracked_modifications,
 )
+from logmind.core.gitattributes import (
+    configure_merge_drivers,
+    install_post_merge_hook,
+    install_post_rewrite_hook,
+)
 from logmind.core.timeline import write_timeline
 from logmind.core.tree_gen import update_file_structure
 
@@ -268,6 +273,28 @@ def log(
         raise FileNotFoundError(
             "docs/ directory not found. Run 'logmind init' first to initialize."
         )
+
+    # v0.5.12: auto-install merge-driver config + post-merge + post-rewrite
+    # hooks on every invocation. All three helpers are idempotent (no-op
+    # when already configured) AND silent no-ops outside a git repo.
+    # Cost: ~3 `git config --get` calls + 2 file stats on each `logmind log`.
+    #
+    # Why: pre-v0.5.12, `logmind init` was the only path that installed
+    # the per-clone git config + hooks. Fresh clones / CI runners /
+    # agents working in throwaway worktrees had the committed
+    # `.gitattributes` reference but no driver registered locally → git
+    # refused to invoke the driver (security guard against untrusted
+    # repos) → fell back to ort 3-way merge → text-valid but
+    # semantically-wrong timeline.md → check-derived-docs failed
+    # downstream. Hit live on tokenomics #21. Captured in memory
+    # `project_timeline_conflict_should_auto_resolve`. v0.5.12 makes
+    # `logmind log` self-healing: the first invocation in any fresh
+    # checkout leaves the clone fully configured for future merges /
+    # rebases / amends.
+    repo_root = docs_path.parent
+    configure_merge_drivers(repo_root)
+    install_post_merge_hook(repo_root)
+    install_post_rewrite_hook(repo_root)
 
     # Load configuration
     config = load_config()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -479,6 +479,127 @@ def test_log_scoped_stage_ignores_untracked_files(
     )
 
 
+# ---------------------------------------------------------------------------
+# v0.5.12 — auto-install merge driver + hooks on every `logmind log`
+#
+# Pre-v0.5.12, `logmind init` was the only path that installed the per-clone
+# git config + hooks. Fresh clones / CI runners / agents in throwaway worktrees
+# had the committed .gitattributes reference but no driver registered locally
+# → git refused to invoke the driver → fell back to ort 3-way merge → ended
+# up with text-valid but semantically-wrong timeline.md → check-derived-docs
+# failed downstream. Hit live on tokenomics #21. Memory:
+# `project_timeline_conflict_should_auto_resolve`.
+# ---------------------------------------------------------------------------
+
+
+def test_log_auto_installs_merge_driver_on_fresh_clone(tmp_path, monkeypatch):
+    """v0.5.12: fresh-clone simulation — git init + committed
+    .gitattributes block but NO per-clone driver config. After running
+    `logmind log`, the driver must be configured and both hooks must
+    be installed."""
+    from logmind.core.gitattributes import (
+        driver_configured,
+        ensure_block as ensure_gitattributes_block,
+        post_merge_hook_installed,
+        post_rewrite_hook_installed,
+    )
+
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Simulate the fresh-clone shape: .gitattributes is committed
+    # (would be the case post-`logmind init` by someone else), but the
+    # per-clone `git config merge.logmind-timeline.driver` is unset
+    # (fresh clone never ran `logmind init` locally).
+    ensure_gitattributes_block(tmp_path / ".gitattributes")
+    assert driver_configured(tmp_path) is False, (
+        "Sanity: fresh clone must start with driver UNconfigured"
+    )
+    assert post_merge_hook_installed(tmp_path) is False
+    assert post_rewrite_hook_installed(tmp_path) is False
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+    (docs / "decisions-archive.md").write_text("# Archive\n\n---\n", encoding="utf-8")
+
+    log(
+        "fresh-clone smoke test",
+        reasoning="verify auto-install on log",
+        docs_path=docs,
+        auto_commit=False,  # auto-install must fire even with --no-commit
+    )
+
+    # After logmind log: driver configured + both hooks installed.
+    assert driver_configured(tmp_path) is True, (
+        "v0.5.12: `logmind log` must auto-install the merge driver "
+        "config so fresh clones self-heal on first use"
+    )
+    assert post_merge_hook_installed(tmp_path) is True, (
+        "v0.5.12: post-merge hook must be auto-installed by `logmind log`"
+    )
+    assert post_rewrite_hook_installed(tmp_path) is True, (
+        "v0.5.12: post-rewrite hook (v0.5.11) must be auto-installed by "
+        "`logmind log`"
+    )
+
+
+def test_log_auto_install_is_silent_noop_outside_git_repo(tmp_path):
+    """v0.5.12: outside a git repo, the auto-install must not crash —
+    all three helpers no-op silently. Regression guard against
+    `Path.cwd()` resolving to a non-repo when logmind log runs from
+    a stray directory."""
+    # No `git init` — just a docs/ directory in a plain folder.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+
+    # Must not raise.
+    log(
+        "non-git-repo log",
+        reasoning="auto-install must be safe outside git",
+        docs_path=docs,
+        auto_commit=False,
+    )
+
+    # Decision still recorded.
+    content = (docs / "decisions.md").read_text(encoding="utf-8")
+    assert "non-git-repo log" in content
+
+
+def test_log_auto_install_is_idempotent_across_repeated_invocations(
+    tmp_path, monkeypatch
+):
+    """v0.5.12: invoking `logmind log` twice in a row must not re-install
+    or double-write hook files. configure_merge_drivers / install_*_hook
+    are individually idempotent; this is the integration regression
+    guard at the log() layer."""
+    from logmind.core.gitattributes import (
+        ensure_block as ensure_gitattributes_block,
+    )
+
+    _git_init(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    ensure_gitattributes_block(tmp_path / ".gitattributes")
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "decisions.md").write_text("# Decision Log\n\n---\n", encoding="utf-8")
+
+    # First call: installs.
+    log("first call", docs_path=docs, auto_commit=False)
+    first_hook_mtime = (tmp_path / ".git" / "hooks" / "post-merge").stat().st_mtime
+
+    # Second call: must NOT touch the hook file again (idempotent).
+    log("second call", docs_path=docs, auto_commit=False)
+    second_hook_mtime = (tmp_path / ".git" / "hooks" / "post-merge").stat().st_mtime
+
+    assert first_hook_mtime == second_hook_mtime, (
+        "v0.5.12: idempotent auto-install must not re-write hook file "
+        "on repeated `logmind log` invocations"
+    )
+
+
 def test_log_stage_all_never_warns(tmp_path, monkeypatch, capsys):
     """v0.5.10 / issue #59: --stage all sweeps the whole working tree
     so the scoped-warning code path must never fire under it."""


### PR DESCRIPTION
Closes the auto-resolve gap captured in memory `project_timeline_conflict_should_auto_resolve`.

## Summary

- Pre-v0.5.12: `logmind init` was the only path that installed the per-clone git config + hooks. Fresh clones / CI / agents in throwaway worktrees had the committed `.gitattributes` but no driver registered → git fell back to ort 3-way merge → semantically-wrong `timeline.md` → `check-derived-docs` failed downstream. Hit live on tokenomics #21.
- v0.5.12: every `logmind log` invocation runs three idempotent installers from `gitattributes.py` (driver config + post-merge hook + post-rewrite hook). First `logmind log` in any fresh clone leaves it fully configured.
- Cost: ~3 `git config --get` + 2 file stats per `logmind log`. Negligible. All silent no-ops outside a git repo.

## Closes the self-healing loop

Combined with prior work, derived-docs are now self-healing across all 3 git operations × all clone states:

|                | Fresh clone | Configured clone |
|---|---|---|
| **merge**      | ✅ (v0.5.12 auto-installs driver + post-merge hook) | ✅ (v0.3.0 driver + post-merge) |
| **rebase**     | ✅ (v0.5.12 auto-installs post-rewrite hook)        | ✅ (v0.5.11 post-rewrite hook)  |
| **amend**      | ✅ (v0.5.12 auto-installs post-rewrite hook)        | ✅ (v0.5.11 post-rewrite hook)  |

## Test plan

- [x] `pytest tests/test_logger.py -v` — 26/26 green (3 new + 23 existing).
- [x] `pytest -q` (full suite) — 639 passed, 1 skipped.
- [x] 3 new tests cover: fresh-clone auto-config, non-git-repo silent no-op, idempotency under repeated invocations.
- [ ] CI green; clud-bug-review (Smart Budget v0.6.27 templates) passes.
- [ ] After merge: tag `v0.5.12` → Trusted Publishing publishes to PyPI within ~1 min.

## Files

- `src/logmind/core/logger.py` — auto-install block + 3 new imports at top of `log()`.
- `tests/test_logger.py` — 3 new tests.
- `pyproject.toml`, `src/logmind/__init__.py`, `src/logmind/cli.py:110` — version bump 0.5.11 → 0.5.12.
- `CHANGELOG.md` — `[0.5.12] - 2026-05-30` entry citing the tokenomics #21 hit + the memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)