### PR TITLE
v0.6.10: hook-version drift detection (tokenomics 2026-06-01 bug report)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.10] - 2026-06-01
+
+### Added — Hook-version drift detection (tokenomics 2026-06-01 bug report)
+
+The tokenomics agent flagged a recurrence of the post-merge hook
+checkout-blocking bug AFTER v0.6.9 propagation. Root cause (correctly
+diagnosed by the reporter): the local CLI binary was still v0.3.4, so
+every `logmind log` overwrote `.git/hooks/post-merge` with v0.3.4's
+body (which stages). The workflow-pin upgrade alone does NOT refresh
+local hooks; that requires a binary upgrade on the user's box.
+
+v0.6.10 makes this drift LOUDLY visible:
+
+1. **Hook bodies now embed a version marker** — every installed
+   post-merge + post-rewrite hook contains a
+   `# logmind-hook-version: <X.Y.Z>` line written by the binary that
+   created it.
+
+2. **`logmind doctor` extracts the marker** and compares to the
+   currently-running binary's `__version__`. Drift surfaces as
+   `stale` (marker version differs) or `markerless` (pre-v0.6.10
+   hook). Both are aggregated into the overall-drift signal so
+   doctor exits non-zero.
+
+3. **`install_post_merge_hook` always rewrites when the body
+   differs** — so when a user upgrades binary (v0.3.4 → v0.6.10),
+   the next `logmind log` automatically refreshes the local hook
+   to v0.6.10's body. Self-healing on first upgrade.
+
+### What this fixes vs doesn't fix
+
+- **Fixes**: future drift is loud. After upgrading to v0.6.10+,
+  `logmind doctor` always tells the user when their on-disk hook
+  is stale relative to the binary running. One-command fix:
+  `pip install --upgrade logmind && logmind log` self-heals.
+- **Doesn't fix on its own**: a user stuck at v0.3.4 today can't
+  benefit until they upgrade. The reporter's immediate remediation:
+  `PYENV_VERSION=3.11.8 pip install --upgrade logmind` then
+  `logmind log` once.
+
+### Code
+
+- `src/logmind/core/gitattributes.py` — `HOOK_VERSION_PREFIX` constant,
+  `_build_post_merge_hook_body()` + `_build_post_rewrite_hook_body()`
+  builders that inject `__version__`, new helpers
+  `installed_post_merge_hook_version` / `installed_post_rewrite_hook_version`.
+- `src/logmind/core/doctor.py` — probes now extract the marker,
+  compare versions, return `drift="stale" | "markerless" | "current"`.
+- `tests/test_merge_driver.py` — 5 new tests pinning marker shape,
+  extractor, doctor drift detection, and auto-refresh path.
+
+### Deferred to v0.6.11
+
+The full root-cause fix (skip regen when current branch is orphaned
+post-merge-away) is captured in the plan as a v0.6.11 candidate. Ships
+after v0.6.10 propagates if the doctor warning isn't enough to close
+the loop in practice.
+
 ## [0.6.9] - 2026-06-01
 
 ### Added — `logmind file-structure --check` (symmetric with `timeline --check`)

--- a/docs/decisions-branches/feat__v0.6.10-hook-drift-detection.md
+++ b/docs/decisions-branches/feat__v0.6.10-hook-drift-detection.md
@@ -1,0 +1,11 @@
+## 2026-06-01 18:16 - feat(v0.6.10): hook-version drift detection (tokenomics 2026-06-01 bug report)
+
+**Reasoning:** Tokenomics agent flagged post-merge hook checkout-blocking bug RECURRED after the v0.6.9 propagation in PR #48. They correctly diagnosed root cause: their local CLI binary is still v0.3.4, so every logmind log overwrites .git/hooks/post-merge with v0.3.4's body (which stages). The workflow-pin upgrade alone does NOT touch local hooks. v0.6.10 makes the drift LOUDLY visible: (1) hook bodies embed a # logmind-hook-version: <X.Y.Z> line; (2) doctor extracts marker + reports stale/markerless drift; (3) install_post_merge_hook auto-rewrites when marker version differs, so the next logmind log after a binary upgrade self-heals the local hook.
+
+**Alternatives considered:** Defer to v0.6.11 (orphaned-branch skip in hook) — capture root cause more aggressively but more invasive, Land a 'logmind upgrade --refresh-hooks' command — adds CLI surface area; less elegant than auto-heal
+
+**Implications:**
+- Future drift becomes loud. After v0.6.10, doctor always tells the user when their on-disk hook is stale relative to the binary running. One-command fix: pip install --upgrade logmind && logmind log.
+- Doesn't fix users stuck at pre-v0.6.10 today — only their NEXT logmind log after upgrading. Reporter's immediate remediation: PYENV_VERSION=3.11.8 pip install --upgrade logmind.
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (15 decisions)
+## 2026-06 (16 decisions)
 
-- **2026-06-01** — feat: `logmind file-structure --check` (v0.6.9 — symmetric CI gate with timeline) *(feat/file-structure-check)* — [decisions-branches/feat__file-structure-check.md](decisions-branches/feat__file-structure-check.md)
-- *... 13 more decisions ...*
+- **2026-06-01** — feat(v0.6.10): hook-version drift detection (tokenomics 2026-06-01 bug report) *(feat/v0.6.10-hook-drift-detection)* — [decisions-branches/feat__v0.6.10-hook-drift-detection.md](decisions-branches/feat__v0.6.10-hook-drift-detection.md)
+- *... 14 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.9"
+version = "0.6.10"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -183,7 +183,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.9", prog_name="logmind")
+@click.version_option(version="0.6.10", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -319,22 +319,48 @@ def _probe_post_merge_hook(project_root: Path) -> WorkflowStatus:
     the merge driver — re-regenerates derived files with the full
     post-merge tree (the driver alone can fire before all merged-in
     files are checked out, producing an incomplete regen).
+
+    v0.6.10: the hook now embeds a ``# logmind-hook-version: <X.Y.Z>``
+    marker so this probe can compare the on-disk hook's version to the
+    currently-running CLI binary's version. Drift means the user's
+    local binary that last wrote the hook is stale relative to the
+    workflow's installed version (the root cause of the tokenomics
+    2026-06-01 bug recurrence).
     """
-    from logmind.core.gitattributes import post_merge_hook_installed
+    from logmind.core.gitattributes import (
+        installed_post_merge_hook_version,
+        post_merge_hook_installed,
+    )
+    from logmind import __version__ as current_version
 
     if not (project_root / ".git").exists():
         return WorkflowStatus(
             name="post-merge hook", installed=False,
             marker=None, bundled_marker=None, drift="missing",
         )
-    if post_merge_hook_installed(project_root):
+    if not post_merge_hook_installed(project_root):
+        return WorkflowStatus(
+            name="post-merge hook", installed=False,
+            marker=None, bundled_marker=current_version, drift="missing",
+        )
+    hook_version = installed_post_merge_hook_version(project_root)
+    if hook_version is None:
+        # Pre-v0.6.10 logmind hook (no marker line). Surface as stale
+        # so the user knows to refresh — older bodies had bugs like
+        # the v0.6.7 staging issue.
         return WorkflowStatus(
             name="post-merge hook", installed=True,
-            marker="installed", bundled_marker="installed", drift="current",
+            marker="markerless (pre-v0.6.10)", bundled_marker=current_version,
+            drift="markerless",
+        )
+    if hook_version != current_version:
+        return WorkflowStatus(
+            name="post-merge hook", installed=True,
+            marker=hook_version, bundled_marker=current_version, drift="stale",
         )
     return WorkflowStatus(
-        name="post-merge hook", installed=False,
-        marker=None, bundled_marker="installed", drift="missing",
+        name="post-merge hook", installed=True,
+        marker=hook_version, bundled_marker=current_version, drift="current",
     )
 
 
@@ -490,22 +516,41 @@ def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
     `git commit --amend` (which the merge driver and post-merge hook
     don't cover), regenerating derived docs against the post-rewrite
     tree so multi-commit rebases don't leave docs/timeline.md stale.
+
+    v0.6.10: extracts the embedded hook-version marker the same way
+    :func:`_probe_post_merge_hook` does.
     """
-    from logmind.core.gitattributes import post_rewrite_hook_installed
+    from logmind.core.gitattributes import (
+        installed_post_rewrite_hook_version,
+        post_rewrite_hook_installed,
+    )
+    from logmind import __version__ as current_version
 
     if not (project_root / ".git").exists():
         return WorkflowStatus(
             name="post-rewrite hook", installed=False,
             marker=None, bundled_marker=None, drift="missing",
         )
-    if post_rewrite_hook_installed(project_root):
+    if not post_rewrite_hook_installed(project_root):
+        return WorkflowStatus(
+            name="post-rewrite hook", installed=False,
+            marker=None, bundled_marker=current_version, drift="missing",
+        )
+    hook_version = installed_post_rewrite_hook_version(project_root)
+    if hook_version is None:
         return WorkflowStatus(
             name="post-rewrite hook", installed=True,
-            marker="installed", bundled_marker="installed", drift="current",
+            marker="markerless (pre-v0.6.10)", bundled_marker=current_version,
+            drift="markerless",
+        )
+    if hook_version != current_version:
+        return WorkflowStatus(
+            name="post-rewrite hook", installed=True,
+            marker=hook_version, bundled_marker=current_version, drift="stale",
         )
     return WorkflowStatus(
-        name="post-rewrite hook", installed=False,
-        marker=None, bundled_marker="installed", drift="missing",
+        name="post-rewrite hook", installed=True,
+        marker=hook_version, bundled_marker=current_version, drift="current",
     )
 
 

--- a/src/logmind/core/gitattributes.py
+++ b/src/logmind/core/gitattributes.py
@@ -193,12 +193,6 @@ def _build_post_merge_hook_body() -> str:
     )
 
 
-# Computed lazily so that tests/agents that swap __version__ at runtime
-# pick up the change. Kept as a module-level helper for callers that
-# still expect a constant (rare; most callers use _build_post_merge_hook_body()).
-_POST_MERGE_HOOK_BODY = _build_post_merge_hook_body()
-
-
 def install_post_merge_hook(repo_root: Path) -> bool:
     """Write `.git/hooks/post-merge` to re-regenerate derived files after
     every merge. Returns True if the hook was created or updated, False
@@ -355,12 +349,6 @@ def _build_post_rewrite_hook_body() -> str:
         "  fi\n"
         "fi\n"
     )
-
-
-# Lazy-init: same pattern as the post-merge body. Computed at module load,
-# but the test suite + agents can rebuild via _build_post_rewrite_hook_body()
-# to pick up a __version__ swap.
-_POST_REWRITE_HOOK_BODY = _build_post_rewrite_hook_body()
 
 
 def install_post_rewrite_hook(repo_root: Path) -> bool:

--- a/src/logmind/core/gitattributes.py
+++ b/src/logmind/core/gitattributes.py
@@ -16,11 +16,37 @@ runs the matching ``git config`` calls every time it runs; see
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 LOGMIND_GITATTRIBUTES_START = "# >>> logmind >>>"
 LOGMIND_GITATTRIBUTES_END = "# <<< logmind <<<"
+
+# v0.6.10 — embed a version marker in every installed hook so doctor can
+# detect drift between the CLI binary that wrote the hook and the binary
+# currently running. The tokenomics agent's 2026-06-01 bug report
+# (post-merge hook still stages after v0.6.9 propagation) had the root
+# cause: their local CLI binary was v0.3.4, so every `logmind log`
+# overwrote the hook with v0.3.4's body even though the workflow pin
+# said v0.6.9. Doctor needs to read THIS marker (not just check
+# presence) to surface the drift loudly.
+HOOK_VERSION_PREFIX = "# logmind-hook-version: "
+_HOOK_VERSION_RE = re.compile(r"^# logmind-hook-version:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _current_logmind_version() -> str:
+    """Return the version string of the currently-running logmind package.
+
+    Imported lazily to avoid circular imports — `gitattributes` is loaded
+    during `logmind` package init, before `__version__` is necessarily
+    bound.
+    """
+    try:
+        from logmind import __version__
+        return __version__
+    except (ImportError, AttributeError):
+        return "unknown"
 
 # Lines that go inside the managed block. Each registers a merge driver
 # for one of logmind's derived files. The driver names match what
@@ -126,37 +152,58 @@ def configure_merge_drivers(repo_root: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 _POST_MERGE_HOOK_MARKER = "# logmind post-merge hook"
-_POST_MERGE_HOOK_BODY = """#!/bin/sh
-# logmind post-merge hook
-# Installed by `logmind init` (v0.3.0+). After every merge, regenerate
-# derived docs from the FULL post-merge working tree. Belt + suspenders
-# with the merge driver in .gitattributes — the driver fires per-file
-# during conflict resolution, before sibling non-conflicted files (e.g.
-# the merged-in branch's docs/decisions-branches/<branch>.md) are
-# checked out. This hook runs once at the end and sweeps any incomplete
-# regenerations.
-#
-# v0.6.7 bug fix: regenerate but do NOT git add. Previously the hook
-# auto-staged docs/timeline.md + docs/file-structure.md, but the
-# staged-but-uncommitted files then blocked `git checkout main` on
-# every PR cycle (post-merge fires from `git pull --rebase` after a
-# squash merge — there's no commit being constructed, so staging was
-# wrong). Leaving them as unstaged modifications lets the next
-# `logmind log` pick them up cleanly without blocking branch switches.
 
-if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
-  if [ -d docs ]; then
-    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
-    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
-  fi
-fi
-"""
+
+def _build_post_merge_hook_body() -> str:
+    """Build the canonical post-merge hook body for the current binary
+    version. The embedded ``# logmind-hook-version:`` line lets ``logmind
+    doctor`` detect drift between the CLI binary that wrote this hook
+    and the binary currently running.
+    """
+    return (
+        "#!/bin/sh\n"
+        "# logmind post-merge hook\n"
+        f"{HOOK_VERSION_PREFIX}{_current_logmind_version()}\n"
+        "# Installed by `logmind init` (v0.3.0+). After every merge, regenerate\n"
+        "# derived docs from the FULL post-merge working tree. Belt + suspenders\n"
+        "# with the merge driver in .gitattributes — the driver fires per-file\n"
+        "# during conflict resolution, before sibling non-conflicted files (e.g.\n"
+        "# the merged-in branch's docs/decisions-branches/<branch>.md) are\n"
+        "# checked out. This hook runs once at the end and sweeps any incomplete\n"
+        "# regenerations.\n"
+        "#\n"
+        "# v0.6.7 bug fix: regenerate but do NOT git add. Previously the hook\n"
+        "# auto-staged docs/timeline.md + docs/file-structure.md, but the\n"
+        "# staged-but-uncommitted files then blocked `git checkout main` on\n"
+        "# every PR cycle (post-merge fires from `git pull --rebase` after a\n"
+        "# squash merge — there's no commit being constructed, so staging was\n"
+        "# wrong). Leaving them as unstaged modifications lets the next\n"
+        "# `logmind log` pick them up cleanly without blocking branch switches.\n"
+        "#\n"
+        "# v0.6.10: the line above embeds the binary version that wrote this hook,\n"
+        "# so doctor reports stale-hook drift loudly when the user's local CLI\n"
+        "# binary is stale relative to the workflow's installed version.\n"
+        "\n"
+        "if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then\n"
+        "  if [ -d docs ]; then\n"
+        "    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true\n"
+        "    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true\n"
+        "  fi\n"
+        "fi\n"
+    )
+
+
+# Computed lazily so that tests/agents that swap __version__ at runtime
+# pick up the change. Kept as a module-level helper for callers that
+# still expect a constant (rare; most callers use _build_post_merge_hook_body()).
+_POST_MERGE_HOOK_BODY = _build_post_merge_hook_body()
 
 
 def install_post_merge_hook(repo_root: Path) -> bool:
     """Write `.git/hooks/post-merge` to re-regenerate derived files after
     every merge. Returns True if the hook was created or updated, False
-    if logmind's version was already present.
+    if logmind's version was already present at the CURRENT binary's
+    version.
 
     Refuses to overwrite a non-logmind hook (someone may have custom
     hook content; we leave it alone and let `logmind doctor` flag the
@@ -166,20 +213,23 @@ def install_post_merge_hook(repo_root: Path) -> bool:
     if not hooks_dir.exists():
         return False
     hook = hooks_dir / "post-merge"
+    body = _build_post_merge_hook_body()
     if hook.exists():
         existing = hook.read_text(encoding="utf-8", errors="ignore")
         if _POST_MERGE_HOOK_MARKER in existing:
-            # Our hook already present (or some legacy version of it).
-            # Rewrite to current canonical contents; same idempotency
-            # contract as the merge-driver git config.
-            if existing == _POST_MERGE_HOOK_BODY:
+            # Our hook (or some prior-version of it) is present. Rewrite
+            # to the current binary's canonical body. The idempotency
+            # contract: if the body byte-matches, no-op; otherwise
+            # overwrite — this handles upgrades cleanly (v0.3.x -> v0.6.10
+            # automatically refreshes the hook on the next `logmind log`).
+            if existing == body:
                 return False
-            hook.write_text(_POST_MERGE_HOOK_BODY, encoding="utf-8")
+            hook.write_text(body, encoding="utf-8")
             hook.chmod(0o755)
             return True
         # Foreign hook — don't trample.
         return False
-    hook.write_text(_POST_MERGE_HOOK_BODY, encoding="utf-8")
+    hook.write_text(body, encoding="utf-8")
     hook.chmod(0o755)
     return True
 
@@ -192,6 +242,55 @@ def post_merge_hook_installed(repo_root: Path) -> bool:
         return _POST_MERGE_HOOK_MARKER in hook.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
+
+
+def extract_hook_version(hook_path: Path) -> Optional[str]:
+    """Read ``hook_path`` and extract the embedded ``# logmind-hook-version: …``
+    marker. Returns the version string, ``None`` if no marker is present
+    (pre-v0.6.10 hooks), or ``None`` if the file is missing / unreadable.
+
+    Used by ``logmind doctor`` to surface drift between the binary that
+    wrote the hook and the binary currently running — the root cause of
+    the tokenomics agent's 2026-06-01 post-merge bug recurrence.
+    """
+    if not hook_path.exists():
+        return None
+    try:
+        content = hook_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    match = _HOOK_VERSION_RE.search(content)
+    return match.group(1) if match else None
+
+
+def installed_post_merge_hook_version(repo_root: Path) -> Optional[str]:
+    """Return the version marker embedded in ``.git/hooks/post-merge``
+    when it exists + is a logmind hook + has a v0.6.10+ marker. Returns
+    ``None`` for pre-v0.6.10 hooks (markerless), missing hooks, or
+    foreign hooks.
+    """
+    hook = repo_root / ".git" / "hooks" / "post-merge"
+    if not hook.exists():
+        return None
+    content = hook.read_text(encoding="utf-8", errors="ignore")
+    if _POST_MERGE_HOOK_MARKER not in content:
+        return None  # Foreign hook; not ours.
+    match = _HOOK_VERSION_RE.search(content)
+    return match.group(1) if match else None
+
+
+def installed_post_rewrite_hook_version(repo_root: Path) -> Optional[str]:
+    """Same as :func:`installed_post_merge_hook_version` but for the
+    post-rewrite hook.
+    """
+    hook = repo_root / ".git" / "hooks" / "post-rewrite"
+    if not hook.exists():
+        return None
+    content = hook.read_text(encoding="utf-8", errors="ignore")
+    if _POST_REWRITE_HOOK_MARKER not in content:
+        return None
+    match = _HOOK_VERSION_RE.search(content)
+    return match.group(1) if match else None
 
 
 # ---------------------------------------------------------------------------
@@ -218,40 +317,57 @@ def post_merge_hook_installed(repo_root: Path) -> bool:
 
 
 _POST_REWRITE_HOOK_MARKER = "# logmind post-rewrite hook"
-_POST_REWRITE_HOOK_BODY = """#!/bin/sh
-# logmind post-rewrite hook
-# Installed by `logmind init` (v0.5.11+). Companion to the post-merge
-# hook. Fires after `git rebase` or `git commit --amend` and
-# regenerates derived docs from the FULL post-rewrite working tree.
-#
-# Why: the merge driver in .gitattributes only fires when a merge
-# produces conflicts on the derived files. A clean rebase rewrites
-# multiple commits without ever invoking the driver — leaving
-# docs/timeline.md and docs/file-structure.md stale relative to the
-# replayed `docs/decisions-branches/<branch>.md` entries. This hook
-# sweeps the final state once and stages the regen for inclusion in
-# the user's next commit / amend cycle.
-#
-# Git invokes post-rewrite with $1 = "rebase" or "amend"; the regen
-# behaviour is identical in both, so we don't branch on $1.
 
-if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
-  if [ -d docs ]; then
-    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
-    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
-    # Stage the regens if they changed anything; user can `git commit --amend`
-    # or include in their next commit.
-    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true
-  fi
-fi
-"""
+
+def _build_post_rewrite_hook_body() -> str:
+    """Build the canonical post-rewrite hook body for the current binary
+    version. v0.6.10 embeds the binary version so doctor can detect drift
+    between the binary that wrote this hook vs the current binary.
+    """
+    return (
+        "#!/bin/sh\n"
+        "# logmind post-rewrite hook\n"
+        f"{HOOK_VERSION_PREFIX}{_current_logmind_version()}\n"
+        "# Installed by `logmind init` (v0.5.11+). Companion to the post-merge\n"
+        "# hook. Fires after `git rebase` or `git commit --amend` and\n"
+        "# regenerates derived docs from the FULL post-rewrite working tree.\n"
+        "#\n"
+        "# Why: the merge driver in .gitattributes only fires when a merge\n"
+        "# produces conflicts on the derived files. A clean rebase rewrites\n"
+        "# multiple commits without ever invoking the driver — leaving\n"
+        "# docs/timeline.md and docs/file-structure.md stale relative to the\n"
+        "# replayed `docs/decisions-branches/<branch>.md` entries. This hook\n"
+        "# sweeps the final state once and stages the regen for inclusion in\n"
+        "# the user's next commit / amend cycle.\n"
+        "#\n"
+        "# Git invokes post-rewrite with $1 = \"rebase\" or \"amend\"; the regen\n"
+        "# behaviour is identical in both, so we don't branch on $1.\n"
+        "#\n"
+        "# v0.6.10: hook-version marker embedded above for doctor drift detection.\n"
+        "\n"
+        "if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then\n"
+        "  if [ -d docs ]; then\n"
+        "    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true\n"
+        "    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true\n"
+        "    # Stage the regens if they changed anything; user can `git commit --amend`\n"
+        "    # or include in their next commit.\n"
+        "    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true\n"
+        "  fi\n"
+        "fi\n"
+    )
+
+
+# Lazy-init: same pattern as the post-merge body. Computed at module load,
+# but the test suite + agents can rebuild via _build_post_rewrite_hook_body()
+# to pick up a __version__ swap.
+_POST_REWRITE_HOOK_BODY = _build_post_rewrite_hook_body()
 
 
 def install_post_rewrite_hook(repo_root: Path) -> bool:
     """Write `.git/hooks/post-rewrite` to re-regenerate derived files
     after every rebase or `git commit --amend`. Returns True if the
     hook was created or updated, False if logmind's version was
-    already present.
+    already present at the CURRENT binary's version.
 
     Refuses to overwrite a non-logmind hook (someone may have custom
     hook content; we leave it alone and let `logmind doctor` flag the
@@ -261,17 +377,17 @@ def install_post_rewrite_hook(repo_root: Path) -> bool:
     if not hooks_dir.exists():
         return False
     hook = hooks_dir / "post-rewrite"
+    body = _build_post_rewrite_hook_body()
     if hook.exists():
         existing = hook.read_text(encoding="utf-8", errors="ignore")
         if _POST_REWRITE_HOOK_MARKER in existing:
-            if existing == _POST_REWRITE_HOOK_BODY:
+            if existing == body:
                 return False
-            hook.write_text(_POST_REWRITE_HOOK_BODY, encoding="utf-8")
+            hook.write_text(body, encoding="utf-8")
             hook.chmod(0o755)
             return True
-        # Foreign hook — don't trample.
         return False
-    hook.write_text(_POST_REWRITE_HOOK_BODY, encoding="utf-8")
+    hook.write_text(body, encoding="utf-8")
     hook.chmod(0o755)
     return True
 

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -388,3 +388,160 @@ def test_logmind_init_installs_post_rewrite_hook(git_repo: Path, monkeypatch):
         f"init output:\n{result.output}"
     )
     assert "logmind timeline --write" in hook.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# v0.6.10 — hook-version drift detection (tokenomics 2026-06-01 bug recurrence)
+#
+# Root cause we want surfaced loudly: the local CLI binary writes the hook
+# body, so if the binary is stale relative to the workflow's pinned version,
+# the hook on disk is stale too. doctor must report this as drift so the
+# user knows to upgrade + refresh.
+# ---------------------------------------------------------------------------
+
+
+def test_post_merge_hook_embeds_logmind_version_marker(git_repo: Path):
+    """v0.6.10: the installed hook body MUST embed a `# logmind-hook-version: …`
+    line so doctor can detect drift between the binary that wrote it and
+    the binary running now."""
+    from logmind import __version__ as current_version
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        install_post_merge_hook,
+    )
+
+    install_post_merge_hook(git_repo)
+    body = (git_repo / ".git" / "hooks" / "post-merge").read_text(
+        encoding="utf-8"
+    )
+    assert HOOK_VERSION_PREFIX in body, (
+        "v0.6.10: post-merge hook must embed the version marker prefix."
+    )
+    assert f"{HOOK_VERSION_PREFIX}{current_version}" in body, (
+        f"v0.6.10: marker must include the CURRENT logmind version "
+        f"({current_version}), not a stale one."
+    )
+
+
+def test_post_rewrite_hook_embeds_logmind_version_marker(git_repo: Path):
+    """Same as the post-merge test — companion hook."""
+    from logmind import __version__ as current_version
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        install_post_rewrite_hook,
+    )
+
+    install_post_rewrite_hook(git_repo)
+    body = (git_repo / ".git" / "hooks" / "post-rewrite").read_text(
+        encoding="utf-8"
+    )
+    assert HOOK_VERSION_PREFIX in body
+    assert f"{HOOK_VERSION_PREFIX}{current_version}" in body
+
+
+def test_installed_post_merge_hook_version_extracts_marker(git_repo: Path):
+    """`installed_post_merge_hook_version` returns the embedded version."""
+    from logmind import __version__ as current_version
+    from logmind.core.gitattributes import (
+        install_post_merge_hook,
+        installed_post_merge_hook_version,
+    )
+
+    assert installed_post_merge_hook_version(git_repo) is None  # No hook yet.
+    install_post_merge_hook(git_repo)
+    assert installed_post_merge_hook_version(git_repo) == current_version
+
+
+def test_doctor_reports_post_merge_hook_drift_when_binary_newer_than_hook(
+    git_repo: Path,
+):
+    """The tokenomics 2026-06-01 case in miniature: a v0.3.4 binary wrote
+    a stale hook (no marker line at all), then the user upgraded to v0.6.10.
+    Doctor must surface this as drift, not report 'current'."""
+    from logmind.core import doctor
+    from logmind.core.gitattributes import _POST_MERGE_HOOK_MARKER
+
+    # Plant a pre-v0.6.10 hook (markerless, but with our hook marker so
+    # we know it's a logmind hook, not a foreign one).
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    legacy_body = (
+        "#!/bin/sh\n"
+        f"{_POST_MERGE_HOOK_MARKER}\n"
+        "# Installed by `logmind init` (v0.3.0+).\n"
+        "logmind timeline --write docs/timeline.md\n"
+    )
+    legacy_hook = hooks_dir / "post-merge"
+    legacy_hook.write_text(legacy_body, encoding="utf-8")
+    legacy_hook.chmod(0o755)
+
+    report = doctor.collect_status(git_repo, offline=True)
+    hook_status = next(
+        w for w in report.tools[0].workflows if "post-merge" in w.name
+    )
+    assert hook_status.installed is True
+    assert hook_status.drift == "markerless", (
+        f"Doctor must surface markerless (pre-v0.6.10) hook as drift so "
+        f"the user knows to refresh. Got drift={hook_status.drift!r}."
+    )
+
+
+def test_doctor_reports_post_merge_hook_drift_when_version_marker_is_stale(
+    git_repo: Path, monkeypatch,
+):
+    """Simulate a hook written by an older v0.6.10+ binary — same prefix
+    but an older version embedded. Doctor must flag drift."""
+    from logmind.core import doctor
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        _POST_MERGE_HOOK_MARKER,
+    )
+
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    stale_body = (
+        "#!/bin/sh\n"
+        f"{_POST_MERGE_HOOK_MARKER}\n"
+        f"{HOOK_VERSION_PREFIX}0.6.7\n"   # Pretend a v0.6.7 binary wrote this.
+        "logmind timeline --write docs/timeline.md\n"
+    )
+    (hooks_dir / "post-merge").write_text(stale_body, encoding="utf-8")
+    (hooks_dir / "post-merge").chmod(0o755)
+
+    report = doctor.collect_status(git_repo, offline=True)
+    hook_status = next(
+        w for w in report.tools[0].workflows if "post-merge" in w.name
+    )
+    assert hook_status.drift == "stale"
+    assert hook_status.marker == "0.6.7"
+
+
+def test_install_post_merge_hook_refreshes_stale_marker(
+    git_repo: Path,
+):
+    """When `logmind log` (or `init`) runs and the hook on disk has a
+    stale version marker, the hook must be rewritten with the current
+    binary's body. This is the auto-self-heal path."""
+    from logmind import __version__ as current_version
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        _POST_MERGE_HOOK_MARKER,
+        install_post_merge_hook,
+        installed_post_merge_hook_version,
+    )
+
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    stale_body = (
+        "#!/bin/sh\n"
+        f"{_POST_MERGE_HOOK_MARKER}\n"
+        f"{HOOK_VERSION_PREFIX}0.6.7\n"
+        "logmind timeline --write docs/timeline.md\n"
+    )
+    hook = hooks_dir / "post-merge"
+    hook.write_text(stale_body, encoding="utf-8")
+    hook.chmod(0o755)
+
+    changed = install_post_merge_hook(git_repo)
+    assert changed is True
+    assert installed_post_merge_hook_version(git_repo) == current_version

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -487,7 +487,7 @@ def test_doctor_reports_post_merge_hook_drift_when_binary_newer_than_hook(
 
 
 def test_doctor_reports_post_merge_hook_drift_when_version_marker_is_stale(
-    git_repo: Path, monkeypatch,
+    git_repo: Path,
 ):
     """Simulate a hook written by an older v0.6.10+ binary — same prefix
     but an older version embedded. Doctor must flag drift."""


### PR DESCRIPTION
## Summary

Closes the "v0.6.9 propagation didn't fix the post-merge bug" gap reported by the tokenomics agent.

**Reporter's correct diagnosis**: their local CLI binary was still v0.3.4, so every `logmind log` overwrote `.git/hooks/post-merge` with v0.3.4's body (which stages) — even though `regen-timeline.yml` pinned `logmind==0.6.9`. The workflow-pin upgrade alone does NOT touch local hooks; that requires a binary upgrade on the user's box.

v0.6.10 makes this drift LOUDLY visible:

1. **Hook bodies embed a version marker** — every installed `post-merge` + `post-rewrite` hook contains a `# logmind-hook-version: <X.Y.Z>` line written by the binary that created it.

2. **`logmind doctor` extracts the marker** and compares to the currently-running binary's `__version__`. Drift surfaces as `stale` (marker exists but differs) or `markerless` (pre-v0.6.10 hook). Both feed into the overall-drift signal so doctor exits non-zero.

3. **`install_post_merge_hook` always rewrites when body differs**. When a user finally upgrades binary (v0.3.4 → v0.6.10), the next `logmind log` automatically refreshes the local hook to v0.6.10's body. Self-healing on first upgrade.

## What this fixes vs doesn't fix

**Fixes**: future drift is loud. After v0.6.10, doctor always tells the user when their on-disk hook is stale relative to the binary running. One-command remediation: `pip install --upgrade logmind && logmind log "any decision"` — the upgrade rewrites the binary, the next log self-heals the hook.

**Doesn't fix on its own**: a user stuck at pre-v0.6.10 today can't benefit until they upgrade. The reporter's immediate remediation: `PYENV_VERSION=3.11.8 pip install --upgrade logmind` then `logmind log` once.

## Files changed

- `src/logmind/core/gitattributes.py` — `HOOK_VERSION_PREFIX` constant + regex; `_build_post_merge_hook_body()` / `_build_post_rewrite_hook_body()` builders that inject `__version__`; new helpers `installed_post_merge_hook_version` / `installed_post_rewrite_hook_version` / `extract_hook_version`.
- `src/logmind/core/doctor.py` — probes now extract the marker, compare versions, return `drift="stale" | "markerless" | "current"`.
- `tests/test_merge_driver.py` — 5 new tests pinning marker shape, extractor, doctor drift detection, and auto-refresh path.
- `CHANGELOG.md` — `[0.6.10]` entry with full mitigation-landscape context.
- 3-spot version bump: `__init__.py`, `pyproject.toml`, `cli.py:186`.

## Test plan

- [x] `pytest -q` green: 810 pass / 1 skip
- [x] Manual smoke: planted pre-v0.6.10 hook → doctor reports `markerless`; planted v0.6.7-marker hook → doctor reports `stale` with marker=0.6.7; `install_post_merge_hook` refreshes both to current version
- [ ] CI green (all 5 org-required checks)
- [ ] After merge: tag v0.6.10 → PyPI publish → propagate to tokenomics (so they see the doctor drift warning + can refresh from there)

## Plan reference

D.0.h in `/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md` — full design context including the deferred v0.6.11 candidate (orphaned-branch skip in hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)