### PR TITLE
chore: propagate clud-bug v0.6.29 (skill-usage workflow integration)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -23,6 +23,6 @@
       "description": "(bundled baseline)"
     }
   ],
-  "lastUpdate": "2026-05-30T13:09:55.697Z",
-  "lastUpdateVersion": "0.6.27"
+  "lastUpdate": "2026-05-31T18:21:22.310Z",
+  "lastUpdateVersion": "0.6.29"
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.27._
+_Installed at clud-bug v0.6.29._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -634,11 +634,35 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.27 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
           $CALIBRATION"
+
+      # v0.6.29 / Component 4 — see workflow.yml.tmpl for design notes.
+      - name: Update skill-usage tracking
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        env:
+          STRUCTURED: ${{ steps.clud-bug-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude/skills
+          if [ ! -f .claude/skills/.clud-bug.json ]; then
+            echo '{"version": 1}' > .claude/skills/.clud-bug.json
+          fi
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.29 update-skill-usage --stdin
+          echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
+
+      - name: Upload skill-usage artifact
+        if: success() && steps.clud-bug-review.outputs.structured_output != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
+          path: .claude/skills/.clud-bug.json
+          retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
       - name: Fallback summary (structured_output empty)
@@ -696,7 +720,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.27
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.29
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,5 +123,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.27._
+_Installed at clud-bug v0.6.29._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.29.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.29.md
@@ -1,0 +1,8 @@
+## 2026-05-31 14:21 - chore: propagate clud-bug v0.6.29 to logmind (skill-usage workflow integration)
+
+**Reasoning:** Self-propagation cycle — logmind eats clud-bug's templates. v0.6.29 adds workflow post-step + artifact upload
+
+**Implications:**
+- Logmind's own clud-bug-review workflow now writes skill-usage deltas to .claude/skills/.clud-bug.json + uploads artifact. Recursive: clud-bug reviewing clud-bug's own dependencies inside logmind
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,8 +13,8 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-05 (86 decisions)
+## 2026-05 (87 decisions)
 
-- **2026-05-31** — v0.6.2 fix: remove unreachable else-branch in notify-skill commit step (claude-review PR #96) *(feat/v0.6.2-notify-skip-noop)* — [decisions-branches/feat__v0.6.2-notify-skip-noop.md](decisions-branches/feat__v0.6.2-notify-skip-noop.md)
-- *... 84 more decisions ...*
+- **2026-05-31** — chore: propagate clud-bug v0.6.29 to logmind (skill-usage workflow integration) *(chore/clud-bug-v0.6.29)* — [decisions-branches/chore__clud-bug-v0.6.29.md](decisions-branches/chore__clud-bug-v0.6.29.md)
+- *... 85 more decisions ...*
 - **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)


### PR DESCRIPTION
Logmind picks up clud-bug v0.6.29 — adds workflow post-step that pipes structured_output through `update-skill-usage --stdin` + uploads `.clud-bug.json` as 90-day artifact.