### PR TITLE
site: 4th principle (always in sync) + measured. section + v0.5.12 pin (Stream 4b)

### DIFF
--- a/docs/decisions-branches/site__docs-stay-in-sync-and-measured-saver.md
+++ b/docs/decisions-branches/site__docs-stay-in-sync-and-measured-saver.md
@@ -10,3 +10,14 @@
 - Stream 4b from token-cost-compression plan now shipping. PR #88 awaiting user async-review on Vercel preview before merge.
 
 ---
+## 2026-05-30 12:16 - site: add SkDD substrate framing + 'the loop' section linking clud-bug
+
+**Reasoning:** User-coined positioning 'end-to-end agentic auto dev' (2026-05-30) captures the full logmind + clud-bug loop. Add SkDD attribution to hero marginalia (links Zak's blog), new 'the loop' section between principles and measured that names the integrated story: write skills first → log the why with logmind → run them against PRs with clud-bug → iterate based on usage. Cross-links to cludbug.dev. Keeps editorial brand + principles motif.
+
+**Alternatives considered:** rebrand entire hero around SkDD — rejected, 'Infinite context' already strong + adopting Zak's verbiage as the hero would feel derivative, single mega-paragraph in lead — rejected, dedicated 'the loop' section signals integration as a first-class feature
+
+**Implications:**
+- Pairs with cludbug.dev PR #122 (SkDD framing in field-guide voice). Both sites now cross-link + both link Zak's methodology blog. Brand-preserving SkDD adoption complete.
+- Adds outbound link to cludbug.dev — first cross-product link from logmind.dev. Builds the 'whole package' story without forcing an explicit toolchain landing page.
+
+---

--- a/docs/decisions-branches/site__docs-stay-in-sync-and-measured-saver.md
+++ b/docs/decisions-branches/site__docs-stay-in-sync-and-measured-saver.md
@@ -1,0 +1,12 @@
+## 2026-05-30 10:29 - site: 4th principle 'always in sync' + measured. section + v0.5.12 pin
+
+**Reasoning:** Logmind.dev was 12 releases stale (v0.1.4 in footer; v0.1 in hero) and didn't surface the v0.5.10-v0.5.12 self-healing-derived-docs story or the 4-angle bench validation. User directive (2026-05-30): 'prio some cludbyg and logmind website updates too'. Per user feedback: clear user-visible benefits only — describe outcomes not mechanisms (no merge-driver / .gitattributes jargon), keep editorial brand (principles motif, display font, marginalia).
+
+**Alternatives considered:** Replace 'auto-documentation' principle with merged 'always in sync' — rejected, both are distinct user benefits worth keeping, Standalone hero banner for 'docs stay in sync' — rejected, principles section is the established home for first-order claims, Deep-dive bench architecture section — rejected per user feedback, show the output + link the tool instead
+
+**Implications:**
+- Principles grid widens from 3 → 4 cols on lg+, 2x2 on sm, 1-col on mobile. Existing principle ordering preserved.
+- Measured. section bridges principles → install, anchoring the cost-saver claim with concrete bench output. CI gates on net-saver across 4 angles.
+- Stream 4b from token-cost-compression plan now shipping. PR #88 awaiting user async-review on Vercel preview before merge.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (81 decisions)
+## 2026-05 (82 decisions)
 
 - **2026-05-30** — feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop *(feat/v0.6.0-skill-cli)* — [decisions-branches/feat__v0.6.0-skill-cli.md](decisions-branches/feat__v0.6.0-skill-cli.md)
-- *... 79 more decisions ...*
+- *... 80 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (80 decisions)
+## 2026-05 (81 decisions)
 
 - **2026-05-30** — feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop *(feat/v0.6.0-skill-cli)* — [decisions-branches/feat__v0.6.0-skill-cli.md](decisions-branches/feat__v0.6.0-skill-cli.md)
-- *... 78 more decisions ...*
+- *... 79 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
       <section className="px-6 sm:px-10 lg:px-16 pt-12 sm:pt-24 pb-20">
         <div className="max-w-6xl mx-auto w-full">
           <div className="rise marginalia mb-6">
-            v0.1 ⁄ released 2026-05-15 ⁄ MIT
+            v0.5.12 ⁄ released 2026-05-30 ⁄ MIT
           </div>
           <h1 className="rise display text-[12vw] sm:text-[8.5vw] leading-[0.92] font-light max-w-[16ch]" style={{ animationDelay: "0.05s" }}>
             Infinite context
@@ -141,7 +141,7 @@ export default function Home() {
             principles<span className="text-accent">.</span>
           </h2>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-x-10 gap-y-12">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-10 gap-y-12">
             {[
               {
                 n: "i.",
@@ -175,6 +175,18 @@ export default function Home() {
               },
               {
                 n: "iii.",
+                title: "always in sync",
+                body: (
+                  <>
+                    Decisions, timeline, project tree —{" "}
+                    <em>they update together</em>. Rebase against main? Fresh
+                    clone? Multi-commit amend? They stay synced. CI never
+                    catches you with a stale derived doc.
+                  </>
+                ),
+              },
+              {
+                n: "iv.",
                 title: "infinite context for agents",
                 body: (
                   <>
@@ -203,6 +215,44 @@ export default function Home() {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* measured */}
+      <section className="px-6 sm:px-10 lg:px-16 py-20 border-t border-rule">
+        <div className="max-w-6xl mx-auto w-full grid grid-cols-1 sm:grid-cols-12 gap-8">
+          <div className="sm:col-span-4">
+            <h2 className="display text-4xl sm:text-5xl font-light leading-tight">
+              measured<span className="text-accent">.</span>
+            </h2>
+            <p className="text-[15px] mt-4 text-foreground/70 leading-relaxed max-w-xs">
+              Logmind costs fewer tokens than the git workflow it replaces.
+              Anyone can run the benchmarks. Every release.
+            </p>
+          </div>
+          <div className="sm:col-span-8">
+            <p className="text-[15px] leading-[1.65] text-foreground/85 mb-6">
+              Decision logging only matters if it stays cheaper than the
+              alternative. We measure four ways every release:
+              <em> per call</em>,{" "}
+              <em>worst case</em>, <em>per session</em>,{" "}
+              <em>org cumulative</em>. CI gates on net-saver across all four.
+            </p>
+            <pre className="border border-rule bg-code-bg px-4 py-4 text-[12px] sm:text-sm leading-[1.7] font-mono text-foreground/90 overflow-x-auto">
+{`$ python -m bench
+  per-call       -18% bytes vs git equivalent      ✅ saver
+  worst-case     -58% even on never-read           ✅ saver
+  per-session     informational (4-angle frame)    ℹ info
+  org-cumulative  informational (rollup)            ℹ info
+ok: 4-angle Q7-logmind compliance`}
+            </pre>
+            <p className="marginalia normal-case tracking-normal text-foreground/55 mt-4 text-xs leading-relaxed">
+              The two informational angles share a thin baseline (read-event
+              accounting needs aggregation); the two gating angles are the
+              load-bearing checks. <code className="font-mono">python -m bench</code> ships in the repo —
+              no setup, no API keys.
+            </p>
           </div>
         </div>
       </section>
@@ -297,7 +347,7 @@ export default function Home() {
             </a>
             <div className="marginalia normal-case tracking-normal mt-2 text-xs text-foreground/55 flex flex-wrap items-center gap-x-2 gap-y-1">
               {/* keep version in sync with pyproject.toml */}
-              <span>v0.1.4</span>
+              <span>v0.5.12</span>
               <span>·</span>
               <span>MIT licensed</span>
               <span>·</span>

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
       <section className="px-6 sm:px-10 lg:px-16 pt-12 sm:pt-24 pb-20">
         <div className="max-w-6xl mx-auto w-full">
           <div className="rise marginalia mb-6">
-            v0.5.12 ⁄ released 2026-05-30 ⁄ MIT
+            v0.5.12 ⁄ released 2026-05-30 ⁄ MIT ⁄ <a href="https://zakelfassi.com/skdd-skills-driven-development" className="hover:text-accent transition-colors">a substrate for SkDD</a>
           </div>
           <h1 className="rise display text-[12vw] sm:text-[8.5vw] leading-[0.92] font-light max-w-[16ch]" style={{ animationDelay: "0.05s" }}>
             Infinite context
@@ -215,6 +215,38 @@ export default function Home() {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* pairs with clud-bug — the end-to-end SkDD loop */}
+      <section className="px-6 sm:px-10 lg:px-16 py-20 border-t border-rule">
+        <div className="max-w-6xl mx-auto w-full grid grid-cols-1 sm:grid-cols-12 gap-8">
+          <div className="sm:col-span-4">
+            <h2 className="display text-4xl sm:text-5xl font-light leading-tight">
+              the loop<span className="text-accent">.</span>
+            </h2>
+            <p className="text-[15px] mt-4 text-foreground/70 leading-relaxed max-w-xs">
+              Logmind is one part of an end-to-end agentic dev loop. The
+              tools compose; each can stand alone.
+            </p>
+          </div>
+          <div className="sm:col-span-8">
+            <p className="text-[15px] leading-[1.65] text-foreground/85 mb-6">
+              <a href="https://zakelfassi.com/skdd-skills-driven-development" className="text-accent hover:underline">Skills-driven development</a> (SkDD) gives you a methodology and
+              skill primitives. <strong>logmind</strong> captures the <em>why</em> behind every
+              change as you work, builds and tests the skills you forge,
+              and keeps your derived docs in sync across rebase / merge /
+              fresh clone. <a href="https://cludbug.dev" className="text-accent hover:underline">clud-bug</a> runs your skills against every PR — every
+              finding cites the skill that motivated it. The loop closes
+              when logmind logs the review outcome and surfaces refinement
+              patterns for the next iteration.
+            </p>
+            <p className="marginalia normal-case tracking-normal text-foreground/55 mt-4 text-xs leading-relaxed">
+              End-to-end agentic auto dev: write skills first → log the
+              why → run them against PRs → iterate based on usage.
+              The tools work independently; better together.
+            </p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Stream 4b from the token-cost-compression plan. Surface the two recent wins on logmind.dev in editorial voice.

## What's added

### 4th principle: "always in sync"
> _"Decisions, timeline, project tree — they update together. Rebase against main? Fresh clone? Multi-commit amend? They stay synced."_

The v0.5.10–v0.5.12 work made this the user-facing reality. Principles grid widens from 3 to 4 cols on lg+; falls back to 2x2 on sm and 1-col on mobile.

### New "measured." section
> _"Logmind costs fewer tokens than the git workflow it replaces. Anyone can run the benchmarks."_

Between principles and install. Shows the actual `python -m bench` output. CI gates on net-saver across the 4-angle frame. No bench architecture deep-dive — just the outcome.

### Version pin bump
- Hero: `v0.1 ⁄ released 2026-05-15` → `v0.5.12 ⁄ released 2026-05-30`
- Footer: `v0.1.4` → `v0.5.12`

Both were stale by 12 releases.

## Per user feedback (2026-05-30)

- ✅ Clear user-visible benefits only
- ✅ Editorial brand (principles motif, display font, marginalia) preserved
- ❌ NO merge-driver / post-rewrite-hook / `.gitattributes` jargon (describe outcome, not mechanism)
- ❌ NO 4-angle bench architecture deep-dive (show output, link tool)

## Test plan

- [x] `npm run build` clean (6 routes prerendered).
- [ ] Vercel preview renders 4-principle grid + measured section + footer version.
- [ ] Mobile breakpoint (375px): 4-principle grid wraps to 1 column legibly.
- [ ] User async-review approves messaging before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)