### PR TITLE
v0.6.11: single-quoted pin regex + self-update template uses PAT for workflow refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.11] - 2026-06-01
+
+### Fixed — Single-quoted workflow pin regex (reporulez silent-miss)
+
+`_PIN_LINE_RE` (inserter.py) + `_LOGMIND_PIN_RE` (doctor.py) only matched bare or double-quoted forms. Single-quoted pins (reporulez convention) silently returned no match → `logmind agents update --apply` reported "nothing to bump" while pins were stale. v0.6.11 widens both regexes to accept all three styles AND preserves the exact quote style on rewrite (no churn).
+
+### Fixed — `logmind-self-update.yml` template uses PAT for workflow refreshes
+
+GitHub blocks `GITHUB_TOKEN` from pushing changes to `.github/workflows/*.yml` for security. When a logmind release touches a workflow template body, the self-update auto-PR step previously failed with a cryptic 403. v5 of the template:
+- Uses `secrets.LOGMIND_AUTO_REGEN_PAT` (same PAT regen-timeline.yml v3 uses) for checkout token + push when available.
+- Falls back to `GITHUB_TOKEN` when missing — but DETECTS when the refresh touches workflow files AND emits a clear actionable `::error::` directing the user to configure the PAT.
+
+3-of-3 propagation blocker on tokenomics / agent-skills / clud-bug during the v0.6.9 cycle today; closed in v0.6.11.
+
+### Code
+
+- `src/logmind/core/inserter.py` — `_PIN_LINE_RE` widened to 5-group capture; rewrite preserves opening + closing quote styles.
+- `src/logmind/core/doctor.py` — `_LOGMIND_PIN_RE` widened (read-path only).
+- `src/logmind/templates/github/logmind-self-update.yml.template` — bumped to v5, uses `LOGMIND_AUTO_REGEN_PAT` for checkout + push.
+- `tests/test_workflow_pin_update.py` — 4 new tests pinning all three quote styles + reporulez regression guard.
+
 ## [0.6.10] - 2026-06-01
 
 ### Added — Hook-version drift detection (tokenomics 2026-06-01 bug report)

--- a/docs/decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md
+++ b/docs/decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md
@@ -1,0 +1,12 @@
+## 2026-06-01 19:15 - feat(v0.6.11): single-quoted pin regex + self-update template uses PAT for workflow refreshes
+
+**Reasoning:** Two follow-on fixes to v0.6.9 propagation issues hit today. (1) inserter.py + doctor.py pin regex didn't match reporulez-style single-quoted pins; widened to all three quote styles AND preserve exact style on rewrite. (2) logmind-self-update.yml.template v5 now uses LOGMIND_AUTO_REGEN_PAT for checkout + push (mirror of regen-timeline.yml v3) so workflow-file refreshes can propagate; falls back to GITHUB_TOKEN with clear error if PAT missing AND workflows changed.
+
+**Alternatives considered:** Wait until needed; current workarounds (manual sed for reporulez + admin merges for workflow-PR failures) work but cost time on every propagation cycle, Drop the GitHub-token-write-to-workflow-file constraint entirely by switching to a fully PAT-based bot identity — bigger architectural change, deferred to D.10 orchestrator App
+
+**Implications:**
+- Resolves the 3-of-3 propagation blocker on tokenomics + agent-skills + clud-bug from the v0.6.9 cycle today
+- Resolves the silent miss on reporulez where logmind agents update --apply returned nothing despite stale pins
+- Next ship is v0.6.12 IF auto-resolve flow ships — or proceed to D.0.h tokenomics outreach with v0.6.10 + v0.6.11 both available
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (16 decisions)
+## 2026-06 (17 decisions)
 
-- **2026-06-01** — feat(v0.6.10): hook-version drift detection (tokenomics 2026-06-01 bug report) *(feat/v0.6.10-hook-drift-detection)* — [decisions-branches/feat__v0.6.10-hook-drift-detection.md](decisions-branches/feat__v0.6.10-hook-drift-detection.md)
-- *... 14 more decisions ...*
+- **2026-06-01** — feat(v0.6.11): single-quoted pin regex + self-update template uses PAT for workflow refreshes *(feat/v0.6.11-pin-regex-and-self-update-pat)* — [decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md](decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md)
+- *... 15 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.10"
+version = "0.6.11"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.10"
+__version__ = "0.6.11"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -183,7 +183,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.10", prog_name="logmind")
+@click.version_option(version="0.6.11", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -37,7 +37,12 @@ CLUD_BUG_WORKFLOWS = (
     "clud-bug-self-update.yml",
 )
 
-_LOGMIND_PIN_RE = re.compile(r'pip install\s+"?logmind==([\d.]+)"?')
+# v0.6.11: widened to accept all three pin-quote styles seen in consumer
+# workflows — no quotes, double quotes, OR single quotes (reporulez
+# convention). The previous double-quote-only pattern silently returned
+# None on single-quoted pins, causing logmind to report "no version
+# detected" when in fact the workflow was perfectly well-pinned.
+_LOGMIND_PIN_RE = re.compile(r"""pip install\s+["']?logmind==([\d.]+)["']?""")
 _LOGMIND_MARKER_RE = re.compile(r"^# logmind-template-version:\s*(\S+)")
 _CLUD_BUG_MARKER_RE = re.compile(r"^# clud-bug-template-version:\s*(\S+)")
 # AGENTS.md ships a `<!-- logmind-block-version: vN -->` comment marking the

--- a/src/logmind/core/inserter.py
+++ b/src/logmind/core/inserter.py
@@ -215,12 +215,20 @@ LOGMIND_PIN_WORKFLOWS = (
     "check-decisions.yml",
 )
 
-# Captures the pin line: prefix up through `==` (group 1), version (group 2),
-# trailing quote (group 3). Matches both `"logmind==X.Y.Z"` and bare
-# `logmind==X.Y.Z` forms. Anchored to `pip install` so we don't false-positive
-# on a comment that happens to mention the package name + version.
+# Captures the pin line: leading quote (group 1, optional), prefix
+# `pip install <q?>logmind==` (group 2), version (group 3), trailing quote
+# (group 4, must match group 1 form). Matches three styles seen across
+# consumer repos:
+#   pip install logmind==X.Y.Z           (no quotes)
+#   pip install "logmind==X.Y.Z"         (double quotes — historic default)
+#   pip install 'logmind==X.Y.Z'         (single quotes — reporulez convention)
+#
+# v0.6.11: widened from the previous double-quote-or-bare-only pattern
+# that silently no-op'd against reporulez-style single-quoted pins.
+# Anchored to `pip install` so we don't false-positive on a comment that
+# happens to mention the package name + version.
 _PIN_LINE_RE = re.compile(
-    r'(pip install\s+"?logmind==)([\d.]+)("?)'
+    r'''(pip install\s+)(["']?)(logmind==)([\d.]+)(["']?)'''
 )
 
 
@@ -262,7 +270,7 @@ def find_outdated_workflow_pins(
         m = _PIN_LINE_RE.search(content)
         if m is None:
             continue  # no pin → nothing to update (dogfood-style installs)
-        found_version = m.group(2)
+        found_version = m.group(4)
         if found_version != current_version:
             outdated.append((wf_path, found_version, current_version))
 
@@ -284,17 +292,21 @@ def update_workflow_pin(content: str, new_version: str) -> Tuple[str, Optional[s
       - ``(content, "X.Y.Z")`` — pin already matches ``new_version``; idempotent no-op
       - ``(rewritten_content, "OLD")`` — pin bumped; old version surfaced for logging
 
+    v0.6.11: the rewrite preserves the EXACT quote style found in source
+    (none, single, or double) so we don't churn reporulez-style
+    single-quoted pins into double quotes.
+
     Idempotent: re-applying the same version is a no-op (content unchanged).
     """
     m = _PIN_LINE_RE.search(content)
     if m is None:
         return content, None
-    previous = m.group(2)
+    previous = m.group(4)
     if previous == new_version:
         return content, previous
 
     new_content = _PIN_LINE_RE.sub(
-        lambda mo: f"{mo.group(1)}{new_version}{mo.group(3)}",
+        lambda mo: f"{mo.group(1)}{mo.group(2)}{mo.group(3)}{new_version}{mo.group(5)}",
         content,
     )
     return new_content, previous

--- a/src/logmind/templates/github/logmind-self-update.yml.template
+++ b/src/logmind/templates/github/logmind-self-update.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v4
+# logmind-template-version: v5
 name: logmind self-update
 
 # Weekly check for a newer published logmind. If one exists, runs
@@ -24,12 +24,31 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # NOTE (v5 / logmind v0.6.11): there is NO `permissions:` knob that
+  # lets GITHUB_TOKEN push to .github/workflows/*.yml — GitHub blocks
+  # that at the git layer for security. When a logmind refresh would
+  # touch a workflow file (e.g. an updated `check-doc-links.yml`
+  # template body), the only path that works is to push via a PAT with
+  # the `workflow` scope. We use the SAME `LOGMIND_AUTO_REGEN_PAT`
+  # secret that `regen-timeline.yml` v3 uses for the same reason
+  # (single secret to configure, both workflows benefit).
+  # Without the PAT: this workflow falls back to non-workflow-only
+  # refreshes (AGENTS.md, .cursorrules, etc.) and prints a one-line
+  # `::warning::` directing the user to configure the PAT to unlock
+  # workflow refreshes. See the "Push step" below.
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # v5 / logmind v0.6.11: use the regen PAT when available so we
+          # can push refreshed workflow files. Falls through to
+          # GITHUB_TOKEN when absent — push works for non-workflow files
+          # but will reject any workflow-file changes (handled in the
+          # push step below).
+          token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -98,6 +117,7 @@ jobs:
           INSTALLED: ${{ steps.compare.outputs.installed }}
           LATEST:    ${{ steps.compare.outputs.latest }}
           GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          PAT:       ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
         run: |
           set -euo pipefail
           BRANCH="logmind/self-update-${LATEST}"
@@ -111,10 +131,24 @@ jobs:
           # + agent files untouched. Idempotent.
           logmind init --no-git --no-skill-install || logmind init
 
+          # v5 / logmind v0.6.11 — detect whether the refresh touched any
+          # `.github/workflows/*.yml`. If so, we NEED the PAT to push
+          # (GitHub blocks GITHUB_TOKEN from creating/updating workflow
+          # files for security). When the PAT is missing AND workflows
+          # changed, fail with a clear actionable error rather than the
+          # generic git push 403.
           git add -A
           if git diff --cached --quiet; then
             echo "::notice::No file changes after logmind init — nothing to PR."
             exit 0
+          fi
+          WORKFLOW_CHANGES=$(git diff --cached --name-only -- '.github/workflows/*.yml' '.github/workflows/*.yaml' || true)
+          if [ -n "$WORKFLOW_CHANGES" ] && [ -z "${PAT:-}" ]; then
+            echo "::error title=Missing LOGMIND_AUTO_REGEN_PAT::This release updated workflow file(s):"
+            echo "::error::$WORKFLOW_CHANGES"
+            echo "::error::GitHub blocks GITHUB_TOKEN from pushing workflow changes. Configure a fine-grained PAT with \`workflow\` scope as the \`LOGMIND_AUTO_REGEN_PAT\` repo or org secret (same secret used by regen-timeline.yml v3), then re-run this workflow."
+            echo "::error::Without the PAT, workflow-template refreshes can't propagate automatically — file the changes manually via \`logmind init\` locally + PR."
+            exit 1
           fi
           git commit -m "logmind self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -196,7 +196,7 @@ def test_shipped_template_markers_match_expected():
         "regen-timeline.yml.template": "v3",  # v0.3.4: auto-fix-with-PAT + fail-fast fallback
         "check-decisions.yml.template": "v2",
         "check-doc-links.yml.template": "v3",
-        "logmind-self-update.yml.template": "v4",
+        "logmind-self-update.yml.template": "v5",  # v0.6.11: PAT-based push for workflow refreshes
     }
     templates_dir = (
         Path(__file__).parent.parent / "src" / "logmind" / "templates" / "github"

--- a/tests/test_workflow_pin_update.py
+++ b/tests/test_workflow_pin_update.py
@@ -163,3 +163,59 @@ def test_canonical_workflow_list_matches_doctor_LOGMIND_WORKFLOWS():
         "LOGMIND_PIN_WORKFLOWS (inserter.py) must match LOGMIND_WORKFLOWS "
         "(doctor.py) — drift would surface as inconsistent reports."
     )
+
+
+# ---------------------------------------------------------------------------
+# v0.6.11 — quote-style coverage for the pin regex
+#
+# reporulez ships single-quoted pins (`pip install 'logmind==X.Y.Z'`); the
+# pre-v0.6.11 regex only matched bare or double-quoted forms, so
+# `logmind agents update --apply` silently returned "nothing to bump" on
+# reporulez during the v0.6.9 propagation cycle (manual sed required).
+# These tests pin all three styles so future regex changes don't regress.
+# ---------------------------------------------------------------------------
+
+
+def test_update_workflow_pin_handles_single_quoted_form():
+    """Single-quoted pins (`'logmind==X.Y.Z'`) are reporulez convention."""
+    content = "      run: pip install 'logmind==0.5.6'\n"
+    new_content, prev = update_workflow_pin(content, "0.6.11")
+    assert prev == "0.5.6"
+    assert new_content == "      run: pip install 'logmind==0.6.11'\n", (
+        "v0.6.11 must preserve the EXACT quote style — no churn to "
+        "double-quote on a single-quoted source."
+    )
+
+
+def test_update_workflow_pin_handles_double_quoted_form():
+    """Double-quoted pins (`\"logmind==X.Y.Z\"`) are the historic default."""
+    content = '      run: pip install "logmind==0.5.6"\n'
+    new_content, prev = update_workflow_pin(content, "0.6.11")
+    assert prev == "0.5.6"
+    assert new_content == '      run: pip install "logmind==0.6.11"\n'
+
+
+def test_update_workflow_pin_handles_bare_form():
+    """Bare pins (no quotes) also work."""
+    content = "      run: pip install logmind==0.5.6\n"
+    new_content, prev = update_workflow_pin(content, "0.6.11")
+    assert prev == "0.5.6"
+    assert new_content == "      run: pip install logmind==0.6.11\n"
+
+
+def test_find_outdated_workflow_pins_finds_single_quoted_pins(tmp_path):
+    """reporulez regression guard: single-quoted pins must be detected as
+    outdated when their version doesn't match `__version__`."""
+    from logmind import __version__ as current_version
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "regen-timeline.yml").write_text(
+        "name: x\njobs:\n  j:\n    steps:\n      - run: pip install 'logmind==0.5.6'\n",
+        encoding="utf-8",
+    )
+    outdated = find_outdated_workflow_pins(tmp_path)
+    assert len(outdated) == 1
+    path, found, target = outdated[0]
+    assert path.name == "regen-timeline.yml"
+    assert found == "0.5.6"
+    assert target == current_version


### PR DESCRIPTION
## Summary

Two follow-on fixes to v0.6.9 propagation issues hit today:

### 1. Single-quoted workflow pin regex (reporulez silent-miss)

`_PIN_LINE_RE` (inserter.py) + `_LOGMIND_PIN_RE` (doctor.py) only matched bare or double-quoted forms. Single-quoted pins (`pip install 'logmind==X.Y.Z'`, the reporulez convention) silently returned no match → `logmind agents update --apply` reported "nothing to bump" while pins were clearly stale.

v0.6.11 widens both regexes to accept all three styles (none / single / double quotes) AND **preserves the exact quote style on rewrite** (no churn from single-quote source to double-quote output).

Tests: 4 new in `tests/test_workflow_pin_update.py` pinning all three styles + reporulez regression guard.

### 2. `logmind-self-update.yml` v5 uses PAT for workflow refreshes

GitHub blocks `GITHUB_TOKEN` from pushing changes to `.github/workflows/*.yml` for security. When a logmind release ships an updated workflow template body, the self-update auto-PR previously failed with a cryptic 403 (`refusing to allow a GitHub App to create or update workflow X.yml without 'workflows' permission`).

v5 of the template:
- Uses `secrets.LOGMIND_AUTO_REGEN_PAT` (same PAT `regen-timeline.yml` v3 uses) for checkout token + push when available.
- Falls back to `GITHUB_TOKEN` when missing — but DETECTS when the refresh touches workflow files AND emits a clear actionable `::error::` directing the user to configure the PAT, rather than failing with the cryptic 403.

This was a **3-of-3 propagation blocker on tokenomics / agent-skills / clud-bug** during the v0.6.9 cycle today — every consumer with a `check-doc-links.yml` template update failed at the push step. v0.6.11 closes that loop.

## Files changed

- `src/logmind/core/inserter.py` — `_PIN_LINE_RE` widened to 5-group capture; rewrite preserves opening + closing quote styles via `mo.group(2)` + `mo.group(5)`.
- `src/logmind/core/doctor.py` — `_LOGMIND_PIN_RE` widened (read-path only).
- `src/logmind/templates/github/logmind-self-update.yml.template` — bumped to v5, uses `LOGMIND_AUTO_REGEN_PAT` for checkout + push, surfaces clear error when workflow changes need the PAT.
- `tests/test_workflow_pin_update.py` — 4 new tests.
- `tests/test_v0_2_1_audit_fixes.py` — bumped expected marker for `logmind-self-update.yml.template` from v4 → v5.
- `CHANGELOG.md` — `[0.6.11]` entry.
- 3-spot version bump: `__init__.py`, `pyproject.toml`, `cli.py:186`.

## Test plan

- [x] `pytest -q` green: 814 pass / 1 skip
- [x] Pin regex: tests cover single + double + bare quote styles; rewrite preserves style
- [ ] CI green (all 5 org-required checks)
- [ ] After merge: tag v0.6.11 → PyPI publish → re-propagate to consumers (the auto-propagation should now work cleanly, including reporulez's single-quoted pins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)