### PR TITLE
v0.6.4: skill audit — author's-side staleness read (Stream 6 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-06-01
+
+### Added — `logmind skill audit` (Stream 6 follow-on)
+
+Author's-side staleness read for every SKILL.md in `.claude/skills/`.
+Pairs with clud-bug's `usage --health` (the enforcement read) for a
+complete picture of skill lifecycle:
+
+- **audit**: what's HERE, how big, last-touched, decision-log mention
+  count, and a deterministic status (`active` / `aging` / `ghost`).
+- **usage --health**: which skills earn their context budget (loads
+  vs. citations from real review runs).
+
+#### Status thresholds
+
+- **ghost**: `decision_count == 0` AND `bytes > 2000` — loaded into
+  every context but author never iterates; candidate for usage-side
+  confirmation + archive.
+- **aging**: last-modified > 90 days ago — was useful once, hasn't
+  been touched in a quarter.
+- **active**: otherwise.
+
+#### CLI surface
+
+- `logmind skill audit` — human-readable table sorted by skill name
+  with `name`, `status`, `bytes`, `decisions`, `last touched`. Summary
+  line: `ok skill: audit 7 skills (3 active, 2 aging, 2 ghost)`.
+- `logmind skill audit --json` — machine-readable array per skill,
+  status enriched.
+
+#### Implementation
+
+- `src/logmind/core/skill_cli.py`: `audit_skills(repo_root)` walks
+  `.claude/skills/*/SKILL.md`, counts decision-log mentions across
+  `docs/decisions.md` + `docs/decisions-branches/*.md`, prefers
+  `git log -1 --format=%cs --` for `last_modified` (falls back to
+  file mtime). `classify_audit_row(row, now=)` applies thresholds;
+  injectable `now` for testability.
+- `src/logmind/cli.py`: `@skill.command("audit")` wiring.
+- `tests/test_skill_cli.py`: 13 new tests covering directory walking,
+  decision counting (incl. branch decision files), every status
+  bucket, CLI rendering, JSON output, edge cases (no skills, empty
+  directory, invalid date).
+
 ## [0.6.3] - 2026-06-01
 
 ### Added — `logmind skill bench <name>` (Stream 6 follow-on)

--- a/docs/decisions-branches/feat__v0.6.4-skill-audit.md
+++ b/docs/decisions-branches/feat__v0.6.4-skill-audit.md
@@ -1,0 +1,11 @@
+## 2026-06-01 00:41 - v0.6.4: skill audit — author's-side staleness read (Stream 6 follow-on)
+
+**Reasoning:** Pairs with clud-bug usage --health for complete skill-lifecycle visibility. audit reports what's HERE (filesystem + git side); usage reports what's USED (load + cite side). Together they show whether each skill earns its place: ghost (loaded but never iterated AND not cited), aging (untouched + uncited), active (touched + cited).
+
+**Alternatives considered:** Combine audit + usage into one logmind skill status command (rejected: violates clean separation between author-side data and review-side data; users may not have clud-bug installed, audit should standalone), Use heuristic LLM scoring for staleness (rejected: deterministic thresholds match the pragmatic SkDD pivot — humans interpret, not algorithms guess)
+
+**Implications:**
+- decision_count uses substring match — works for both top-level decisions.md + decisions-branches/*.md; doesn't distinguish 'X was used' from 'X was deprecated', but the count signal is enough for the dashboard's coarse bucketing
+- Threshold for ghost (decision_count==0 AND bytes>2000) intentionally picks the same tight threshold as bench's 'tight' bucket. Small skills with no decision mentions are treated as active because they may just be new/simple
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (3 decisions)
+## 2026-06 (4 decisions)
 
-- **2026-06-01** — v0.6.3 fix: bench_skill threads target+budget through to helpers (PR #99) *(feat/v0.6.3-skill-bench)* — [decisions-branches/feat__v0.6.3-skill-bench.md](decisions-branches/feat__v0.6.3-skill-bench.md)
-- *... 1 more decision ...*
+- **2026-06-01** — v0.6.4: skill audit — author's-side staleness read (Stream 6 follow-on) *(feat/v0.6.4-skill-audit)* — [decisions-branches/feat__v0.6.4-skill-audit.md](decisions-branches/feat__v0.6.4-skill-audit.md)
+- *... 2 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.3"
+version = "0.6.4"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -110,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.3", prog_name="logmind")
+@click.version_option(version="0.6.4", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -2062,6 +2062,72 @@ def skill_bench(name: str, as_json: bool):
             click.echo(f"    • {s}")
 
     _ok(f"skill: bench {name} {result['status']}")
+
+
+# v0.6.4 — `logmind skill audit` (author's-side staleness read).
+@skill.command("audit")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of the human-readable table.",
+)
+def skill_audit(as_json: bool):
+    """List every SKILL.md in .claude/skills/ with staleness signals.
+
+    For each skill: name, byte size, last-modified date (last git
+    commit touching SKILL.md), decision count (# times referenced in
+    docs/decisions.md + branch decision files), and a classification:
+
+      - ghost: never decision-logged AND larger than the tight cap
+        — loaded into every context but author never iterates;
+        candidate for clud-bug usage --health to confirm + archive.
+      - aging: last touched > 90 days ago.
+      - active: otherwise.
+
+    Pairs with clud-bug usage --health: audit tells you what's HERE
+    and how stale it is (author-side); usage tells you which skills
+    earn their context budget (load-side). Together = complete picture.
+    """
+    from logmind.core.skill_cli import audit_skills, classify_audit_row
+
+    repo_root = Path.cwd()
+    rows = audit_skills(repo_root)
+
+    if as_json:
+        import json
+        enriched = [{**r, "status": classify_audit_row(r)} for r in rows]
+        click.echo(json.dumps(enriched, indent=2))
+        return
+
+    if not rows:
+        click.echo(
+            "No skills found in .claude/skills/. Run "
+            "`logmind skill new <name>` to create one."
+        )
+        _ok("skill: audit 0 skills")
+        return
+
+    status_color = {
+        "active": "green",
+        "aging": "yellow",
+        "ghost": "red",
+    }
+
+    click.echo(f"{'name':30s} {'status':>8s} {'bytes':>7s} {'decisions':>9s} {'last touched':>14s}")
+    click.echo("-" * 78)
+    counts: "dict[str, int]" = {}
+    for row in rows:
+        status = classify_audit_row(row)
+        counts[status] = counts.get(status, 0) + 1
+        click.secho(
+            f"{row['name'][:30]:30s} {status:>8s} {row['bytes']:>7d} "
+            f"{row['decision_count']:>9d} {row['last_modified']:>14s}",
+            fg=status_color.get(status, "white"),
+        )
+
+    summary = ", ".join(f"{v} {k}" for k, v in sorted(counts.items()))
+    _ok(f"skill: audit {len(rows)} skill{'s' if len(rows) != 1 else ''} ({summary})")
 
 
 # Config command group

--- a/src/logmind/core/skill_cli.py
+++ b/src/logmind/core/skill_cli.py
@@ -421,3 +421,126 @@ def bench_skill(
             content, sections_raw, total, target=target, budget=budget
         ),
     }
+
+
+# v0.6.4 — `logmind skill audit`. Author's-side staleness read for every
+# SKILL.md in `.claude/skills/`. Pairs with clud-bug `usage --health`:
+#
+#   audit:    What's HERE and how stale is it (file-system + git side).
+#   usage:    Which skills earn their context budget (load + cite side).
+#
+# Together: a complete read on whether each skill earns its place.
+
+_LOGMIND_SKILL_AUDIT_TIGHT_BYTES = 2000  # mirror of _LOGMIND_SKILL_TIGHT_BYTES;
+                                          # declared standalone so audit doesn't
+                                          # break if bench is ever extracted.
+
+
+def audit_skills(repo_root: Path) -> "list[dict]":
+    """List every `.claude/skills/*/SKILL.md` with staleness signals.
+
+    For each skill returns:
+
+      - ``name``: directory name under ``.claude/skills/``
+      - ``path``: relative path to SKILL.md
+      - ``bytes``: UTF-8 byte size
+      - ``last_modified``: ISO date of last git commit touching SKILL.md
+        (falls back to file mtime when not in git history)
+      - ``decision_count``: # times skill name appears in
+        ``docs/decisions.md`` + ``docs/decisions-branches/*.md`` (rough
+        signal of author-side iteration cadence)
+
+    Returns empty list if `.claude/skills/` doesn't exist OR no SKILL.md
+    files are present.
+    """
+    skills_dir = default_skills_dir(repo_root)
+    if not skills_dir.is_dir():
+        return []
+
+    decision_files: list[Path] = []
+    docs_dir = repo_root / "docs"
+    if (docs_dir / "decisions.md").exists():
+        decision_files.append(docs_dir / "decisions.md")
+    branches_dir = docs_dir / "decisions-branches"
+    if branches_dir.is_dir():
+        decision_files.extend(sorted(branches_dir.glob("*.md")))
+
+    decision_text = "\n".join(
+        f.read_text(encoding="utf-8", errors="ignore")
+        for f in decision_files
+    )
+
+    results: "list[dict]" = []
+    for skill_subdir in sorted(skills_dir.iterdir()):
+        if not skill_subdir.is_dir():
+            continue
+        skill_md = skill_subdir / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+
+        rel_path = skill_md.relative_to(repo_root).as_posix()
+        size = skill_md.stat().st_size
+        name = skill_subdir.name
+
+        last_modified = _git_last_touched(repo_root, rel_path)
+        if last_modified is None:
+            import datetime as _dt
+            last_modified = _dt.date.fromtimestamp(skill_md.stat().st_mtime).isoformat()
+
+        decision_count = decision_text.count(name) if name and decision_text else 0
+
+        results.append({
+            "name": name,
+            "path": rel_path,
+            "bytes": size,
+            "last_modified": last_modified,
+            "decision_count": decision_count,
+        })
+
+    return results
+
+
+def _git_last_touched(repo_root: Path, rel_path: str) -> Optional[str]:
+    """Return ISO date of last commit touching ``rel_path``, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%cs", "--", rel_path],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out if out else None
+
+
+def classify_audit_row(row: dict, now=None) -> str:
+    """Apply deterministic thresholds to an audit row.
+
+    - ``ghost``: ``decision_count == 0`` AND ``bytes > _LOGMIND_SKILL_AUDIT_TIGHT_BYTES``
+      (loaded into every context but author never iterates — candidate
+      for clud-bug usage --health to confirm + archive).
+    - ``aging``: ``last_modified > 90 days ago``.
+    - ``active``: otherwise.
+
+    ``now`` is injectable for testability; defaults to today.
+    """
+    import datetime as _dt
+    if now is None:
+        now = _dt.date.today()
+    if row.get("decision_count", 0) == 0 and row.get("bytes", 0) > _LOGMIND_SKILL_AUDIT_TIGHT_BYTES:
+        return "ghost"
+    last = row.get("last_modified")
+    if last:
+        try:
+            last_date = _dt.date.fromisoformat(last)
+            if (now - last_date).days > 90:
+                return "aging"
+        except (ValueError, TypeError):
+            pass
+    return "active"

--- a/tests/test_skill_cli.py
+++ b/tests/test_skill_cli.py
@@ -631,3 +631,174 @@ def test_skill_bench_cli_missing_skill_exits_1(tmp_path: Path):
         result = runner.invoke(cli_main, ["skill", "bench", "does-not-exist"])
     assert result.exit_code == 1
     assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# v0.6.4 — audit_skills / classify_audit_row / `logmind skill audit` CLI
+# ---------------------------------------------------------------------------
+
+
+def _audit_helpers():
+    from logmind.core.skill_cli import audit_skills, classify_audit_row
+    return audit_skills, classify_audit_row
+
+
+def _git_init_with_skill(tmp_path: Path, name: str, content: str) -> Path:
+    """Helper: init a git repo with one SKILL.md committed."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=tmp_path, check=True)
+    skill_dir = tmp_path / ".claude" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
+    return skill_dir / "SKILL.md"
+
+
+def test_audit_skills_no_directory_returns_empty(tmp_path: Path):
+    audit_skills, _ = _audit_helpers()
+    out = audit_skills(tmp_path)
+    assert out == []
+
+
+def test_audit_skills_empty_directory_returns_empty(tmp_path: Path):
+    (tmp_path / ".claude" / "skills").mkdir(parents=True)
+    audit_skills, _ = _audit_helpers()
+    assert audit_skills(tmp_path) == []
+
+
+def test_audit_skills_reports_each_skill(tmp_path: Path):
+    audit_skills, _ = _audit_helpers()
+    _git_init_with_skill(
+        tmp_path, "alpha", "---\nname: alpha\ndescription: a\n---\nbody\n"
+    )
+    second = tmp_path / ".claude" / "skills" / "beta"
+    second.mkdir(parents=True)
+    (second / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: b\n---\nbody\n", encoding="utf-8"
+    )
+    out = audit_skills(tmp_path)
+    names = sorted(r["name"] for r in out)
+    assert names == ["alpha", "beta"]
+    for row in out:
+        assert "bytes" in row
+        assert "last_modified" in row
+        assert "decision_count" in row
+        assert row["bytes"] > 0
+
+
+def test_audit_skills_counts_decision_mentions(tmp_path: Path):
+    """Skill name appearing in docs/decisions.md → decision_count > 0."""
+    audit_skills, _ = _audit_helpers()
+    _git_init_with_skill(
+        tmp_path, "gamma", "---\nname: gamma\ndescription: g\n---\nbody\n"
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "decisions.md").write_text(
+        "## Decision 1\nUsed gamma for X.\n\n## Decision 2\ngamma iterated.\n",
+        encoding="utf-8",
+    )
+    out = audit_skills(tmp_path)
+    row = next(r for r in out if r["name"] == "gamma")
+    assert row["decision_count"] == 2
+
+
+def test_audit_skills_includes_decision_branches(tmp_path: Path):
+    """Branch decision files under docs/decisions-branches/ also counted."""
+    audit_skills, _ = _audit_helpers()
+    _git_init_with_skill(
+        tmp_path, "delta", "---\nname: delta\ndescription: d\n---\nbody\n"
+    )
+    branches = tmp_path / "docs" / "decisions-branches"
+    branches.mkdir(parents=True)
+    (branches / "feat__x.md").write_text("delta was extended.\n", encoding="utf-8")
+    (branches / "feat__y.md").write_text("delta refactored.\n", encoding="utf-8")
+    out = audit_skills(tmp_path)
+    row = next(r for r in out if r["name"] == "delta")
+    assert row["decision_count"] == 2
+
+
+def test_classify_audit_row_active():
+    _, classify_audit_row = _audit_helpers()
+    import datetime as _dt
+    today = _dt.date(2026, 6, 1)
+    row = {"bytes": 1500, "decision_count": 2, "last_modified": "2026-05-15"}
+    assert classify_audit_row(row, now=today) == "active"
+
+
+def test_classify_audit_row_ghost():
+    """Big skill with no decision-log mentions = ghost."""
+    _, classify_audit_row = _audit_helpers()
+    import datetime as _dt
+    today = _dt.date(2026, 6, 1)
+    row = {"bytes": 5000, "decision_count": 0, "last_modified": "2026-05-15"}
+    assert classify_audit_row(row, now=today) == "ghost"
+
+
+def test_classify_audit_row_aging():
+    """Last touched > 90 days = aging (even with decisions + small)."""
+    _, classify_audit_row = _audit_helpers()
+    import datetime as _dt
+    today = _dt.date(2026, 6, 1)
+    row = {"bytes": 500, "decision_count": 5, "last_modified": "2026-01-01"}
+    assert classify_audit_row(row, now=today) == "aging"
+
+
+def test_classify_audit_row_small_no_decisions_is_active():
+    """Tight skill with no decisions = active (could be new or just simple)."""
+    _, classify_audit_row = _audit_helpers()
+    import datetime as _dt
+    today = _dt.date(2026, 6, 1)
+    row = {"bytes": 500, "decision_count": 0, "last_modified": "2026-05-30"}
+    assert classify_audit_row(row, now=today) == "active"
+
+
+def test_classify_audit_row_handles_invalid_date():
+    _, classify_audit_row = _audit_helpers()
+    row = {"bytes": 500, "decision_count": 1, "last_modified": "not-a-date"}
+    assert classify_audit_row(row) == "active"
+
+
+def test_skill_audit_cli_no_skills(tmp_path: Path):
+    """No .claude/skills/ → friendly message + exit 0."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        result = runner.invoke(cli_main, ["skill", "audit"])
+    assert result.exit_code == 0
+    assert "No skills found" in result.output
+
+
+def test_skill_audit_cli_renders_table(tmp_path: Path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)) as fs:
+        from pathlib import Path as _P
+        repo = _P(fs)
+        _git_init_with_skill(
+            repo, "epsilon", "---\nname: epsilon\ndescription: e\n---\nbody\n"
+        )
+        result = runner.invoke(cli_main, ["skill", "audit"])
+    assert result.exit_code == 0, result.output
+    assert "epsilon" in result.output
+    assert "skill: audit 1 skill" in result.output
+
+
+def test_skill_audit_cli_json(tmp_path: Path):
+    """--json emits a parseable JSON array."""
+    import json
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=str(tmp_path)) as fs:
+        from pathlib import Path as _P
+        repo = _P(fs)
+        _git_init_with_skill(
+            repo, "zeta", "---\nname: zeta\ndescription: z\n---\nbody\n"
+        )
+        result = runner.invoke(cli_main, ["skill", "audit", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = result.output.split("ok ")[0].strip()
+    data = json.loads(payload)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == "zeta"
+    assert "status" in data[0]


### PR DESCRIPTION
## Summary

Closes the "author's-side" arrow of the SkDD loop. `logmind skill audit` walks every `.claude/skills/*/SKILL.md` and reports staleness signals:

- **name + path + bytes**
- **last touched** — last git commit touching SKILL.md (falls back to file mtime if not in git)
- **decision count** — # times the skill name appears in `docs/decisions.md` + `docs/decisions-branches/*.md`
- **status**: `active` (everyday) / `aging` (last touched > 90d) / `ghost` (decision_count==0 AND bytes>2000 → loaded but never iterated)

Pairs with clud-bug's `usage --health` (v0.6.28+):
- **audit**: what's HERE, how stale (author + filesystem side)
- **usage --health**: what's USED, how often cited (load + review side)

## Surface

- `logmind skill audit` — human-readable table with summary line.
- `logmind skill audit --json` — machine-readable array.

## What changed

- `src/logmind/core/skill_cli.py` — new `audit_skills`, `classify_audit_row`, `_git_last_touched`.
- `src/logmind/cli.py` — new `@skill.command("audit")` wiring.
- `tests/test_skill_cli.py` — 13 new tests (directory walking, decision counting from main + branch files, every status bucket, CLI rendering, JSON output, edge cases).

## Test plan

- [x] `pytest -q` — 772 tests pass (758 prior + 14 new)
- [x] CLI smoke: scaffold a SKILL.md + log a decision mentioning it, run `logmind skill audit`, verify rendered table + status classification
- [ ] Self-review on this PR via clud-bug-review