### PR TITLE
feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-30
+
+### Added — `logmind skill` subgroup (Stream 6 v0.6.0)
+
+First step of the **end-to-end agentic auto-dev loop** the user
+coined (2026-05-30): _"development with skills, logging with
+logmind to document the changes, then using logmind runnerbot to
+forge and update skills, and then cludbug reviews with those
+skills and against them, rinse repeat."_
+
+Two CLI subcommands ship in v0.6.0; bench + log subcommands queued
+for v0.6.1+.
+
+#### `logmind skill new <name>`
+
+Scaffolds a new SKILL.md against the
+[agentskills.io/v1](https://agentskills.io) spec. Composes with
+Zak Elfassi's [`@zakelfassi/skdd`](https://zakelfassi.com/skdd-skills-driven-development):
+
+- If `skdd` is on PATH → delegates to `skdd forge <name>` (canonical
+  SkDD authoring path)
+- Otherwise → scaffolds a basic SKILL.md with required frontmatter
+  fields + a TODO trigger description (the discovery surface)
+
+Auto-decision-logs the skill creation via `logmind log` (audit
+trail of every skill iteration). Pass `--no-log` to skip.
+
+```bash
+logmind skill new my-team-conventions \
+    --description "Apply our team's review checklist on every PR"
+```
+
+#### `logmind skill test <name>`
+
+Validates a SKILL.md against the spec + logmind layered checks.
+
+- If `skdd` is on PATH → delegates to `skdd validate`
+- Layers logmind-specific checks: frontmatter required fields
+  (`name` + `description`), soft size cap (8KB — guards against
+  skills that bloat every agent load)
+- Exits non-zero on any check failure so CI can gate on it
+
+```bash
+logmind skill test my-team-conventions
+# ✓ skdd validate passed
+# ✓ frontmatter required fields: ok
+# ✓ size cap: 2934 bytes (cap: 8000)
+```
+
+### Architecture (per explore-agent strategic analysis, 2026-05-30)
+
+- **Don't reimplement Zak's `forge` / `validate`** when `skdd` is on
+  PATH. Wire to it instead — the canonical SkDD methodology lives
+  upstream.
+- **Layer logmind-specific value** AFTER his CLI does its work:
+  decision-log on creation; size cap + frontmatter checks on test.
+- **Scope discipline**: v0.6.0 ships `new` + `test` only.
+  - v0.6.1: `bench` (per-call token-cost measurement per skill)
+  - v0.6.2: `log` (decision-log a skill iteration, automatable from
+    a parallel bot per Stream 9)
+
+### Tests
+
+20 new tests in `tests/test_skill_cli.py`:
+- 3 cover `scaffold_basic_skill` (creates valid SKILL.md, refuses
+  clobber, TODO when no description)
+- 7 cover validation helpers (`check_frontmatter_required_fields`,
+  `check_size_cap` — passing + failing cases)
+- 8 cover the CLI commands (basic-scaffold path, --no-log, missing
+  skill, broken frontmatter, oversized skill)
+- 2 cover the skdd delegate path via subprocess mocking
+
+Full suite: 693 passed, 1 skipped (was 673 at v0.5.13).
+
+### Upstream collaboration context
+
+Zak Elfassi's `@zakelfassi/skdd` (npm) is the canonical SkDD CLI.
+This release positions logmind as the **complementor**: when his
+CLI is available, we wire to it; when it's not, we degrade
+gracefully to a basic scaffold. The vendored `skillforge` skill
+also lands in agent-skills in parallel (PR #73 there), preserving
+his attribution.
+
+### v0.6.0 vs v0.5.x
+
+Minor version bump because `logmind skill` is a new CLI subgroup —
+new user-visible surface. No breaking changes; all v0.5.x APIs
+unchanged. Consumers upgrading from v0.5.13 → v0.6.0 see the new
+subcommand + zero regressions.
+
 ## [0.5.13] - 2026-05-30
 
 ### Added — 5-item quality batch

--- a/docs/decisions-branches/feat__v0.6.0-skill-cli.md
+++ b/docs/decisions-branches/feat__v0.6.0-skill-cli.md
@@ -1,0 +1,12 @@
+## 2026-05-30 12:53 - feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop
+
+**Reasoning:** User-coined positioning (2026-05-30): 'end-to-end agentic auto dev' loop = development with skills + logging changes + logmind runnerbot forging skills + clud-bug reviewing against them. v0.6.0 ships the first two arrows of that loop: scaffold (logmind skill new) + validate (logmind skill test) SKILL.md files against the agentskills.io/v1 spec. Per explore-agent strategic analysis: compose with Zak Elfassi's @zakelfassi/skdd when on PATH, layer logmind-specific value (decision-log on create, size cap + frontmatter checks on test). Minor version bump because new CLI subgroup = new user-visible surface; no breaking changes.
+
+**Alternatives considered:** v0.5.14 instead of v0.6.0 — rejected, new CLI subgroup deserves a minor bump under semver, Reimplement skdd forge/validate from scratch — rejected per explore agent (USE Zak's CLI; don't fragment ecosystem), Ship bench + log subcommands in v0.6.0 too — rejected, v0.6.0 scope discipline ships new+test only; bench (v0.6.1) + log (v0.6.2) follow
+
+**Implications:**
+- First concrete artifact in the 'recursive skill building' loop the user envisioned. logmind is no longer just substrate; it's the skill craftsperson's workbench.
+- Composes with Zak's CLI gracefully — when skdd is on PATH we use it; when not, we degrade to basic scaffold. Zero hard dependency. Python ecosystem teams (no Node) still get a functional path.
+- Auto-decision-logs every skill creation via logmind log. Stream 9 parallel bot (later) can watch the decision stream + suggest skill iterations from observed clud-bug finding patterns. v0.6.0 lays the groundwork.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -86,6 +86,7 @@ logmind
 │   ├── test_propose_skill_update.py
 │   ├── test_rebase_cmd.py
 │   ├── test_search.py
+│   ├── test_skill_cli.py
 │   ├── test_skill_install.py
 │   ├── test_stale_derived_docs_warning.py
 │   ├── test_templates_v0_1_2.py

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (79 decisions)
+## 2026-05 (80 decisions)
 
-- **2026-05-30** — feat(v0.5.13): 5-item quality batch — §4b.2 + workflow pin auto-update + doctor non-zero + doctor stale-derived-docs warning + logmind rebase *(feat/v0.5.13-quality-batch)* — [decisions-branches/feat__v0.5.13-quality-batch.md](decisions-branches/feat__v0.5.13-quality-batch.md)
-- *... 77 more decisions ...*
+- **2026-05-30** — feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop *(feat/v0.6.0-skill-cli)* — [decisions-branches/feat__v0.6.0-skill-cli.md](decisions-branches/feat__v0.6.0-skill-cli.md)
+- *... 78 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.5.13"
+version = "0.6.0"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.5.13"
+__version__ = "0.6.0"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -110,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.5.13", prog_name="logmind")
+@click.version_option(version="0.6.0", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -1798,6 +1798,182 @@ def agents_migrate(no_commit: bool):
             click.echo("✓ Committed migration")
         except Exception as e:
             click.secho(f"Warning: Failed to commit: {e}", fg="yellow")
+
+
+# v0.6.0 — `logmind skill` subgroup (SkDD skill authoring + validation)
+@main.group()
+def skill():
+    """Author + validate SKILL.md files (composes with Zak Elfassi's skdd CLI).
+
+    Per the Skills-Driven Development (SkDD) methodology — see
+    https://zakelfassi.com/skdd-skills-driven-development.
+
+    These commands compose with `@zakelfassi/skdd` when it's on PATH:
+
+      - `logmind skill new` prefers `skdd forge` if available
+      - `logmind skill test` prefers `skdd validate` if available
+
+    Logmind layers on: decision-logging on skill creation (audit
+    trail), additional validation (byte cap, frontmatter required
+    fields), and the recursive-iteration loop logmind is positioned
+    to handle (v0.6.1+).
+    """
+    pass
+
+
+@skill.command("new")
+@click.argument("name")
+@click.option(
+    "--description",
+    default="",
+    help="One-sentence trigger description. The discovery surface.",
+)
+@click.option(
+    "--no-log",
+    is_flag=True,
+    help="Skip decision-logging the skill creation.",
+)
+def skill_new(name: str, description: str, no_log: bool):
+    """Create a new SKILL.md scaffolded for the agentskills.io/v1 spec.
+
+    Prefers `skdd forge <name>` when on PATH (canonical SkDD authoring).
+    Falls back to a basic scaffold otherwise. In both cases, the skill
+    creation is decision-logged via `logmind log` (audit trail).
+
+    Refuses to clobber an existing skill of the same name — delete
+    first if you want to recreate.
+    """
+    from logmind.core.skill_cli import (
+        delegate_skdd_forge,
+        has_skdd,
+        scaffold_basic_skill,
+        skill_md_path,
+    )
+
+    repo_root = Path.cwd()
+    target = skill_md_path(repo_root, name)
+    if target.exists():
+        click.secho(
+            f"Error: skill '{name}' already exists at {target}",
+            fg="red",
+        )
+        sys.exit(1)
+
+    if has_skdd():
+        click.echo(f"→ skdd forge {name}")
+        ok, output = delegate_skdd_forge(repo_root, name)
+        if not ok:
+            click.secho(
+                f"Error: skdd forge failed.\n{output}\n"
+                f"Falling back to basic scaffold.",
+                fg="yellow",
+            )
+            scaffold_basic_skill(repo_root, name, description=description)
+        else:
+            click.echo(output.strip() if output.strip() else "(skdd produced no output)")
+    else:
+        click.echo(
+            "→ scaffolding basic SKILL.md (`skdd` not on PATH; install "
+            "@zakelfassi/skdd for canonical SkDD authoring)"
+        )
+        scaffold_basic_skill(repo_root, name, description=description)
+
+    click.secho(f"✓ Created skill '{name}' at {skill_md_path(repo_root, name)}", fg="green")
+
+    # Decision-log the skill creation. Skip on --no-log (test scenarios,
+    # CI runs that don't want the auto-decision).
+    if not no_log:
+        docs_path = repo_root / "docs"
+        if docs_path.exists():
+            try:
+                from logmind.core.logger import log as _logmind_log
+                _logmind_log(
+                    f"Created skill '{name}' via `logmind skill new`",
+                    reasoning=(
+                        f"Skill scaffolded {'via skdd forge' if has_skdd() else 'via basic scaffold (skdd not on PATH)'}. "
+                        f"Trigger description: {description or '(TODO)'}. "
+                        f"Per SkDD methodology (Zak Elfassi)."
+                    ),
+                    docs_path=docs_path,
+                    auto_commit=False,  # let the user commit when ready
+                )
+                click.echo("✓ Decision-logged the skill creation (uncommitted).")
+            except Exception as e:
+                click.secho(
+                    f"Warning: failed to decision-log skill creation: {e}",
+                    fg="yellow",
+                )
+        else:
+            click.echo(
+                "(skipped decision-log: docs/ not present — run `logmind init` to enable)"
+            )
+
+    _ok(f"skill: created {name}")
+
+
+@skill.command("test")
+@click.argument("name")
+def skill_test(name: str):
+    """Validate a SKILL.md against the agentskills.io/v1 spec + logmind checks.
+
+    Prefers `skdd validate` when on PATH (canonical spec validation).
+    Layers logmind-specific checks: frontmatter required fields,
+    soft size cap (8KB — guards against skills that bloat every load).
+
+    Exits non-zero on any validation failure so CI can gate on it.
+    """
+    from logmind.core.skill_cli import (
+        check_frontmatter_required_fields,
+        check_size_cap,
+        delegate_skdd_validate,
+        has_skdd,
+        skill_md_path,
+    )
+
+    repo_root = Path.cwd()
+    target = skill_md_path(repo_root, name)
+    if not target.exists():
+        click.secho(
+            f"Error: skill '{name}' not found at {target}",
+            fg="red",
+        )
+        sys.exit(1)
+
+    failed = False
+
+    if has_skdd():
+        click.echo(f"→ skdd validate (filtering for '{name}')")
+        ok, output = delegate_skdd_validate(repo_root, name)
+        if output.strip():
+            click.echo(output.strip())
+        if not ok:
+            failed = True
+            click.secho("✗ skdd validate failed", fg="red")
+        else:
+            click.secho("✓ skdd validate passed", fg="green")
+    else:
+        click.echo(
+            "(skipping skdd validate — `skdd` not on PATH; install "
+            "@zakelfassi/skdd for canonical spec checks)"
+        )
+
+    # Always run logmind-specific layered checks.
+    content = target.read_text(encoding="utf-8")
+    for check_name, check_fn in [
+        ("frontmatter required fields", check_frontmatter_required_fields),
+        ("size cap", check_size_cap),
+    ]:
+        ok, msg = check_fn(content)
+        if ok:
+            click.secho(f"✓ {check_name}: {msg or 'ok'}", fg="green")
+        else:
+            failed = True
+            click.secho(f"✗ {check_name}: {msg}", fg="red")
+
+    if failed:
+        _ok(f"skill: {name} FAILED validation")
+        sys.exit(1)
+    _ok(f"skill: {name} validated")
 
 
 # Config command group

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -1864,11 +1864,27 @@ def skill_new(name: str, description: str, no_log: bool):
         ok, output = delegate_skdd_forge(repo_root, name)
         if not ok:
             click.secho(
-                f"Error: skdd forge failed.\n{output}\n"
-                f"Falling back to basic scaffold.",
+                f"Error: skdd forge failed.\n{output}",
                 fg="yellow",
             )
-            scaffold_basic_skill(repo_root, name, description=description)
+            # v0.6.0 PR #92 review fix: skdd forge may create the SKILL.md
+            # AND THEN exit non-zero (e.g., post-creation validation fails).
+            # In that case, our fallback scaffold_basic_skill raises
+            # FileExistsError (its clobber-guard). Catch it so the user
+            # sees a clean error instead of a raw traceback.
+            try:
+                click.echo("Falling back to basic scaffold.")
+                scaffold_basic_skill(repo_root, name, description=description)
+            except FileExistsError:
+                # skdd already created the file but reported failure on it
+                click.secho(
+                    f"Error: skdd forge partially succeeded (file exists "
+                    f"at {target}) but reported failure. Inspect the file "
+                    f"+ skdd output above, then either fix it manually or "
+                    f"`rm -r {target.parent}` and re-run.",
+                    fg="red",
+                )
+                sys.exit(1)
         else:
             click.echo(output.strip() if output.strip() else "(skdd produced no output)")
     else:

--- a/src/logmind/core/skill_cli.py
+++ b/src/logmind/core/skill_cli.py
@@ -1,0 +1,197 @@
+"""v0.6.0 — `logmind skill new/test` CLI implementations.
+
+Composes with Zak Elfassi's ``@zakelfassi/skdd`` (the canonical SkDD
+methodology toolkit) when present on PATH:
+
+- ``logmind skill new <name>``: prefers ``skdd forge <name>`` if available;
+  otherwise scaffolds a basic SKILL.md against the agentskills.io/v1 spec.
+- ``logmind skill test <name>``: prefers ``skdd validate <name>``; layers
+  logmind-specific checks (size cap, frontmatter presence) on top.
+
+Design (per explore-agent strategic analysis, 2026-05-30):
+- Don't reimplement Zak's ``forge`` / ``validate`` if the upstream CLI is
+  available. Wire to it.
+- Inject logmind-specific behavior AFTER his CLI does its work:
+  decision-log the skill creation; layer additional validation.
+- Spec compliance: SKILL.md frontmatter follows agentskills.io/v1
+  (``name``, ``description`` required; ``metadata`` optional).
+
+Scope:
+- v0.6.0: ``new`` + ``test`` (minimum viable; ships the loop's first
+  two arrows).
+- v0.6.1: ``bench`` (token-cost measurement per skill).
+- v0.6.2: ``log`` (decision-log a skill iteration, automatable from a bot).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+# Per agentskills.io/v1 spec: required fields are `name` + `description`.
+# `metadata` is optional; we add a logmind-specific marker inside it.
+_BASIC_SKILL_TEMPLATE = """---
+name: {name}
+description: {description}
+metadata:
+  logmind-managed: true
+  spec: agentskills.io
+---
+
+# {title}
+
+<!-- One short paragraph describing what this skill does + when an agent
+should load it. The description field above is the discovery surface;
+this body is what the agent reads once they decide to load it. -->
+
+## When to use
+
+- Trigger condition 1
+- Trigger condition 2
+
+## Steps
+
+1. Step one
+2. Step two
+
+## Examples
+
+<!-- Concrete examples make skills easier to apply correctly. -->
+"""
+
+
+def has_skdd() -> bool:
+    """Return True iff Zak's ``skdd`` CLI is on PATH."""
+    return shutil.which("skdd") is not None
+
+
+def default_skills_dir(repo_root: Path) -> Path:
+    """The canonical location for SKILL.md files in a repo.
+
+    Defaults to ``.claude/skills/`` — the Claude Code convention that
+    clud-bug and the agent-skills catalog use. Other harnesses (Cursor,
+    Codex) follow the same per-skill subdirectory layout, so this works
+    for any consumer.
+    """
+    return repo_root / ".claude" / "skills"
+
+
+def skill_dir(repo_root: Path, name: str) -> Path:
+    """Return the canonical directory for a skill of the given name."""
+    return default_skills_dir(repo_root) / name
+
+
+def skill_md_path(repo_root: Path, name: str) -> Path:
+    return skill_dir(repo_root, name) / "SKILL.md"
+
+
+def scaffold_basic_skill(
+    repo_root: Path, name: str, description: str = ""
+) -> Path:
+    """Scaffold a basic agentskills.io/v1-compliant SKILL.md.
+
+    Used when ``skdd`` is not on PATH. Creates the skill directory + a
+    minimal SKILL.md with the required frontmatter fields.
+
+    Raises ``FileExistsError`` if the skill already exists (refuse to
+    clobber).
+    """
+    target = skill_md_path(repo_root, name)
+    if target.exists():
+        raise FileExistsError(f"Skill '{name}' already exists at {target}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not description:
+        description = (
+            f"TODO: one-sentence trigger description for '{name}'. "
+            f"Be specific — this field is the discovery surface."
+        )
+    target.write_text(
+        _BASIC_SKILL_TEMPLATE.format(
+            name=name,
+            description=description,
+            title=name.replace("-", " ").replace("_", " ").title(),
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def delegate_skdd_forge(repo_root: Path, name: str) -> Tuple[bool, str]:
+    """Run ``skdd forge <name>`` in ``repo_root``. Returns (success, output)."""
+    try:
+        result = subprocess.run(
+            ["skdd", "forge", name],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (result.returncode == 0, result.stdout + result.stderr)
+    except (FileNotFoundError, OSError) as e:
+        return (False, str(e))
+
+
+def delegate_skdd_validate(repo_root: Path, name: str) -> Tuple[bool, str]:
+    """Run ``skdd validate`` in ``repo_root``. Returns (success, output).
+
+    Zak's ``skdd validate`` walks every SKILL.md in the colony and
+    reports per-file pass/fail. We don't pass a name filter — the
+    upstream CLI doesn't take one — and instead read the full output
+    so the caller can grep for the target skill's section if needed.
+    """
+    try:
+        result = subprocess.run(
+            ["skdd", "validate"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (result.returncode == 0, result.stdout + result.stderr)
+    except (FileNotFoundError, OSError) as e:
+        return (False, str(e))
+
+
+# Logmind-specific validation layered on top of skdd validate. Each
+# returns (ok, message). When `ok is False`, message explains why.
+
+# Soft size cap — most well-written skills land 50-200 lines. The cap
+# guards against runaway skills that bloat every agent invocation.
+_LOGMIND_SKILL_BYTE_CAP = 8000
+
+
+def check_frontmatter_required_fields(content: str) -> Tuple[bool, str]:
+    """Required fields per agentskills.io/v1: ``name`` + ``description``.
+
+    Lightweight check — proper validation is `skdd validate`'s job.
+    This catches the most common authoring mistakes when skdd isn't
+    available.
+    """
+    if not content.startswith("---"):
+        return (False, "SKILL.md must start with YAML frontmatter (--- block)")
+    end = content.find("\n---", 4)
+    if end == -1:
+        return (False, "SKILL.md frontmatter is unterminated (missing closing ---)")
+    fm = content[4:end]
+    if "name:" not in fm:
+        return (False, "SKILL.md frontmatter missing required field: name")
+    if "description:" not in fm:
+        return (False, "SKILL.md frontmatter missing required field: description")
+    return (True, "")
+
+
+def check_size_cap(content: str, cap: int = _LOGMIND_SKILL_BYTE_CAP) -> Tuple[bool, str]:
+    """Soft size cap — warns + fails if skill is unreasonably large."""
+    size = len(content.encode("utf-8"))
+    if size > cap:
+        return (
+            False,
+            f"SKILL.md is {size} bytes — over the {cap}-byte logmind cap. "
+            f"Large skills bloat every agent load. Consider splitting "
+            f"into multiple focused skills."
+        )
+    return (True, f"{size} bytes (cap: {cap})")

--- a/src/logmind/core/skill_cli.py
+++ b/src/logmind/core/skill_cli.py
@@ -25,6 +25,7 @@ Scope:
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -136,12 +137,22 @@ def delegate_skdd_forge(repo_root: Path, name: str) -> Tuple[bool, str]:
 
 
 def delegate_skdd_validate(repo_root: Path, name: str) -> Tuple[bool, str]:
-    """Run ``skdd validate`` in ``repo_root``. Returns (success, output).
+    """Run ``skdd validate`` in ``repo_root`` + filter result to ``name``.
 
     Zak's ``skdd validate`` walks every SKILL.md in the colony and
-    reports per-file pass/fail. We don't pass a name filter — the
-    upstream CLI doesn't take one — and instead read the full output
-    so the caller can grep for the target skill's section if needed.
+    reports per-file pass/fail. The upstream CLI doesn't take a name
+    filter, so we run it once + parse the output for the line
+    referencing ``name``. Returns:
+
+      - (True, lines mentioning ``name`` — should be a pass marker)
+      - (False, lines mentioning ``name`` — should be a fail marker)
+      - (False, full output) when ``name`` isn't found in the output
+        (defensive: report the whole thing rather than silently passing)
+
+    **v0.6.0 PR #92 review fix**: previously returned the colony-wide
+    exit code. Any unrelated broken skill in the repo caused
+    ``logmind skill test <good-skill>`` to fail. Now we extract just
+    the lines about ``name`` so the gate is per-skill as intended.
     """
     try:
         result = subprocess.run(
@@ -151,9 +162,35 @@ def delegate_skdd_validate(repo_root: Path, name: str) -> Tuple[bool, str]:
             text=True,
             check=False,
         )
-        return (result.returncode == 0, result.stdout + result.stderr)
     except (FileNotFoundError, OSError) as e:
         return (False, str(e))
+
+    combined = result.stdout + result.stderr
+    # Pull out lines referencing the target skill. `skdd validate`'s
+    # output format mentions the skill by path or name; we match both
+    # to stay format-tolerant.
+    relevant = [
+        line for line in combined.splitlines()
+        if name in line or f"skills/{name}/" in line
+    ]
+
+    if not relevant:
+        # Skill not mentioned in output — likely means it wasn't found
+        # by skdd OR the output format changed. Report the whole output
+        # + fail, rather than silently passing.
+        return (
+            False,
+            f"skdd validate did not mention '{name}' in its output. "
+            f"Full output:\n{combined}",
+        )
+
+    # Determine pass/fail per-skill from the relevant lines. skdd's
+    # convention: pass lines look like "✓" / "PASS" / "ok"; fail lines
+    # look like "✗" / "FAIL" / "error". Be permissive on the markers.
+    relevant_text = "\n".join(relevant)
+    fail_markers = ("✗", "FAIL", "fail", "ERROR", "error")
+    has_fail = any(m in relevant_text for m in fail_markers)
+    return (not has_fail, relevant_text)
 
 
 # Logmind-specific validation layered on top of skdd validate. Each
@@ -164,12 +201,25 @@ def delegate_skdd_validate(repo_root: Path, name: str) -> Tuple[bool, str]:
 _LOGMIND_SKILL_BYTE_CAP = 8000
 
 
+# Anchored regexes to detect required-field presence in YAML
+# frontmatter. Substring matches (e.g. `"name:" in fm`) false-positive on
+# nested fields like `domain_name:` or `package_name:`. Per v0.6.0 PR #92
+# review (evidence-based-review). Multiline + start-anchor matches both
+# top-level fields AND fields nested under a single indent level (which
+# is fine — they're still real `name:` declarations).
+_FRONTMATTER_NAME_RE = re.compile(r"^\s*name\s*:", re.MULTILINE)
+_FRONTMATTER_DESCRIPTION_RE = re.compile(r"^\s*description\s*:", re.MULTILINE)
+
+
 def check_frontmatter_required_fields(content: str) -> Tuple[bool, str]:
     """Required fields per agentskills.io/v1: ``name`` + ``description``.
 
     Lightweight check — proper validation is `skdd validate`'s job.
     This catches the most common authoring mistakes when skdd isn't
     available.
+
+    v0.6.0 PR #92 review fix: use anchored regexes instead of substring
+    `in` checks so `domain_name:` doesn't false-positive as `name:`.
     """
     if not content.startswith("---"):
         return (False, "SKILL.md must start with YAML frontmatter (--- block)")
@@ -177,9 +227,9 @@ def check_frontmatter_required_fields(content: str) -> Tuple[bool, str]:
     if end == -1:
         return (False, "SKILL.md frontmatter is unterminated (missing closing ---)")
     fm = content[4:end]
-    if "name:" not in fm:
+    if not _FRONTMATTER_NAME_RE.search(fm):
         return (False, "SKILL.md frontmatter missing required field: name")
-    if "description:" not in fm:
+    if not _FRONTMATTER_DESCRIPTION_RE.search(fm):
         return (False, "SKILL.md frontmatter missing required field: description")
     return (True, "")
 

--- a/tests/test_skill_cli.py
+++ b/tests/test_skill_cli.py
@@ -1,0 +1,301 @@
+"""Tests for v0.6.0 `logmind skill new/test` CLI.
+
+These cover the basic-scaffold path (no `skdd` on PATH) since that's
+what's deterministically reproducible in CI. The skdd-delegate path
+is exercised via subprocess mocking.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from logmind.cli import main as cli_main
+from logmind.core.skill_cli import (
+    check_frontmatter_required_fields,
+    check_size_cap,
+    scaffold_basic_skill,
+    skill_md_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# scaffold_basic_skill — pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_scaffold_basic_skill_creates_valid_skill_md(tmp_path):
+    target = scaffold_basic_skill(tmp_path, "my-skill", description="trigger")
+    assert target.exists()
+    assert target == tmp_path / ".claude" / "skills" / "my-skill" / "SKILL.md"
+    content = target.read_text(encoding="utf-8")
+    assert "name: my-skill" in content
+    assert "description: trigger" in content
+    assert "metadata:" in content
+    assert "spec: agentskills.io" in content
+
+
+def test_scaffold_basic_skill_refuses_to_clobber(tmp_path):
+    scaffold_basic_skill(tmp_path, "my-skill")
+    with pytest.raises(FileExistsError):
+        scaffold_basic_skill(tmp_path, "my-skill")
+
+
+def test_scaffold_basic_skill_emits_TODO_when_no_description(tmp_path):
+    """When the user doesn't pass --description, scaffold a TODO so they
+    know it needs filling — the description IS the discovery surface."""
+    target = scaffold_basic_skill(tmp_path, "my-skill")
+    content = target.read_text(encoding="utf-8")
+    assert "TODO" in content
+    assert "trigger description" in content
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_check_frontmatter_required_fields_passes_valid():
+    content = "---\nname: x\ndescription: y\n---\n\nbody\n"
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is True
+
+
+def test_check_frontmatter_required_fields_fails_no_frontmatter():
+    ok, msg = check_frontmatter_required_fields("just body text\n")
+    assert ok is False
+    assert "frontmatter" in msg.lower()
+
+
+def test_check_frontmatter_required_fields_fails_missing_name():
+    content = "---\ndescription: y\n---\nbody\n"
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is False
+    assert "name" in msg
+
+
+def test_check_frontmatter_required_fields_fails_missing_description():
+    content = "---\nname: x\n---\nbody\n"
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is False
+    assert "description" in msg
+
+
+def test_check_frontmatter_required_fields_fails_unterminated():
+    content = "---\nname: x\ndescription: y\n\nno closing dashes\n"
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is False
+
+
+def test_check_size_cap_passes_small_skill():
+    ok, msg = check_size_cap("---\nname: x\ndescription: y\n---\n\nshort body\n")
+    assert ok is True
+
+
+def test_check_size_cap_fails_large_skill():
+    bloat = "x" * 10000
+    ok, msg = check_size_cap(bloat)
+    assert ok is False
+    assert "8000" in msg  # cap mentioned in error
+
+
+# ---------------------------------------------------------------------------
+# `logmind skill new` CLI (basic-scaffold path, skdd mocked off)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_new_creates_skill_via_basic_scaffold(tmp_path, monkeypatch):
+    """When skdd is NOT on PATH, fall back to basic scaffold."""
+    monkeypatch.chdir(tmp_path)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["skill", "new", "my-skill", "--description", "trigger here", "--no-log"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Created skill 'my-skill'" in result.output
+    target = skill_md_path(tmp_path, "my-skill")
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "name: my-skill" in content
+    assert "description: trigger here" in content
+
+
+def test_skill_new_refuses_to_clobber(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    scaffold_basic_skill(tmp_path, "existing")
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "new", "existing", "--no-log"])
+
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+
+def test_skill_new_no_log_flag_skips_decision_log(tmp_path, monkeypatch):
+    """--no-log skips the auto-decision-log even when docs/ exists."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "decisions.md").write_text("# Decisions\n", encoding="utf-8")
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["skill", "new", "no-log-skill", "--no-log"],
+        )
+
+    assert result.exit_code == 0, result.output
+    decisions = (tmp_path / "docs" / "decisions.md").read_text(encoding="utf-8")
+    assert "no-log-skill" not in decisions, (
+        "v0.6.0 --no-log: must not write to decisions.md"
+    )
+
+
+def test_skill_new_without_docs_dir_silently_skips_decision_log(tmp_path, monkeypatch):
+    """When docs/ doesn't exist (logmind init not run yet), skill new still
+    succeeds — the decision-log step is skipped with a helpful note."""
+    monkeypatch.chdir(tmp_path)
+    # No docs/ directory
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["skill", "new", "first-skill", "--description", "trigger"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "skipped decision-log" in result.output.lower() or "docs/" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `logmind skill test` CLI (basic checks only, skdd mocked off)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_test_fails_on_missing_skill(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["skill", "test", "does-not-exist"])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_skill_test_passes_on_valid_skill(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    scaffold_basic_skill(tmp_path, "good-skill", description="valid trigger")
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "good-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert "frontmatter required fields" in result.output
+    assert "size cap" in result.output
+
+
+def test_skill_test_fails_on_broken_frontmatter(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Create a SKILL.md without frontmatter
+    target = tmp_path / ".claude" / "skills" / "broken" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("just body text — no frontmatter\n", encoding="utf-8")
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "broken"])
+
+    assert result.exit_code == 1
+    assert "frontmatter" in result.output.lower()
+
+
+def test_skill_test_fails_on_oversized_skill(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / ".claude" / "skills" / "bloat" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "---\nname: bloat\ndescription: huge\n---\n" + "x" * 10000,
+        encoding="utf-8",
+    )
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "bloat"])
+
+    assert result.exit_code == 1
+    assert "8000" in result.output  # cap mentioned
+
+
+# ---------------------------------------------------------------------------
+# Skdd delegate paths (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_new_delegates_to_skdd_forge_when_available(tmp_path, monkeypatch):
+    """When `skdd` is on PATH, prefer `skdd forge <name>` over basic scaffold."""
+    monkeypatch.chdir(tmp_path)
+
+    forge_calls: list = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["skdd", "forge"]:
+            forge_calls.append(cmd)
+            # Pretend skdd succeeded + created the file
+            target = skill_md_path(tmp_path, cmd[2])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                f"---\nname: {cmd[2]}\ndescription: forged\n---\nbody\n",
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="forged", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value="/usr/bin/skdd"), \
+         patch("logmind.core.skill_cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["skill", "new", "forged-skill", "--no-log"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert len(forge_calls) == 1
+    assert forge_calls[0] == ["skdd", "forge", "forged-skill"]
+    target = skill_md_path(tmp_path, "forged-skill")
+    assert target.exists()
+
+
+def test_skill_test_delegates_to_skdd_validate_when_available(tmp_path, monkeypatch):
+    """When `skdd` is on PATH, run `skdd validate` AND the logmind layered checks."""
+    monkeypatch.chdir(tmp_path)
+    scaffold_basic_skill(tmp_path, "delegated-skill", description="trigger")
+
+    validate_calls: list = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["skdd", "validate"]:
+            validate_calls.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="all skills passed validation", stderr=""
+            )
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value="/usr/bin/skdd"), \
+         patch("logmind.core.skill_cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "delegated-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert len(validate_calls) == 1
+    assert "skdd validate passed" in result.output
+    # Logmind-layered checks also ran
+    assert "frontmatter required fields" in result.output

--- a/tests/test_skill_cli.py
+++ b/tests/test_skill_cli.py
@@ -285,7 +285,9 @@ def test_skill_test_delegates_to_skdd_validate_when_available(tmp_path, monkeypa
         if cmd[:2] == ["skdd", "validate"]:
             validate_calls.append(cmd)
             return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="all skills passed validation", stderr=""
+                args=cmd, returncode=0,
+                stdout="✓ skills/delegated-skill/SKILL.md: ok",
+                stderr="",
             )
         return real_run(cmd, *args, **kwargs)
 
@@ -299,3 +301,149 @@ def test_skill_test_delegates_to_skdd_validate_when_available(tmp_path, monkeypa
     assert "skdd validate passed" in result.output
     # Logmind-layered checks also ran
     assert "frontmatter required fields" in result.output
+
+
+# ---------------------------------------------------------------------------
+# v0.6.0 PR #92 review fixes — regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_skill_test_per_skill_gate_not_colony_gate(tmp_path, monkeypatch):
+    """v0.6.0 PR #92 critical #1: `logmind skill test <name>` must gate on
+    that skill's pass/fail line, NOT the colony-wide exit code. Setup:
+    `skdd validate` exits non-zero (some OTHER skill broken in the colony)
+    but the target skill's line is a pass — we should still pass.
+    """
+    monkeypatch.chdir(tmp_path)
+    scaffold_basic_skill(tmp_path, "good-skill", description="trigger")
+    scaffold_basic_skill(tmp_path, "broken-other", description="")
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["skdd", "validate"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=1,  # colony-wide failure due to broken-other
+                stdout=(
+                    "✓ skills/good-skill/SKILL.md: ok\n"
+                    "✗ skills/broken-other/SKILL.md: missing description\n"
+                ),
+                stderr="",
+            )
+        return subprocess.run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value="/usr/bin/skdd"), \
+         patch("logmind.core.skill_cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "good-skill"])
+
+    assert result.exit_code == 0, (
+        f"v0.6.0 PR #92 critical #1 regression: per-skill test must pass "
+        f"when target skill's line is ok even if colony-wide exit is "
+        f"non-zero. Got:\n{result.output}"
+    )
+    assert "skdd validate passed" in result.output
+
+
+def test_skill_test_per_skill_gate_fails_when_target_fails(tmp_path, monkeypatch):
+    """Inverse: when the target skill's line shows fail, exit 1 even if
+    other skills passed (no false-pass from grepping the right line)."""
+    monkeypatch.chdir(tmp_path)
+    scaffold_basic_skill(tmp_path, "broken-target", description="trigger")
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["skdd", "validate"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,  # colony-wide OK
+                stdout=(
+                    "✓ skills/good-skill/SKILL.md: ok\n"
+                    "✗ skills/broken-target/SKILL.md: invalid frontmatter\n"
+                ),
+                stderr="",
+            )
+        return subprocess.run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value="/usr/bin/skdd"), \
+         patch("logmind.core.skill_cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["skill", "test", "broken-target"])
+
+    assert result.exit_code == 1
+
+
+def test_skill_new_skdd_partial_failure_no_traceback(tmp_path, monkeypatch):
+    """v0.6.0 PR #92 critical #2: when skdd forge CREATES the SKILL.md
+    AND THEN exits non-zero (post-creation check fails), the fallback
+    scaffold_basic_skill must NOT raise an uncaught FileExistsError.
+    User sees a clean error + clean exit, not a Python traceback.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    def mock_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["skdd", "forge"]:
+            # Create the SKILL.md AND return non-zero — the bug scenario
+            target = skill_md_path(tmp_path, cmd[2])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                f"---\nname: {cmd[2]}\ndescription: \n---\nbody\n",
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1,
+                stdout="created file but description is empty", stderr="",
+            )
+        return subprocess.run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.skill_cli.shutil.which", return_value="/usr/bin/skdd"), \
+         patch("logmind.core.skill_cli.subprocess.run", side_effect=mock_run):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["skill", "new", "partial-fail-skill", "--no-log"]
+        )
+
+    assert result.exit_code == 1
+    # No raw Python traceback in the output
+    assert "FileExistsError" not in result.output, (
+        f"v0.6.0 PR #92 critical #2 regression: raw FileExistsError "
+        f"traceback in user-facing output. Got:\n{result.output}"
+    )
+    assert "Traceback" not in result.output
+    # User-friendly error mentions next steps
+    assert (
+        "partially succeeded" in result.output.lower()
+        or "rm -r" in result.output
+    )
+
+
+def test_check_frontmatter_no_false_positive_on_domain_name(tmp_path):
+    """v0.6.0 PR #92 minor: `domain_name:` must NOT satisfy the `name:`
+    required-field check. Pre-fix used substring `in`; now uses anchored
+    regex.
+    """
+    content = (
+        "---\n"
+        "domain_name: my-domain\n"
+        "description: missing real name field\n"
+        "---\n"
+        "body\n"
+    )
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is False, (
+        f"v0.6.0 PR #92 minor regression: 'domain_name:' falsely passed "
+        f"as 'name:'. Got ok={ok}, msg={msg!r}"
+    )
+    assert "name" in msg
+
+
+def test_check_frontmatter_no_false_positive_on_description_nested():
+    """Mirror test for description field — `pkg_description:` shouldn't pass."""
+    content = (
+        "---\n"
+        "name: x\n"
+        "pkg_description: nested only\n"
+        "---\n"
+        "body\n"
+    )
+    ok, msg = check_frontmatter_required_fields(content)
+    assert ok is False
+    assert "description" in msg


### PR DESCRIPTION
First step of the **end-to-end agentic auto-dev loop** the user coined (2026-05-30):

> _"development with skills, logging with logmind to document the changes, then using logmind runnerbot to forge and update skills, and then cludbug reviews with those skills and against them, rinse repeat."_

Per the explore agent's strategic analysis (2026-05-30): logmind composes with Zak Elfassi's [`@zakelfassi/skdd`](https://zakelfassi.com/skdd-skills-driven-development) (the canonical SkDD CLI) when on PATH, layers logmind-specific value on top.

## What ships in v0.6.0

### `logmind skill new <name>`
Scaffolds a SKILL.md against the agentskills.io/v1 spec.
- If `skdd` on PATH → delegates to `skdd forge <name>`
- Otherwise → basic scaffold with required frontmatter + TODO trigger description
- Auto-decision-logs the skill creation via `logmind log` (audit trail). `--no-log` to skip.

### `logmind skill test <name>`
Validates a SKILL.md against the spec + logmind layered checks.
- If `skdd` on PATH → delegates to `skdd validate`
- Layers: frontmatter required fields (`name` + `description`), soft 8KB size cap
- Exits non-zero on any failure so CI gates on it

## Scope discipline

v0.6.0 ships `new` + `test` only. Queued for next:
- v0.6.1 — `logmind skill bench` (per-call token-cost measurement)
- v0.6.2 — `logmind skill log` (decision-log a skill iteration; automatable from Stream 9 parallel bot)

## Architecture (per explore-agent recommendation)

- **Don't reimplement Zak's CLI.** Wire to it when available.
- **Compose, don't dependency-bind.** Zero hard requirement on Node/npm — Python-only teams still get a working path via the basic scaffold.
- **Layer logmind-specific value.** Decision-log on create. Layered validation on test. Both compose with `skdd`'s spec checks rather than replacing them.

## Tests

20 new tests in `tests/test_skill_cli.py` covering: scaffold helper (3 tests), validation helpers (7), CLI commands basic-scaffold path (5), skdd-delegate path via subprocess mocking (2), edge cases (refuse clobber, missing skill, broken frontmatter, oversized skill).

Full suite: **693 passed, 1 skipped** (was 673 at v0.5.13).

## Test plan

- [x] `pytest tests/test_skill_cli.py -v` — 20/20 green
- [x] `pytest -q` (full suite) — 693 passed, 1 skipped
- [ ] CI: paths-check + check-derived-docs + clud-bug-review green
- [ ] After merge: tag `v0.6.0` → Trusted Publishing OIDC publishes to PyPI within ~1 min
- [ ] Smoke test post-publish: `logmind skill new test-skill --no-log` in a tmpdir → scaffold present + valid frontmatter

## Upstream context

- Parallel agent-skills PR #73 bundles Zak's `skillforge` SKILL.md with attribution
- Parallel agent-skills PR #72 + logmind PR #91 + clud-bug PR #123 add identical "Part of the thrillmade SkDD toolchain" README footers
- The 4 PRs together establish the **complementor** positioning: thrillmade toolchain composes with Zak's methodology + upstream CLI rather than competing

🤖 Generated with [Claude Code](https://claude.com/claude-code)