### PR TITLE
bench: Stream 1 Path C — calibration_aggregate.py

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -57,3 +57,33 @@ changes meaningfully.
 
 Users don't need this. It's our QA gate. Keeps logmind's user-facing
 CLI surface clean.
+
+## `bench/scripts/` — Stream 1 calibration tooling
+
+Companion scripts for clud-bug's Smart Budget calibration (Stream 1
+of the token-cost-compression plan). Not part of the 4-angle Q7-logmind
+gate above — these inform clud-bug's Layer 1 estimator tuning, not
+logmind's net-saver story.
+
+### Path C — aggregate Layer 1.5 calibration markers
+
+```bash
+python -m bench.scripts.calibration_aggregate
+```
+
+Walks every consumer repo's PR comments via `gh api`, filters to
+`<!-- clud-bug-calibration: ... -->` markers (emitted on every
+clud-bug-review summary since v0.6.25), and computes:
+
+- Per-repo marker count
+- cap / est ratio distribution (p50, p90, min, max) — validates that
+  Layer 1's 1.2× safety margin is being applied consistently
+- Sorted table of (repo, shape, est, cap) per marker
+- JSON rows (one per marker) for downstream tooling
+
+Read-only; requires `gh auth login`. Run anytime to see current data;
+no waiting on the 30-day window.
+
+To add a repo to the sweep, edit `REPOS` in the script. Marker regex
+is locked to v0.6.25 format — any clud-bug release that changes the
+marker shape requires a corresponding bench/ bump.

--- a/bench/scripts/calibration_aggregate.py
+++ b/bench/scripts/calibration_aggregate.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Stream 1 Path C: aggregate Layer 1.5 calibration markers across consumer repos.
+
+Fetches every PR comment from the GH org's clud-bug-using repos, filters to
+the ``<!-- clud-bug-calibration: ... -->`` HTML markers that clud-bug
+v0.6.25+ emits on every review summary, and computes the distribution of
+estimator outputs.
+
+Background:
+  clud-bug v0.6.25 (Smart Budget Phase 1) introduced a jq-driven line-based
+  budget estimator + a calibration marker that records the estimator's
+  output on every PR review:
+
+      <!-- clud-bug-calibration: turns_estimated=N, max_turns=M,
+           files=F, lines_added=A, lines_deleted=D, threads=T -->
+
+  Path C of the Stream 1 (calibration acceleration) work watches these
+  markers accumulate via the natural PR flow and computes the distribution
+  of estimator outputs across the org. Combined with Path A (action-log
+  scrape for actual turn usage) and Path B (synthetic stress PRs), gates
+  the clud-bug v0.6.28 L5 auto-retry ship decision.
+
+  This script is the Path C piece — runnable today against whatever data
+  has accumulated, no waiting required.
+
+Usage:
+  python -m bench.scripts.calibration_aggregate
+
+Configuration:
+  GH org + repo list lives in REPOS below. To add a repo, append its name.
+  The marker regex is locked to the v0.6.25 format; future format changes
+  bump the version-pinned regex.
+
+Output:
+  - Per-repo counts to stderr
+  - Distribution stats + per-row table to stdout
+  - One JSON object per marker (newline-delimited) for downstream tooling
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from statistics import median, quantiles
+from typing import Any
+
+GH_ORG = "thrillmade"
+REPOS = (
+    "logmind",
+    "clud-bug",
+    "tokenomics",
+    "agent-skills",
+    "reporulez",
+    "rezgen",
+)
+
+# v0.6.25+ Layer 1.5 marker. Comment is emitted by the post-step renderer
+# on every clud-bug-review summary. Format is fixed; any format change is a
+# clud-bug release bump + a corresponding bench/ change.
+MARKER_RE = re.compile(
+    r"<!--\s*clud-bug-calibration:\s*"
+    r"turns_estimated=(\d+),\s*"
+    r"max_turns=(\d+),\s*"
+    r"files=(\d+),\s*"
+    r"lines_added=(\d+),\s*"
+    r"lines_deleted=(\d+),\s*"
+    r"threads=(\d+)\s*-->"
+)
+
+
+def fetch_markers(repo: str) -> list[dict[str, Any]]:
+    """Return every calibration marker found in ``repo``'s PR comments.
+
+    Uses ``gh api --paginate`` to walk all pages; emits one record per
+    matching marker. Comments without markers are silently skipped.
+    Returns an empty list on any gh / API failure (best-effort by design).
+    """
+    out = subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{GH_ORG}/{repo}/issues/comments?per_page=100",
+            "--paginate",
+            "--jq", ".[] | {body, html_url, created_at}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        print(f"[{repo}] gh api failed: {out.stderr.strip()}", file=sys.stderr)
+        return []
+
+    markers: list[dict[str, Any]] = []
+    # `gh api --paginate --jq` emits one JSON-line per matched object.
+    for line in out.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        body = obj.get("body") or ""
+        m = MARKER_RE.search(body)
+        if not m:
+            continue
+        markers.append({
+            "repo": repo,
+            "comment_url": obj.get("html_url"),
+            "created_at": obj.get("created_at"),
+            "turns_estimated": int(m.group(1)),
+            "max_turns": int(m.group(2)),
+            "files": int(m.group(3)),
+            "lines_added": int(m.group(4)),
+            "lines_deleted": int(m.group(5)),
+            "threads": int(m.group(6)),
+        })
+    return markers
+
+
+def _format_distribution(markers: list[dict[str, Any]]) -> str:
+    """Compute + format the cap/est ratio distribution. Returns a multi-line string."""
+    ratios = [
+        m["max_turns"] / m["turns_estimated"]
+        for m in markers
+        if m["turns_estimated"] > 0
+    ]
+    if not ratios:
+        return ""
+
+    lines = [
+        "cap / est ratio (Layer 1 safety margin = 1.2x rounded up to integer turn):",
+        f"  p50: {median(ratios):.2f}",
+    ]
+    if len(ratios) >= 4:
+        q = quantiles(ratios, n=10)
+        lines.append(f"  p90: {q[-1]:.2f}")
+    else:
+        lines.append(f"  p90: N/A (need >= 4 samples)")
+    lines.append(f"  min: {min(ratios):.2f}   max: {max(ratios):.2f}")
+    return "\n".join(lines)
+
+
+def _format_per_pr_table(markers: list[dict[str, Any]]) -> str:
+    """Render a sorted-by-estimated-turns table of (repo, shape, est, cap)."""
+    rows = ["Estimated turns by PR size (sorted ascending):",
+            f"  {'repo':>14}  {'files':>5}  {'+lines':>6}  {'-lines':>6}  "
+            f"{'threads':>7}  {'est':>3}  {'cap':>3}"]
+    for m in sorted(markers, key=lambda x: x["turns_estimated"]):
+        rows.append(
+            f"  {m['repo']:>14}  {m['files']:>5}  {m['lines_added']:>6}  "
+            f"{m['lines_deleted']:>6}  {m['threads']:>7}  "
+            f"{m['turns_estimated']:>3}  {m['max_turns']:>3}"
+        )
+    return "\n".join(rows)
+
+
+def main() -> int:
+    all_markers: list[dict[str, Any]] = []
+    per_repo: dict[str, int] = defaultdict(int)
+
+    print("Fetching calibration markers from", file=sys.stderr)
+    for repo in REPOS:
+        ms = fetch_markers(repo)
+        all_markers.extend(ms)
+        per_repo[repo] = len(ms)
+        print(f"  {repo:>14}  N = {len(ms)}", file=sys.stderr)
+
+    print(f"\n=== Stream 1 Path C — calibration markers (N = {len(all_markers)}) ===\n")
+
+    print("Per-repo counts:")
+    for repo in REPOS:
+        print(f"  {repo:>14}: {per_repo[repo]}")
+
+    if not all_markers:
+        print("\nNo markers yet. Need at least one v0.6.25+ clud-bug-review to land.")
+        return 0
+
+    dist = _format_distribution(all_markers)
+    if dist:
+        print(f"\n{dist}")
+
+    print(f"\n{_format_per_pr_table(all_markers)}")
+
+    # JSON output for downstream tooling — one object per line.
+    print("\n--- JSON rows (one per marker) ---")
+    for m in all_markers:
+        print(json.dumps(m, separators=(",", ":")))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/decisions-branches/feat__calibration-aggregate-path-c.md
+++ b/docs/decisions-branches/feat__calibration-aggregate-path-c.md
@@ -1,0 +1,12 @@
+## 2026-05-30 11:08 - bench: Stream 1 Path C — calibration_aggregate.py
+
+**Reasoning:** Productionize the inline script that aggregated 26 Layer 1.5 calibration markers across the org (logmind=3, clud-bug=6, tokenomics=2, agent-skills=15, reporulez=0, rezgen=0). Path C of Stream 1 (calibration acceleration) per the token-cost-compression plan. Lives in bench/scripts/ alongside future Path A (historical scrape) + Path B (synthetic stress sandbox). Read-only, runnable today against whatever data has accumulated — no 30-day window wait. User directive (2026-05-30): 'why do we need to wait so long? is there any benefit? other ways to test?'
+
+**Alternatives considered:** ship as a real CLI command (logmind bench-calibration) — rejected, this is QA tooling not a user-facing surface; lives in bench/ same as the 4-angle scripts, PyPI-ship bench/ — captured as deferred feature in plan; not now, REST API integration test mocking gh subprocess — rejected for v1; regex test exercises the load-bearing parsing logic without I/O
+
+**Implications:**
+- 26 markers already accumulated organically + N grows by ~3/day at current PR cadence. Tokenomics velocity boost (Stream 3 user-side) amplifies further.
+- Distribution stats (cap/est ratio p50=1.24, p90=1.36) confirm Layer 1's 1.2x safety margin is being applied consistently. To validate actual_used / estimated, Path A (action log scrape) is the next piece — captures tool_use count from completed runs.
+- Marker regex is locked to v0.6.25 format. Any clud-bug release that changes the marker shape needs a corresponding bench/scripts/calibration_aggregate.py bump + the regex test surfaces the change loudly.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -17,6 +17,7 @@ logmind
 ├── .logmind
 │   └── config.yml
 ├── bench
+│   ├── scripts
 │   ├── __init__.py
 │   ├── __main__.py
 │   ├── org_cumulative.py
@@ -65,6 +66,7 @@ logmind
 │   ├── test_analytics.py
 │   ├── test_bench.py
 │   ├── test_branch_aware_logging.py
+│   ├── test_calibration_aggregate.py
 │   ├── test_changelog.py
 │   ├── test_cli.py
 │   ├── test_config.py

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (77 decisions)
+## 2026-05 (78 decisions)
 
-- **2026-05-30** — feat(v0.5.12): `logmind log` auto-installs merge driver + hooks on every invocation (fresh-clone auto-resolve) *(fix/v0.5.12-auto-install-merge-driver-on-log)* — [decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md](decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md)
-- *... 75 more decisions ...*
+- **2026-05-30** — bench: Stream 1 Path C — calibration_aggregate.py *(feat/calibration-aggregate-path-c)* — [decisions-branches/feat__calibration-aggregate-path-c.md](decisions-branches/feat__calibration-aggregate-path-c.md)
+- *... 76 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/tests/test_calibration_aggregate.py
+++ b/tests/test_calibration_aggregate.py
@@ -1,0 +1,86 @@
+"""Test the Layer 1.5 calibration marker regex in bench/scripts/calibration_aggregate.py.
+
+Avoids gh-API mocking (the fetcher is intentionally I/O bound). Locks down
+the regex against the v0.6.25 marker format so any clud-bug-side format
+change surfaces as a test failure rather than silent zero markers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bench.scripts.calibration_aggregate import MARKER_RE
+
+
+def test_marker_regex_matches_canonical_v0625_format():
+    """The marker shape that clud-bug v0.6.25+ emits on every review."""
+    body = (
+        "## 🐛 Clud Bug review\n"
+        "(...summary content...)\n"
+        "<!-- last-reviewed-sha: abc123 -->\n"
+        "<!-- clud-bug-calibration: turns_estimated=17, max_turns=21, "
+        "files=10, lines_added=299, lines_deleted=10, threads=0 -->\n"
+    )
+    m = MARKER_RE.search(body)
+    assert m is not None, "regex must match the canonical v0.6.25 marker format"
+    assert int(m.group(1)) == 17  # turns_estimated
+    assert int(m.group(2)) == 21  # max_turns
+    assert int(m.group(3)) == 10  # files
+    assert int(m.group(4)) == 299  # lines_added
+    assert int(m.group(5)) == 10  # lines_deleted
+    assert int(m.group(6)) == 0  # threads
+
+
+def test_marker_regex_handles_extra_whitespace():
+    """The renderer may inject extra whitespace; tolerate it without breaking."""
+    body = (
+        "<!--   clud-bug-calibration:    "
+        "turns_estimated=5,   max_turns=10,  files=1, lines_added=5, "
+        "lines_deleted=0,  threads=0   -->"
+    )
+    m = MARKER_RE.search(body)
+    assert m is not None
+    assert int(m.group(1)) == 5
+    assert int(m.group(2)) == 10
+
+
+def test_marker_regex_does_not_match_partial_or_malformed_markers():
+    """Don't false-positive on near-misses (missing fields, typos).
+
+    Path C's downstream stats break if we miscount; better to silently
+    skip a malformed marker than count it wrongly.
+    """
+    cases = [
+        # Missing threads field
+        "<!-- clud-bug-calibration: turns_estimated=5, max_turns=10, "
+        "files=1, lines_added=5, lines_deleted=0 -->",
+        # Typo in marker prefix
+        "<!-- clud-buug-calibration: turns_estimated=5, max_turns=10, "
+        "files=1, lines_added=5, lines_deleted=0, threads=0 -->",
+        # Non-numeric value
+        "<!-- clud-bug-calibration: turns_estimated=many, max_turns=10, "
+        "files=1, lines_added=5, lines_deleted=0, threads=0 -->",
+        # Empty body
+        "",
+        # No marker at all
+        "## 🐛 Clud Bug review\n0 critical · 0 minor",
+    ]
+    for body in cases:
+        assert MARKER_RE.search(body) is None, (
+            f"regex must not match malformed/missing marker: {body!r}"
+        )
+
+
+def test_marker_regex_extracts_only_one_per_comment():
+    """A comment with multiple marker-shaped strings (e.g. quoted in a fix-push)
+    should still extract the FIRST one — downstream code uses .search() not
+    .findall() since the renderer emits exactly one per review."""
+    body = (
+        "<!-- clud-bug-calibration: turns_estimated=1, max_turns=1, files=1, "
+        "lines_added=1, lines_deleted=0, threads=0 -->\n"
+        "<!-- clud-bug-calibration: turns_estimated=99, max_turns=99, "
+        "files=99, lines_added=99, lines_deleted=99, threads=9 -->\n"
+    )
+    m = MARKER_RE.search(body)
+    assert m is not None
+    assert int(m.group(1)) == 1  # first marker wins


### PR DESCRIPTION
Stream 1 Path C from the token-cost-compression plan. Productionizes the inline script that aggregated 26 Layer 1.5 calibration markers across the org.

## What's added

- **`bench/scripts/calibration_aggregate.py`** — walks every consumer repo's PR comments via `gh api`, filters to `<!-- clud-bug-calibration: ... -->` markers (emitted by clud-bug v0.6.25+ on every review summary), computes distribution + per-row table.
- **`bench/README.md`** — surfaces the new script in a "Stream 1 calibration tooling" subsection (kept separate from the 4-angle Q7-logmind gate above — Path C informs clud-bug's Layer 1 tuning, not logmind's net-saver story).
- **`tests/test_calibration_aggregate.py`** — 4 regex tests pin the v0.6.25 marker format; any clud-bug release that changes the marker shape surfaces as a loud test failure rather than silent zero markers.

## Sample output (live, just now)

```
=== Stream 1 Path C — calibration markers (N = 26) ===

Per-repo counts:
         logmind: 3
        clud-bug: 6
      tokenomics: 2
    agent-skills: 15
       reporulez: 0
          rezgen: 0

cap / est ratio (Layer 1 safety margin = 1.2x rounded up to integer turn):
  p50: 1.24
  p90: 1.36
  min: 1.20   max: 1.36
```

Shape range covered: 1-14 files, 47-2760 added lines, 0-28 deleted, 0 prior threads. Already enough diversity to gut-check the estimator across small/medium/large PRs.

## Why this matters

User pushback on the 30-day calibration window (2026-05-30): _"why do we need to wait so long? is there any benefit? other ways to test?"_

Answer: 30d was calendar-arbitrary. The real gate is **data quantity × shape diversity**. Path C runs anytime against whatever data has accumulated organically. Combined with Path A (action-log scrape for actual `turns_used`) + Path B (synthetic stress sandbox), gates clud-bug v0.6.28 L5 auto-retry ship decision in ~7d instead of 30d.

## Test plan

- [x] `pytest tests/test_calibration_aggregate.py -v` — 4/4 green.
- [x] `python -m bench.scripts.calibration_aggregate` runs end-to-end with current org state (N=26 markers).
- [ ] CI: full `pytest -q` green, no regressions.
- [ ] No version bump — `bench/` is internal-only, not shipped to PyPI.

## Files

- `bench/scripts/calibration_aggregate.py` (new, 156 lines)
- `bench/README.md` (+24 lines)
- `tests/test_calibration_aggregate.py` (new, 65 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)