### PR TITLE
v0.6.12: doctor surfaces LOGMIND_AUTO_REGEN_PAT status proactively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.12] - 2026-06-01
+
+### Added — Proactive `LOGMIND_AUTO_REGEN_PAT` secret check in `logmind doctor`
+
+The v0.6.11 propagation cycle exposed two related PAT-misconfiguration failure modes that previously surfaced only as cryptic 403s during PR push:
+
+1. Secret entirely absent
+2. Secret present but with insufficient scopes (the reporter's case today — `Workflows: write` was missing after GitHub's fine-grained-token rollout)
+
+v0.6.12 adds a `_probe_auto_regen_pat` check to doctor that runs when a logmind workflow body references the secret. Status semantics:
+
+- **Workflow doesn't need PAT** → row is `installed=False` + `marker=None`; aggregator skips it
+- **PAT-required workflow present + secret confirmed missing** → `drift="stale"` (visible drift; doctor exits non-zero)
+- **PAT-required workflow present + secret confirmed present** → `drift="current"` (with caveat that scopes are NOT verified — surfaces required scopes in remediation text)
+- **PAT-required workflow present + can't verify** (no gh CLI, no auth, no remote) → `drift="markerless"` informational row
+
+Required scopes surfaced in `_PAT_REQUIRED_SCOPES`: Contents: write, Workflows: write, Pull-requests: write.
+
+### Plan ahead — three improvement levers for the PAT-as-UX-wart concern
+
+1. **v0.6.12** (this release) — doctor proactive check: catches users BEFORE the cryptic failure
+2. **v0.6.13 candidate** — smart workflow-skip: self-update detects "would this release touch workflow files?" If yes AND no PAT, skip + post a one-line notice. Pin-bump releases still auto-propagate even without the PAT.
+3. **D.10 `thrillmade-orchestrator[bot]` App** (the GitHub App in the Phase D plan) — App-authenticated push has `workflows: write` natively; removes the per-consumer PAT requirement entirely. Multi-week build.
+
+The v0.6.12 doctor surface + v0.6.13 smart-skip together provide the bridge UX until D.10 ships.
+
+### Code
+
+- `src/logmind/core/doctor.py` — new `_probe_auto_regen_pat` + helpers `_workflow_needs_pat`, `_detect_owner_repo`. `collect_logmind_status` appends PAT row when applicable.
+- `tests/test_merge_driver.py` — 3 new tests pinning the PAT probe's three primary states.
+- 3-spot version bump.
+
 ## [0.6.11] - 2026-06-01
 
 ### Fixed — Single-quoted workflow pin regex (reporulez silent-miss)

--- a/docs/decisions-branches/feat__v0.6.12-doctor-pat-check.md
+++ b/docs/decisions-branches/feat__v0.6.12-doctor-pat-check.md
@@ -1,0 +1,11 @@
+## 2026-06-01 21:07 - feat(v0.6.12): doctor surfaces LOGMIND_AUTO_REGEN_PAT status proactively
+
+**Reasoning:** Today's v0.6.11 propagation cycle exposed a second-order PAT failure mode: the secret existed at the org level but had insufficient scopes (missing Workflows: write after fine-grained-token migration). Manifested as cryptic 'refusing to allow workflow' 403s at push step. Doctor now proactively detects PAT-dependent workflow bodies and queries gh secret list when possible — surfaces 'missing' / 'present' / 'cannot-verify' status with the required scopes documented inline.
+
+**Alternatives considered:** Wait for D.10 GitHub App which removes PAT requirement entirely — but multi-week build, Add a runtime self-test step in the workflows that ACTIVELY exercises the PAT scope — but adds complexity + scope-checking calls
+
+**Implications:**
+- Externally-hosted consumers get a proactive heads-up before their auto-propagation breaks (the v0.6.11 cycle showed this is the dominant failure mode)
+- Plan D.0.j captures the three-lever path: v0.6.12 doctor (this) → v0.6.13 smart workflow-skip → D.10 App (removes problem entirely)
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (17 decisions)
+## 2026-06 (18 decisions)
 
-- **2026-06-01** — feat(v0.6.11): single-quoted pin regex + self-update template uses PAT for workflow refreshes *(feat/v0.6.11-pin-regex-and-self-update-pat)* — [decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md](decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md)
-- *... 15 more decisions ...*
+- **2026-06-01** — feat(v0.6.12): doctor surfaces LOGMIND_AUTO_REGEN_PAT status proactively *(feat/v0.6.12-doctor-pat-check)* — [decisions-branches/feat__v0.6.12-doctor-pat-check.md](decisions-branches/feat__v0.6.12-doctor-pat-check.md)
+- *... 16 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.11"
+version = "0.6.12"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -183,7 +183,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.11", prog_name="logmind")
+@click.version_option(version="0.6.12", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -687,13 +687,19 @@ def _probe_auto_regen_pat(project_root: Path) -> WorkflowStatus:
     try:
         secrets = json.loads(result.stdout or "[]")
         names = {s.get("name") for s in secrets}
-    except (json.JSONDecodeError, AttributeError):
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        # TypeError covers the case where `gh` returned malformed JSON
+        # that decodes to a non-iterable (e.g. a bare integer), which
+        # would otherwise crash the `for s in secrets` iteration with
+        # an uncaught TypeError and bring down `doctor`.
         names = set()
+
+    scopes_hint = ", ".join(_PAT_REQUIRED_SCOPES)
 
     if _PAT_SECRET_NAME in names:
         return WorkflowStatus(
             name=f"{_PAT_SECRET_NAME} secret", installed=True,
-            marker="present (scopes NOT verified from doctor)",
+            marker=f"present (verify scopes: {scopes_hint})",
             bundled_marker="present",
             drift="current",
         )
@@ -701,7 +707,7 @@ def _probe_auto_regen_pat(project_root: Path) -> WorkflowStatus:
     # Workflow expects the PAT; secret is confirmed missing.
     return WorkflowStatus(
         name=f"{_PAT_SECRET_NAME} secret", installed=False,
-        marker="MISSING",
+        marker=f"MISSING — configure at github.com/{owner_repo}/settings/secrets/actions/new with scopes: {scopes_hint}",
         bundled_marker="present",
         drift="stale",
     )

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -559,6 +559,154 @@ def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
     )
 
 
+# ---------------------------------------------------------------------------
+# v0.6.12 — proactive `LOGMIND_AUTO_REGEN_PAT` check
+#
+# The v0.6.11 propagation cycle exposed two related secret-misconfiguration
+# failure modes that previously surfaced as cryptic 403s during PR push:
+#   1. Secret entirely absent.
+#   2. Secret present but with insufficient scope (missing `workflows: write`
+#      and/or `contents: write` — the old PAT scopes hadn't been refreshed
+#      after GitHub's fine-grained-token rollout).
+#
+# Doctor can't read secret VALUES (would need the PAT itself), but it can:
+#   - detect that an installed workflow (regen-timeline.yml v3 OR
+#     logmind-self-update.yml v5+) DEPENDS on the secret;
+#   - probe presence via `gh secret list` when the gh CLI is available
+#     + authenticated AND the user has secret-read access;
+#   - always print the required scopes so users who hit the warning know
+#     what to configure.
+#
+# Surface as a WorkflowStatus row so it slots into the existing drift
+# aggregator + --exit-zero / overall drift handling.
+# ---------------------------------------------------------------------------
+
+
+_PAT_SECRET_NAME = "LOGMIND_AUTO_REGEN_PAT"
+_PAT_REQUIRED_SCOPES = ("Contents: write", "Workflows: write", "Pull-requests: write")
+
+
+def _workflow_needs_pat(project_root: Path) -> bool:
+    """Return True iff at least one installed workflow needs the PAT.
+
+    Today's PAT-dependent workflows:
+    - `regen-timeline.yml` v3+ (uses PAT for auto-fix push)
+    - `logmind-self-update.yml` v5+ (uses PAT for workflow-file push)
+
+    We check by looking for `LOGMIND_AUTO_REGEN_PAT` literal in each
+    candidate workflow's body — cheap + version-agnostic.
+    """
+    for name in ("regen-timeline.yml", "logmind-self-update.yml"):
+        content = _read_workflow(project_root, name)
+        if content and _PAT_SECRET_NAME in content:
+            return True
+    return False
+
+
+def _detect_owner_repo(project_root: Path) -> Optional[str]:
+    """Return ``<owner>/<repo>`` parsed from the project's git origin URL,
+    or ``None`` when no git remote / no origin / unrecognized URL shape."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, check=False, timeout=2,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    # Match both `git@github.com:owner/repo.git` and `https://github.com/owner/repo(.git)`
+    match = re.search(
+        r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$",
+        url,
+    )
+    if match is None:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def _probe_auto_regen_pat(project_root: Path) -> WorkflowStatus:
+    """v0.6.12: surface PAT-secret status proactively.
+
+    Status semantics:
+    - ``drift="missing"``: no workflow needs the PAT yet — status row is
+      `installed=False` and doctor skips reporting it as drift (the row is
+      effectively "not applicable here").
+    - ``drift="markerless"``: a workflow NEEDS the PAT but we can't tell if
+      it's configured (no gh CLI, no auth, or no remote). Informational.
+    - ``drift="stale"``: a workflow needs the PAT AND `gh secret list`
+      confirms it is NOT present. Treated as drift; doctor surfaces it.
+    - ``drift="current"``: secret is present (scope sufficiency NOT verified
+      from doctor's vantage — surface required-scopes in remediation).
+    """
+    import subprocess
+
+    if not _workflow_needs_pat(project_root):
+        return WorkflowStatus(
+            name=f"{_PAT_SECRET_NAME} secret", installed=False,
+            marker=None, bundled_marker=None, drift="missing",
+        )
+
+    owner_repo = _detect_owner_repo(project_root)
+    if owner_repo is None:
+        return WorkflowStatus(
+            name=f"{_PAT_SECRET_NAME} secret", installed=False,
+            marker="cannot-verify (no github remote)",
+            bundled_marker="present",
+            drift="markerless",
+        )
+
+    # Best-effort `gh secret list` — succeeds only when gh CLI exists
+    # AND the caller has secrets:read on the repo. Failure here is NOT
+    # an error — we report "markerless" so doctor surfaces the required
+    # remediation text without making a hard claim.
+    try:
+        result = subprocess.run(
+            ["gh", "secret", "list", "-R", owner_repo, "--json", "name"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return WorkflowStatus(
+            name=f"{_PAT_SECRET_NAME} secret", installed=False,
+            marker="cannot-verify (gh CLI unavailable)",
+            bundled_marker="present",
+            drift="markerless",
+        )
+
+    if result.returncode != 0:
+        return WorkflowStatus(
+            name=f"{_PAT_SECRET_NAME} secret", installed=False,
+            marker="cannot-verify (no secrets-read permission)",
+            bundled_marker="present",
+            drift="markerless",
+        )
+
+    try:
+        secrets = json.loads(result.stdout or "[]")
+        names = {s.get("name") for s in secrets}
+    except (json.JSONDecodeError, AttributeError):
+        names = set()
+
+    if _PAT_SECRET_NAME in names:
+        return WorkflowStatus(
+            name=f"{_PAT_SECRET_NAME} secret", installed=True,
+            marker="present (scopes NOT verified from doctor)",
+            bundled_marker="present",
+            drift="current",
+        )
+
+    # Workflow expects the PAT; secret is confirmed missing.
+    return WorkflowStatus(
+        name=f"{_PAT_SECRET_NAME} secret", installed=False,
+        marker="MISSING",
+        bundled_marker="present",
+        drift="stale",
+    )
+
+
 def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     installed = _logmind_installed_version(project_root)
     latest: Optional[str] = None
@@ -582,6 +730,10 @@ def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     workflows.append(_probe_merge_driver_config(project_root))
     workflows.append(_probe_post_merge_hook(project_root))
     workflows.append(_probe_post_rewrite_hook(project_root))
+    # v0.6.12: surface PAT secret status for repos whose workflows depend on it.
+    pat_status = _probe_auto_regen_pat(project_root)
+    if pat_status.installed or pat_status.marker is not None:
+        workflows.append(pat_status)
 
     # Drift = any installed workflow with a marker that's stale,
     # OR installed version != latest version (when both known),

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -545,3 +545,53 @@ def test_install_post_merge_hook_refreshes_stale_marker(
     changed = install_post_merge_hook(git_repo)
     assert changed is True
     assert installed_post_merge_hook_version(git_repo) == current_version
+
+
+# ---------------------------------------------------------------------------
+# v0.6.12 — LOGMIND_AUTO_REGEN_PAT secret probe (tokenomics 2026-06-01 PM
+# follow-up: PAT was already configured but had insufficient scopes; doctor
+# should now surface the dependency proactively.)
+# ---------------------------------------------------------------------------
+
+
+def test_pat_probe_returns_inapplicable_when_no_workflow_needs_it(tmp_path):
+    """If a project has no workflow that references the PAT, the probe
+    returns an `installed=False` + `marker=None` row that the aggregator
+    skips. We don't surface PAT drift on projects that don't need it."""
+    from logmind.core.doctor import _probe_auto_regen_pat
+
+    status = _probe_auto_regen_pat(tmp_path)
+    assert status.installed is False
+    assert status.marker is None
+
+
+def test_pat_probe_flags_markerless_when_workflow_present_but_no_git_remote(
+    tmp_path,
+):
+    """When a logmind workflow references the secret but the project has
+    no git remote (so we can't query secrets), the probe returns
+    `drift="markerless"` — informational, not a hard fail."""
+    from logmind.core.doctor import _probe_auto_regen_pat
+
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "regen-timeline.yml").write_text(
+        "name: x\n# uses ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}\n",
+        encoding="utf-8",
+    )
+    status = _probe_auto_regen_pat(tmp_path)
+    assert status.installed is False
+    assert status.drift == "markerless"
+    assert "cannot-verify" in (status.marker or "")
+
+
+def test_pat_required_scopes_constant_is_complete():
+    """The required-scopes string must enumerate Contents / Workflows /
+    Pull-requests writes — the exact set the regen-timeline.yml v3 and
+    logmind-self-update.yml v5 templates need."""
+    from logmind.core.doctor import _PAT_REQUIRED_SCOPES
+
+    s = " ".join(_PAT_REQUIRED_SCOPES).lower()
+    assert "contents" in s
+    assert "workflows" in s
+    assert "pull-requests" in s

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -595,3 +595,135 @@ def test_pat_required_scopes_constant_is_complete():
     assert "contents" in s
     assert "workflows" in s
     assert "pull-requests" in s
+
+
+def _make_git_repo(tmp_path):
+    """Make tmp_path look like a git repo with a github.com origin so the
+    PAT probe can run its `gh secret list` step."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:thrillmade/example-repo.git"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+
+def _write_pat_dependent_workflow(tmp_path):
+    """Drop a workflow that references the PAT, so the probe knows to look
+    up the secret."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "regen-timeline.yml").write_text(
+        "name: x\n# uses ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}\n",
+        encoding="utf-8",
+    )
+
+
+def test_pat_probe_reports_stale_when_gh_confirms_secret_missing(
+    tmp_path, monkeypatch,
+):
+    """Primary feature path: workflow needs the PAT AND `gh secret list`
+    confirms it's not configured. doctor must surface drift="stale" with
+    actionable remediation in the marker text."""
+    import subprocess
+    from logmind.core import doctor as doctor_mod
+
+    _make_git_repo(tmp_path)
+    _write_pat_dependent_workflow(tmp_path)
+
+    import subprocess as real_subprocess
+    _original_run = real_subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        # gh secret list — return an empty list (no secrets configured)
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] == "secret":
+            class R:
+                returncode = 0
+                stdout = "[]"
+                stderr = ""
+            return R()
+        # All other subprocess.run calls (git operations, etc.) pass through.
+        return _original_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    status = doctor_mod._probe_auto_regen_pat(tmp_path)
+    assert status.drift == "stale"
+    assert "MISSING" in (status.marker or "")
+    # Remediation must embed both the URL pattern AND the required scopes
+    # — otherwise a user hitting this row doesn't know what to configure.
+    marker = status.marker or ""
+    assert "thrillmade/example-repo" in marker, (
+        f"marker must include repo URL for one-click remediation. Got: {marker!r}"
+    )
+    assert "Contents: write" in marker
+    assert "Workflows: write" in marker
+    assert "Pull-requests: write" in marker
+
+
+def test_pat_probe_reports_current_when_gh_confirms_secret_present(
+    tmp_path, monkeypatch,
+):
+    """Mirror test: workflow needs PAT and gh secret list confirms presence."""
+    import subprocess
+    from logmind.core import doctor as doctor_mod
+
+    _make_git_repo(tmp_path)
+    _write_pat_dependent_workflow(tmp_path)
+
+    import subprocess as real_subprocess
+    _original_run = real_subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] == "secret":
+            class R:
+                returncode = 0
+                stdout = '[{"name":"LOGMIND_AUTO_REGEN_PAT"},{"name":"OTHER"}]'
+                stderr = ""
+            return R()
+        return _original_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    status = doctor_mod._probe_auto_regen_pat(tmp_path)
+    assert status.drift == "current"
+    assert status.installed is True
+    # Even on "current", the marker MUST surface the required scopes so
+    # users know to verify the existing token is properly scoped — today's
+    # tokenomics case had the secret present but under-scoped.
+    marker = status.marker or ""
+    assert "Contents: write" in marker
+    assert "Workflows: write" in marker
+    assert "Pull-requests: write" in marker
+
+
+def test_pat_probe_tolerates_malformed_gh_json(tmp_path, monkeypatch):
+    """Defensive: if `gh secret list --json name` returns a bare integer
+    (or any non-list), the iteration must not crash. Should fall through
+    to "missing"."""
+    import subprocess
+    from logmind.core import doctor as doctor_mod
+
+    _make_git_repo(tmp_path)
+    _write_pat_dependent_workflow(tmp_path)
+
+    import subprocess as real_subprocess
+    _original_run = real_subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] == "secret":
+            class R:
+                returncode = 0
+                stdout = "42"  # Malformed: a bare JSON integer.
+                stderr = ""
+            return R()
+        return _original_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    # Must not raise TypeError; should fall through to "missing" since the
+    # set of recognized secret names is empty.
+    status = doctor_mod._probe_auto_regen_pat(tmp_path)
+    assert status.drift == "stale"
+    assert "MISSING" in (status.marker or "")


### PR DESCRIPTION
## Summary

The v0.6.11 propagation cycle today exposed a sneaky second-order PAT failure mode: the secret existed at the org level but had **insufficient scopes** (missing \`Workflows: write\` after the fine-grained-token migration). Manifests as cryptic \`refusing to allow a GitHub App to create or update workflow\` 403s at the push step — the user has no clear remediation hint.

v0.6.12 adds a \`_probe_auto_regen_pat\` check to \`logmind doctor\` that runs whenever a logmind workflow body references \`LOGMIND_AUTO_REGEN_PAT\`. Status semantics:

| State | When | Drift class |
|---|---|---|
| **(no probe)** | Project has no workflow that uses the PAT (the dominant default case for fresh projects) | row skipped — no false positive |
| \`drift="markerless"\` | Workflow uses the PAT but we can't verify (no gh CLI, no remote, no permission) | informational |
| \`drift="stale"\` | Workflow uses the PAT AND \`gh secret list\` confirms it is NOT present | surfaces as drift; doctor exits non-zero |
| \`drift="current"\` | Workflow uses the PAT AND \`gh secret list\` confirms the secret name is present (scope sufficiency NOT verified — surfaces required scopes in remediation text) | clean |

Required scopes surfaced for users: \`Contents: write\`, \`Workflows: write\`, \`Pull-requests: write\`.

## Why doctor can't fully verify scope sufficiency

Doctor runs on the user's box; it has no access to the PAT VALUE (would need to be exfiltrated from the secret store to test it). The only true scope test is actually USING the token, which doctor can't do safely. So v0.6.12 catches "secret entirely missing" but leaves "secret present but under-scoped" to surface during actual workflow runs (via the v5 self-update template's clear \`::error::\`).

## Improvement-lever path (captured in plan D.0.j)

1. **v0.6.12** (this PR) — doctor proactive PAT-presence check
2. **v0.6.13 candidate** — smart workflow-skip: self-update detects "would this release touch any workflow file?" → if no PAT AND yes workflows touched, skip + post a one-line notice; pin-bump releases propagate normally even without the PAT
3. **D.10 \`thrillmade-orchestrator[bot]\` App** — long-term: App-authenticated push has \`workflows: write\` natively; removes the entire PAT-as-UX-wart class

## Files changed

- \`src/logmind/core/doctor.py\` — new \`_probe_auto_regen_pat\` + helpers; appended to workflow drift report
- \`tests/test_merge_driver.py\` — 3 new tests
- \`CHANGELOG.md\` — \`[0.6.12]\` entry
- 3-spot version bump

## Test plan

- [x] \`pytest -q\` green: 817 pass / 1 skip
- [x] Manual smoke: \`logmind doctor\` in tokenomics (where v5 templates now installed) reports the PAT row correctly
- [ ] CI green
- [ ] After merge: tag v0.6.12 → PyPI publish → consumers pick up the doctor surface on next propagation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)