### PR TITLE
v0.6.8: logmind init --with-skdd flag (unified install, Python entry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-06-01
+
+### Added — `logmind init --with-skdd` (unified install, Python entry)
+
+One-command bootstrap for the full SkDD toolchain. Previously the
+install sequence was 3 commands across 2 ecosystems:
+
+```bash
+pip install logmind
+logmind init
+npx clud-bug init
+```
+
+The new `--with-skdd` flag collapses the last two:
+
+```bash
+pip install logmind
+logmind init --with-skdd   # logmind + clud-bug, one command
+```
+
+#### Why the bundle naming
+
+The flag name describes the BUNDLE TARGET (the SkDD toolchain),
+not a specific tool. As the toolchain grows beyond logmind + clud-bug
+(future skills authoring tools, etc.), the same flag stays — no
+flag-explosion API surface. The Node side ships a symmetric mirror
+in clud-bug v0.6.33 (`clud-bug init --with-skdd`).
+
+#### Behavior
+
+- Default (no flag): logmind init unchanged — Python-only install.
+- With `--with-skdd` + `npx` on PATH: subprocesses to
+  `npx --yes clud-bug@latest init` after logmind setup completes.
+  Stream output to user (not silenced).
+- With `--with-skdd` + no `npx`: emits a clear warning with the
+  recovery command (`npx --yes clud-bug@latest init`), exit code 0.
+- Subprocess failure (non-zero exit, OSError): warning surfaced but
+  logmind init still succeeds — clud-bug is an additive layer.
+
+#### Anti-loop guarantee
+
+`logmind init --with-skdd` invokes `npx clud-bug init` (NOT
+`clud-bug init --with-skdd`). v0.6.33's mirror does the same
+in reverse. Each opt-in only goes one level deep; no mutual
+recursion possible.
+
+#### Implementation
+
+- `src/logmind/cli.py`: new `--with-skdd` flag (mirrors the existing
+  `--install-hook` opt-in pattern) + `_install_skdd_via_npx()` helper
+  with `shutil.which` check + graceful subprocess error handling.
+- `tests/test_init_with_skdd.py`: 6 new tests covering flag
+  acceptance / no-flag baseline / npx-invocation / no-npx-warning /
+  non-zero-exit-warning / OSError-warning.
+
 ## [0.6.7] - 2026-06-01
 
 ### Fixed — post-merge hook no longer blocks `git checkout main`

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ curl -fsSL https://raw.githubusercontent.com/thrillmade/reporulez/main/bin/apply
 cd your-project
 logmind init
 
+# OR — install the full SkDD toolchain (logmind + clud-bug) in one go:
+logmind init --with-skdd      # subprocesses to `npx clud-bug init` (requires Node 20+)
+
 # Log decisions - Python API
 from logmind import log
 log("Chose FastAPI over Flask",

--- a/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
+++ b/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
@@ -18,3 +18,11 @@
 - Selective mock pattern: intercept only when cmd[0] == 'npx', delegate everything else to real subprocess.run. Standard test isolation that should have been the original implementation
 
 ---
+## 2026-06-01 14:23 - v0.6.8 fix: 5-min timeout on npx subprocess + catch TimeoutExpired (PR #106)
+
+**Reasoning:** clud-bug-review caught: subprocess.run had no timeout= AND the except clause didn't catch TimeoutExpired. Slow/down npm registry could block logmind init indefinitely with no recovery. Added NPX_TIMEOUT_SECONDS = 5*60 (generous for cold caches + slow networks) + dedicated TimeoutExpired handler with a clear recovery message
+
+**Implications:**
+- Regression test asserts timeout= is actually passed to subprocess.run + that TimeoutExpired surfaces the right warning. Mirrors v0.6.5's --since fix pattern (don't trust kwargs, verify they thread through)
+
+---

--- a/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
+++ b/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
@@ -1,0 +1,12 @@
+## 2026-06-01 13:46 - v0.6.8: logmind init --with-skdd flag (unified install, Python entry)
+
+**Reasoning:** User directive 2026-06-01 PM: pull Stream 7 forward for ease-of-use. The 3-command install (pip install logmind → logmind init → npx clud-bug init) becomes 2 (pip install + logmind init --with-skdd). Flag name uses BUNDLE TARGET (--with-skdd) not specific tool (--with-clud-bug) so future toolchain growth doesn't change the API surface. Symmetric mirror v0.6.33 ships on clud-bug side with --with-skdd opt-in for Node-first users.
+
+**Alternatives considered:** Use --with-clud-bug flag name (rejected: ties API to specific tool; future tools would force flag explosion), Use --with-thrillmade flag name (rejected: brand-forward but the SkDD methodology framing better describes what users get — the loop, not the brand), Make clud-bug installation the default (rejected: aggressive — would install a Node tool when user might want logmind standalone in a Python-only repo), Interactive prompt during init (rejected: breaks CI/agent usage where prompts hang; opt-in flag is the right severity)
+
+**Implications:**
+- Mirrors the existing --install-hook pattern (line 338-347 in cli.py) — proven precedent for opt-in flag triggering a secondary action after main scaffolding
+- Anti-loop: --with-skdd invokes 'npx clud-bug init' NOT 'npx clud-bug init --with-skdd'. v0.6.33's mirror does same in reverse. No mutual recursion possible
+- Subprocess errors warn but don't fail logmind init — clud-bug is an additive layer; logmind side has already succeeded by the time --with-skdd runs
+
+---

--- a/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
+++ b/docs/decisions-branches/feat__v0.6.8-with-skdd-flag.md
@@ -10,3 +10,11 @@
 - Subprocess errors warn but don't fail logmind init — clud-bug is an additive layer; logmind side has already succeeded by the time --with-skdd runs
 
 ---
+## 2026-06-01 14:04 - v0.6.8 fix: selective subprocess mock in tests (Windows OSError 22)
+
+**Reasoning:** Windows CI failed: blanket subprocess.run mock intercepted ALL subprocess calls in cli.py, breaking git-status checks etc. that need real behavior on Windows. The 6th test (OSError case) already used selective mocking; applying same pattern to the other 2 tests
+
+**Implications:**
+- Selective mock pattern: intercept only when cmd[0] == 'npx', delegate everything else to real subprocess.run. Standard test isolation that should have been the original implementation
+
+---

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -80,6 +80,7 @@ logmind
 │   ├── test_file_structure_updates.py
 │   ├── test_git_handler.py
 │   ├── test_gitignore_management.py
+│   ├── test_init_with_skdd.py
 │   ├── test_inserter.py
 │   ├── test_integrations.py
 │   ├── test_link_check.py

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (12 decisions)
+## 2026-06 (13 decisions)
 
-- **2026-06-01** — v0.6.8 fix: selective subprocess mock in tests (Windows OSError 22) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
-- *... 10 more decisions ...*
+- **2026-06-01** — v0.6.8 fix: 5-min timeout on npx subprocess + catch TimeoutExpired (PR #106) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
+- *... 11 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (10 decisions)
+## 2026-06 (11 decisions)
 
-- **2026-06-01** — v0.6.7: post-merge hook leaves derived docs unstaged (downstream bug fix) *(fix/v0.6.7-post-merge-no-stage)* — [decisions-branches/fix__v0.6.7-post-merge-no-stage.md](decisions-branches/fix__v0.6.7-post-merge-no-stage.md)
-- *... 8 more decisions ...*
+- **2026-06-01** — v0.6.8: logmind init --with-skdd flag (unified install, Python entry) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
+- *... 9 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (11 decisions)
+## 2026-06 (12 decisions)
 
-- **2026-06-01** — v0.6.8: logmind init --with-skdd flag (unified install, Python entry) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
-- *... 9 more decisions ...*
+- **2026-06-01** — v0.6.8 fix: selective subprocess mock in tests (Windows OSError 22) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
+- *... 10 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.7"
+version = "0.6.8"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for logmind."""
 
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -109,8 +110,64 @@ def _ok(msg: str, *, err: bool = False) -> None:
     _orig_click_echo(f"ok {msg}", err=err)
 
 
+def _install_skdd_via_npx() -> None:
+    """v0.6.8 — `logmind init --with-skdd` handler.
+
+    Subprocesses to `npx --yes clud-bug@latest init` in the current cwd.
+    Best-effort: warns but does NOT fail logmind init if the subprocess
+    errors (the logmind side has already succeeded; clud-bug is an
+    additive layer).
+
+    Graceful when Node.js / npx isn't installed — emits an actionable
+    message + how to recover.
+    """
+    if shutil.which("npx") is None:
+        click.secho(
+            "Warning: --with-skdd requested but `npx` is not on PATH.",
+            fg="yellow",
+        )
+        click.echo(
+            "  Install Node.js 20+ (https://nodejs.org), then run:"
+        )
+        click.secho(
+            "    npx --yes clud-bug@latest init",
+            fg="cyan",
+        )
+        click.echo(
+            "  Or skip this flag if you only want logmind standalone."
+        )
+        return
+
+    click.echo()
+    click.secho(
+        "→ --with-skdd: installing clud-bug (npx --yes clud-bug@latest init)",
+        fg="cyan",
+    )
+    try:
+        result = subprocess.run(
+            ["npx", "--yes", "clud-bug@latest", "init"],
+            check=False,
+        )
+        if result.returncode != 0:
+            click.secho(
+                f"Warning: `npx clud-bug init` exited {result.returncode}. "
+                f"logmind side succeeded; clud-bug install is incomplete. "
+                f"Inspect output above and re-run manually if needed.",
+                fg="yellow",
+            )
+        else:
+            click.secho("✓ clud-bug installed via --with-skdd", fg="green")
+    except (FileNotFoundError, OSError) as e:
+        click.secho(
+            f"Warning: --with-skdd subprocess failed: {e}. "
+            f"logmind side succeeded; run `npx --yes clud-bug@latest init` "
+            f"manually to complete the SkDD bundle install.",
+            fg="yellow",
+        )
+
+
 @click.group()
-@click.version_option(version="0.6.7", prog_name="logmind")
+@click.version_option(version="0.6.8", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -345,6 +402,16 @@ def _install_github_action_templates(
         "so each contributor must run this once on their machine."
     ),
 )
+@click.option(
+    "--with-skdd",
+    is_flag=True,
+    help=(
+        "Also install the rest of the SkDD toolchain (currently: clud-bug "
+        "for skill-driven PR review). Subprocesses to `npx --yes clud-bug@latest "
+        "init` after logmind setup completes. Requires Node.js on PATH; "
+        "skip this flag if you only want logmind standalone."
+    ),
+)
 def init(
     no_git: bool,
     agents_list: Optional[str],
@@ -352,6 +419,7 @@ def init(
     github_actions: bool,
     skill_install_flag: Optional[bool],
     install_hook: bool,
+    with_skdd: bool,
 ):
     """
     Initialize logmind in the current project.
@@ -609,6 +677,16 @@ def init(
             ctx.invoke(install_hook_cmd, force=True)
         except Exception as e:
             click.secho(f"Warning: --install-hook failed: {e}", fg="yellow")
+
+    # v0.6.8 — opt-in unified install: also bring in clud-bug (and any
+    # future SkDD-bundle tools) via the same one-command path.
+    # Subprocess invokes `npx clud-bug@latest init` IN this cwd. The
+    # flag name (`--with-skdd`) describes the bundle target, not a
+    # specific tool, so future toolchain growth doesn't change the API.
+    # IMPORTANT: invoke `clud-bug init` (NOT `clud-bug init --with-skdd`)
+    # to avoid mutual-recursion. Each opt-in only goes one level deep.
+    if with_skdd:
+        _install_skdd_via_npx()
 
     click.echo()
     click.secho("logmind initialized successfully!", fg="green")

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -143,10 +143,18 @@ def _install_skdd_via_npx() -> None:
         "→ --with-skdd: installing clud-bug (npx --yes clud-bug@latest init)",
         fg="cyan",
     )
+    # 5-minute ceiling: npm package install + clud-bug init typically
+    # complete in 30-60s. 5 minutes is generous enough to absorb cold
+    # caches + slow networks; past that, the user is better off bailing
+    # and re-running manually rather than blocking init forever.
+    # PR #106 review fix: SkDD was previously missing both timeout=
+    # and the TimeoutExpired catch — npm registry hiccup = infinite hang.
+    NPX_TIMEOUT_SECONDS = 5 * 60
     try:
         result = subprocess.run(
             ["npx", "--yes", "clud-bug@latest", "init"],
             check=False,
+            timeout=NPX_TIMEOUT_SECONDS,
         )
         if result.returncode != 0:
             click.secho(
@@ -157,6 +165,14 @@ def _install_skdd_via_npx() -> None:
             )
         else:
             click.secho("✓ clud-bug installed via --with-skdd", fg="green")
+    except subprocess.TimeoutExpired:
+        click.secho(
+            f"Warning: `npx clud-bug init` timed out after "
+            f"{NPX_TIMEOUT_SECONDS}s (slow npm registry or hung subprocess). "
+            f"logmind side succeeded. Re-run `npx --yes clud-bug@latest init` "
+            f"manually to complete the SkDD bundle install.",
+            fg="yellow",
+        )
     except (FileNotFoundError, OSError) as e:
         click.secho(
             f"Warning: --with-skdd subprocess failed: {e}. "

--- a/tests/test_init_with_skdd.py
+++ b/tests/test_init_with_skdd.py
@@ -1,0 +1,126 @@
+"""Tests for v0.6.8's `logmind init --with-skdd` opt-in flag.
+
+The flag subprocesses to `npx --yes clud-bug@latest init` after the
+standard logmind scaffolding completes. Failure modes:
+- npx missing on PATH → graceful warning, logmind side still succeeds
+- subprocess returns non-zero → warning surfaced, logmind side unaffected
+- subprocess raises OSError → defensive catch, warning surfaced
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from logmind.cli import main as cli_main
+
+
+def test_init_with_skdd_flag_is_accepted(tmp_path: Path, monkeypatch):
+    """Flag exists + doesn't error during parse."""
+    monkeypatch.chdir(tmp_path)
+    # Run with --no-git to skip git ops + --skill-install false to avoid prompt
+    # + use a mock for npx absence (which triggers the warning-not-error path).
+    with patch("logmind.cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    assert result.exit_code == 0, result.output
+
+
+def test_init_without_skdd_flag_does_not_invoke_npx(tmp_path: Path, monkeypatch):
+    """Default behavior (no --with-skdd) skips the subprocess entirely."""
+    monkeypatch.chdir(tmp_path)
+    with patch("logmind.cli.subprocess.run") as mock_run, \
+         patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["init", "--no-git", "--no-skill-install"]
+        )
+        assert result.exit_code == 0, result.output
+        # Subprocess.run should NOT have been called for npx (no flag).
+        npx_calls = [c for c in mock_run.call_args_list if c.args[0][0] == "npx"]
+        assert len(npx_calls) == 0, "npx should not run without --with-skdd"
+
+
+def test_init_with_skdd_invokes_npx_when_available(tmp_path: Path, monkeypatch):
+    """When --with-skdd is passed AND npx is on PATH, subprocess fires."""
+    monkeypatch.chdir(tmp_path)
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    with patch("logmind.cli.subprocess.run", return_value=fake_result) as mock_run, \
+         patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    assert result.exit_code == 0, result.output
+    # Find the npx call specifically.
+    npx_calls = [c for c in mock_run.call_args_list if c.args[0][0] == "npx"]
+    assert len(npx_calls) == 1, "exactly one npx call expected"
+    assert npx_calls[0].args[0] == ["npx", "--yes", "clud-bug@latest", "init"]
+
+
+def test_init_with_skdd_warns_when_npx_missing(tmp_path: Path, monkeypatch):
+    """No npx on PATH → friendly warning, exit 0 (logmind side succeeded)."""
+    monkeypatch.chdir(tmp_path)
+    with patch("logmind.cli.shutil.which", return_value=None):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "npx" in result.output.lower()
+    assert "node" in result.output.lower()
+    # Recovery hint surfaced
+    assert "clud-bug@latest init" in result.output
+
+
+def test_init_with_skdd_warns_when_npx_exits_nonzero(tmp_path: Path, monkeypatch):
+    """If npx subprocess returns non-zero, warn but do not fail init."""
+    monkeypatch.chdir(tmp_path)
+    fake_result = MagicMock()
+    fake_result.returncode = 7
+    with patch("logmind.cli.subprocess.run", return_value=fake_result), \
+         patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    # logmind init still succeeds despite npx failure
+    assert result.exit_code == 0, result.output
+    assert "exited 7" in result.output or "warning" in result.output.lower()
+
+
+def test_init_with_skdd_warns_when_npx_raises_oserror(tmp_path: Path, monkeypatch):
+    """Defensive: if subprocess raises OSError (e.g., permission error)
+    when invoking npx, catch + warn + still succeed.
+
+    The mock targets only the npx invocation specifically — other
+    subprocess.run calls in init (git config, etc.) need to work
+    normally, otherwise the test fails for the wrong reason.
+    """
+    monkeypatch.chdir(tmp_path)
+    real_run = subprocess.run
+
+    def selective_run(cmd, *a, **kw):
+        if isinstance(cmd, list) and cmd and cmd[0] == "npx":
+            raise OSError("simulated npx failure")
+        return real_run(cmd, *a, **kw)
+
+    with patch("logmind.cli.subprocess.run", side_effect=selective_run), \
+         patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.output.lower()

--- a/tests/test_init_with_skdd.py
+++ b/tests/test_init_with_skdd.py
@@ -32,27 +32,47 @@ def test_init_with_skdd_flag_is_accepted(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0, result.output
 
 
+def _selective_subprocess_mock(npx_returncode: int = 0):
+    """Build a selective subprocess.run mock that intercepts ONLY npx
+    invocations, leaving other subprocess.run calls (git status checks,
+    etc.) to the real implementation.
+
+    Returns (side_effect_fn, npx_calls_list). After invocation, inspect
+    npx_calls_list to assert on call args.
+    """
+    real_run = subprocess.run
+    npx_calls = []
+
+    def selective_run(cmd, *a, **kw):
+        if isinstance(cmd, list) and cmd and cmd[0] == "npx":
+            npx_calls.append(cmd)
+            mock_result = MagicMock()
+            mock_result.returncode = npx_returncode
+            return mock_result
+        return real_run(cmd, *a, **kw)
+
+    return selective_run, npx_calls
+
+
 def test_init_without_skdd_flag_does_not_invoke_npx(tmp_path: Path, monkeypatch):
     """Default behavior (no --with-skdd) skips the subprocess entirely."""
     monkeypatch.chdir(tmp_path)
-    with patch("logmind.cli.subprocess.run") as mock_run, \
+    selective_run, npx_calls = _selective_subprocess_mock()
+    with patch("logmind.cli.subprocess.run", side_effect=selective_run), \
          patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
         runner = CliRunner()
         result = runner.invoke(
             cli_main, ["init", "--no-git", "--no-skill-install"]
         )
-        assert result.exit_code == 0, result.output
-        # Subprocess.run should NOT have been called for npx (no flag).
-        npx_calls = [c for c in mock_run.call_args_list if c.args[0][0] == "npx"]
-        assert len(npx_calls) == 0, "npx should not run without --with-skdd"
+    assert result.exit_code == 0, result.output
+    assert len(npx_calls) == 0, "npx should not run without --with-skdd"
 
 
 def test_init_with_skdd_invokes_npx_when_available(tmp_path: Path, monkeypatch):
     """When --with-skdd is passed AND npx is on PATH, subprocess fires."""
     monkeypatch.chdir(tmp_path)
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    with patch("logmind.cli.subprocess.run", return_value=fake_result) as mock_run, \
+    selective_run, npx_calls = _selective_subprocess_mock(npx_returncode=0)
+    with patch("logmind.cli.subprocess.run", side_effect=selective_run), \
          patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
         runner = CliRunner()
         result = runner.invoke(
@@ -60,10 +80,8 @@ def test_init_with_skdd_invokes_npx_when_available(tmp_path: Path, monkeypatch):
             ["init", "--no-git", "--no-skill-install", "--with-skdd"],
         )
     assert result.exit_code == 0, result.output
-    # Find the npx call specifically.
-    npx_calls = [c for c in mock_run.call_args_list if c.args[0][0] == "npx"]
     assert len(npx_calls) == 1, "exactly one npx call expected"
-    assert npx_calls[0].args[0] == ["npx", "--yes", "clud-bug@latest", "init"]
+    assert npx_calls[0] == ["npx", "--yes", "clud-bug@latest", "init"]
 
 
 def test_init_with_skdd_warns_when_npx_missing(tmp_path: Path, monkeypatch):
@@ -85,9 +103,8 @@ def test_init_with_skdd_warns_when_npx_missing(tmp_path: Path, monkeypatch):
 def test_init_with_skdd_warns_when_npx_exits_nonzero(tmp_path: Path, monkeypatch):
     """If npx subprocess returns non-zero, warn but do not fail init."""
     monkeypatch.chdir(tmp_path)
-    fake_result = MagicMock()
-    fake_result.returncode = 7
-    with patch("logmind.cli.subprocess.run", return_value=fake_result), \
+    selective_run, _ = _selective_subprocess_mock(npx_returncode=7)
+    with patch("logmind.cli.subprocess.run", side_effect=selective_run), \
          patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/test_init_with_skdd.py
+++ b/tests/test_init_with_skdd.py
@@ -116,6 +116,33 @@ def test_init_with_skdd_warns_when_npx_exits_nonzero(tmp_path: Path, monkeypatch
     assert "exited 7" in result.output or "warning" in result.output.lower()
 
 
+def test_init_with_skdd_warns_when_npx_times_out(tmp_path: Path, monkeypatch):
+    """PR #106 regression guard: subprocess.TimeoutExpired must be caught.
+    Before the fix, npx had no timeout AND no except for TimeoutExpired,
+    so a slow npm registry could block init forever with no recovery.
+    """
+    monkeypatch.chdir(tmp_path)
+    real_run = subprocess.run
+
+    def selective_run(cmd, *a, **kw):
+        if isinstance(cmd, list) and cmd and cmd[0] == "npx":
+            # Verify the implementation passed timeout=, then raise the
+            # exception the implementation should catch.
+            assert "timeout" in kw, "npx invocation must include timeout="
+            raise subprocess.TimeoutExpired(cmd, kw["timeout"])
+        return real_run(cmd, *a, **kw)
+
+    with patch("logmind.cli.subprocess.run", side_effect=selective_run), \
+         patch("logmind.cli.shutil.which", return_value="/usr/bin/npx"):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            ["init", "--no-git", "--no-skill-install", "--with-skdd"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "timed out" in result.output.lower()
+
+
 def test_init_with_skdd_warns_when_npx_raises_oserror(tmp_path: Path, monkeypatch):
     """Defensive: if subprocess raises OSError (e.g., permission error)
     when invoking npx, catch + warn + still succeed.


### PR DESCRIPTION
## Summary

One-command bootstrap for the full SkDD toolchain. Collapses the 3-command install (`pip install logmind` → `logmind init` → `npx clud-bug init`) to 2:

```bash
pip install logmind
logmind init --with-skdd   # logmind + clud-bug, one command
```

User directive 2026-06-01 PM: pull Stream 7 forward for ease-of-use.

## Why `--with-skdd` (not `--with-clud-bug`)

Flag name describes the **bundle target** (the SkDD toolchain), not a specific tool. As the toolchain grows beyond logmind + clud-bug, the same flag stays — no flag-explosion API surface. Symmetric mirror ships on clud-bug v0.6.33 (`clud-bug init --with-skdd` for Node-first users).

## Behavior

| Condition | Outcome |
|---|---|
| No flag | `logmind init` unchanged (default Python-only path) |
| Flag + `npx` on PATH | Subprocesses to `npx --yes clud-bug@latest init`; streams output |
| Flag + no `npx` | Clear warning with recovery command; exit 0 |
| Subprocess non-zero exit | Warning surfaced; logmind init still succeeds |
| Subprocess OSError | Defensive catch; warning surfaced; logmind init still succeeds |

## Anti-loop guarantee

`logmind init --with-skdd` invokes `npx clud-bug init` (NOT `--with-skdd`). v0.6.33's mirror does same in reverse. Each opt-in flag only goes one level — no mutual recursion possible.

## What changed

- **`src/logmind/cli.py`** — new `--with-skdd` opt-in flag on `init` + `_install_skdd_via_npx()` helper. Mirrors the existing `--install-hook` pattern.
- **`tests/test_init_with_skdd.py`** — 6 new tests (flag accept / no-flag baseline / npx-invocation / no-npx-warning / non-zero-exit-warning / OSError-warning).
- **`README.md`** — quickstart shows the unified path.
- Version 0.6.7 → 0.6.8 in the 3 standard spots.

## Test plan

- [x] `pytest -q` — 800 tests pass (794 prior + 6 new)
- [x] Selective subprocess mocking confirms anti-loop + graceful error paths
- [ ] Self-review on this PR via clud-bug-review
- [ ] Post-merge: tag v0.6.8 → PyPI publish → 4th recursive notify-skills self-test (expected: judged skill-relevant — first user-visible CLI flag since v0.6.5)