### PR TITLE
v0.6.3: skill bench — per-call token-cost measurement (Stream 6 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-01
+
+### Added — `logmind skill bench <name>` (Stream 6 follow-on)
+
+Closes the "measure" arrow of the SkDD loop. Every time an agent loads
+a SKILL.md, the whole file enters the context window. `bench` reports
+exactly what that costs in bytes + estimated tokens + a status bucket
+(`tight` / `typical` / `verbose` / `over-budget`) + per-section
+breakdown + trim suggestions when over budget.
+
+Pair with clud-bug's `usage --health` (v0.6.28+) for the complete
+picture: bench tells you what each skill COSTS, usage tells you whether
+it EARNS that cost in citations.
+
+#### Thresholds
+
+- **tight**: ≤ 2000 bytes (~500 tokens) — focused, well-trimmed
+- **typical**: ≤ 6000 bytes (~1500 tokens) — most skills land here
+- **verbose**: ≤ 8000 bytes (~2000 tokens) — past budget, suggestions emitted
+- **over-budget**: > 8000 bytes — past hard cap, split recommended
+
+#### Suggestions emitted when verbose+
+
+- Dominant section (>30% of total): "Section 'Examples' is N bytes
+  (35% of total) — consider linking out OR moving to its own skill."
+- Large HTML comment volume: agents load them too; move authoring
+  notes to a sibling NOTES.md.
+- Past the 8KB hard cap: "split into multiple focused skills."
+
+#### CLI surface
+
+- `logmind skill bench <name>` — human-readable table with section
+  breakdown + suggestions.
+- `logmind skill bench <name> --json` — machine-readable for automation.
+
+#### Implementation
+
+- `src/logmind/core/skill_cli.py`: new `bench_skill(content, target?, budget?)`
+  pure function returning `{bytes, est_tokens, status, sections, suggestions}`.
+- `src/logmind/cli.py`: new `@skill.command("bench")` wiring.
+- `tests/test_skill_cli.py`: 11 new tests covering all status buckets,
+  section parsing, suggestion heuristics, CLI integration.
+
 ## [0.6.2] - 2026-05-31
 
 ### Fixed — notify-agent-skills no longer opens churn PRs

--- a/docs/decisions-branches/feat__v0.6.3-skill-bench.md
+++ b/docs/decisions-branches/feat__v0.6.3-skill-bench.md
@@ -1,0 +1,12 @@
+## 2026-06-01 00:12 - v0.6.3: skill bench — per-call token-cost measurement (Stream 6 follow-on)
+
+**Reasoning:** Closes the measure arrow of the SkDD loop. Every SKILL.md load enters the agent's context window verbatim; bench reports exactly what that costs (bytes + est_tokens + status bucket + section breakdown + trim suggestions). Pairs with clud-bug usage --health (the enforcement read) for cost-vs-earning visibility per skill.
+
+**Alternatives considered:** Pipe SKILL.md through tiktoken for an exact token count (rejected: adds heavy dep for marginal precision gain — bytes/4 is good enough for the bucket-status decision; precision matters only for finance-grade reporting which isn't this command's job), Bench the loading-by-clud-bug end-to-end (rejected: that's what clud-bug usage --health measures via real review runs; this command is the author-side equivalent that runs offline)
+
+**Implications:**
+- Section-breakdown parser splits on level-2 (##) headers; level-3+ stays bundled. Sufficient for most SKILL.md structures
+- Suggestions are heuristic, not rules — designed to start the human conversation about what to trim, not auto-edit the file
+- Thresholds (2KB/6KB/8KB) match the existing soft cap from v0.6.0's check_size_cap so behavior is consistent across logmind skill commands
+
+---

--- a/docs/decisions-branches/feat__v0.6.3-skill-bench.md
+++ b/docs/decisions-branches/feat__v0.6.3-skill-bench.md
@@ -10,3 +10,13 @@
 - Thresholds (2KB/6KB/8KB) match the existing soft cap from v0.6.0's check_size_cap so behavior is consistent across logmind skill commands
 
 ---
+## 2026-06-01 00:29 - v0.6.3 fix: bench_skill threads target+budget through to helpers (PR #99)
+
+**Reasoning:** clud-bug-review caught a silent-failure bug on PR #99: bench_skill accepted target+budget kwargs but _bench_status() + _trim_suggestions() used the module-level constants instead. Calling bench_skill(content, budget=2000) returned budget=2000 in the dict but computed status against the hardcoded 6000. Threading the values through fixes it; added regression test that asserts custom budget actually changes the status bucket.
+
+**Alternatives considered:** Make target+budget required kwargs (rejected: breaks the existing CLI which calls bench_skill() with no args; default-using callers shouldn't have to pass them), Read target+budget from env vars (rejected: kwarg passing is the standard Python idiom; env vars are reserved for runtime-tuning not API-shape changes)
+
+**Implications:**
+- Now bench_skill is parameterized end-to-end; future automations (e.g., per-skill budget overrides in .clud-bug.json) can tune thresholds without modifying the module
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-06
 
+- **2026-06-01** — v0.6.3: skill bench — per-call token-cost measurement (Stream 6 follow-on) *(feat/v0.6.3-skill-bench)* — [decisions-branches/feat__v0.6.3-skill-bench.md](decisions-branches/feat__v0.6.3-skill-bench.md)
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,9 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06
+## 2026-06 (3 decisions)
 
-- **2026-06-01** — v0.6.3: skill bench — per-call token-cost measurement (Stream 6 follow-on) *(feat/v0.6.3-skill-bench)* — [decisions-branches/feat__v0.6.3-skill-bench.md](decisions-branches/feat__v0.6.3-skill-bench.md)
+- **2026-06-01** — v0.6.3 fix: bench_skill threads target+budget through to helpers (PR #99) *(feat/v0.6.3-skill-bench)* — [decisions-branches/feat__v0.6.3-skill-bench.md](decisions-branches/feat__v0.6.3-skill-bench.md)
+- *... 1 more decision ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.2"
+version = "0.6.3"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -110,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.2", prog_name="logmind")
+@click.version_option(version="0.6.3", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -1990,6 +1990,78 @@ def skill_test(name: str):
         _ok(f"skill: {name} FAILED validation")
         sys.exit(1)
     _ok(f"skill: {name} validated")
+
+
+# v0.6.3 — `logmind skill bench` (per-call token-cost measurement).
+@skill.command("bench")
+@click.argument("name")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of the human-readable table.",
+)
+def skill_bench(name: str, as_json: bool):
+    """Measure per-call token cost of a SKILL.md.
+
+    Every time an agent loads this skill, the entire SKILL.md goes into
+    the context window. This command reports the byte size, an estimated
+    token count, a status bucket (tight / typical / verbose /
+    over-budget), and per-section breakdown. Over-budget skills get
+    trim suggestions.
+
+    Pair with `clud-bug usage --health` for the complete picture: bench
+    tells you what each skill COSTS, usage tells you whether it EARNS
+    that cost in citations.
+    """
+    from logmind.core.skill_cli import bench_skill, skill_md_path
+
+    repo_root = Path.cwd()
+    target = skill_md_path(repo_root, name)
+    if not target.exists():
+        click.secho(
+            f"Error: skill '{name}' not found at {target}",
+            fg="red",
+        )
+        sys.exit(1)
+
+    content = target.read_text(encoding="utf-8")
+    result = bench_skill(content)
+
+    if as_json:
+        import json
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    status_color = {
+        "tight": "green",
+        "typical": "green",
+        "verbose": "yellow",
+        "over-budget": "red",
+    }.get(result["status"], "white")
+
+    click.secho(
+        f"{name}: {result['bytes']} bytes (~{result['est_tokens']} tokens) "
+        f"— {result['status']}",
+        fg=status_color,
+    )
+    click.echo(
+        f"  target: {result['target']} bytes  budget: {result['budget']} bytes"
+    )
+
+    if result["sections"]:
+        click.echo("\n  Section breakdown:")
+        for sec in result["sections"]:
+            click.echo(
+                f"    {sec['name']:30s} {sec['bytes']:>6d} bytes  ({sec['pct']:>3d}%)"
+            )
+
+    if result["suggestions"]:
+        click.echo("\n  Suggestions:")
+        for s in result["suggestions"]:
+            click.echo(f"    • {s}")
+
+    _ok(f"skill: bench {name} {result['status']}")
 
 
 # Config command group

--- a/src/logmind/core/skill_cli.py
+++ b/src/logmind/core/skill_cli.py
@@ -245,3 +245,166 @@ def check_size_cap(content: str, cap: int = _LOGMIND_SKILL_BYTE_CAP) -> Tuple[bo
             f"into multiple focused skills."
         )
     return (True, f"{size} bytes (cap: {cap})")
+
+
+# v0.6.3 — `logmind skill bench <name>`. Per-call token-cost measurement.
+#
+# Every time a skill triggers, its SKILL.md gets loaded into the agent's
+# context window. The per-call cost is the byte size translated to an
+# approximate token count (English text ≈ 4 bytes/token). This is the
+# "measure" arrow of the SkDD loop — pairs with clud-bug's
+# `usage --health` (the enforcement read) for a complete picture of
+# whether each skill earns its token budget.
+
+_LOGMIND_SKILL_TIGHT_BYTES = 2000   # ~500 tokens — a focused, well-trimmed skill
+_LOGMIND_SKILL_BUDGET_BYTES = 6000  # ~1500 tokens — past this, splitting helps
+
+
+_HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def _split_into_sections(content: str) -> "list[Tuple[str, int]]":
+    """Return [(header_text, body_bytes)] for each top-level (##) section.
+
+    Frontmatter (the leading --- block) is counted as its own section
+    named "frontmatter". The body before the first ## is named "intro".
+    Bytes per section = UTF-8 byte count of the SECTION BODY (not the
+    header line itself), so trimming suggestions point at the prose,
+    not the structural markers.
+    """
+    sections: "list[Tuple[str, int]]" = []
+
+    # Frontmatter — leading ---...--- block.
+    rest = content
+    if content.startswith("---"):
+        end = content.find("\n---", 4)
+        if end != -1:
+            frontmatter = content[: end + 4]
+            sections.append(("frontmatter", len(frontmatter.encode("utf-8"))))
+            rest = content[end + 4 :].lstrip("\n")
+
+    # Find every ## section header (level 2) in the body.
+    headers = [
+        (m.start(), len(m.group(1)), m.group(2))
+        for m in _HEADER_RE.finditer(rest)
+        if len(m.group(1)) == 2
+    ]
+
+    if not headers:
+        # Whole body is one chunk.
+        body = rest.strip()
+        if body:
+            sections.append(("body", len(body.encode("utf-8"))))
+        return sections
+
+    # Intro = anything before the first ## header.
+    intro = rest[: headers[0][0]].strip()
+    if intro:
+        sections.append(("intro", len(intro.encode("utf-8"))))
+
+    for i, (pos, _level, title) in enumerate(headers):
+        end = headers[i + 1][0] if i + 1 < len(headers) else len(rest)
+        section_body = rest[pos:end].strip()
+        sections.append((title, len(section_body.encode("utf-8"))))
+
+    return sections
+
+
+def _bench_status(size: int) -> str:
+    """Bucket the size into a status label."""
+    if size <= _LOGMIND_SKILL_TIGHT_BYTES:
+        return "tight"
+    if size <= _LOGMIND_SKILL_BUDGET_BYTES:
+        return "typical"
+    if size <= _LOGMIND_SKILL_BYTE_CAP:
+        return "verbose"
+    return "over-budget"
+
+
+def _trim_suggestions(content: str, sections: "list[Tuple[str, int]]", total: int) -> "list[str]":
+    """Heuristic suggestions for trimming an oversized skill.
+
+    Triggered only when total > _LOGMIND_SKILL_BUDGET_BYTES. Returns
+    empty list when the skill is already tight.
+    """
+    suggestions: list[str] = []
+    if total <= _LOGMIND_SKILL_BUDGET_BYTES:
+        return suggestions
+
+    # Heuristic 1: any single section taking >30% of the total is a
+    # prime candidate for trimming or linking out.
+    for name, size in sections:
+        if name in ("frontmatter", "intro", "body"):
+            continue
+        if total > 0 and size / total > 0.30:
+            suggestions.append(
+                f"Section '{name}' is {size} bytes ({size * 100 // total}% of total) — "
+                f"consider linking out to docs OR moving to its own skill."
+            )
+
+    # Heuristic 2: many HTML comments inflate size without paying back
+    # — they're invisible to the rendered prompt but charged in tokens.
+    comment_bytes = sum(
+        len(m.encode("utf-8")) for m in _HTML_COMMENT_RE.findall(content)
+    )
+    if comment_bytes >= 200:
+        suggestions.append(
+            f"{comment_bytes} bytes of HTML comments — agents load them too. "
+            f"Move authoring notes to a sibling NOTES.md if they're not for the agent."
+        )
+
+    # Heuristic 3: if over the hard cap, recommend split.
+    if total > _LOGMIND_SKILL_BYTE_CAP:
+        suggestions.append(
+            f"Total exceeds {_LOGMIND_SKILL_BYTE_CAP}-byte cap — split into "
+            f"multiple focused skills."
+        )
+    elif not suggestions:
+        # Generic fallback when the skill is verbose but no clear culprit section.
+        suggestions.append(
+            f"Total is {total} bytes (target: {_LOGMIND_SKILL_TIGHT_BYTES}, "
+            f"budget: {_LOGMIND_SKILL_BUDGET_BYTES}). Tighten the largest "
+            f"sections or move detailed examples behind links."
+        )
+
+    return suggestions
+
+
+def bench_skill(
+    content: str,
+    *,
+    target: int = _LOGMIND_SKILL_TIGHT_BYTES,
+    budget: int = _LOGMIND_SKILL_BUDGET_BYTES,
+) -> dict:
+    """Measure per-call token cost of a skill body.
+
+    Returns a dict with:
+
+      - bytes: UTF-8 byte size of the whole SKILL.md
+      - est_tokens: bytes / 4 (rough English-text approximation)
+      - status: 'tight' | 'typical' | 'verbose' | 'over-budget'
+      - target: the tight-skill target (info)
+      - budget: the soft-budget threshold (info)
+      - sections: [{name, bytes, pct}] per ## section
+      - suggestions: trim hints when status is 'verbose' or worse
+    """
+    total = len(content.encode("utf-8"))
+    sections_raw = _split_into_sections(content)
+    sections = [
+        {
+            "name": name,
+            "bytes": size,
+            "pct": (size * 100 // total) if total else 0,
+        }
+        for name, size in sections_raw
+    ]
+    return {
+        "bytes": total,
+        "est_tokens": total // 4,
+        "status": _bench_status(total),
+        "target": target,
+        "budget": budget,
+        "sections": sections,
+        "suggestions": _trim_suggestions(content, sections_raw, total),
+    }

--- a/src/logmind/core/skill_cli.py
+++ b/src/logmind/core/skill_cli.py
@@ -311,25 +311,32 @@ def _split_into_sections(content: str) -> "list[Tuple[str, int]]":
     return sections
 
 
-def _bench_status(size: int) -> str:
-    """Bucket the size into a status label."""
-    if size <= _LOGMIND_SKILL_TIGHT_BYTES:
+def _bench_status(size: int, target: int, budget: int) -> str:
+    """Bucket the size into a status label using the caller's thresholds."""
+    if size <= target:
         return "tight"
-    if size <= _LOGMIND_SKILL_BUDGET_BYTES:
+    if size <= budget:
         return "typical"
     if size <= _LOGMIND_SKILL_BYTE_CAP:
         return "verbose"
     return "over-budget"
 
 
-def _trim_suggestions(content: str, sections: "list[Tuple[str, int]]", total: int) -> "list[str]":
+def _trim_suggestions(
+    content: str,
+    sections: "list[Tuple[str, int]]",
+    total: int,
+    *,
+    target: int,
+    budget: int,
+) -> "list[str]":
     """Heuristic suggestions for trimming an oversized skill.
 
-    Triggered only when total > _LOGMIND_SKILL_BUDGET_BYTES. Returns
-    empty list when the skill is already tight.
+    Triggered only when total > budget. Returns empty list when the
+    skill is at or under budget.
     """
     suggestions: list[str] = []
-    if total <= _LOGMIND_SKILL_BUDGET_BYTES:
+    if total <= budget:
         return suggestions
 
     # Heuristic 1: any single section taking >30% of the total is a
@@ -363,9 +370,8 @@ def _trim_suggestions(content: str, sections: "list[Tuple[str, int]]", total: in
     elif not suggestions:
         # Generic fallback when the skill is verbose but no clear culprit section.
         suggestions.append(
-            f"Total is {total} bytes (target: {_LOGMIND_SKILL_TIGHT_BYTES}, "
-            f"budget: {_LOGMIND_SKILL_BUDGET_BYTES}). Tighten the largest "
-            f"sections or move detailed examples behind links."
+            f"Total is {total} bytes (target: {target}, budget: {budget}). "
+            f"Tighten the largest sections or move detailed examples behind links."
         )
 
     return suggestions
@@ -378,6 +384,11 @@ def bench_skill(
     budget: int = _LOGMIND_SKILL_BUDGET_BYTES,
 ) -> dict:
     """Measure per-call token cost of a skill body.
+
+    ``target`` and ``budget`` are honored by the status bucketer + the
+    suggestion heuristics (PR #99 review fix — prior versions accepted
+    these kwargs but threaded only the module-level constants through
+    to the helpers, silently ignoring the caller's overrides).
 
     Returns a dict with:
 
@@ -402,9 +413,11 @@ def bench_skill(
     return {
         "bytes": total,
         "est_tokens": total // 4,
-        "status": _bench_status(total),
+        "status": _bench_status(total, target, budget),
         "target": target,
         "budget": budget,
         "sections": sections,
-        "suggestions": _trim_suggestions(content, sections_raw, total),
+        "suggestions": _trim_suggestions(
+            content, sections_raw, total, target=target, budget=budget
+        ),
     }

--- a/tests/test_skill_cli.py
+++ b/tests/test_skill_cli.py
@@ -447,3 +447,164 @@ def test_check_frontmatter_no_false_positive_on_description_nested():
     ok, msg = check_frontmatter_required_fields(content)
     assert ok is False
     assert "description" in msg
+
+
+# ---------------------------------------------------------------------------
+# v0.6.3 — bench_skill
+# ---------------------------------------------------------------------------
+
+
+def _bench_skill():
+    """Late import so the rest of the test file doesn't pay the cost."""
+    from logmind.core.skill_cli import bench_skill
+    return bench_skill
+
+
+def test_bench_skill_tight():
+    """A short skill lands in the 'tight' bucket."""
+    bench_skill = _bench_skill()
+    content = (
+        "---\nname: x\ndescription: y\n---\n"
+        "# Title\n\n## When to use\n- a\n- b\n\n## Steps\n1. one\n"
+    )
+    out = bench_skill(content)
+    assert out["status"] == "tight"
+    assert out["bytes"] < 2000
+    assert out["est_tokens"] == out["bytes"] // 4
+    assert out["suggestions"] == []
+
+
+def test_bench_skill_typical():
+    """Between tight and budget = 'typical'."""
+    bench_skill = _bench_skill()
+    body = "x " * 1500  # ~3000 bytes — between tight (2000) and budget (6000)
+    content = f"---\nname: x\ndescription: y\n---\n# T\n{body}"
+    out = bench_skill(content)
+    assert out["status"] == "typical"
+    assert out["suggestions"] == []
+
+
+def test_bench_skill_verbose_emits_suggestions():
+    """Past budget = 'verbose' AND gets at least one suggestion."""
+    bench_skill = _bench_skill()
+    body = "y " * 3500  # ~7000 bytes, past 6000 budget but under 8000 cap
+    content = f"---\nname: x\ndescription: y\n---\n# T\n## Examples\n{body}"
+    out = bench_skill(content)
+    assert out["status"] == "verbose"
+    assert len(out["suggestions"]) >= 1
+
+
+def test_bench_skill_over_budget_recommends_split():
+    """Past 8KB hard cap = 'over-budget' AND suggestion mentions splitting."""
+    bench_skill = _bench_skill()
+    body = "z " * 5000  # ~10000 bytes — past the 8000 cap
+    content = f"---\nname: x\ndescription: y\n---\n# T\n## Examples\n{body}"
+    out = bench_skill(content)
+    assert out["status"] == "over-budget"
+    assert any("split" in s.lower() for s in out["suggestions"])
+
+
+def test_bench_skill_section_breakdown():
+    """Each ## section appears in the breakdown with its byte count."""
+    bench_skill = _bench_skill()
+    content = (
+        "---\nname: x\ndescription: y\n---\n"
+        "# Title\n\n"
+        "## When to use\n- short trigger\n\n"
+        "## Steps\n1. first\n2. second\n\n"
+        "## Examples\nlorem ipsum dolor sit amet " * 30 + "\n"
+    )
+    out = bench_skill(content)
+    section_names = [s["name"] for s in out["sections"]]
+    assert "frontmatter" in section_names
+    assert "When to use" in section_names
+    assert "Steps" in section_names
+    assert "Examples" in section_names
+    # Each pct is non-negative + sums roughly to 100% (rounding).
+    assert all(0 <= s["pct"] <= 100 for s in out["sections"])
+
+
+def test_bench_skill_dominant_section_flagged():
+    """A section taking >30% of the total gets called out in suggestions."""
+    bench_skill = _bench_skill()
+    # Make the Examples section dominate (over budget + over 30%).
+    big_examples = "example " * 1200  # ~9600 bytes — definitively dominant
+    content = (
+        "---\nname: x\ndescription: y\n---\n"
+        "# T\n## When to use\n- a\n\n## Examples\n" + big_examples
+    )
+    out = bench_skill(content)
+    assert any("Examples" in s for s in out["suggestions"])
+
+
+def test_bench_skill_html_comments_flagged_when_large():
+    """Many HTML comments are flagged as wasted bytes."""
+    bench_skill = _bench_skill()
+    big_comment = "<!-- " + ("authoring note " * 50) + "-->"  # ~750 bytes
+    body = "real prose " * 1000  # ~11000 bytes, pushes past 8KB
+    content = (
+        f"---\nname: x\ndescription: y\n---\n"
+        f"# T\n## When\n{big_comment}\n\n## Body\n{body}"
+    )
+    out = bench_skill(content)
+    assert any("HTML comments" in s for s in out["suggestions"])
+
+
+def test_bench_skill_no_headers_falls_into_body():
+    """A skill with no ## headers gets a single 'body' section."""
+    bench_skill = _bench_skill()
+    content = "---\nname: x\ndescription: y\n---\n# Title\njust prose, no sections.\n"
+    out = bench_skill(content)
+    names = [s["name"] for s in out["sections"]]
+    assert "body" in names
+
+
+def test_skill_bench_cli_emits_status_line(tmp_path: Path):
+    """End-to-end: `logmind skill bench <name>` exits 0 + prints status."""
+    skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: trigger\n---\n# My\n## When\n- a\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)) as fs:
+        # Re-create the skill under the isolated cwd.
+        from pathlib import Path as _P
+        target = _P(fs) / ".claude" / "skills" / "my-skill"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: trigger\n---\n# My\n## When\n- a\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli_main, ["skill", "bench", "my-skill"])
+    assert result.exit_code == 0, result.output
+    assert "my-skill" in result.output
+    assert "tight" in result.output or "typical" in result.output
+
+
+def test_skill_bench_cli_json(tmp_path: Path):
+    """--json emits a parseable JSON object."""
+    import json
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)) as fs:
+        from pathlib import Path as _P
+        target = _P(fs) / ".claude" / "skills" / "x"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(
+            "---\nname: x\ndescription: y\n---\n# X\n## Y\nz\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli_main, ["skill", "bench", "x", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.split("ok ")[0].strip())
+    assert "bytes" in data and "status" in data and "sections" in data
+
+
+def test_skill_bench_cli_missing_skill_exits_1(tmp_path: Path):
+    """Missing skill = non-zero exit."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        result = runner.invoke(cli_main, ["skill", "bench", "does-not-exist"])
+    assert result.exit_code == 1
+    assert "not found" in result.output

--- a/tests/test_skill_cli.py
+++ b/tests/test_skill_cli.py
@@ -559,6 +559,29 @@ def test_bench_skill_no_headers_falls_into_body():
     assert "body" in names
 
 
+def test_bench_skill_honors_custom_budget():
+    """PR #99 regression: target + budget kwargs must thread through to
+    _bench_status + _trim_suggestions, not be silently ignored.
+
+    A 3KB skill is 'typical' under the default 6KB budget, but should
+    be 'verbose' when the caller passes budget=2000.
+    """
+    bench_skill = _bench_skill()
+    body = "y " * 1500  # ~3000 bytes
+    content = f"---\nname: x\ndescription: y\n---\n# T\n## Examples\n{body}"
+    default = bench_skill(content)
+    custom = bench_skill(content, target=500, budget=2000)
+    assert default["status"] == "typical"
+    assert custom["status"] == "verbose", (
+        f"PR #99 review fix: custom budget=2000 should be honored. "
+        f"Got status={custom['status']}"
+    )
+    # Suggestions should fire under the tighter budget.
+    assert len(custom["suggestions"]) >= 1
+    # And not under the looser default.
+    assert default["suggestions"] == []
+
+
 def test_skill_bench_cli_emits_status_line(tmp_path: Path):
     """End-to-end: `logmind skill bench <name>` exits 0 + prints status."""
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"


### PR DESCRIPTION
## Summary

Closes the "measure" arrow of the SkDD loop. `logmind skill bench <name>` reports exactly what each SKILL.md costs to load:

- **Bytes + estimated tokens** (bytes/4 — good enough for the bucket decision)
- **Status bucket**: `tight` (≤2KB) / `typical` (≤6KB) / `verbose` (≤8KB) / `over-budget` (>8KB)
- **Per-section breakdown** (each `##` header gets its own row + percentage)
- **Trim suggestions** when verbose+ (dominant section, large HTML-comment volume, hard-cap split)

Pairs with `clud-bug usage --health` (v0.6.28+) — bench tells you what each skill COSTS; usage tells you whether it EARNS that cost in citations.

## Surface

- `logmind skill bench <name>` — human-readable table.
- `logmind skill bench <name> --json` — machine-readable for automation.

## What changed

- `src/logmind/core/skill_cli.py` — new `bench_skill` pure function + section parser + suggestion heuristics.
- `src/logmind/cli.py` — new `@skill.command("bench")` wiring.
- `tests/test_skill_cli.py` — 11 new tests (all status buckets, section parse, dominant-section flag, HTML-comment flag, CLI integration, JSON output, missing-skill exit code).

## Test plan

- [x] `pytest -q` — 758 tests pass (747 prior + 11 new)
- [x] CLI smoke: scaffold a SKILL.md, run `logmind skill bench`, verify status + section breakdown render correctly
- [ ] Self-review on this PR via clud-bug-review