### PR TITLE
v0.6.6: doctor surfaces clud-bug skill-usage upload drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-06-01
+
+### Added — `logmind doctor` surfaces clud-bug skill-usage upload drift
+
+New diagnostic check that warns when a consumer's
+`.github/workflows/clud-bug-review.yml` is out of sync with the
+clud-bug v0.6.29-v0.6.31 skill-usage upload-step contract:
+
+- Missing `Upload skill-usage artifact` step → consumer pre-v0.6.29.
+  Skill-usage data won't accumulate. Suggests `npx clud-bug update`.
+- Has the step but missing `include-hidden-files: true` → consumer on
+  v0.6.29 or v0.6.30 and silently dropping every artifact (dot-file
+  exclusion bug). Suggests `npx clud-bug update` to pick up v0.6.31.
+- Step present + flag present → silent (everything's wired correctly).
+
+Surfaces propagation drift early — before the consumer wastes review
+cycles producing artifacts that never reach GitHub. Matches the shape
+of `check_stale_derived_docs_warning` (predictive heads-up in
+suggestions list, not a fatal DRIFT flip).
+
+#### Implementation
+
+- `src/logmind/core/doctor.py`: new `check_clud_bug_skill_usage_integration(project_root)`
+  function. Anchored-regex check (`^\s+include-hidden-files:\s*true`)
+  matches the v0.6.32 release-discipline guard's pattern in clud-bug —
+  the two gates stay aligned. Wired into `collect_status` after the
+  existing stale-derived-docs check.
+- `tests/test_clud_bug_skill_usage_check.py`: 6 new tests covering
+  no-workflow / pre-v0.6.29 / pre-v0.6.31 / current / commented-out /
+  defensive-directory cases.
+
+#### Recovery flow
+
+A consumer hitting either warning runs `npx clud-bug update`. That
+single command re-renders all workflow files from the latest
+templates + bumps composite pins. No manual editing required.
+
 ## [0.6.5] - 2026-06-01
 
 ### Added — `logmind skill suggest` (Stream 6 follow-on, killed-Stream-9 replacement)

--- a/docs/decisions-branches/feat__v0.6.6-doctor-skill-usage-check.md
+++ b/docs/decisions-branches/feat__v0.6.6-doctor-skill-usage-check.md
@@ -1,0 +1,11 @@
+## 2026-06-01 11:12 - v0.6.6: doctor surfaces clud-bug skill-usage upload drift (post-v0.6.31 hardening)
+
+**Reasoning:** Today's v0.6.31 hotfix revealed the silent-failure pattern in actions/upload-artifact@v4 (dot-file exclusion). Without a consumer-side preflight, repos can lag on the upload fix indefinitely with no error surface. New doctor check warns when clud-bug-review.yml is missing the v0.6.29 Upload skill-usage step OR the v0.6.31 include-hidden-files flag. Anchored regex matches the v0.6.32 clud-bug release-discipline guard's pattern — the two gates stay aligned.
+
+**Alternatives considered:** Auto-run npx clud-bug update when drift detected (rejected: violates 'humans gate' constraint + breaks the doctor's read-only contract), Make this a hard DRIFT signal instead of a suggestion line (rejected: consumer might be intentionally on an older pin during gradual rollout; predictive heads-up is the right severity)
+
+**Implications:**
+- Pairs the v0.6.32 clud-bug-side guard with a logmind-side consumer-side check. Each gate catches the drift on a different surface: discipline guard catches at clud-bug release time, doctor check catches at consumer use time
+- Tokenomics specifically: when the user runs tokenomics work soon, a tokenomics-side logmind doctor invocation will confirm the v0.6.31 upload fix is in place before any review fires
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -71,6 +71,7 @@ logmind
 │   ├── test_calibration_layer1.py
 │   ├── test_changelog.py
 │   ├── test_cli.py
+│   ├── test_clud_bug_skill_usage_check.py
 │   ├── test_config.py
 │   ├── test_decision_templates.py
 │   ├── test_decorators.py

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (8 decisions)
+## 2026-06 (9 decisions)
 
-- **2026-06-01** — chore: propagate clud-bug v0.6.32 *(chore/clud-bug-v0.6.32)* — [decisions-branches/chore__clud-bug-v0.6.32.md](decisions-branches/chore__clud-bug-v0.6.32.md)
-- *... 6 more decisions ...*
+- **2026-06-01** — v0.6.6: doctor surfaces clud-bug skill-usage upload drift (post-v0.6.31 hardening) *(feat/v0.6.6-doctor-skill-usage-check)* — [decisions-branches/feat__v0.6.6-doctor-skill-usage-check.md](decisions-branches/feat__v0.6.6-doctor-skill-usage-check.md)
+- *... 7 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.5"
+version = "0.6.6"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -110,7 +110,7 @@ def _ok(msg: str, *, err: bool = False) -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.5", prog_name="logmind")
+@click.version_option(version="0.6.6", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -429,6 +429,61 @@ def check_stale_derived_docs_warning(project_root: Path) -> Optional[str]:
     )
 
 
+def check_clud_bug_skill_usage_integration(project_root: Path) -> Optional[str]:
+    """v0.6.6 — surface drift between consumer's clud-bug-review workflow
+    and the v0.6.29-v0.6.31 skill-usage upload-step contract.
+
+    Reports when a consumer's `.github/workflows/clud-bug-review.yml`:
+
+    1. Is missing the `Upload skill-usage artifact` step entirely
+       → consumer hasn't propagated v0.6.29+ (Component 4 workflow integration).
+       Run `npx clud-bug update`.
+
+    2. HAS the step but is missing `include-hidden-files: true`
+       → consumer is on v0.6.29 or v0.6.30 and is hitting the silent
+       artifact-drop bug (dot-file exclusion in upload-artifact@v4).
+       The CLI side works, but artifacts never reach GitHub. Run
+       `npx clud-bug update` to pick up the v0.6.31 hotfix.
+
+    Returns a one-line warning when drift is detected, else ``None``.
+    Silent no-op when clud-bug-review.yml doesn't exist (repo doesn't
+    use clud-bug — nothing to check).
+    """
+    workflow = project_root / ".github" / "workflows" / "clud-bug-review.yml"
+    if not workflow.is_file():
+        return None  # repo doesn't use clud-bug — silent no-op
+
+    try:
+        content = workflow.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+
+    has_upload_step = "Upload skill-usage artifact" in content
+    if not has_upload_step:
+        return (
+            "⚠ .github/workflows/clud-bug-review.yml is missing the "
+            "'Upload skill-usage artifact' step (clud-bug v0.6.29+ contract). "
+            "Skill-usage data won't accumulate. Run `npx clud-bug update`."
+        )
+
+    # Step exists; verify the include-hidden-files: true flag is also present
+    # (v0.6.31 hotfix). Use the same anchored regex pattern the release-
+    # discipline test in clud-bug uses, so the gates stay aligned.
+    upload_idx = content.find("Upload skill-usage artifact")
+    # 1500-byte window after the step name catches the multi-line block +
+    # comment context that v0.6.31 added.
+    step_block = content[upload_idx : upload_idx + 1500]
+    has_flag = bool(re.search(r"^\s+include-hidden-files:\s*true", step_block, re.MULTILINE))
+    if not has_flag:
+        return (
+            "⚠ .github/workflows/clud-bug-review.yml has the skill-usage upload "
+            "step but is missing `include-hidden-files: true` (clud-bug v0.6.31 "
+            "hotfix). Artifacts will silently drop. Run `npx clud-bug update`."
+        )
+
+    return None
+
+
 def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
     """v0.5.11 / issue #58: .git/hooks/post-rewrite installed by logmind.
     Companion to the post-merge hook. Fires after `git rebase` or
@@ -629,6 +684,15 @@ def collect_status(project_root: Optional[Path] = None, *, offline: bool = False
     stale_warning = check_stale_derived_docs_warning(project_root)
     if stale_warning:
         suggestions.append(stale_warning)
+
+    # v0.6.6 — surface drift between consumer's clud-bug-review workflow
+    # and the v0.6.29+ skill-usage upload-step contract (esp. the v0.6.31
+    # `include-hidden-files: true` hotfix that fixed silent artifact-drop).
+    # Non-fatal: doesn't flip overall to DRIFT. Surfaces a concrete repair
+    # command (`npx clud-bug update`).
+    skill_usage_warning = check_clud_bug_skill_usage_integration(project_root)
+    if skill_usage_warning:
+        suggestions.append(skill_usage_warning)
 
     return StatusReport(
         project_root=project_root,

--- a/tests/test_clud_bug_skill_usage_check.py
+++ b/tests/test_clud_bug_skill_usage_check.py
@@ -1,0 +1,119 @@
+"""Tests for v0.6.6's `check_clud_bug_skill_usage_integration` doctor probe.
+
+Mirrors the shape of `test_stale_derived_docs_warning.py`. The probe
+surfaces drift between consumers' clud-bug-review.yml and the v0.6.29+
+skill-usage upload-step contract (incl. v0.6.31 `include-hidden-files`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from logmind.core.doctor import check_clud_bug_skill_usage_integration
+
+
+def _write_workflow(repo: Path, content: str) -> Path:
+    wf = repo / ".github" / "workflows" / "clud-bug-review.yml"
+    wf.parent.mkdir(parents=True, exist_ok=True)
+    wf.write_text(content, encoding="utf-8")
+    return wf
+
+
+def test_no_workflow_returns_none(tmp_path: Path):
+    """Silent no-op when clud-bug-review.yml doesn't exist."""
+    assert check_clud_bug_skill_usage_integration(tmp_path) is None
+
+
+def test_workflow_without_upload_step_warns_v0_6_29_drift(tmp_path: Path):
+    """Pre-v0.6.29 workflow has no Upload skill-usage step → warn."""
+    _write_workflow(
+        tmp_path,
+        "name: clud-bug-review\n"
+        "on:\n  pull_request:\n"
+        "jobs:\n  clud-bug-review:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v6\n"
+        "      - name: Run clud-bug review\n"
+        "        run: npx --yes clud-bug@0.6.28 review\n",
+    )
+    msg = check_clud_bug_skill_usage_integration(tmp_path)
+    assert msg is not None
+    assert "Upload skill-usage artifact" in msg
+    assert "npx clud-bug update" in msg
+
+
+def test_workflow_with_upload_but_missing_include_hidden_warns_v0_6_31_drift(tmp_path: Path):
+    """v0.6.29 or v0.6.30 workflow has the step but no include-hidden-files → warn."""
+    _write_workflow(
+        tmp_path,
+        "name: clud-bug-review\n"
+        "jobs:\n  clud-bug-review:\n"
+        "    steps:\n"
+        "      - name: Upload skill-usage artifact\n"
+        "        if: success()\n"
+        "        continue-on-error: true\n"
+        "        uses: actions/upload-artifact@v4\n"
+        "        with:\n"
+        "          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}\n"
+        "          path: .claude/skills/.clud-bug.json\n"
+        "          retention-days: 90\n",
+    )
+    msg = check_clud_bug_skill_usage_integration(tmp_path)
+    assert msg is not None
+    assert "include-hidden-files" in msg
+    assert "v0.6.31" in msg
+    assert "npx clud-bug update" in msg
+
+
+def test_workflow_with_v0_6_31_fix_returns_none(tmp_path: Path):
+    """Workflow with both the step + the flag → no warning."""
+    _write_workflow(
+        tmp_path,
+        "name: clud-bug-review\n"
+        "jobs:\n  clud-bug-review:\n"
+        "    steps:\n"
+        "      - name: Upload skill-usage artifact\n"
+        "        if: success()\n"
+        "        continue-on-error: true\n"
+        "        uses: actions/upload-artifact@v4\n"
+        "        with:\n"
+        "          name: clud-bug-skill-usage-pr-${{ github.event.pull_request.number }}\n"
+        "          path: .claude/skills/.clud-bug.json\n"
+        "          include-hidden-files: true\n"
+        "          retention-days: 90\n",
+    )
+    assert check_clud_bug_skill_usage_integration(tmp_path) is None
+
+
+def test_commented_out_flag_does_not_satisfy_check(tmp_path: Path):
+    """Commented include-hidden-files line must NOT be treated as present.
+
+    Mirror of clud-bug's v0.6.32 release-discipline test — same anchored-regex
+    behavior. If the consumer's workflow has a commented-out version of the
+    flag (perhaps from a botched merge resolution), the check should still warn.
+    """
+    _write_workflow(
+        tmp_path,
+        "name: clud-bug-review\n"
+        "jobs:\n  clud-bug-review:\n"
+        "    steps:\n"
+        "      - name: Upload skill-usage artifact\n"
+        "        uses: actions/upload-artifact@v4\n"
+        "        with:\n"
+        "          name: clud-bug-skill-usage-pr-1\n"
+        "          path: .claude/skills/.clud-bug.json\n"
+        "          # include-hidden-files: true  (commented out)\n"
+        "          retention-days: 90\n",
+    )
+    msg = check_clud_bug_skill_usage_integration(tmp_path)
+    assert msg is not None
+    assert "include-hidden-files" in msg
+
+
+def test_workflow_is_directory_returns_none(tmp_path: Path):
+    """If `.github/workflows/clud-bug-review.yml` is a directory (unusual but
+    possible from a botched checkout), the `is_file()` guard returns None
+    rather than letting `read_text` raise. Defensive."""
+    weird = tmp_path / ".github" / "workflows" / "clud-bug-review.yml"
+    weird.mkdir(parents=True)
+    assert check_clud_bug_skill_usage_integration(tmp_path) is None


### PR DESCRIPTION
## Summary

Consumer-side preflight for today's v0.6.29-v0.6.31 silent-failure incident. `logmind doctor` now warns when `.github/workflows/clud-bug-review.yml` drifts from the v0.6.31 upload-step contract:

| State | Warning |
|---|---|
| No `Upload skill-usage artifact` step | "clud-bug v0.6.29+ contract — run \`npx clud-bug update\`" |
| Step present, no `include-hidden-files: true` | "v0.6.31 hotfix — artifacts will silently drop. Run \`npx clud-bug update\`" |
| Step + flag both present | (silent — everything wired correctly) |

Surfaces drift before consumers waste review cycles on artifacts that never reach GitHub.

## Why now

Today shipped:
- clud-bug v0.6.29 (workflow integration — buggy: silent artifact-drop)
- clud-bug v0.6.30 (aggregation dashboard — found the bug)
- clud-bug v0.6.31 (hotfix: `include-hidden-files: true`)
- clud-bug v0.6.32 (release-discipline guard in clud-bug itself)

The release-discipline guard catches clud-bug-side regressions. This logmind check catches **consumer-side** drift — i.e., a repo lagging on the upload fix gets a clear warning the next time `logmind doctor` runs.

## What changed

- `src/logmind/core/doctor.py` — new `check_clud_bug_skill_usage_integration(project_root)`. Anchored regex matches the v0.6.32 clud-bug guard's pattern, so the two gates stay aligned.
- `tests/test_clud_bug_skill_usage_check.py` — 6 new tests (no workflow / pre-v0.6.29 / pre-v0.6.31 / current / commented-out / defensive directory).

## Test plan

- [x] `pytest -q` — 793 tests pass (787 prior + 6 new)
- [x] CLI smoke: `logmind doctor --offline` on logmind itself → no skill-usage warning (workflow has v0.6.31 fix)
- [ ] Self-review via clud-bug-review