### PR TITLE
feat(v0.6.1): deterministic auto-rebase on timeline.md gap (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-30
+
+### Added — deterministic auto-rebase on timeline.md gap (opt-in)
+
+User-coined direction (2026-05-30): _"auto rebase must must be very
+deterministic and safe, only the timeline md file as you noted"_.
+
+Saves **~5-8 agent turns per DIRTY incident** (the
+tokenomics-Phase-D scenario): when a PR batch lands out-of-order,
+the trailing branch goes DIRTY because main's timeline.md gained
+new entries. Recovery is mechanical (rebase + regen timeline +
+force-with-lease push) and entirely contained in one derived doc —
+exactly the right case to automate behind a strong opt-in flag.
+
+#### Opt-in configuration
+
+Default OFF. Enable in `.logmind/config.yml`:
+
+```yaml
+git:
+  auto_rebase: true
+```
+
+When enabled, `logmind log` checks 6 conditions BEFORE any local
+state changes:
+
+1. `auto_rebase: true` in config
+2. Branch is NOT the default branch
+3. `git fetch origin <default>` succeeds
+4. `origin/<default>` ref exists
+5. Branch is behind `origin/<default>` (commits_behind > 0)
+6. **The gap touches EXACTLY `docs/timeline.md`** — no code, no
+   other derived docs, not even `docs/file-structure.md`
+
+If all 6 hold: rebase + (on conflict only in timeline.md) regen +
+continue, then `git push --force-with-lease`. On any unexpected
+conflict surface: `git rebase --abort` + bail safely (no
+half-applied state).
+
+#### Why the narrow scope
+
+`docs/timeline.md` is fully derived (regenerated from
+`docs/decisions.md` + per-branch decision files). Conflict
+resolution = re-run the generator. Deterministic by construction.
+
+Other files — even `docs/file-structure.md` — depend on broader
+repo state and have subtler conflict shapes. v0.6.1's safety
+posture: **single-file scope = trusted scope**. Future versions
+may widen, but only after observed behavior justifies it.
+
+#### Always `--force-with-lease`, never `--force`
+
+Tested explicitly in `test_uses_force_with_lease_not_force`.
+
+#### User-visible logging
+
+```
+↻ logmind auto-rebased 'feature' onto origin/main
+  (was 2 commits behind, only docs/timeline.md affected
+  — safely deterministic).
+```
+
+When enabled but conditions don't hold, emits a predictive heads-up
+naming the disqualifying files.
+
+### Added
+
+- `logmind.core.auto_rebase.maybe_auto_rebase()` — pure function
+  returning an `AutoRebaseResult` dataclass; never raises.
+- `Config.auto_rebase` property — opt-in via `git.auto_rebase`.
+- `logmind.core.logger.log()` — early integration block calling
+  `maybe_auto_rebase` BEFORE any local state changes.
+
+### Tests
+
+8 new tests in `tests/test_auto_rebase.py`:
+- 6 safety-gate tests (refuses when disabled / on default branch /
+  not in git repo / branch up-to-date / gap includes code / gap
+  includes file-structure.md)
+- 1 happy-path test (fires when gap is exactly `{docs/timeline.md}`)
+- 1 force-with-lease invariant test (must NEVER use `--force`)
+
+Full suite: 706 passed, 1 skipped (was 693 at v0.6.0).
+
+### Upstream context
+
+Pairs with v0.5.13's `logmind doctor --check-stale-derived-docs`
+(predictive heads-up) + `logmind rebase` (manual action). v0.6.1
+is the same detection + same action wrapped in opt-in config.
+
+Does NOT widen scope to `file-structure.md` this release — narrow
+scope is the safety lever.
+
 ## [0.6.0] - 2026-05-30
 
 ### Added — `logmind skill` subgroup (Stream 6 v0.6.0)

--- a/docs/decisions-branches/feat__v0.5.14-auto-rebase.md
+++ b/docs/decisions-branches/feat__v0.5.14-auto-rebase.md
@@ -1,0 +1,12 @@
+## 2026-05-30 14:30 - feat(v0.6.1): deterministic auto-rebase on timeline.md gap (opt-in)
+
+**Reasoning:** User-coined direction (2026-05-30): 'auto rebase must must be very deterministic and safe, only the timeline md file'. Closes the tokenomics-Phase-D pain by automating the rebase + regen + force-with-lease push when conditions hold. Saves ~5-8 agent turns per DIRTY incident. 6 hard safety gates: opt-in via config (default OFF), not default branch, fetch succeeds, upstream ref exists, branch behind, gap is EXACTLY {docs/timeline.md} and nothing else. Always --force-with-lease (never --force, tested explicitly). Abort safely on any unexpected conflict.
+
+**Alternatives considered:** default-on with --no-auto-rebase opt-out — rejected, force-push is destructive enough that opt-in is the correct posture, widen scope to file-structure.md too in v0.6.1 — rejected, narrow scope is the safety lever; widen only after observed behavior justifies, ship as v0.5.14 — rejected, v0.5.14 < v0.6.0 numerically would confuse semver; v0.6.1 is the right slot
+
+**Implications:**
+- Pairs with v0.5.13's doctor warning + logmind rebase manual command. Same detection logic, automated under opt-in.
+- Future: v0.6.2+ may widen the allowed-gap set (file-structure.md) once v0.6.1 is observed safe in production. Don't widen until evidence justifies.
+- 8 new tests in test_auto_rebase.py. Most load-bearing: test_uses_force_with_lease_not_force — explicit guard that the push NEVER uses bare --force.
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -64,6 +64,7 @@ logmind
 │   ├── test_agents_consolidation.py
 │   ├── test_aggregator.py
 │   ├── test_analytics.py
+│   ├── test_auto_rebase.py
 │   ├── test_bench.py
 │   ├── test_branch_aware_logging.py
 │   ├── test_calibration_aggregate.py

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (82 decisions)
+## 2026-05 (83 decisions)
 
-- **2026-05-30** — feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop *(feat/v0.6.0-skill-cli)* — [decisions-branches/feat__v0.6.0-skill-cli.md](decisions-branches/feat__v0.6.0-skill-cli.md)
-- *... 80 more decisions ...*
+- **2026-05-30** — feat(v0.6.1): deterministic auto-rebase on timeline.md gap (opt-in) *(feat/v0.5.14-auto-rebase)* — [decisions-branches/feat__v0.5.14-auto-rebase.md](decisions-branches/feat__v0.5.14-auto-rebase.md)
+- *... 81 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.0"
+version = "0.6.1"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -110,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.0", prog_name="logmind")
+@click.version_option(version="0.6.1", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/auto_rebase.py
+++ b/src/logmind/core/auto_rebase.py
@@ -1,0 +1,287 @@
+"""v0.5.14 — deterministic auto-rebase when the gap is timeline.md only.
+
+User-requested feature (2026-05-30): _"auto rebase must must be very
+deterministic and safe, only the timeline md file"_.
+
+Saves ~5-8 agent turns per DIRTY incident (Phase D tokenomics
+scenario): when a PR batch lands out-of-order, the trailing branch
+goes DIRTY because main's timeline.md has new entries. The recovery
+is mechanical (rebase + regen timeline.md + force-with-lease push)
+and entirely contained in a derived doc — exactly the kind of action
+to automate behind a strong opt-in flag.
+
+**Hard safety guards** (all must hold or auto-rebase REFUSES to act):
+
+1. ``auto_rebase: true`` is explicit (opt-in; default OFF)
+2. Branch is NOT the default branch (no rebasing main onto main)
+3. Branch is behind ``origin/<default>`` (otherwise nothing to do)
+4. The gap touches **exactly** ``docs/timeline.md`` and nothing else —
+   not even ``docs/file-structure.md``, not any code, not any other
+   derived doc. Single-file scope is the safety lever.
+5. ``--force-with-lease`` (never ``--force``) so a concurrent push
+   aborts safely
+6. Any unexpected rebase conflict triggers ``git rebase --abort`` +
+   bail out (no half-applied state)
+
+Returns a small report so the caller can emit user-visible logging
+about what happened (or didn't).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+# The single file the gap is allowed to touch. Anything else aborts.
+_ALLOWED_GAP_FILE = "docs/timeline.md"
+
+
+@dataclass
+class AutoRebaseResult:
+    """Outcome of an auto-rebase attempt. Always non-None even when no-op."""
+
+    fired: bool                # True iff the rebase + push actually ran
+    reason: str                # human-readable explanation
+    commits_behind: int = 0    # how many commits the branch was behind
+    pushed: bool = False       # True iff the force-with-lease push succeeded
+
+
+def maybe_auto_rebase(
+    repo_root: Path,
+    branch: str,
+    default_branch_name: str,
+    *,
+    enabled: bool,
+) -> AutoRebaseResult:
+    """Attempt a deterministic timeline-md-only auto-rebase.
+
+    Returns an :class:`AutoRebaseResult` describing what happened.
+    Never raises — every failure mode returns a fired=False result
+    with a reason string the caller can surface as a warning.
+
+    Caller is responsible for:
+      - deciding whether to print the result (most cases the reason
+        is only interesting when ``fired=True``)
+      - any post-rebase regeneration (the function handles the
+        rebase-time regen for timeline.md but the broader logmind log
+        flow continues from there)
+    """
+    if not enabled:
+        return AutoRebaseResult(fired=False, reason="auto_rebase disabled in config")
+
+    if branch == default_branch_name:
+        return AutoRebaseResult(
+            fired=False, reason=f"on default branch '{branch}' — nothing to rebase onto"
+        )
+
+    upstream = f"origin/{default_branch_name}"
+
+    # Fetch — best-effort, abort on failure (offline / no remote).
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "fetch", "origin", default_branch_name],
+            capture_output=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
+        return AutoRebaseResult(fired=False, reason=f"fetch failed: {e}")
+
+    # Verify the upstream ref now exists. If not, abort cleanly.
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", upstream],
+            capture_output=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return AutoRebaseResult(fired=False, reason=f"no upstream ref {upstream}")
+
+    # How far behind?
+    try:
+        behind = int(subprocess.run(
+            ["git", "-C", str(repo_root), "rev-list", "--count",
+             f"{branch}..{upstream}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip() or "0")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return AutoRebaseResult(fired=False, reason="unable to count commits behind")
+
+    if behind == 0:
+        return AutoRebaseResult(
+            fired=False, reason="branch up-to-date with upstream", commits_behind=0
+        )
+
+    # SAFETY GATE: only allow auto-rebase when the gap touches EXACTLY
+    # docs/timeline.md and nothing else. Any other file in the gap
+    # means we don't know how to resolve safely, and we bail out so
+    # the user/agent does the manual rebase.
+    try:
+        files_in_gap_raw = subprocess.run(
+            ["git", "-C", str(repo_root), "log",
+             f"{branch}..{upstream}", "--name-only", "--format="],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return AutoRebaseResult(
+            fired=False, reason="unable to list files in upstream gap",
+            commits_behind=behind,
+        )
+
+    files_in_gap = {line for line in files_in_gap_raw.splitlines() if line.strip()}
+    if files_in_gap != {_ALLOWED_GAP_FILE}:
+        # The deterministic-safety gate. We do NOT extend this to
+        # file-structure.md or any other derived doc in v0.5.14.
+        # Narrow scope = trusted scope.
+        other_files = sorted(files_in_gap - {_ALLOWED_GAP_FILE})
+        return AutoRebaseResult(
+            fired=False,
+            reason=(
+                f"upstream gap touches files beyond {_ALLOWED_GAP_FILE}: "
+                f"{', '.join(other_files) if other_files else '(empty diff?)'}"
+            ),
+            commits_behind=behind,
+        )
+
+    # OK, safe to rebase. Run it.
+    rebase = subprocess.run(
+        ["git", "-C", str(repo_root), "rebase", upstream],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if rebase.returncode != 0:
+        # Did rebase produce conflicts? If yes, check they're ONLY in
+        # docs/timeline.md before we attempt regen-and-continue.
+        conflicted = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", "--diff-filter=U"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.splitlines()
+        conflicted_set = {line for line in conflicted if line.strip()}
+
+        if conflicted_set != {_ALLOWED_GAP_FILE}:
+            # Unexpected conflict surface — abort safely.
+            subprocess.run(
+                ["git", "-C", str(repo_root), "rebase", "--abort"],
+                capture_output=True,
+                check=False,
+            )
+            return AutoRebaseResult(
+                fired=False,
+                reason=(
+                    f"rebase produced unexpected conflicts in {sorted(conflicted_set)}; "
+                    f"aborted safely"
+                ),
+                commits_behind=behind,
+            )
+
+        # Conflict is exactly timeline.md. Regenerate from sources +
+        # continue. Loop on conflict per commit since multi-commit
+        # branches may hit timeline.md conflicts on EACH replay step.
+        max_iterations = 50  # paranoid cap; real branches have <10 commits
+        for _ in range(max_iterations):
+            # Regenerate timeline.md from current decision files.
+            regen = subprocess.run(
+                ["logmind", "timeline", "--write", "docs/timeline.md"],
+                cwd=repo_root,
+                capture_output=True,
+                check=False,
+            )
+            if regen.returncode != 0:
+                subprocess.run(
+                    ["git", "-C", str(repo_root), "rebase", "--abort"],
+                    capture_output=True,
+                    check=False,
+                )
+                return AutoRebaseResult(
+                    fired=False,
+                    reason="timeline regen failed mid-rebase; aborted safely",
+                    commits_behind=behind,
+                )
+
+            subprocess.run(
+                ["git", "-C", str(repo_root), "add", "docs/timeline.md"],
+                capture_output=True,
+                check=False,
+            )
+
+            cont = subprocess.run(
+                ["git", "-C", str(repo_root), "rebase", "--continue"],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={"GIT_EDITOR": "true"},  # don't open editor for continue
+            )
+            if cont.returncode == 0:
+                break  # rebase complete
+
+            # Still conflicted? Verify it's still timeline.md only.
+            still_conflicted = set(subprocess.run(
+                ["git", "-C", str(repo_root), "diff", "--name-only", "--diff-filter=U"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.splitlines())
+            still_conflicted.discard("")
+            if still_conflicted != {_ALLOWED_GAP_FILE}:
+                subprocess.run(
+                    ["git", "-C", str(repo_root), "rebase", "--abort"],
+                    capture_output=True,
+                    check=False,
+                )
+                return AutoRebaseResult(
+                    fired=False,
+                    reason=(
+                        f"rebase continuation surfaced unexpected conflicts in "
+                        f"{sorted(still_conflicted)}; aborted safely"
+                    ),
+                    commits_behind=behind,
+                )
+        else:
+            # Hit the iteration cap (shouldn't happen on real branches).
+            subprocess.run(
+                ["git", "-C", str(repo_root), "rebase", "--abort"],
+                capture_output=True,
+                check=False,
+            )
+            return AutoRebaseResult(
+                fired=False,
+                reason=f"rebase exceeded {max_iterations} iterations; aborted",
+                commits_behind=behind,
+            )
+
+    # Rebase complete. Now force-with-lease push. Failure here means
+    # someone else pushed between our fetch + push — abort safely
+    # (the user/agent should retry rather than us looping).
+    push = subprocess.run(
+        ["git", "-C", str(repo_root), "push", "--force-with-lease",
+         "origin", branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if push.returncode != 0:
+        return AutoRebaseResult(
+            fired=False,
+            reason=(
+                f"rebase succeeded locally but force-with-lease push failed "
+                f"(concurrent push?): {push.stderr.strip()}"
+            ),
+            commits_behind=behind,
+        )
+
+    return AutoRebaseResult(
+        fired=True,
+        reason=f"rebased onto {upstream} (gap was {_ALLOWED_GAP_FILE} only)",
+        commits_behind=behind,
+        pushed=True,
+    )

--- a/src/logmind/core/config.py
+++ b/src/logmind/core/config.py
@@ -16,6 +16,15 @@ DEFAULT_CONFIG = {
         "auto_commit": True,
         "auto_push": True,
         "commit_message_template": "logmind: {decision}",
+        # v0.5.14: opt-in deterministic auto-rebase. Default OFF — auto
+        # force-with-lease push is destructive enough that users should
+        # opt in explicitly. When True, `logmind log` detects the
+        # tokenomics-Phase-D scenario (branch behind origin/<default> +
+        # the gap touches docs/timeline.md ONLY, no other files) and
+        # rebases + regenerates timeline + force-with-lease pushes
+        # silently as part of the log invocation. Saves ~5-8 agent
+        # turns per incident.
+        "auto_rebase": False,
     },
     "decisions": {
         "max_recent": 20,
@@ -183,6 +192,17 @@ class Config:
     def auto_push(self) -> bool:
         """Whether to auto-push after committing."""
         return self.get("git.auto_push", True)
+
+    @property
+    def auto_rebase(self) -> bool:
+        """v0.5.14 — opt-in deterministic auto-rebase on timeline.md gap.
+
+        When True + the very narrow conditions hold (branch behind
+        origin/<default>; gap touches exactly docs/timeline.md and no
+        other files), `logmind log` rebases + regenerates timeline +
+        force-with-lease pushes as part of the log invocation.
+        """
+        return self.get("git.auto_rebase", False)
 
     @property
     def commit_message_template(self) -> str:

--- a/src/logmind/core/logger.py
+++ b/src/logmind/core/logger.py
@@ -274,6 +274,42 @@ def log(
             "docs/ directory not found. Run 'logmind init' first to initialize."
         )
 
+    # v0.5.14: deterministic auto-rebase BEFORE any local state changes.
+    # When git.auto_rebase is true in config AND the branch is behind
+    # origin/<default> AND the gap touches docs/timeline.md ONLY
+    # (no other files), rebase + regenerate + force-with-lease push
+    # silently. Saves ~5-8 agent turns per DIRTY incident. Default OFF
+    # — opt-in via .logmind/config.yml because force-push is destructive.
+    # All other conditions: silent no-op, log() continues normally.
+    if is_git_repo():
+        from logmind.core.auto_rebase import maybe_auto_rebase
+
+        config_for_rebase = load_config()
+        if config_for_rebase.auto_rebase:
+            branch_for_rebase = current_branch()
+            if branch_for_rebase:
+                ar_result = maybe_auto_rebase(
+                    docs_path.parent,
+                    branch_for_rebase,
+                    default_branch(docs_path.parent),
+                    enabled=True,
+                )
+                if ar_result.fired:
+                    sys.stderr.write(
+                        f"\n↻ logmind auto-rebased '{branch_for_rebase}' onto "
+                        f"origin/{default_branch(docs_path.parent)} "
+                        f"(was {ar_result.commits_behind} commits behind, "
+                        f"only docs/timeline.md affected — safely deterministic).\n\n"
+                    )
+                elif ar_result.commits_behind > 0:
+                    # Predictive heads-up when we DIDN'T fire but
+                    # the branch IS stale. Mirrors the doctor warning.
+                    sys.stderr.write(
+                        f"\n⚠ logmind auto-rebase skipped: {ar_result.reason}. "
+                        f"Branch is {ar_result.commits_behind} commits behind. "
+                        f"Run `logmind rebase` manually if needed.\n\n"
+                    )
+
     # v0.5.12: auto-install merge-driver config + post-merge + post-rewrite
     # hooks on every invocation. All three helpers are idempotent (no-op
     # when already configured) AND silent no-ops outside a git repo.

--- a/tests/test_auto_rebase.py
+++ b/tests/test_auto_rebase.py
@@ -1,0 +1,261 @@
+"""Tests for v0.6.1 deterministic auto-rebase.
+
+Hard safety guards: opt-in only; timeline.md-only gap; never --force
+(always --force-with-lease); aborts cleanly on any unexpected conflict.
+
+These tests cover the GUARDS — the most important property is that
+auto-rebase REFUSES TO ACT in any case beyond the very narrow target
+scenario. False-positives here = silent destruction of user work.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from logmind.core.auto_rebase import (
+    AutoRebaseResult,
+    maybe_auto_rebase,
+)
+
+
+def _git_init_with_remote(local: Path, remote: Path) -> None:
+    subprocess.run(["git", "init", "--bare", "-b", "main"], cwd=remote, check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=local, check=True, capture_output=True)
+    (local / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=local, check=True, capture_output=True)
+
+
+def _make_feature_branch_with_decision(local: Path, branch: str = "feature") -> None:
+    subprocess.run(["git", "checkout", "-b", branch], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "timeline.md").write_text(
+        "# Timeline\n\n- branch entry 1\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "add", "docs/timeline.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "branch decision"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", branch], cwd=local, check=True, capture_output=True)
+
+
+def _push_to_main_timeline_only(local: Path) -> None:
+    """Push a commit to main that ONLY touches docs/timeline.md."""
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "timeline.md").write_text(
+        "# Timeline\n\n- main entry 1\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "add", "docs/timeline.md"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "main timeline update"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+
+
+# ---------------------------------------------------------------------------
+# Hard safety gates — auto-rebase REFUSES when conditions don't hold
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_when_disabled(tmp_path):
+    result = maybe_auto_rebase(tmp_path, "feature", "main", enabled=False)
+    assert result.fired is False
+    assert "disabled" in result.reason.lower()
+
+
+def test_refuses_on_default_branch(tmp_path):
+    """On main itself, no upstream-vs-feature gap to rebase across."""
+    result = maybe_auto_rebase(tmp_path, "main", "main", enabled=True)
+    assert result.fired is False
+    assert "default branch" in result.reason.lower()
+
+
+def test_refuses_when_not_a_git_repo(tmp_path):
+    """No .git dir → fetch fails → graceful no-op."""
+    result = maybe_auto_rebase(tmp_path, "feature", "main", enabled=True)
+    assert result.fired is False
+    # Either "fetch failed" or "no upstream ref" — both acceptable
+    assert result.fired is False
+
+
+def test_noop_when_branch_up_to_date(tmp_path):
+    """Branch level with upstream → fired=False, reason="up-to-date"."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "-u", "origin", "feature"], cwd=local, check=True, capture_output=True)
+
+    result = maybe_auto_rebase(local, "feature", "main", enabled=True)
+    assert result.fired is False
+    assert "up-to-date" in result.reason.lower() or "up to date" in result.reason.lower()
+    assert result.commits_behind == 0
+
+
+# ---------------------------------------------------------------------------
+# The deterministic-safety gate — gap must be EXACTLY {docs/timeline.md}
+# ---------------------------------------------------------------------------
+
+
+def test_refuses_when_gap_includes_code_file(tmp_path):
+    """Code change on main → REFUSE. Even if timeline.md is also touched,
+    the presence of any code file means we don't know how to resolve."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    _make_feature_branch_with_decision(local, "feature")
+
+    # Main commit: touch both code + timeline
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    (local / "feature.py").write_text("def f(): pass\n", encoding="utf-8")
+    (local / "docs").mkdir(exist_ok=True)
+    (local / "docs" / "timeline.md").write_text(
+        "# Timeline\n\n- main timeline\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "add", "-A"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "main code + timeline"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+
+    result = maybe_auto_rebase(local, "feature", "main", enabled=True)
+    assert result.fired is False, (
+        f"v0.6.1: auto-rebase MUST refuse when gap touches non-timeline files. "
+        f"Got: {result}"
+    )
+    assert "feature.py" in result.reason
+    assert result.commits_behind == 1
+
+
+def test_refuses_when_gap_includes_file_structure_md(tmp_path):
+    """SAFETY: even file-structure.md (also a derived doc) is NOT allowed
+    in the v0.6.1 gap. Narrow scope = trusted scope."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    _make_feature_branch_with_decision(local, "feature")
+
+    subprocess.run(["git", "checkout", "main"], cwd=local, check=True, capture_output=True)
+    docs = local / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "timeline.md").write_text("# Timeline\n\n- main\n", encoding="utf-8")
+    (docs / "file-structure.md").write_text("# Tree\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "main timeline + file-structure"], cwd=local, check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=local, check=True, capture_output=True)
+
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+
+    result = maybe_auto_rebase(local, "feature", "main", enabled=True)
+    assert result.fired is False, (
+        f"v0.6.1: file-structure.md in the gap MUST refuse — only timeline.md "
+        f"is in the allowed set. Got: {result}"
+    )
+    assert "file-structure.md" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# The narrow happy path: gap is EXACTLY {docs/timeline.md}
+# ---------------------------------------------------------------------------
+
+
+def test_fires_when_gap_is_timeline_md_only(tmp_path, monkeypatch):
+    """The whole point: when conditions hold (timeline.md-only gap),
+    auto-rebase + push. We mock `logmind timeline --write` since the
+    test repo doesn't have the full logmind install context, but the
+    rebase + push flow is exercised end-to-end."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    _make_feature_branch_with_decision(local, "feature")
+    _push_to_main_timeline_only(local)
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+
+    # Mock the `logmind timeline --write docs/timeline.md` subprocess
+    # call to actually write a unified file (since the real CLI needs
+    # logmind installed in the test repo's venv).
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        # Convert PosixPath cmd elements to strings
+        cmd_list = [str(c) for c in cmd] if isinstance(cmd, list) else cmd
+        if cmd_list[:2] == ["logmind", "timeline"]:
+            # Pretend the regen produces the union of branch + main entries
+            target = local / "docs" / "timeline.md"
+            target.parent.mkdir(exist_ok=True)
+            target.write_text(
+                "# Timeline\n\n- main entry 1\n- branch entry 1\n",
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.auto_rebase.subprocess.run", side_effect=mock_run):
+        result = maybe_auto_rebase(local, "feature", "main", enabled=True)
+
+    assert result.fired is True, (
+        f"v0.6.1 happy path: timeline-md-only gap MUST fire auto-rebase. "
+        f"Got: {result}"
+    )
+    assert result.pushed is True
+    assert result.commits_behind == 1
+    assert "timeline.md" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Force-with-lease is ALWAYS used (never --force)
+# ---------------------------------------------------------------------------
+
+
+def test_uses_force_with_lease_not_force(tmp_path, monkeypatch):
+    """Critical safety property: the push must use --force-with-lease,
+    never --force. This guards against concurrent-push races."""
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+    local = tmp_path / "local"
+    local.mkdir()
+    _git_init_with_remote(local, remote)
+    _make_feature_branch_with_decision(local, "feature")
+    _push_to_main_timeline_only(local)
+    subprocess.run(["git", "checkout", "feature"], cwd=local, check=True, capture_output=True)
+
+    push_commands: list = []
+    real_run = subprocess.run
+
+    def mock_run(cmd, *args, **kwargs):
+        cmd_list = [str(c) for c in cmd] if isinstance(cmd, list) else cmd
+        if "push" in cmd_list:
+            push_commands.append(cmd_list)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd_list[:2] == ["logmind", "timeline"]:
+            target = local / "docs" / "timeline.md"
+            target.write_text("# Timeline\n- m\n- b\n", encoding="utf-8")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return real_run(cmd, *args, **kwargs)
+
+    with patch("logmind.core.auto_rebase.subprocess.run", side_effect=mock_run):
+        maybe_auto_rebase(local, "feature", "main", enabled=True)
+
+    assert push_commands, "v0.6.1: must invoke at least one git push"
+    for cmd in push_commands:
+        assert "--force-with-lease" in cmd, (
+            f"v0.6.1 SAFETY: must use --force-with-lease, not --force. Got: {cmd}"
+        )
+        assert "--force" not in [c for c in cmd if c != "--force-with-lease"], (
+            f"v0.6.1 SAFETY: must NEVER use --force. Got: {cmd}"
+        )


### PR DESCRIPTION
User-coined direction (2026-05-30): _"auto rebase must must be very deterministic and safe, only the timeline md file as you noted"_.

Saves ~5-8 agent turns per DIRTY incident (tokenomics-Phase-D scenario).

## How it works

Default OFF. Enable in `.logmind/config.yml`:

```yaml
git:
  auto_rebase: true
```

When enabled, `logmind log` checks 6 conditions BEFORE any local state changes:

1. `auto_rebase: true` in config
2. Branch is NOT the default branch
3. `git fetch origin <default>` succeeds
4. `origin/<default>` ref exists
5. Branch is behind `origin/<default>`
6. **The gap touches EXACTLY `docs/timeline.md`** — no code, no other derived docs, not even `docs/file-structure.md`

If all 6 hold: rebase + regen + `--force-with-lease` push. Any unexpected conflict → `git rebase --abort` + bail safely.

## Why narrow scope

`docs/timeline.md` is fully derived. Conflict resolution = re-run the generator. Deterministic by construction.

Other files (even `docs/file-structure.md`) depend on broader repo state. v0.6.1 ships only the timeline.md path; future versions may widen after observed safety.

## Always `--force-with-lease`

Tested explicitly in `test_uses_force_with_lease_not_force` — the push command must NEVER use bare `--force`. This is the single most load-bearing test in the file.

## Test plan

- [x] 8 new tests in `tests/test_auto_rebase.py`
  - 6 safety-gate tests (refuses when conditions don't hold)
  - 1 happy-path test (fires when conditions hold)
  - 1 force-with-lease invariant test
- [x] `pytest -q` (full suite) — 706 passed, 1 skipped
- [ ] CI: paths-check + check-derived-docs + clud-bug-review green
- [ ] After merge: tag `v0.6.1` → Trusted Publishing publishes to PyPI within ~1 min

## Files

- `src/logmind/core/auto_rebase.py` (new, 200 lines) — pure function with safety gates
- `src/logmind/core/config.py` — adds `auto_rebase` default + property
- `src/logmind/core/logger.py` — early integration block in `log()`
- `tests/test_auto_rebase.py` (new, 8 tests)
- `pyproject.toml`, `src/logmind/__init__.py`, `src/logmind/cli.py` — version bump 0.6.0 → 0.6.1
- `CHANGELOG.md` — `[0.6.1] - 2026-05-30` entry

## Upstream context

Pairs with v0.5.13's `logmind doctor --check-stale-derived-docs` (predictive heads-up) + `logmind rebase` (manual action). v0.6.1 is the same detection + same action wrapped in opt-in config — same code paths, automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)