### PR TITLE
chore: propagate clud-bug v0.6.31 (hotfix — upload-artifact include-hidden-files)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -23,6 +23,6 @@
       "description": "(bundled baseline)"
     }
   ],
-  "lastUpdate": "2026-06-01T04:04:56.804Z",
-  "lastUpdateVersion": "0.6.30"
+  "lastUpdate": "2026-06-01T12:45:06.289Z",
+  "lastUpdateVersion": "0.6.31"
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.30._
+_Installed at clud-bug v0.6.31._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -634,7 +634,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.31 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -652,7 +652,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.30 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.31 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -662,6 +662,9 @@ jobs:
         with:
           name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}
           path: .claude/skills/.clud-bug.json
+          # v0.6.31 hotfix: upload-artifact@v4 excludes hidden files
+          # by default. See workflow.yml.tmpl for full context.
+          include-hidden-files: true
           retention-days: 90
 
       # v0.6.26 / §5.5 Layer 6 fallback render-from-inlines — see workflow.yml.tmpl for design notes.
@@ -720,7 +723,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.30
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,5 +123,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.30._
+_Installed at clud-bug v0.6.31._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.31.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.31.md
@@ -1,0 +1,5 @@
+## 2026-06-01 08:45 - chore: propagate clud-bug v0.6.31 (hotfix)
+
+**Reasoning:** v0.6.31 fixes silent artifact-drop bug; logmind reviews will now upload artifacts properly
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (6 decisions)
+## 2026-06 (7 decisions)
 
-- **2026-06-01** — v0.6.5 fix: --since filters by entry **Date** stamp + suggest UI count mismatch (PR #101) *(feat/v0.6.5-skill-suggest)* — [decisions-branches/feat__v0.6.5-skill-suggest.md](decisions-branches/feat__v0.6.5-skill-suggest.md)
-- *... 4 more decisions ...*
+- **2026-06-01** — chore: propagate clud-bug v0.6.31 (hotfix) *(chore/clud-bug-v0.6.31)* — [decisions-branches/chore__clud-bug-v0.6.31.md](decisions-branches/chore__clud-bug-v0.6.31.md)
+- *... 5 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)


### PR DESCRIPTION
Picks up v0.6.31 hotfix that enables artifact uploads.