### PR TITLE
docs: SkDD toolchain footer for logmind README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,16 @@ See [docs/custom-integrations.md](docs/custom-integrations.md) for patterns, exa
 - **Automatic:** Commits and pushes on every log
 
 See [docs/plan.md](docs/plan.md) for complete architecture and roadmap.
+
+---
+
+## Part of the thrillmade SkDD toolchain
+
+[Skills-Driven Development](https://zakelfassi.com/skdd-skills-driven-development) (Zak Elfassi's methodology) gives you the loop; the thrillmade toolchain ships the parts:
+
+- **[logmind](https://github.com/thrillmade/logmind)** — the *why* behind every change (decision logging as commit primitive); skill-creation + testing + auditing
+- **[clud-bug](https://github.com/thrillmade/clud-bug)** — skill-driven PR review at gate time; every finding cites the skill that motivated it
+- **[agent-skills](https://github.com/thrillmade/agent-skills)** — public catalog of reusable skills
+- **[skills.sh](https://skills.sh)** — skill discovery + install
+
+End-to-end agentic auto dev: write skills first → log the *why* → run them against PRs → iterate based on usage. The tools work independently; better together.


### PR DESCRIPTION
Stream 5 cleanup. Adds identical 'Part of the thrillmade SkDD toolchain' footer to logmind README.md. Parallel commits land on clud-bug + agent-skills.

Footer:
- Names SkDD (Zak Elfassi's methodology, links his blog)
- Lists the 4 thrillmade toolchain parts
- Captures the end-to-end auto-dev loop

Repetition aids recognition — same paragraph on all 3 READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)