### PR TITLE
feat(v0.5.13): 5-item quality batch — §4b.2 + workflow pin + doctor non-zero + doctor stale-derived + logmind rebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,16 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v6-pointer -->
+<!-- logmind-block-version: v7-pointer -->
 ## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+**`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
 
 ```bash
 logmind log "summary" -r "why" -a "alternative" -i "implication"
 ```
 
-What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
+This project uses [logmind](https://logmind.dev). What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.13] - 2026-05-30
+
+### Added — 5-item quality batch
+
+1. **AGENTS.md slim template promoted to v7-pointer (§4b.2)** —
+   the load-bearing "`logmind log` replaces `git add` + `git commit`
+   + `git push`" rule was buried as the second sentence; now lands
+   first after the heading. Cap stays under 1500 bytes.
+2. **`logmind agents update --apply` sweeps CI workflow pins** —
+   closes recurring gotcha #1 (clud-bug update re-renders workflows
+   without bumping the `pip install "logmind==X.Y.Z"` line).
+   `find_outdated_workflow_pins()` + `update_workflow_pin()` helpers
+   in `core/inserter.py`. Sweeps the canonical 4 workflows.
+3. **`logmind doctor` exits non-zero on missing merge-driver
+   config in git repos** — pre-v0.5.13 a fresh clone silently
+   reported OK while one merge away from a check-derived-docs
+   failure. Outside a git repo: still OK (no false positives).
+4. **`logmind doctor` predictive heads-up: stale-derived-docs
+   warning** — when the current branch is behind
+   `origin/<default-branch>` AND the gap touches `docs/timeline.md`
+   or `docs/file-structure.md`, doctor surfaces "next push will
+   likely DIRTY this PR; consider `logmind rebase` now."
+   Predictive (doesn't flip overall to DRIFT). Addresses the
+   tokenomics agent's Phase D pain.
+5. **`logmind rebase` convenience subcommand** — one-command
+   wrapper for `git fetch origin && git rebase origin/<base> &&
+   git push --force-with-lease`. Flags: `--base`, `--no-push`,
+   `--no-fetch`. Refuses on detached HEAD or default branch.
+   Clear recovery hints on rebase / push failures.
+
+### Tests
+
+30+ new tests across `tests/test_agents_consolidation.py`,
+`tests/test_rebase_cmd.py`, `tests/test_doctor.py`,
+`tests/test_workflow_pin_update.py`,
+`tests/test_stale_derived_docs_warning.py`. Full suite: 673 pass,
+1 skipped.
+
+### Upstream context
+
+Items #4 + #5 address the tokenomics agent's 2026-05-30 Phase D
+report (3-PR batch went DIRTY when middle PR merged first). Items
+#1 + #3 close prior-plan quality items preserved into this batch.
+Item #2 closes a recurring gotcha surfaced across every clud-bug
+propagation cycle.
+
 ## [0.5.12] - 2026-05-30
 
 ### Fixed — `timeline.md` auto-resolves on fresh clones / CI / throwaway worktrees

--- a/docs/decisions-branches/feat__v0.5.13-quality-batch.md
+++ b/docs/decisions-branches/feat__v0.5.13-quality-batch.md
@@ -1,0 +1,14 @@
+## 2026-05-30 12:11 - feat(v0.5.13): 5-item quality batch — §4b.2 + workflow pin auto-update + doctor non-zero + doctor stale-derived-docs warning + logmind rebase
+
+**Reasoning:** Closes recurring gotcha #1 (workflow pin staleness across clud-bug update cycles) + addresses the tokenomics agent's 2026-05-30 Phase D merge-order pain (3-PR batch went DIRTY when middle PR merged first). Five items shipped in one batch since they share a logical theme (logmind quality + merge-resilience) and consumers prefer one workflow-re-render PR over five.
+
+**Alternatives considered:** ship items one-by-one as v0.5.13/14/15/16/17 — rejected, batching reduces propagation overhead for the same release surface, skip §4b.2 — rejected, it was the original v0.5.8 promise that got deferred, defer #4/#5 to v0.5.14 (tokenomics enhancements separate) — rejected, they're load-bearing for the merge-order story #2/#3 enable
+
+**Implications:**
+- Bumps AGENTS.md.slim.template marker from v6-pointer to v7-pointer. Consumer repos will need to run logmind agents update --apply on their next logmind upgrade to pick up the new lead-line ordering.
+- logmind agents update --apply now does TWO things instead of one (AGENTS.md block + CI workflow pin). Surfaces both in the dry-run summary so users see what changes.
+- logmind doctor now exits non-zero on missing merge-driver config inside a git repo. CI pipelines that gate on 'logmind doctor' will start surfacing pre-merge config drift before it causes check-derived-docs failures.
+- Tokenomics agent's Phase D pain (out-of-order merge → DIRTY trailing PRs) is now predicted + remediated by tools: doctor #4 warns before push; rebase #5 fixes in one command.
+- Outreach to tokenomics agent unblocked once v0.5.13 publishes — they can upgrade from logmind==0.5.6 → logmind==0.5.13 and get auto-install (v0.5.12) + new rebase command + stale-derived-docs warning in one bump.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -84,13 +84,16 @@ logmind
 │   ├── test_merge_driver.py
 │   ├── test_parser.py
 │   ├── test_propose_skill_update.py
+│   ├── test_rebase_cmd.py
 │   ├── test_search.py
 │   ├── test_skill_install.py
+│   ├── test_stale_derived_docs_warning.py
 │   ├── test_templates_v0_1_2.py
 │   ├── test_timeline.py
 │   ├── test_tree_gen.py
 │   ├── test_v0_1_3_structural.py
-│   └── test_v0_2_1_audit_fixes.py
+│   ├── test_v0_2_1_audit_fixes.py
+│   └── test_workflow_pin_update.py
 ├── .cursorrules
 ├── .gitignore
 ├── .pre-commit-config.yaml

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (78 decisions)
+## 2026-05 (79 decisions)
 
-- **2026-05-30** — bench: Stream 1 Path C — calibration_aggregate.py *(feat/calibration-aggregate-path-c)* — [decisions-branches/feat__calibration-aggregate-path-c.md](decisions-branches/feat__calibration-aggregate-path-c.md)
-- *... 76 more decisions ...*
+- **2026-05-30** — feat(v0.5.13): 5-item quality batch — §4b.2 + workflow pin auto-update + doctor non-zero + doctor stale-derived-docs warning + logmind rebase *(feat/v0.5.13-quality-batch)* — [decisions-branches/feat__v0.5.13-quality-batch.md](decisions-branches/feat__v0.5.13-quality-batch.md)
+- *... 77 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.12"
+version = "0.5.13"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.12"
+__version__ = "0.5.13"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -28,12 +28,14 @@ from logmind.core.inserter import (
     _replace_marker_block,
     create_agent_file,
     find_outdated_marker_blocks,
+    find_outdated_workflow_pins,
     get_agent_file_path,
     get_agent_status,
     get_all_agent_names,
     insert_into_all_ai_files,
     insert_logmind_section,
     migrate_to_agents_md,
+    update_workflow_pin,
     remove_agent_file,
     sync_agent_files_from_config,
 )
@@ -108,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.12", prog_name="logmind")
+@click.version_option(version="0.5.13", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -926,6 +928,136 @@ def log(
 
 @main.command()
 @click.option(
+    "--base",
+    default=None,
+    help="Base branch to rebase onto. Defaults to the repo's default branch.",
+)
+@click.option(
+    "--no-push",
+    is_flag=True,
+    help="Skip the push step. Just fetch + rebase.",
+)
+@click.option(
+    "--no-fetch",
+    is_flag=True,
+    help="Skip the fetch step. Rebase against whatever origin/<base> already points at.",
+)
+def rebase(base: Optional[str], no_push: bool, no_fetch: bool):
+    """Fetch origin, rebase the current branch onto origin/<base>, and force-with-lease push.
+
+    Convenience wrapper for the recurring three-step pattern hit when a PR
+    goes DIRTY after another PR's derived-doc regen lands on main:
+
+        git fetch origin
+        git rebase origin/<default-branch>
+        git push --force-with-lease
+
+    Reported by the tokenomics agent (2026-05-30) as Phase D friction:
+    out-of-order merges in a PR batch trigger timeline.md / file-structure.md
+    conflicts in the trailing PRs even when their substantive content
+    doesn't overlap. Logmind's post-rewrite hook (v0.5.11) makes the
+    rebase regen-clean; this wrapper makes the three-command dance one
+    command.
+
+    Exits non-zero on any step failure with a clear message about which
+    step failed and what to do next. Refuses to run on a detached HEAD
+    or on the default branch itself (rebasing main onto main is nonsense).
+    """
+    from logmind.core.git_handler import current_branch, default_branch, is_git_repo
+
+    if not is_git_repo():
+        click.secho("Error: not in a git repository.", fg="red")
+        sys.exit(1)
+
+    branch = current_branch()
+    if branch is None:
+        click.secho(
+            "Error: detached HEAD — `logmind rebase` needs a named branch.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    base_branch = base if base else default_branch()
+    if branch == base_branch:
+        click.secho(
+            f"Error: refusing to rebase '{base_branch}' onto itself. "
+            f"Check out a feature branch first.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    repo_root = Path.cwd()
+    steps_run: List[str] = []
+
+    # Step 1: fetch
+    if not no_fetch:
+        click.echo(f"→ git fetch origin {base_branch}")
+        try:
+            subprocess.run(
+                ["git", "fetch", "origin", base_branch],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            steps_run.append("fetch")
+        except subprocess.CalledProcessError as e:
+            click.secho(
+                f"Error: git fetch failed.\n{e.stderr}",
+                fg="red",
+            )
+            sys.exit(1)
+
+    # Step 2: rebase
+    click.echo(f"→ git rebase origin/{base_branch}")
+    try:
+        subprocess.run(
+            ["git", "rebase", f"origin/{base_branch}"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        steps_run.append("rebase")
+    except subprocess.CalledProcessError as e:
+        click.secho(
+            f"Error: git rebase failed.\n{e.stderr}\n"
+            f"Resolve conflicts manually, then run "
+            f"`git rebase --continue` (or `git rebase --abort` to bail).",
+            fg="red",
+        )
+        sys.exit(1)
+
+    # Step 3: push (unless --no-push)
+    if no_push:
+        click.echo(f"✓ Rebased '{branch}' onto origin/{base_branch} (push skipped).")
+        _ok(f"rebased: {branch} onto origin/{base_branch} (no push)")
+        return
+
+    click.echo(f"→ git push --force-with-lease origin {branch}")
+    try:
+        subprocess.run(
+            ["git", "push", "--force-with-lease", "origin", branch],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        steps_run.append("push")
+    except subprocess.CalledProcessError as e:
+        click.secho(
+            f"Error: git push --force-with-lease failed.\n{e.stderr}\n"
+            f"Rebase succeeded locally; you can retry push manually.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    click.echo(f"✓ Rebased '{branch}' onto origin/{base_branch} and pushed.")
+    _ok(f"rebased: {branch} onto origin/{base_branch} (pushed)")
+
+
+@main.command()
+@click.option(
     "--all",
     "-a",
     "show_all",
@@ -1522,8 +1654,14 @@ def agents_update(do_apply: bool, commit: bool):
     """
     root_path = Path.cwd()
     outdated = find_outdated_marker_blocks(root_path)
+    # v0.5.13: also sweep CI workflow pin lines. The clud-bug update
+    # cycle re-renders workflows in consumer repos without bumping the
+    # logmind pin — pre-v0.5.13 this required manual `sed -i` after
+    # every cycle. Bundling here means one `logmind agents update
+    # --apply` refreshes both AGENTS.md AND the CI pins in one shot.
+    stale_pins = find_outdated_workflow_pins(root_path)
 
-    if not outdated:
+    if not outdated and not stale_pins:
         # v0.5.8 / issue #57: "All agent files are current" was misleading
         # in two distinct cases — AGENTS.md absent, or AGENTS.md present
         # without a logmind marker block. Split them out so the message
@@ -1557,15 +1695,28 @@ def agents_update(do_apply: bool, commit: bool):
 
     # v0.5.8 / issue #57: surface the version delta on dry-run so the
     # user knows what `--apply` would actually do.
-    if not do_apply:
-        click.echo(
-            f"Would update {len(outdated)} file(s) with stale logmind block(s):"
-        )
-    else:
-        click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
-    for file_path, _old, _new in outdated:
-        rel = file_path.relative_to(root_path)
-        click.echo(f"  - {rel}")
+    if outdated:
+        if not do_apply:
+            click.echo(
+                f"Would update {len(outdated)} file(s) with stale logmind block(s):"
+            )
+        else:
+            click.echo(f"Found {len(outdated)} file(s) with stale logmind block(s):")
+        for file_path, _old, _new in outdated:
+            rel = file_path.relative_to(root_path)
+            click.echo(f"  - {rel}")
+
+    # v0.5.13: report workflow pin drift alongside AGENTS.md drift.
+    if stale_pins:
+        if not do_apply:
+            click.echo(
+                f"Would update {len(stale_pins)} CI workflow pin(s):"
+            )
+        else:
+            click.echo(f"Found {len(stale_pins)} CI workflow pin(s) to bump:")
+        for wf_path, old_v, new_v in stale_pins:
+            rel = wf_path.relative_to(root_path)
+            click.echo(f"  - {rel} (logmind=={old_v} → logmind=={new_v})")
 
     if not do_apply:
         click.echo()
@@ -1583,6 +1734,15 @@ def agents_update(do_apply: bool, commit: bool):
         rel = file_path.relative_to(root_path)
         refreshed_paths.append(str(rel))
         click.secho(f"✓ Refreshed {rel}", fg="green")
+
+    # v0.5.13: write the refreshed pins.
+    for wf_path, _old, new_v in stale_pins:
+        content = wf_path.read_text(encoding="utf-8")
+        new_content, _ = update_workflow_pin(content, new_v)
+        wf_path.write_text(new_content, encoding="utf-8")
+        rel = wf_path.relative_to(root_path)
+        refreshed_paths.append(str(rel))
+        click.secho(f"✓ Bumped logmind pin in {rel}", fg="green")
 
     if commit and is_git_repo():
         try:

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -338,6 +338,97 @@ def _probe_post_merge_hook(project_root: Path) -> WorkflowStatus:
     )
 
 
+def check_stale_derived_docs_warning(project_root: Path) -> Optional[str]:
+    """v0.5.13 / tokenomics agent #2 — warn when the current branch is
+    behind ``origin/<default-branch>`` AND the gap touches
+    ``docs/timeline.md`` or ``docs/file-structure.md``.
+
+    Symptom this surfaces: the tokenomics agent's Phase D pain — a PR
+    batch where the trailing PRs go ``mergeStateStatus: DIRTY``
+    immediately after an earlier PR merges (the merge regenerates a
+    derived doc on main; trailing branches now have a textual
+    conflict). Running `logmind doctor` early surfaces "your branch
+    will go DIRTY on the next main push; consider `logmind rebase`
+    now" before the failure manifests.
+
+    Returns a one-line warning string when the condition fires, else
+    ``None``. Silent no-op outside a git repo, on the default branch
+    itself, when no remote is configured, or when the upstream tracking
+    ref is missing.
+    """
+    import subprocess
+
+    if not (project_root / ".git").exists():
+        return None
+
+    # Get current branch via existing helpers (avoid re-implementing).
+    try:
+        from logmind.core.git_handler import current_branch, default_branch
+    except ImportError:  # pragma: no cover — defensive only
+        return None
+
+    branch = current_branch(project_root)
+    if branch is None:
+        return None  # detached HEAD
+    default = default_branch(project_root)
+    if branch == default:
+        return None  # we ARE the default branch
+
+    # Files we care about. Hard-coded to the canonical set; if a user
+    # adds custom derived docs they can extend this list via a future
+    # config knob, not for v0.5.13.
+    derived_docs = ("docs/timeline.md", "docs/file-structure.md")
+
+    # Resolve `origin/<default>` — graceful no-op if origin isn't set.
+    upstream = f"origin/{default}"
+    try:
+        subprocess.run(
+            ["git", "-C", str(project_root), "rev-parse", "--verify", "--quiet", upstream],
+            capture_output=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None  # no remote / not yet fetched
+
+    # List files touched by commits on origin/<default> that aren't on
+    # this branch. `--format=` suppresses commit messages so the output
+    # is just file paths (deduplicated by set membership downstream).
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "log",
+             f"{branch}..{upstream}", "--name-only", "--format="],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+    touched_files = {line for line in result.stdout.splitlines() if line}
+    overlap = sorted(touched_files & set(derived_docs))
+    if not overlap:
+        return None
+
+    # Count commits in the gap so the warning quantifies "how stale."
+    try:
+        count_result = subprocess.run(
+            ["git", "-C", str(project_root), "rev-list", "--count",
+             f"{branch}..{upstream}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        n_commits = count_result.stdout.strip() or "?"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        n_commits = "?"
+
+    return (
+        f"⚠ '{branch}' is {n_commits} commits behind {upstream} AND the gap "
+        f"touches {', '.join(overlap)}. Next push will likely DIRTY this "
+        f"PR. Consider `logmind rebase` now."
+    )
+
+
 def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
     """v0.5.11 / issue #58: .git/hooks/post-rewrite installed by logmind.
     Companion to the post-merge hook. Fires after `git rebase` or
@@ -388,12 +479,33 @@ def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     workflows.append(_probe_post_rewrite_hook(project_root))
 
     # Drift = any installed workflow with a marker that's stale,
-    # OR installed version != latest version (when both known).
+    # OR installed version != latest version (when both known),
+    # OR (v0.5.13) merge-driver config / post-merge hook /
+    # post-rewrite hook missing inside a git repo. The "merge driver
+    # missing" cases default to "missing" (not "stale") per their
+    # probe contract, but in a git repo they indicate the local
+    # clone hasn't run `logmind init` yet and rebases/merges on
+    # derived docs will silently fall back to git's textual merge.
+    # Treating that as drift means CI gates surface the missing
+    # config before it produces a check-derived-docs failure.
     drift = "ok"
     if any(w.drift == "stale" for w in workflows):
         drift = "stale"
     if installed and latest and installed != latest:
         drift = "stale"
+    # v0.5.13: a git repo without merge-driver config / hooks is
+    # one merge away from a check-derived-docs failure. Surface as
+    # drift so `logmind doctor` exits non-zero on CI.
+    if (project_root / ".git").exists():
+        critical_missing_names = {
+            "git config (merge driver)",
+            "post-merge hook",
+            "post-rewrite hook",
+        }
+        for w in workflows:
+            if w.name in critical_missing_names and w.drift == "missing":
+                drift = "stale"
+                break
 
     return ToolStatus(
         name="logmind",
@@ -510,6 +622,13 @@ def collect_status(project_root: Optional[Path] = None, *, offline: bool = False
                 suggestions.append("pip install --upgrade logmind && logmind init")
             elif t.name == "clud-bug":
                 suggestions.append("npx clud-bug update")
+
+    # v0.5.13 / tokenomics agent #2 — surface the stale-derived-docs
+    # warning as a suggestion line. Non-fatal (doesn't flip overall to
+    # DRIFT) since it's a predictive heads-up, not a current failure.
+    stale_warning = check_stale_derived_docs_warning(project_root)
+    if stale_warning:
+        suggestions.append(stale_warning)
 
     return StatusReport(
         project_root=project_root,

--- a/src/logmind/core/inserter.py
+++ b/src/logmind/core/inserter.py
@@ -1,5 +1,6 @@
 """AI instruction file insertion and management logic."""
 
+import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -195,6 +196,102 @@ def get_stub_template() -> str:
     """Return the per-agent AGENTS.md-pointer stub content."""
     template_path = Path(__file__).parent.parent / "templates" / "agent-stub.md"
     return template_path.read_text(encoding="utf-8")
+
+
+# v0.5.13 / recurring gotcha #1: pin auto-update for CI workflows.
+# When `clud-bug update` re-renders workflows in consumer repos, the
+# logmind==X.Y.Z pin inside our CI workflows goes stale (clud-bug
+# doesn't know about logmind releases). Pre-v0.5.13, this required
+# manual `sed -i` after every clud-bug update cycle. Now `logmind
+# agents update --apply` sweeps the pin alongside the AGENTS.md
+# block — one command, two refreshes.
+
+# Workflows whose pin should track __version__. Names match the
+# canonical templates shipped under templates/github/.
+LOGMIND_PIN_WORKFLOWS = (
+    "regen-timeline.yml",
+    "check-doc-links.yml",
+    "logmind-self-update.yml",
+    "check-decisions.yml",
+)
+
+# Captures the pin line: prefix up through `==` (group 1), version (group 2),
+# trailing quote (group 3). Matches both `"logmind==X.Y.Z"` and bare
+# `logmind==X.Y.Z` forms. Anchored to `pip install` so we don't false-positive
+# on a comment that happens to mention the package name + version.
+_PIN_LINE_RE = re.compile(
+    r'(pip install\s+"?logmind==)([\d.]+)("?)'
+)
+
+
+def find_outdated_workflow_pins(
+    root_path: Optional[Path] = None,
+) -> List[Tuple[Path, str, str]]:
+    """
+    Return [(workflow_file, current_pin_version, target_version), ...] for
+    every `.github/workflows/<name>.yml` whose `pip install "logmind==X.Y.Z"`
+    pin doesn't match the running logmind's `__version__`.
+
+    Only the workflows in `LOGMIND_PIN_WORKFLOWS` are checked — the canonical
+    set logmind ships templates for. Custom user workflows aren't swept
+    (would risk surprising users with rewrites of files they own).
+
+    Returns empty list when:
+      - `.github/workflows/` doesn't exist
+      - none of the canonical workflows are present
+      - all present workflows already pin the current `__version__`
+    """
+    if root_path is None:
+        root_path = Path.cwd()
+
+    from logmind import __version__ as current_version
+
+    outdated: List[Tuple[Path, str, str]] = []
+    workflows_dir = root_path / ".github" / "workflows"
+    if not workflows_dir.exists():
+        return outdated
+
+    for name in LOGMIND_PIN_WORKFLOWS:
+        wf_path = workflows_dir / name
+        if not wf_path.exists():
+            continue
+        try:
+            content = wf_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        m = _PIN_LINE_RE.search(content)
+        if m is None:
+            continue  # no pin → nothing to update (dogfood-style installs)
+        found_version = m.group(2)
+        if found_version != current_version:
+            outdated.append((wf_path, found_version, current_version))
+
+    return outdated
+
+
+def update_workflow_pin(content: str, new_version: str) -> Tuple[str, Optional[str]]:
+    """
+    Rewrite every `pip install "logmind==X.Y.Z"` line in ``content`` to pin
+    ``new_version`` instead.
+
+    Returns ``(new_content, previous_version_or_None)``. ``previous_version``
+    is taken from the FIRST pin found. Returns ``(content, None)`` unchanged
+    when no pin is present or when the pin already matches.
+
+    Idempotent: re-applying the same version is a no-op.
+    """
+    m = _PIN_LINE_RE.search(content)
+    if m is None:
+        return content, None
+    previous = m.group(2)
+    if previous == new_version:
+        return content, previous
+
+    new_content = _PIN_LINE_RE.sub(
+        lambda mo: f"{mo.group(1)}{new_version}{mo.group(3)}",
+        content,
+    )
+    return new_content, previous
 
 
 def find_outdated_marker_blocks(

--- a/src/logmind/core/inserter.py
+++ b/src/logmind/core/inserter.py
@@ -275,10 +275,16 @@ def update_workflow_pin(content: str, new_version: str) -> Tuple[str, Optional[s
     ``new_version`` instead.
 
     Returns ``(new_content, previous_version_or_None)``. ``previous_version``
-    is taken from the FIRST pin found. Returns ``(content, None)`` unchanged
-    when no pin is present or when the pin already matches.
+    is taken from the FIRST pin found, so it's the version string in both
+    the rewrite case AND the idempotent (already-current) case.
+    ``previous`` is ``None`` only when no pin is present at all (dogfood-
+    style workflows). The 3 return shapes:
 
-    Idempotent: re-applying the same version is a no-op.
+      - ``(content, None)`` — no pin in content; nothing to do
+      - ``(content, "X.Y.Z")`` — pin already matches ``new_version``; idempotent no-op
+      - ``(rewritten_content, "OLD")`` — pin bumped; old version surfaced for logging
+
+    Idempotent: re-applying the same version is a no-op (content unchanged).
     """
     m = _PIN_LINE_RE.search(content)
     if m is None:

--- a/src/logmind/templates/AGENTS.md.slim.template
+++ b/src/logmind/templates/AGENTS.md.slim.template
@@ -7,16 +7,16 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v6-pointer -->
+<!-- logmind-block-version: v7-pointer -->
 ## Decision logging — `logmind log` is the commit primitive
 
-This project uses [logmind](https://logmind.dev). **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+**`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
 
 ```bash
 logmind log "summary" -r "why" -a "alternative" -i "implication"
 ```
 
-What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
+This project uses [logmind](https://logmind.dev). What counts as a decision, branch routing, `--stage scoped` for unrelated WIP, `logmind doctor`, and the required-reading list ([`docs/timeline.md`](docs/timeline.md), [`docs/decisions.md`](docs/decisions.md), [`docs/file-structure.md`](docs/file-structure.md), `docs/decisions-branches/<branch>.md`) all live in the **`logmind` agent skill** at https://github.com/thrillmade/agent-skills/tree/main/skills/logmind.
 <!-- logmind-end -->
 
 ## Project Overview

--- a/tests/test_agents_consolidation.py
+++ b/tests/test_agents_consolidation.py
@@ -109,12 +109,19 @@ def test_get_agents_md_template_returns_slim_when_skills_available(monkeypatch):
     inline procedure (covered by the skill at the linked URL), keeps
     the load-bearing "commit primitive" rule + bash example + skill
     pointer.
+
+    §4b.2 (v0.5.13): block bumped to v7-pointer — promotes the
+    commit-primitive rule to the FIRST line after the heading. The
+    `logmind log replaces git add+commit+push` sentence was buried
+    as the second sentence of the lead paragraph; agents skim
+    instructions top-down, so the cost-avoidance rule now lands
+    first, link-to-logmind.dev demoted to context.
     """
     from logmind.core import skill_install
 
     monkeypatch.setattr(skill_install, "is_skills_available", lambda: True)
     slim = get_agents_md_template()
-    assert "logmind-block-version: v6-pointer" in slim
+    assert "logmind-block-version: v7-pointer" in slim
     # The load-bearing contract — "logmind log replaces git add+commit+push"
     # — must survive every future trim. If this assertion fails, the
     # block was over-trimmed and agents will fall back to direct git.
@@ -123,16 +130,36 @@ def test_get_agents_md_template_returns_slim_when_skills_available(monkeypatch):
     # Skill pointer is the authority delegation — without it, agents
     # have no way to find the full procedure when this block trims it out.
     assert "agent-skills/tree/main/skills/logmind" in slim
-    # Hard size cap on the slim variant — guards against future block
-    # growth re-bloating it. v6 is ~770 bytes; cap at 1500 leaves 2×
-    # headroom for additions while preventing return to v5's 2526.
+
+    # §4b.2: the commit-primitive rule must be the FIRST line after
+    # the heading (not buried mid-paragraph). Find the heading line,
+    # then the first non-empty line below — assert it starts with
+    # the `**\`logmind log\`` bold marker, not the link to logmind.dev.
     block_start = slim.find("<!-- logmind-start -->")
     block_end = slim.find("<!-- logmind-end -->") + len("<!-- logmind-end -->")
     assert block_start != -1 and block_end > block_start
     block = slim[block_start:block_end]
+    block_lines = block.splitlines()
+    heading_idx = next(
+        i for i, line in enumerate(block_lines)
+        if line.startswith("## Decision logging")
+    )
+    first_content_idx = next(
+        i for i in range(heading_idx + 1, len(block_lines))
+        if block_lines[i].strip()
+    )
+    first_content = block_lines[first_content_idx]
+    assert first_content.startswith("**`logmind log`"), (
+        f"§4b.2 (v0.5.13): commit-primitive rule must be the FIRST line "
+        f"after the heading. Got: {first_content!r}"
+    )
+
+    # Hard size cap on the slim variant — guards against future block
+    # growth re-bloating it. v7 is ~830 bytes; cap at 1500 leaves
+    # headroom for additions while preventing return to v5's 2526.
     assert len(block.encode("utf-8")) <= 1500, (
         f"slim logmind-block is {len(block.encode('utf-8'))} bytes "
-        f"— v6-pointer should stay under 1500 (current ~770)"
+        f"— v7-pointer should stay under 1500 (current ~830)"
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -289,6 +289,50 @@ def test_cli_doctor_ok_exits_zero(project: Path, monkeypatch):
         assert "Stack status: OK" in result.output
 
 
+def test_cli_doctor_missing_merge_driver_in_git_repo_exits_one(project: Path, monkeypatch):
+    """v0.5.13 / tokenomics issue: a git repo with missing merge-driver
+    config OR missing post-merge / post-rewrite hooks is one merge away
+    from a check-derived-docs failure. doctor must exit non-zero so CI
+    gates catch this before the failure manifests.
+
+    Pre-v0.5.13, `_probe_merge_driver_config` returned drift="missing"
+    but `collect_logmind_status` only escalated to "stale" on workflow
+    template drift — so a fresh clone with no merge-driver config
+    silently reported OK. Now: any critical missing in a git repo →
+    overall DRIFT.
+    """
+    import subprocess
+    # Make the project a real git repo (without any logmind init).
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    monkeypatch.setattr(doctor, "_http_get_json", lambda *_a, **_kw: None)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--offline"])
+    assert result.exit_code == 1, result.output
+    assert "Stack status: DRIFT" in result.output
+    # The signal should mention either the merge driver or a hook (so
+    # users see WHICH critical-missing tripped the gate).
+    assert (
+        "merge driver" in result.output.lower()
+        or "post-merge" in result.output.lower()
+        or "post-rewrite" in result.output.lower()
+    )
+
+
+def test_cli_doctor_missing_merge_driver_outside_git_repo_is_ok(project: Path, monkeypatch):
+    """v0.5.13: outside a git repo, missing merge-driver config is NOT
+    drift — the driver only matters for git operations, so there's
+    nothing for it to fail at. Test fixture: bare project dir (no .git/)
+    must stay OK so test fixtures don't false-positive."""
+    # NOTE: `project` fixture creates `.github/workflows` but no `.git/`
+    monkeypatch.setattr(doctor, "_http_get_json", lambda *_a, **_kw: None)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--offline"])
+    assert result.exit_code == 0, result.output
+    assert "Stack status: OK" in result.output
+
+
 def test_cli_doctor_drift_exits_one(project: Path, monkeypatch):
     """Stale marker → exit 1."""
     _write_workflow(

--- a/tests/test_rebase_cmd.py
+++ b/tests/test_rebase_cmd.py
@@ -1,0 +1,221 @@
+"""Tests for `logmind rebase` (v0.5.13).
+
+Convenience wrapper around the fetch + rebase + force-with-lease pattern
+captured from the tokenomics agent's Phase D friction report (2026-05-30).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from logmind.cli import main as cli_main
+
+
+def _git_init_with_branch(repo: Path, branch: str = "feature") -> None:
+    """Init repo + commit to main + check out a feature branch."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True, capture_output=True)
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True, capture_output=True)
+    if branch != "main":
+        subprocess.run(["git", "checkout", "-b", branch], cwd=repo, check=True, capture_output=True)
+
+
+def test_rebase_refuses_outside_git_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["rebase"])
+    assert result.exit_code == 1
+    assert "not in a git repository" in result.output.lower()
+
+
+def test_rebase_refuses_on_detached_head(tmp_path, monkeypatch):
+    _git_init_with_branch(tmp_path, branch="main")
+    # Make a second commit so we can detach onto the first one.
+    (tmp_path / "x.txt").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "x.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "second"], cwd=tmp_path, check=True, capture_output=True)
+    # Detach.
+    first_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD~1"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "checkout", "--detach", first_sha], cwd=tmp_path, check=True, capture_output=True
+    )
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["rebase"])
+    assert result.exit_code == 1
+    assert "detached head" in result.output.lower()
+
+
+def test_rebase_refuses_on_default_branch(tmp_path, monkeypatch):
+    _git_init_with_branch(tmp_path, branch="main")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["rebase"])
+    assert result.exit_code == 1
+    # Either "main" mentioned OR "refusing to rebase ... onto itself"
+    assert "main" in result.output.lower() or "itself" in result.output.lower()
+
+
+def test_rebase_happy_path_runs_fetch_rebase_push(tmp_path, monkeypatch):
+    """Happy path: fetch + rebase + push --force-with-lease in order."""
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        # Capture git fetch / rebase / push; let everything else through.
+        if cmd[:1] == ["git"] and cmd[1:2] in (["fetch"], ["rebase"], ["push"]):
+            calls.append(cmd)
+            # Pretend all 3 succeed cleanly.
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase"])
+
+    assert result.exit_code == 0, result.output
+    # Three commands in order: fetch, rebase, push --force-with-lease.
+    assert calls[0][:3] == ["git", "fetch", "origin"]
+    assert calls[1][:2] == ["git", "rebase"]
+    assert calls[1][2].startswith("origin/")
+    assert calls[2][:4] == ["git", "push", "--force-with-lease", "origin"]
+
+
+def test_rebase_no_push_flag_skips_push(tmp_path, monkeypatch):
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:1] == ["git"] and cmd[1:2] in (["fetch"], ["rebase"], ["push"]):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase", "--no-push"])
+
+    assert result.exit_code == 0, result.output
+    # Only fetch + rebase ran; push skipped.
+    git_verbs = [c[1] for c in calls]
+    assert "push" not in git_verbs
+    assert "fetch" in git_verbs and "rebase" in git_verbs
+
+
+def test_rebase_no_fetch_flag_skips_fetch(tmp_path, monkeypatch):
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:1] == ["git"] and cmd[1:2] in (["fetch"], ["rebase"], ["push"]):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase", "--no-fetch"])
+
+    assert result.exit_code == 0, result.output
+    git_verbs = [c[1] for c in calls]
+    assert "fetch" not in git_verbs
+    assert "rebase" in git_verbs and "push" in git_verbs
+
+
+def test_rebase_rebase_failure_surfaces_clear_message(tmp_path, monkeypatch):
+    """When git rebase fails (conflicts), surface the error + recovery hint."""
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rebase"]:
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=cmd, stderr="CONFLICT (content): merge conflict in docs/timeline.md"
+            )
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase"])
+
+    assert result.exit_code == 1
+    assert "rebase failed" in result.output.lower()
+    # User-facing recovery hint must be present.
+    assert "rebase --continue" in result.output or "rebase --abort" in result.output
+
+
+def test_rebase_push_failure_surfaces_clear_message(tmp_path, monkeypatch):
+    """When push fails (e.g., protected branch), surface the error and
+    note that rebase succeeded locally."""
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] in (["git", "fetch"], ["git", "rebase"]):
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["git", "push"]:
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=cmd, stderr="remote: branch protection rejected"
+            )
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase"])
+
+    assert result.exit_code == 1
+    assert "push" in result.output.lower() and "failed" in result.output.lower()
+    # Reassures user that local rebase succeeded (only push failed).
+    assert "rebase succeeded locally" in result.output.lower()
+
+
+def test_rebase_custom_base_branch_via_flag(tmp_path, monkeypatch):
+    _git_init_with_branch(tmp_path, branch="feature")
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:1] == ["git"] and cmd[1:2] in (["fetch"], ["rebase"], ["push"]):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["rebase", "--base", "develop"])
+
+    assert result.exit_code == 0, result.output
+    # Both fetch + rebase target the custom base.
+    fetch_cmd = next(c for c in calls if c[1] == "fetch")
+    rebase_cmd = next(c for c in calls if c[1] == "rebase")
+    assert fetch_cmd[-1] == "develop"
+    assert rebase_cmd[-1] == "origin/develop"

--- a/tests/test_stale_derived_docs_warning.py
+++ b/tests/test_stale_derived_docs_warning.py
@@ -1,0 +1,173 @@
+"""Tests for v0.5.13 stale-derived-docs heads-up warning in `logmind doctor`.
+
+When the current branch is behind ``origin/<default-branch>`` AND the gap
+touches ``docs/timeline.md`` or ``docs/file-structure.md``, doctor surfaces
+a heads-up warning predicting the trailing-PR DIRTY scenario reported by
+the tokenomics agent (2026-05-30).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from logmind.core.doctor import (
+    check_stale_derived_docs_warning,
+    collect_status,
+)
+
+
+def _git_init_with_remote(local: Path, remote: Path) -> None:
+    """Set up a bare remote + local clone with an initial commit on main."""
+    subprocess.run(["git", "init", "--bare", "-b", "main"], cwd=remote, check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=local, check=True, capture_output=True)
+    (local / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=local, check=True, capture_output=True)
+
+
+def test_warning_silent_outside_git_repo(tmp_path):
+    """No `.git/` dir → silent no-op."""
+    assert check_stale_derived_docs_warning(tmp_path) is None
+
+
+def test_warning_silent_on_default_branch(tmp_path):
+    """On main itself, there's no upstream-vs-feature divergence to warn about."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "x.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "x.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True, capture_output=True)
+    assert check_stale_derived_docs_warning(tmp_path) is None
+
+
+def test_warning_silent_when_no_upstream(tmp_path):
+    """Repo with no `origin` remote → silent no-op."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "x.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "x.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=tmp_path, check=True, capture_output=True)
+    assert check_stale_derived_docs_warning(tmp_path) is None
+
+
+def test_warning_silent_when_branch_is_up_to_date(tmp_path):
+    """Feature branch with origin/main reachable + no derived-doc changes
+    on main → silent."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    # Fetch origin so origin/main ref exists
+    subprocess.run(["git", "fetch", "origin"], cwd=local, check=True, capture_output=True)
+    assert check_stale_derived_docs_warning(local) is None
+
+
+def test_warning_silent_when_gap_does_not_touch_derived_docs(tmp_path):
+    """Main moves ahead but only touches code → silent (gap doesn't
+    intersect with the derived-doc set)."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    # Switch back to main, add a code-only commit, push
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    (local / "main.py").write_text("print('x')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "main.py"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "add code"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+    # Back to feature; fetch
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=local, check=True, capture_output=True)
+    assert check_stale_derived_docs_warning(local) is None
+
+
+def test_warning_fires_when_gap_touches_timeline_md(tmp_path):
+    """Main moves ahead with a docs/timeline.md change → warning fires."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    # Switch back to main, add a docs/timeline.md commit, push
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir()
+    (docs / "timeline.md").write_text("# timeline\n- entry\n", encoding="utf-8")
+    subprocess.run(["git", "add", "docs/timeline.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "regen timeline"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+    # Back to feature; fetch + check warning
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=local, check=True, capture_output=True)
+
+    warning = check_stale_derived_docs_warning(local)
+    assert warning is not None, "warning must fire when gap touches docs/timeline.md"
+    assert "feature" in warning
+    assert "docs/timeline.md" in warning
+    assert "logmind rebase" in warning
+    assert "DIRTY" in warning or "behind" in warning
+
+
+def test_warning_fires_for_file_structure_md(tmp_path):
+    """Mirror test for docs/file-structure.md — both derived docs trip the warning."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir()
+    (docs / "file-structure.md").write_text("# tree\n", encoding="utf-8")
+    subprocess.run(["git", "add", "docs/file-structure.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "regen tree"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=local, check=True, capture_output=True)
+
+    warning = check_stale_derived_docs_warning(local)
+    assert warning is not None
+    assert "docs/file-structure.md" in warning
+
+
+def test_doctor_collect_status_surfaces_warning_as_suggestion(tmp_path, monkeypatch):
+    """End-to-end: the warning lands in StatusReport.suggestions when fired,
+    so `logmind doctor` (CLI) renders it in the suggestions block."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir()
+    (docs / "timeline.md").write_text("# timeline\n", encoding="utf-8")
+    subprocess.run(["git", "add", "docs/timeline.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "regen"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=local, check=True, capture_output=True)
+
+    report = collect_status(local, offline=True)
+    # The warning shows up in suggestions, NOT as overall DRIFT
+    # (predictive heads-up, not a current failure).
+    assert any("docs/timeline.md" in s for s in report.suggestions), (
+        f"warning must be in suggestions list. Got: {report.suggestions}"
+    )

--- a/tests/test_workflow_pin_update.py
+++ b/tests/test_workflow_pin_update.py
@@ -1,0 +1,165 @@
+"""Tests for v0.5.13 workflow pin auto-update.
+
+`logmind agents update --apply` now sweeps `pip install "logmind==X.Y.Z"`
+lines in `.github/workflows/<canonical>.yml` files alongside the AGENTS.md
+block refresh. Closes recurring gotcha #1 (logmind workflow install pin
+goes stale when consumer repos re-render workflows via `clud-bug update`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from logmind import __version__ as current_version
+from logmind.cli import main as cli_main
+from logmind.core.inserter import (
+    LOGMIND_PIN_WORKFLOWS,
+    find_outdated_workflow_pins,
+    update_workflow_pin,
+)
+
+
+def _write_workflow(root: Path, name: str, pin_version: str) -> Path:
+    wf_dir = root / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    wf_path = wf_dir / name
+    wf_path.write_text(
+        f"name: Test\n"
+        f"on: push\n"
+        f"jobs:\n"
+        f"  go:\n"
+        f"    runs-on: ubuntu-latest\n"
+        f"    steps:\n"
+        f"      - run: pip install \"logmind=={pin_version}\"\n",
+        encoding="utf-8",
+    )
+    return wf_path
+
+
+def test_update_workflow_pin_bumps_stale_version():
+    content = '      - run: pip install "logmind==0.3.4"\n'
+    new_content, prev = update_workflow_pin(content, "0.5.13")
+    assert prev == "0.3.4"
+    assert 'pip install "logmind==0.5.13"' in new_content
+    assert 'pip install "logmind==0.3.4"' not in new_content
+
+
+def test_update_workflow_pin_idempotent_when_already_current():
+    content = '      - run: pip install "logmind==0.5.13"\n'
+    new_content, prev = update_workflow_pin(content, "0.5.13")
+    assert prev == "0.5.13"
+    assert new_content == content
+
+
+def test_update_workflow_pin_noop_when_no_pin_present():
+    """Dogfood-style workflow files (no pin, uses pip install -e .) are
+    untouched. Returns the original content + None."""
+    content = "name: dogfood\non: push\n# no pin line\n"
+    new_content, prev = update_workflow_pin(content, "0.5.13")
+    assert prev is None
+    assert new_content == content
+
+
+def test_find_outdated_workflow_pins_finds_stale(tmp_path):
+    _write_workflow(tmp_path, "regen-timeline.yml", "0.3.4")
+    _write_workflow(tmp_path, "check-doc-links.yml", "0.3.4")
+
+    outdated = find_outdated_workflow_pins(tmp_path)
+    assert len(outdated) == 2
+    for wf_path, old, new in outdated:
+        assert old == "0.3.4"
+        assert new == current_version
+
+
+def test_find_outdated_workflow_pins_skips_current(tmp_path):
+    """Workflows already pinning the current version are NOT returned."""
+    _write_workflow(tmp_path, "regen-timeline.yml", current_version)
+
+    outdated = find_outdated_workflow_pins(tmp_path)
+    assert outdated == []
+
+
+def test_find_outdated_workflow_pins_only_canonical_workflows(tmp_path):
+    """Only LOGMIND_PIN_WORKFLOWS files are checked — user-authored
+    workflow files with similar names are NOT touched."""
+    _write_workflow(tmp_path, "regen-timeline.yml", "0.3.4")  # canonical
+    _write_workflow(tmp_path, "my-custom-workflow.yml", "0.3.4")  # NOT canonical
+
+    outdated = find_outdated_workflow_pins(tmp_path)
+    assert len(outdated) == 1
+    assert outdated[0][0].name == "regen-timeline.yml"
+
+
+def test_find_outdated_workflow_pins_handles_missing_workflows_dir(tmp_path):
+    """No `.github/workflows/` at all → empty list (no crash)."""
+    assert find_outdated_workflow_pins(tmp_path) == []
+
+
+def test_agents_update_dry_run_reports_stale_pins(tmp_path, monkeypatch):
+    """Dry-run output mentions the stale pins so user sees what --apply would change."""
+    _write_workflow(tmp_path, "regen-timeline.yml", "0.3.4")
+    _write_workflow(tmp_path, "check-doc-links.yml", "0.3.4")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["agents", "update"])
+    assert result.exit_code == 0, result.output
+    assert "CI workflow pin" in result.output
+    assert "logmind==0.3.4" in result.output
+    assert f"logmind=={current_version}" in result.output
+    # Dry-run does NOT modify files
+    assert 'pip install "logmind==0.3.4"' in (
+        tmp_path / ".github" / "workflows" / "regen-timeline.yml"
+    ).read_text()
+
+
+def test_agents_update_apply_rewrites_stale_pins(tmp_path, monkeypatch):
+    """--apply actually writes the new pins."""
+    _write_workflow(tmp_path, "regen-timeline.yml", "0.3.4")
+    _write_workflow(tmp_path, "check-doc-links.yml", "0.3.4")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["agents", "update", "--apply"])
+    assert result.exit_code == 0, result.output
+
+    regen = (tmp_path / ".github" / "workflows" / "regen-timeline.yml").read_text()
+    cdl = (tmp_path / ".github" / "workflows" / "check-doc-links.yml").read_text()
+    assert f'logmind=={current_version}' in regen
+    assert f'logmind=={current_version}' in cdl
+    assert 'logmind==0.3.4' not in regen
+    assert 'logmind==0.3.4' not in cdl
+
+
+def test_agents_update_apply_is_idempotent(tmp_path, monkeypatch):
+    """Second --apply run is a no-op (nothing to update)."""
+    _write_workflow(tmp_path, "regen-timeline.yml", "0.3.4")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    first = runner.invoke(cli_main, ["agents", "update", "--apply"])
+    assert first.exit_code == 0
+    second = runner.invoke(cli_main, ["agents", "update", "--apply"])
+    assert second.exit_code == 0
+    # After the first update everything is current → some flavor of
+    # "nothing to update" message (exact phrasing depends on whether
+    # AGENTS.md exists; both "No AGENTS.md / nothing to update" and
+    # "block is current (no update needed)" satisfy this).
+    out = second.output.lower()
+    assert "nothing to update" in out or "current" in out or "no update" in out
+
+
+def test_canonical_workflow_list_matches_doctor_LOGMIND_WORKFLOWS():
+    """Sanity: the pin-update workflow list should match the canonical set
+    surfaced by `logmind doctor`. Drift between the two would mean doctor
+    reports a workflow as "current" while the pin sweeper silently skips it
+    (or vice-versa)."""
+    from logmind.core.doctor import LOGMIND_WORKFLOWS
+
+    assert set(LOGMIND_PIN_WORKFLOWS) == set(LOGMIND_WORKFLOWS), (
+        "LOGMIND_PIN_WORKFLOWS (inserter.py) must match LOGMIND_WORKFLOWS "
+        "(doctor.py) — drift would surface as inconsistent reports."
+    )


### PR DESCRIPTION
Five-item quality batch closing prior-plan items + the tokenomics agent's 2026-05-30 Phase D merge-order pain.

## Items

### 1. §4b.2 — AGENTS.md slim template promoted to v7-pointer
The "`logmind log` replaces `git add` + `git commit` + `git push`" rule was buried as the second sentence. Now lands first after the heading. Cap stays under 1500 bytes.

### 2. `logmind agents update --apply` sweeps CI workflow pins
Closes recurring gotcha #1. New helpers `find_outdated_workflow_pins()` + `update_workflow_pin()` in `core/inserter.py`. Sweeps the canonical 4 workflows alongside the AGENTS.md block refresh.

### 3. `logmind doctor` exits non-zero on missing merge-driver config in git repos
Pre-v0.5.13: fresh clone silently reported OK while one merge away from a check-derived-docs failure. Outside git: still OK (no false positives).

### 4. `logmind doctor` predictive stale-derived-docs warning
When the current branch is behind `origin/<default>` AND the gap touches `docs/timeline.md` or `docs/file-structure.md`, doctor surfaces:
> ⚠ 'feature' is N commits behind origin/main AND the gap touches docs/timeline.md. Next push will likely DIRTY this PR. Consider `logmind rebase` now.

Predictive (doesn't flip overall to DRIFT). Addresses tokenomics agent's Phase D pain BEFORE the next main push DIRTYies the PR.

### 5. `logmind rebase` convenience subcommand
One command for `git fetch origin && git rebase origin/<base> && git push --force-with-lease`. Flags: `--base`, `--no-push`, `--no-fetch`. Refuses on detached HEAD or default branch. Clear recovery hints on failure.

## Tests

30+ new tests across:
- `tests/test_agents_consolidation.py` — v7-pointer first-line assertion
- `tests/test_rebase_cmd.py` (9 tests) — happy path, flags, refuses, failure paths
- `tests/test_doctor.py` (2 new tests) — missing-driver in git → exit 1; outside git → exit 0
- `tests/test_workflow_pin_update.py` (11 tests) — update_workflow_pin idempotency, find_outdated_workflow_pins canonical-only sweep, dry-run vs --apply, sanity matching doctor's canonical list
- `tests/test_stale_derived_docs_warning.py` (8 tests) — silent cases (no-git/no-remote/default/clean/code-only-gap), fires for both timeline.md AND file-structure.md, end-to-end through `collect_status`

Full suite: **673 pass, 1 skipped**.

## Upstream context

- Items #4 + #5 directly address [tokenomics agent's Phase D report](https://github.com/thrillmade/tokenomics) (3-PR batch went DIRTY when middle PR merged first)
- Item #2 closes the recurring gotcha #1 surfaced across every clud-bug propagation cycle
- Items #1 + #3 close prior-plan quality items preserved into this batch

## Test plan

- [x] `pytest -q` (full suite) — 673 passed, 1 skipped
- [ ] CI: paths-check + check-derived-docs + check-links + clud-bug-review green
- [ ] After merge: tag `v0.5.13` → Trusted Publishing OIDC publishes to PyPI within ~1 min
- [ ] Consumers can `pip install --upgrade logmind && logmind agents update --apply` to bump both AGENTS.md to v7-pointer AND CI workflow pins to v0.5.13 in one shot

🤖 Generated with [Claude Code](https://claude.com/claude-code)