### PR TITLE
v0.6.9: `logmind file-structure --check` (symmetric CI gate with timeline) + close #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-06-01
+
+### Added — `logmind file-structure --check` (symmetric with `timeline --check`)
+
+`logmind timeline --check` has shipped since v0.5.13 — exits non-zero when
+the on-disk `docs/timeline.md` differs from a fresh regen, so CI can fail
+the build before the auto-fix step. The mirror command `logmind
+file-structure` has been missing the same flag; v0.6.9 closes that
+asymmetry.
+
+```bash
+# Used by CI / pre-commit gates: "are derived docs stale?"
+logmind file-structure --write docs/file-structure.md --check
+#   → exit 0 + "✓ up to date"  if current
+#   → exit 1 + "✗ stale — re-run …" if regen would change the file
+#   → exit 2 + "requires --write" if --write is missing
+```
+
+The `regen-timeline.yml` workflow template can now use explicit `--check`
+calls for both derived docs (cleaner than the current
+`--write` + `git diff --quiet` pattern, though that still works fine).
+
+### Context — closes #93 (the v0.5.14 "conflict-tolerant regen merge driver" candidate)
+
+The original framing of "always-fire merge driver to catch silent-success
+3-way merge interleaves on `docs/timeline.md`" turned out to be infeasible
+by git design — merge drivers only invoke on conflict, and
+`pre-merge-commit` hooks don't fire on GitHub's server-side squash-merge
+flow (the dominant case). Practical coverage of the original problem has
+been built up across multiple releases:
+
+- **v0.5.11** post-rewrite hook (rebases + amends regen + stage)
+- **v0.5.12** driver auto-install on fresh clones / CI
+- **v0.5.13** `logmind rebase` convenience + doctor stale-derived warning
+- **v0.6.7** post-merge leaves regen unstaged (next `logmind log` picks
+  up cleanly)
+- `regen-timeline.yml` v3 template with `LOGMIND_AUTO_REGEN_PAT`-driven
+  auto-fix mode (regenerates derived docs + pushes back to the PR branch
+  when the PAT secret is configured; PAT-pushed commits re-trigger
+  downstream checks, unlike GITHUB_TOKEN-pushed ones)
+- `logmind timeline --check` (CI gate) since v0.5.13
+
+v0.6.9's `file-structure --check` completes the CI-gate symmetry. The
+practical problem #93 surfaced is now covered end-to-end:
+
+```text
+local merge → post-merge hook regens → unstaged → next `logmind log` stages
+       OR
+GitHub squash-merge → check-derived-docs workflow on next PR catches stale
+       OR (with PAT)
+GitHub squash-merge → check-derived-docs auto-regens + pushes back
+       OR (in pre-commit / CI)
+`logmind timeline --check` + `logmind file-structure --check` exit non-zero
+```
+
+No new merge-driver mechanism is shipping. Issue #93 closed with this
+context.
+
 ## [0.6.8] - 2026-06-01
 
 ### Added — `logmind init --with-skdd` (unified install, Python entry)

--- a/docs/decisions-branches/feat__file-structure-check.md
+++ b/docs/decisions-branches/feat__file-structure-check.md
@@ -1,0 +1,11 @@
+## 2026-06-01 17:06 - feat: `logmind file-structure --check` (v0.6.9 — symmetric CI gate with timeline)
+
+**Reasoning:** logmind timeline --check has shipped since v0.5.13; the mirror command file-structure has been missing the same flag. Adding it closes the asymmetry and gives CI / pre-commit / doctor a single scriptable verification primitive for the second derived doc. Also closes issue #93 (the v0.5.14 'always-fire merge driver' candidate, which turned out to be infeasible by git design — drivers only invoke on conflict, pre-merge-commit hooks don't fire on GitHub squash-merge). Mitigations (v0.5.11/12/13 + v0.6.7 + PAT-driven auto-fix in regen-timeline.yml) cover the practical cases end-to-end.
+
+**Alternatives considered:** Skip ship — leave file-structure asymmetric with timeline (consumer-product wart), Always-fire merge driver — infeasible per git design (rejected), Pre-merge-commit hook — doesn't help squash-merge flow (rejected)
+
+**Implications:**
+- Closes issue #93. v0.6.9 ships as a small symmetric-completeness PR.
+- Validated 804 pytest pass / 1 skip. Editable install needed re-running pip install -e . to pick up source edits — caught during pytest run when the installed cli.py was stale (worth noting for any contributor running tests after a CLI edit).
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (14 decisions)
+## 2026-06 (15 decisions)
 
-- **2026-06-01** — fix(README): use full skill path in skills.sh badge URL *(fix/skills-sh-badge-url)* — [decisions-branches/fix__skills-sh-badge-url.md](decisions-branches/fix__skills-sh-badge-url.md)
-- *... 12 more decisions ...*
+- **2026-06-01** — feat: `logmind file-structure --check` (v0.6.9 — symmetric CI gate with timeline) *(feat/file-structure-check)* — [decisions-branches/feat__file-structure-check.md](decisions-branches/feat__file-structure-check.md)
+- *... 13 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.8"
+version = "0.6.9"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -183,7 +183,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.8", prog_name="logmind")
+@click.version_option(version="0.6.9", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -2694,6 +2694,14 @@ def tree_cmd(max_depth: Optional[int]):
     "Without this flag, prints to stdout.",
 )
 @click.option(
+    "--check",
+    is_flag=True,
+    default=False,
+    help="Exit nonzero if writing would change the file. Used in CI to fail "
+    "the build before regen so the auto-commit step runs and updates the PR. "
+    "Mirrors `logmind timeline --check`.",
+)
+@click.option(
     "--max-depth",
     "max_depth",
     type=int,
@@ -2701,7 +2709,9 @@ def tree_cmd(max_depth: Optional[int]):
     help="Cap the tree at depth N (root is depth 0). Default: 2 (token-frugal). "
     "Pass 0 for unbounded (full tree); pass a positive integer to truncate.",
 )
-def file_structure_cmd(write_path: Optional[Path], max_depth: Optional[int]):
+def file_structure_cmd(
+    write_path: Optional[Path], check: bool, max_depth: Optional[int]
+):
     """
     Print or regenerate the derived docs/file-structure.md tree snapshot.
 
@@ -2711,9 +2721,10 @@ def file_structure_cmd(write_path: Optional[Path], max_depth: Optional[int]):
     parallel-PR rebases without falling through to textual three-way merge.
 
     Examples:
-        logmind file-structure                                # depth 2, stdout
-        logmind file-structure --max-depth 0                  # full tree
-        logmind file-structure --write docs/file-structure.md # regenerate file at depth 2
+        logmind file-structure                                       # depth 2, stdout
+        logmind file-structure --max-depth 0                         # full tree
+        logmind file-structure --write docs/file-structure.md        # regenerate file at depth 2
+        logmind file-structure --write docs/file-structure.md --check  # CI gate
     """
     from logmind.core.tree_gen import (
         DEFAULT_FILE_STRUCTURE_DEPTH,
@@ -2733,6 +2744,29 @@ def file_structure_cmd(write_path: Optional[Path], max_depth: Optional[int]):
     depth_label = "unbounded" if effective_depth is None else f"depth={effective_depth}"
 
     repo_root = Path.cwd()
+
+    if check:
+        if write_path is None:
+            click.secho(
+                "Error: --check requires --write PATH to compare against.",
+                fg="red",
+            )
+            sys.exit(2)
+        rendered = generate_file_structure(repo_root, max_depth=effective_depth)
+        existing = (
+            write_path.read_text(encoding="utf-8") if write_path.exists() else ""
+        )
+        if existing != rendered:
+            click.secho(
+                f"✗ {write_path} is stale — re-run "
+                f"`logmind file-structure --write {write_path}` and commit.",
+                fg="yellow",
+            )
+            sys.exit(1)
+        click.secho(f"✓ {write_path} is up to date", fg="green")
+        _ok(f"file-structure: {write_path} up to date")
+        return
+
     if write_path is None:
         rendered = generate_file_structure(repo_root, max_depth=effective_depth)
         # Use unpatched echo so the tree itself isn't suppressed by --quiet;

--- a/tests/test_file_structure_updates.py
+++ b/tests/test_file_structure_updates.py
@@ -188,3 +188,78 @@ def test_log_updates_file_structure(tmp_path, monkeypatch):
     fs_content = (docs / "file-structure.md").read_text(encoding="utf-8")
     assert "interesting_new_file.py" in fs_content
     assert "# File Structure" in fs_content
+
+
+# ---------------------------------------------------------------------------
+# v0.6.9 — `file-structure --check` CI gate (symmetric with `timeline --check`)
+# ---------------------------------------------------------------------------
+
+
+def test_file_structure_cli_check_fails_when_stale(tmp_path, monkeypatch):
+    """--check exits 1 when on-disk file-structure.md differs from fresh regen."""
+    from click.testing import CliRunner
+
+    from logmind.cli import main as cli_main
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (tmp_path / "marker.txt").write_text("ok", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    target = docs / "file-structure.md"
+    target.write_text("stale\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main, ["file-structure", "--write", str(target), "--check"]
+    )
+    assert result.exit_code == 1
+    assert "stale" in result.output.lower() or "re-run" in result.output.lower()
+    # Regression guard: the remediation hint must interpolate the actual path,
+    # not print literal `{write_path}` (mirrors timeline's clud-bug PR #36 fix).
+    assert str(target) in result.output
+    assert "{write_path}" not in result.output
+
+
+def test_file_structure_cli_check_passes_when_fresh(tmp_path, monkeypatch):
+    """--check exits 0 + says 'up to date' when on-disk matches fresh regen.
+
+    Subtlety: `write_file_structure` walks the tree, so creating
+    docs/file-structure.md itself *changes the tree* — meaning a single
+    --write on a brand-new repo isn't immediately stable. Real CI has
+    the file already committed (the v0.6.x init scaffold writes it once);
+    second invocations are then stable. To model the steady state in the
+    test, we --write twice: first creates the file, second stabilizes
+    content to reflect the file's now-present-in-tree status.
+    """
+    from click.testing import CliRunner
+
+    from logmind.cli import main as cli_main
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (tmp_path / "marker.txt").write_text("ok", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    target = docs / "file-structure.md"
+    runner = CliRunner()
+    # 1st write — creates file; tree now includes it.
+    runner.invoke(cli_main, ["file-structure", "--write", str(target)])
+    # 2nd write — stabilizes content with the file's tree presence.
+    runner.invoke(cli_main, ["file-structure", "--write", str(target)])
+    # --check now reflects steady state and should pass.
+    result = runner.invoke(
+        cli_main, ["file-structure", "--write", str(target), "--check"]
+    )
+    assert result.exit_code == 0
+    assert "up to date" in result.output
+
+
+def test_file_structure_cli_check_requires_write_path(tmp_path, monkeypatch):
+    """--check without --write is a user error (exit 2) — same shape as timeline."""
+    from click.testing import CliRunner
+
+    from logmind.cli import main as cli_main
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli_main, ["file-structure", "--check"])
+    assert result.exit_code == 2
+    assert "requires --write" in result.output.lower()


### PR DESCRIPTION
## Summary

Adds `--check` flag to `logmind file-structure`, mirroring `logmind timeline --check` (which shipped in v0.5.13). Exits non-zero when the on-disk `docs/file-structure.md` differs from a fresh regen — usable from CI, pre-commit, and `logmind doctor`.

```bash
logmind file-structure --write docs/file-structure.md --check
#   → exit 0 + "✓ up to date"  if current
#   → exit 1 + "✗ stale — re-run …" if regen would change the file
#   → exit 2 + "requires --write" if --write is missing
```

## Closes #93 — the v0.5.14 "conflict-tolerant regen merge driver" candidate

Audit during Phase D planning concluded that the original "always-fire merge driver" framing is **infeasible by git design**:

- Merge drivers only invoke on conflict — git provides no "always fire" knob
- `pre-merge-commit` hooks don't fire on GitHub server-side squash-merge (the dominant flow)

Practical coverage of the silent-success-interleave concern is already strong across multiple releases:

- **v0.5.11** post-rewrite hook (rebases + amends regen + stage)
- **v0.5.12** driver auto-install on fresh clones / CI
- **v0.5.13** `logmind rebase` convenience + doctor stale-derived warning + `logmind timeline --check`
- **v0.6.7** post-merge hook leaves regen unstaged (next `logmind log` picks up cleanly)
- `regen-timeline.yml` v3 template with `LOGMIND_AUTO_REGEN_PAT`-driven auto-fix mode (regenerates derived docs + pushes back to the PR branch when the PAT secret is configured; PAT-pushed commits re-trigger downstream checks, unlike GITHUB_TOKEN-pushed ones)

v0.6.9's `file-structure --check` completes the CI-gate symmetry. No new merge-driver mechanism shipping.

## Files changed

- `src/logmind/cli.py:2687-2752` — `file_structure_cmd`: add `--check` flag mirroring `timeline_cmd`'s implementation at cli.py:2525-2586
- `tests/test_file_structure_updates.py` — 3 new tests (`fails_when_stale`, `passes_when_fresh`, `requires_write_path`) mirroring `test_timeline.py:392-431`
- `CHANGELOG.md` — `[0.6.9]` entry with full mitigation-landscape context
- 3-spot version bump: `__init__.py`, `pyproject.toml`, `cli.py:186`

## Test plan

- [x] `pytest -q` green: 804 pass / 1 skip
- [x] Manual smoke (in tmp repo): `logmind file-structure --write docs/file-structure.md --check` returns 0 in clean state, 1 after manual edit
- [x] Existing `logmind timeline --check` behavior unchanged (no shared code modified)
- [ ] CI green (all 5 org-required checks)
- [ ] After merge: tag v0.6.9 → PyPI publish via OIDC → close #93 with the mitigation-landscape comment from this PR body

## Subtle test note

`write_file_structure` walks the tree; the act of writing `docs/file-structure.md` *changes the tree* (the file now exists). On a brand-new repo, the first `--write` produces content stale-by-the-time-it's-written; a second `--write` stabilizes. Real CI is unaffected because `docs/file-structure.md` is committed by `logmind init` — but the test for `passes_when_fresh` documents this subtlety with two `--write`s + a `--check`, mimicking steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)