### PR TITLE
fix(README): use full skill path in skills.sh badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/logmind.svg)](https://pypi.org/project/logmind/)
 [![Python versions](https://img.shields.io/pypi/pyversions/logmind.svg)](https://pypi.org/project/logmind/)
 [![CI](https://github.com/thrillmade/logmind/actions/workflows/test.yml/badge.svg)](https://github.com/thrillmade/logmind/actions/workflows/test.yml)
-[![skills.sh](https://skills.sh/b/thrillmade/agent-skills)](https://www.skills.sh/thrillmade/agent-skills/logmind)
+[![skills.sh](https://www.skills.sh/b/thrillmade/agent-skills/logmind)](https://www.skills.sh/thrillmade/agent-skills/logmind)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 AI decision logging for development projects — branch-aware by default.

--- a/docs/decisions-branches/fix__skills-sh-badge-url.md
+++ b/docs/decisions-branches/fix__skills-sh-badge-url.md
@@ -1,0 +1,11 @@
+## 2026-06-01 16:30 - fix(README): use full skill path in skills.sh badge URL
+
+**Reasoning:** README badge rendered as 'resource not found' (red) because the badge image URL was https://skills.sh/b/thrillmade/agent-skills (missing the skill name). skills.sh badge endpoint requires the full /b/<owner>/<repo>/<skill-name> shape — verified that https://www.skills.sh/b/thrillmade/agent-skills/logmind returns 200 SVG. The click-through URL was already correct; only the image URL needed the trailing /logmind segment.
+
+**Alternatives considered:** Remove the skills.sh badge entirely (loses the install-count signal), Use shields.io custom badge wrapper instead (adds redirect latency, more brittle)
+
+**Implications:**
+- Consumer-facing first-impression bug — first thing any visitor to the logmind README sees. Closes a low-cost trust gap before Phase D scope.
+- Verified the same pattern is NOT present on sister READMEs (clud-bug / agent-skills / reporulez / tokenomics / rezgen) — fix is localized to logmind.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (13 decisions)
+## 2026-06 (14 decisions)
 
-- **2026-06-01** — v0.6.8 fix: 5-min timeout on npx subprocess + catch TimeoutExpired (PR #106) *(feat/v0.6.8-with-skdd-flag)* — [decisions-branches/feat__v0.6.8-with-skdd-flag.md](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
-- *... 11 more decisions ...*
+- **2026-06-01** — fix(README): use full skill path in skills.sh badge URL *(fix/skills-sh-badge-url)* — [decisions-branches/fix__skills-sh-badge-url.md](decisions-branches/fix__skills-sh-badge-url.md)
+- *... 12 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)


### PR DESCRIPTION
## Summary

The skills.sh badge in `README.md` line 6 rendered as a red "resource not found" pill because the badge image URL omitted the skill name segment.

Before: `https://skills.sh/b/thrillmade/agent-skills` → 308 → page-not-found at skills.sh
After: `https://www.skills.sh/b/thrillmade/agent-skills/logmind` → 200 image/svg+xml

The click-through URL was already correct; only the badge image URL needed the trailing `/logmind`. Also switched to `www.` form to skip the 308 redirect.

## Test plan

- [x] Visual verification: badge URL responds 200 with SVG content-type
- [x] No sister-repo regressions: grepped clud-bug / agent-skills / reporulez / tokenomics / rezgen READMEs — none have the same broken pattern
- [ ] CI green (all 5 org-required checks)
- [ ] After merge: re-load https://github.com/thrillmade/logmind to confirm badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)