### PR TITLE
chore: propagate clud-bug v0.6.32 (release-discipline guard + dashboard text)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -23,6 +23,6 @@
       "description": "(bundled baseline)"
     }
   ],
-  "lastUpdate": "2026-06-01T12:45:06.289Z",
-  "lastUpdateVersion": "0.6.31"
+  "lastUpdate": "2026-06-01T14:17:40.430Z",
+  "lastUpdateVersion": "0.6.32"
 }

--- a/.cursorrules
+++ b/.cursorrules
@@ -19,5 +19,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.31._
+_Installed at clud-bug v0.6.32._
 <!-- clud-bug-end -->

--- a/.github/workflows/clud-bug-review.yml
+++ b/.github/workflows/clud-bug-review.yml
@@ -634,7 +634,7 @@ jobs:
           THREADS_COUNT: ${{ needs.paths-check.outputs.threads_count }}
         run: |
           set -euo pipefail
-          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.31 render --stdin)
+          BODY=$(printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.32 render --stdin)
           CALIBRATION="<!-- clud-bug-calibration: turns_estimated=$TURNS_ESTIMATED, max_turns=$MAX_TURNS, files=$FILES_COUNT, lines_added=$LINES_ADDED, lines_deleted=$LINES_DELETED, threads=$THREADS_COUNT -->"
           gh pr comment "$PR_NUMBER" --body "$BODY
 
@@ -652,7 +652,7 @@ jobs:
           if [ ! -f .claude/skills/.clud-bug.json ]; then
             echo '{"version": 1}' > .claude/skills/.clud-bug.json
           fi
-          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.31 update-skill-usage --stdin
+          printf '%s\n' "$STRUCTURED" | npx --yes clud-bug@0.6.32 update-skill-usage --stdin
           echo "::notice title=skill-usage::recorded review delta to ephemeral .clud-bug.json (v0.6.30 will add cross-review aggregation)"
 
       - name: Upload skill-usage artifact
@@ -723,7 +723,7 @@ jobs:
       # Strict-mode gate — composite action; see workflow.yml.tmpl for design notes.
       - name: Strict mode — fail check on critical findings
         if: success()
-        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.31
+        uses: thrillmade/clud-bug/.github/actions/strict-mode-gate@v0.6.32
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # v0.6.22 / 0.0.O: summary now posted by github-actions[bot].

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,5 +123,5 @@ For agent invocations of the `clud-bug` CLI, prefer `CLUD_BUG_QUIET=1`
 (or pass `--quiet`) — suppresses progress chatter and emits a single
 `ok <key-value>` summary line per command.
 
-_Installed at clud-bug v0.6.31._
+_Installed at clud-bug v0.6.32._
 <!-- clud-bug-end -->

--- a/docs/decisions-branches/chore__clud-bug-v0.6.32.md
+++ b/docs/decisions-branches/chore__clud-bug-v0.6.32.md
@@ -1,0 +1,5 @@
+## 2026-06-01 10:17 - chore: propagate clud-bug v0.6.32
+
+**Reasoning:** Pin bump + discipline guard
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (7 decisions)
+## 2026-06 (8 decisions)
 
-- **2026-06-01** — chore: propagate clud-bug v0.6.31 (hotfix) *(chore/clud-bug-v0.6.31)* — [decisions-branches/chore__clud-bug-v0.6.31.md](decisions-branches/chore__clud-bug-v0.6.31.md)
-- *... 5 more decisions ...*
+- **2026-06-01** — chore: propagate clud-bug v0.6.32 *(chore/clud-bug-v0.6.32)* — [decisions-branches/chore__clud-bug-v0.6.32.md](decisions-branches/chore__clud-bug-v0.6.32.md)
+- *... 6 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)


### PR DESCRIPTION
Picks up v0.6.32.