### PR TITLE
v0.6.14: propagation-pipeline polish — doctor content-diff + [skip-logmind] auto-title + PyPI CDN retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.14] - 2026-06-02
+
+Three propagation-pipeline polish fixes surfaced during the v0.6.13 cycle (2026-06-02). All three address pain points that required manual intervention during v0.6.13 propagation and that the workflow should handle structurally going forward.
+
+### Fixed — Doctor content-diff for installed hooks (issue #112 addendum)
+
+`logmind doctor` now content-diffs installed `.git/hooks/post-merge` (and `post-rewrite`) bytes against the bundled canonical body, in addition to the v0.6.10 version-marker equality check. Closes the failure mode the tokenomics reporter flagged in the #112 addendum: "doctor's check is too cheap a signal" — if the hook drifts after install while preserving the marker line (manual edit, clobber-then-restore by another tool, marker-propagation bug), the v0.6.10 check would still report `current` while the body is genuinely stale.
+
+v0.6.14: marker equality stays as the cheap fast-path; the content-diff is the expensive correctness check that fires when it matters. Drift surfaces as `STALE (content drift)` with the existing "reinstall via `logmind self-update`" remediation pointer.
+
+Files: `src/logmind/core/doctor.py` (`_probe_post_merge_hook` + `_probe_post_rewrite_hook`); `tests/test_merge_driver.py` (new content-drift and byte-identical tests).
+
+### Fixed — `logmind-self-update.yml` v7: `[skip-logmind]` PR title prefix
+
+Bot-generated propagation PRs from `logmind-self-update.yml` are by-definition NOT decision commits — they're pin-bumps + template body refreshes owned by the workflow itself. v0.6.13 propagation surfaced this as a consistent failure: consumer-repo `check-decisions.yml` failed every PR because the diff exceeded the 20-line threshold AND no decision file was present. The fix required manually editing each PR title to include `[skip-logmind]` (the existing maintainer-override path) + closing and reopening the PR to re-fire the title-cached check-decisions workflow.
+
+v0.6.14: the self-update template now sets `[skip-logmind] logmind self-update: X.Y.Z → A.B.C` as both the commit message AND the `gh pr create --title` at workflow creation time. Eliminates the manual editing + close+reopen ritual entirely.
+
+Files: `src/logmind/templates/github/logmind-self-update.yml.template` (bumped to v7); `tests/test_v0_2_1_audit_fixes.py` (new test + marker bump).
+
+### Fixed — `logmind-self-update.yml` v7: PyPI CDN-aware retry
+
+The version-check step polls the PyPI simple/ index OR JSON API to find the latest published `logmind`. Both propagate via a CDN that lags 30-60s behind a publish event. Cron-triggered self-update workflows can fire during the gap, see "Latest: <previous version>", and silently no-op. Hit on v0.6.12 (1/5 propagations) and v0.6.13 (1/5 propagations).
+
+v0.6.14: wraps the version-check in a 3-attempt exponential backoff (0s → 30s → 60s). If all 3 see the same version, accept and proceed as today (legitimate no-op). If any sees a higher version, use it. Adds 0-90s to worst-case workflow runtime; eliminates the silent-skip class of bug.
+
+Files: same template; same test file.
+
+### Validation gate end-to-end
+
+After v0.6.14 propagates through all 5 thrillmade consumer repos, the next release cycle (v0.6.15+) should:
+- 5/5 consumers' self-update workflows pin-bump-only releases succeed first attempt with NO manual title editing, NO close+reopen rituals, NO CDN-race silent-skips
+- doctor on any repo with a hand-edited or drifted hook body reports `STALE (content drift)` with the `logmind self-update` remediation pointer
+
 ## [0.6.13] - 2026-06-01
 
 Four consumer-product UX fixes accumulated from the 2026-06-01 propagation cycle. All four ship together.

--- a/docs/decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md
+++ b/docs/decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md
@@ -10,3 +10,14 @@
 - v6 template's gh pr create PAT fix (shipped in v0.6.13) + v7 template's [skip-logmind] + CDN retry compose at v0.6.15 propagation
 
 ---
+## 2026-06-01 23:56 - test(v0.6.14): add post-rewrite content-drift symmetry tests (clud-bug-review PR #115 thread)
+
+**Reasoning:** clud-bug-review on PR #115 surfaced that v0.6.14 added content-diff to both _probe_post_merge_hook AND _probe_post_rewrite_hook but only the post-merge probe had test coverage. A copy-paste error in the post-rewrite path (wrong builder, wrong hook filename) would have been invisible. Added symmetric tests: test_doctor_reports_post_rewrite_content_drift_when_body_differs and test_doctor_reports_post_rewrite_current_when_marker_and_body_match. Discipline: every clud-bug-review citation must resolve before merge (dogfood rule).
+
+**Alternatives considered:** Resolve the thread without adding tests — would be cheating the dogfood rule on the very first PR we apply it to, Wave the symmetry away as obvious — but the bug is exactly the kind that's invisible without a test
+
+**Implications:**
+- Sets precedent: clud-bug-review feedback resolves with code + tests, not just thread-resolution
+- Test count rises 826 → 828; all green
+
+---

--- a/docs/decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md
+++ b/docs/decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md
@@ -1,0 +1,12 @@
+## 2026-06-01 23:09 - feat(v0.6.14): propagation-pipeline polish — doctor content-diff + [skip-logmind] auto-title + PyPI CDN retry
+
+**Reasoning:** Three follow-up fixes from v0.6.13 propagation friction. (a) doctor.py: content-diff against bundled hook body when marker matches — closes the #112-addendum 'too cheap a signal' meta-concern; catches drift where bytes differ but marker line is preserved (manual edits, clobber-then-restore, marker-propagation bugs). (b) self-update template v7: prefixes both git commit -m and gh pr create --title with [skip-logmind] — bot-generated propagation PRs are by-definition not decision commits; eliminates the manual title-edit + close+reopen ritual that v0.6.13 required for all 5/5 consumers. (c) self-update template v7: 3-attempt CDN-aware retry on the PyPI version-check (0/30/60s backoff) — closes the silent-skip class where workflow polls during PyPI CDN propagation lag and sees stale 'latest' (hit v0.6.12 1/5 + v0.6.13 1/5). Per the plan's v0.6.14 NEXT slot.
+
+**Alternatives considered:** Fold logmind upgrade self-dispatch into v0.6.14 — deferred to v0.6.15 alongside brew-first README and v1.0-TS-rewrite plan, Wait for D.10 orchestrator App to subsume entire propagation friction class — multi-week vs 1 day
+
+**Implications:**
+- Doctor's signal becomes a TRUE staleness check, not just version marker — addresses 'too cheap' user feedback
+- Next propagation cycle (v0.6.15 → 5 consumers) should be 5/5 first-attempt with no manual title edits, no close+reopen, no silent CDN-race skips — first pure self-heal cycle since LOGMIND_AUTO_REGEN_PAT scope upgrade
+- v6 template's gh pr create PAT fix (shipped in v0.6.13) + v7 template's [skip-logmind] + CDN retry compose at v0.6.15 propagation
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (19 decisions)
+## 2026-06 (20 decisions)
 
-- **2026-06-01** — feat(v0.6.13): 4 consumer-product UX fixes (issues #112 + #113 + propagation friction) *(feat/v0.6.13-orphan-hook-skip-log-no-self-update)* — [decisions-branches/feat__v0.6.13-orphan-hook-skip-log-no-self-update.md](decisions-branches/feat__v0.6.13-orphan-hook-skip-log-no-self-update.md)
-- *... 17 more decisions ...*
+- **2026-06-01** — feat(v0.6.14): propagation-pipeline polish — doctor content-diff + [skip-logmind] auto-title + PyPI CDN retry *(feat/v0.6.14-doctor-content-diff-and-skip-logmind-title)* — [decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md](decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md)
+- *... 18 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (20 decisions)
+## 2026-06 (21 decisions)
 
-- **2026-06-01** — feat(v0.6.14): propagation-pipeline polish — doctor content-diff + [skip-logmind] auto-title + PyPI CDN retry *(feat/v0.6.14-doctor-content-diff-and-skip-logmind-title)* — [decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md](decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md)
-- *... 18 more decisions ...*
+- **2026-06-01** — test(v0.6.14): add post-rewrite content-drift symmetry tests (clud-bug-review PR #115 thread) *(feat/v0.6.14-doctor-content-diff-and-skip-logmind-title)* — [decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md](decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md)
+- *... 19 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.13"
+version = "0.6.14"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.13"
+__version__ = "0.6.14"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -183,7 +183,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.13", prog_name="logmind")
+@click.version_option(version="0.6.14", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -363,6 +363,24 @@ def _probe_post_merge_hook(project_root: Path) -> WorkflowStatus:
             name="post-merge hook", installed=True,
             marker=hook_version, bundled_marker=current_version, drift="stale",
         )
+    # v0.6.14 / issue #112 addendum: marker equality is the cheap fast-path,
+    # but content can drift while the marker line is preserved (manual edits,
+    # clobber-then-restore by another tool, bug in marker propagation).
+    # Diff installed bytes vs bundled body; report stale when they differ.
+    from logmind.core.gitattributes import _build_post_merge_hook_body
+    bundled_body = _build_post_merge_hook_body()
+    try:
+        installed_body = (project_root / ".git" / "hooks" / "post-merge").read_text(
+            encoding="utf-8", errors="ignore"
+        )
+    except OSError:
+        installed_body = bundled_body  # fall through to current
+    if installed_body != bundled_body:
+        return WorkflowStatus(
+            name="post-merge hook", installed=True,
+            marker=f"{hook_version} (content drift)",
+            bundled_marker=current_version, drift="stale",
+        )
     return WorkflowStatus(
         name="post-merge hook", installed=True,
         marker=hook_version, bundled_marker=current_version, drift="current",
@@ -552,6 +570,21 @@ def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
         return WorkflowStatus(
             name="post-rewrite hook", installed=True,
             marker=hook_version, bundled_marker=current_version, drift="stale",
+        )
+    # v0.6.14: same content-diff fallback as the post-merge probe.
+    from logmind.core.gitattributes import _build_post_rewrite_hook_body
+    bundled_body = _build_post_rewrite_hook_body()
+    try:
+        installed_body = (project_root / ".git" / "hooks" / "post-rewrite").read_text(
+            encoding="utf-8", errors="ignore"
+        )
+    except OSError:
+        installed_body = bundled_body
+    if installed_body != bundled_body:
+        return WorkflowStatus(
+            name="post-rewrite hook", installed=True,
+            marker=f"{hook_version} (content drift)",
+            bundled_marker=current_version, drift="stale",
         )
     return WorkflowStatus(
         name="post-rewrite hook", installed=True,

--- a/src/logmind/templates/github/logmind-self-update.yml.template
+++ b/src/logmind/templates/github/logmind-self-update.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v6
+# logmind-template-version: v7
 name: logmind self-update
 
 # Weekly check for a newer published logmind. If one exists, runs
@@ -88,11 +88,31 @@ jobs:
               || echo "")
           fi
 
-          LATEST=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true
-          if [ -z "$LATEST" ]; then
-            # Fallback: PyPI JSON API
-            LATEST=$(curl -fsSL https://pypi.org/pypi/logmind/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])")
-          fi
+          # v7 / logmind v0.6.14 — CDN-aware retry. The PyPI JSON API + simple
+          # index propagate via a CDN that lags 30-60s behind a publish event.
+          # Cron-triggered self-update workflows can fire during the gap and
+          # see a stale "latest", silently no-op'ing. Three attempts with 0s
+          # / 30s / 60s backoff cover the typical CDN tail; if all three
+          # report the same version, accept it (legitimate no-op).
+          fetch_latest() {
+            local v
+            v=$(pip index versions logmind 2>/dev/null | grep -oE 'logmind \([0-9]+\.[0-9]+\.[0-9]+\)' | head -1 | sed 's/logmind (\(.*\))/\1/') || true
+            if [ -z "$v" ]; then
+              v=$(curl -fsSL https://pypi.org/pypi/logmind/json 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null) || true
+            fi
+            echo "$v"
+          }
+          LATEST=$(fetch_latest)
+          for delay in 30 60; do
+            if [ -n "$LATEST" ] && [ "$LATEST" != "$INSTALLED" ]; then
+              break  # found a newer version on attempt 1 or 2
+            fi
+            sleep "$delay"
+            CANDIDATE=$(fetch_latest)
+            if [ -n "$CANDIDATE" ]; then
+              LATEST="$CANDIDATE"
+            fi
+          done
 
           echo "installed=$INSTALLED" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST"       >> "$GITHUB_OUTPUT"
@@ -151,7 +171,15 @@ jobs:
             echo "::notice::OR: skip this release by running \`logmind init\` locally and opening a PR manually."
             exit 0
           fi
-          git commit -m "logmind self-update: ${INSTALLED} → ${LATEST}"
+          # v7 / logmind v0.6.14 — `[skip-logmind]` title prefix. These are
+          # bot-generated propagation PRs (pin-bump + template-body refresh)
+          # owned by the workflow itself; they're NOT decision commits.
+          # Without the prefix, consumer-repo `check-decisions.yml` fails
+          # because the diff exceeds the threshold AND no decision file is
+          # present. The prefix lets consumer-repo check-decisions skip via
+          # its existing maintainer-override path. Bot-PR semantics align
+          # with consumer-repo gates without manual title editing rituals.
+          git commit -m "[skip-logmind] logmind self-update: ${INSTALLED} → ${LATEST}"
           git push -u origin "$BRANCH"
           # v6 / logmind v0.6.13 — `gh pr create` uses PAT too when available.
           # Per-repo "Allow GitHub Actions to create and approve pull
@@ -161,7 +189,7 @@ jobs:
           # this step too eliminates the second per-repo setup checkbox.
           PR_TOKEN="${PAT:-${GH_TOKEN}}"
           GH_TOKEN="$PR_TOKEN" gh pr create \
-            --title "logmind self-update: ${INSTALLED} → ${LATEST}" \
+            --title "[skip-logmind] logmind self-update: ${INSTALLED} → ${LATEST}" \
             --body "Automated upgrade from logmind ${INSTALLED} → ${LATEST}.
 
           Refresh mode (v0.2.1+) only touched workflow templates whose \`# logmind-template-version:\` marker is stale; \`docs/\`, \`.logmind/config.yml\`, and agent files were left alone.

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -817,3 +817,59 @@ def test_doctor_reports_current_when_marker_and_body_both_match(git_repo: Path):
         f"Expected freshly-installed hook to be current; got drift={status.drift!r} "
         f"marker={status.marker!r}"
     )
+
+
+def test_doctor_reports_post_rewrite_content_drift_when_body_differs(
+    git_repo: Path,
+):
+    """v0.6.14 / clud-bug-review PR #115 thread: post-rewrite probe must
+    have symmetric content-diff test to post-merge. A copy-paste error
+    (wrong builder function, wrong hook path) would be invisible without
+    this. Guards the post-rewrite probe path that uses
+    `_build_post_rewrite_hook_body()` + `.git/hooks/post-rewrite`.
+    """
+    from logmind import __version__ as current_version
+    from logmind.core.doctor import _probe_post_rewrite_hook
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        _POST_REWRITE_HOOK_MARKER,
+    )
+
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    drifted_body = (
+        "#!/bin/sh\n"
+        f"{_POST_REWRITE_HOOK_MARKER}\n"
+        f"{HOOK_VERSION_PREFIX}{current_version}\n"
+        "# Manually edited by user — added a comment that bundled body doesn't have.\n"
+        "echo 'this is not the bundled body' >/dev/null\n"
+    )
+    hook = hooks_dir / "post-rewrite"
+    hook.write_text(drifted_body, encoding="utf-8")
+    hook.chmod(0o755)
+
+    status = _probe_post_rewrite_hook(git_repo)
+    assert status.drift == "stale", (
+        f"Expected post-rewrite content-drift to be reported as stale; "
+        f"got drift={status.drift!r}"
+    )
+    assert "content drift" in (status.marker or ""), (
+        f"Expected post-rewrite marker to indicate content drift; "
+        f"got marker={status.marker!r}"
+    )
+
+
+def test_doctor_reports_post_rewrite_current_when_marker_and_body_match(
+    git_repo: Path,
+):
+    """v0.6.14 sanity for post-rewrite (symmetric to post-merge):
+    freshly-installed hook is byte-identical to bundled body → `current`."""
+    from logmind.core.doctor import _probe_post_rewrite_hook
+    from logmind.core.gitattributes import install_post_rewrite_hook
+
+    install_post_rewrite_hook(git_repo)
+    status = _probe_post_rewrite_hook(git_repo)
+    assert status.drift == "current", (
+        f"Expected freshly-installed post-rewrite hook to be current; "
+        f"got drift={status.drift!r} marker={status.marker!r}"
+    )

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -761,3 +761,59 @@ def test_post_merge_hook_body_embeds_orphan_branch_skip_logic():
         "v0.6.13 issue #112: post-merge hook must SKIP regen (exit 0) on "
         "orphan-branch detection, not fall through."
     )
+
+
+def test_doctor_reports_content_drift_when_marker_matches_but_body_differs(
+    git_repo: Path,
+):
+    """v0.6.14 / issue #112 addendum: marker-equality is the cheap fast-path,
+    but doctor must ALSO content-diff bytes against the bundled body so it
+    catches drift where marker is preserved but the hook body has been
+    manually edited (or clobbered + partially restored by another tool).
+    Without this, doctor reports `current` while the hook is genuinely
+    stale, masking the real bug.
+    """
+    from logmind import __version__ as current_version
+    from logmind.core.doctor import _probe_post_merge_hook
+    from logmind.core.gitattributes import (
+        HOOK_VERSION_PREFIX,
+        _POST_MERGE_HOOK_MARKER,
+    )
+
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    # Construct a hook body that has the CURRENT marker (so marker check
+    # passes) but content that differs from the bundled body.
+    drifted_body = (
+        "#!/bin/sh\n"
+        f"{_POST_MERGE_HOOK_MARKER}\n"
+        f"{HOOK_VERSION_PREFIX}{current_version}\n"
+        "# Manually edited by user — added a comment that bundled body doesn't have.\n"
+        "echo 'this is not the bundled body' >/dev/null\n"
+    )
+    hook = hooks_dir / "post-merge"
+    hook.write_text(drifted_body, encoding="utf-8")
+    hook.chmod(0o755)
+
+    status = _probe_post_merge_hook(git_repo)
+    assert status.drift == "stale", (
+        f"Expected content-drift to be reported as stale; got drift={status.drift!r}"
+    )
+    assert "content drift" in (status.marker or ""), (
+        f"Expected marker to indicate content drift; got marker={status.marker!r}"
+    )
+
+
+def test_doctor_reports_current_when_marker_and_body_both_match(git_repo: Path):
+    """v0.6.14 sanity: doctor reports `current` when the installed hook
+    is BYTE-IDENTICAL to the bundled body. Guards against false-positive
+    drift reports."""
+    from logmind.core.doctor import _probe_post_merge_hook
+    from logmind.core.gitattributes import install_post_merge_hook
+
+    install_post_merge_hook(git_repo)  # writes canonical body
+    status = _probe_post_merge_hook(git_repo)
+    assert status.drift == "current", (
+        f"Expected freshly-installed hook to be current; got drift={status.drift!r} "
+        f"marker={status.marker!r}"
+    )

--- a/tests/test_v0_2_1_audit_fixes.py
+++ b/tests/test_v0_2_1_audit_fixes.py
@@ -196,7 +196,7 @@ def test_shipped_template_markers_match_expected():
         "regen-timeline.yml.template": "v3",  # v0.3.4: auto-fix-with-PAT + fail-fast fallback
         "check-decisions.yml.template": "v2",
         "check-doc-links.yml.template": "v3",
-        "logmind-self-update.yml.template": "v6",  # v0.6.13: smart workflow-skip + PAT for gh pr create
+        "logmind-self-update.yml.template": "v7",  # v0.6.14: [skip-logmind] title prefix + CDN-aware retry
     }
     templates_dir = (
         Path(__file__).parent.parent / "src" / "logmind" / "templates" / "github"
@@ -243,6 +243,78 @@ def test_self_update_template_no_unescaped_backticks_in_notice():
             assert i > 0 and line[i - 1] == "\\", (
                 f"unescaped backtick at column {i}: {line!r}"
             )
+
+
+def test_self_update_template_prefixes_pr_title_with_skip_logmind():
+    """v0.6.14 fix: bot-generated propagation PRs are NOT decision commits,
+    so consumer-repo `check-decisions.yml` shouldn't gate on them. The
+    self-update template now prefixes BOTH the git commit message AND the
+    `gh pr create --title` with `[skip-logmind] ` so the existing
+    maintainer-override path in check-decisions skips them automatically.
+    Without this, every propagation PR requires a manual title edit + a
+    close+reopen ritual (which was the workflow during v0.6.13 propagation
+    until the title-fix sequence was hand-applied)."""
+    template = (
+        Path(__file__).parent.parent
+        / "src"
+        / "logmind"
+        / "templates"
+        / "github"
+        / "logmind-self-update.yml.template"
+    ).read_text(encoding="utf-8")
+
+    # Both must include the [skip-logmind] prefix.
+    assert '[skip-logmind] logmind self-update' in template, (
+        "v0.6.14: self-update template must prefix titles with `[skip-logmind] ` "
+        "so consumer-repo check-decisions skips on bot-generated propagation PRs"
+    )
+    # Specifically: the gh pr create --title line must use it.
+    pr_create_title_lines = [
+        ln for ln in template.splitlines()
+        if "--title" in ln and "logmind self-update" in ln
+    ]
+    assert pr_create_title_lines, "expected to find a --title line with logmind self-update"
+    for ln in pr_create_title_lines:
+        assert "[skip-logmind]" in ln, (
+            f"every `--title` line referencing logmind self-update must include "
+            f"the [skip-logmind] prefix; missing in: {ln.strip()}"
+        )
+    # And the git commit -m line must use it.
+    commit_lines = [
+        ln for ln in template.splitlines()
+        if "git commit -m" in ln and "logmind self-update" in ln
+    ]
+    assert commit_lines, "expected git commit -m line"
+    for ln in commit_lines:
+        assert "[skip-logmind]" in ln, (
+            f"git commit message must include [skip-logmind] prefix; missing in: {ln.strip()}"
+        )
+
+
+def test_self_update_template_includes_pypi_cdn_retry_loop():
+    """v0.6.14 fix: the PyPI version-check step now retries with backoff
+    (0/30/60s) to ride out the 30-60s CDN sync lag between publish and
+    simple/-index availability. Hit on v0.6.12 (1/5 propagations) and
+    v0.6.13 (1/5) where the workflow saw the prior version and silently
+    no-op'd. Without the retry, every release has a coin-flip chance of
+    one or more consumer repos silently skipping."""
+    template = (
+        Path(__file__).parent.parent
+        / "src"
+        / "logmind"
+        / "templates"
+        / "github"
+        / "logmind-self-update.yml.template"
+    ).read_text(encoding="utf-8")
+    # The retry block defines a fetch helper and loops with sleep.
+    assert "fetch_latest" in template, (
+        "v0.6.14: CDN-aware retry requires a fetch_latest helper that wraps "
+        "pip index + curl fallback"
+    )
+    assert "sleep" in template and 'for delay in 30 60' in template, (
+        "v0.6.14: CDN-aware retry must use 0/30/60s backoff (sleep with "
+        "30 + 60 second intervals on attempts 2 and 3)"
+    )
 
 
 def test_self_update_template_uses_grep_not_pyyaml():


### PR DESCRIPTION
## Summary

Three follow-up fixes from the v0.6.13 propagation cycle. All three address pain points that required manual intervention during that cycle and should be handled structurally going forward.

### (a) Issue #112 addendum — Doctor content-diff for installed hooks

`logmind doctor` now content-diffs installed \`.git/hooks/post-merge\` (and \`post-rewrite\`) bytes against the bundled canonical body, in addition to the v0.6.10 version-marker equality check.

Closes the "too cheap a signal" meta-concern: if the hook drifts after install while preserving the marker line (manual edit, clobber-then-restore by another tool, marker-propagation bug), v0.6.10's check still reports \`current\` while the body is genuinely stale. v0.6.14 keeps the marker check as the cheap fast-path and adds a byte-diff as the expensive correctness check that fires when it matters. Drift surfaces as \`STALE (content drift)\` with the existing remediation pointer.

### (b) Self-update template v7 — \`[skip-logmind]\` PR title prefix

Bot-generated propagation PRs from \`logmind-self-update.yml\` are by-definition NOT decision commits. v0.6.13 propagation surfaced this as a 5/5 failure: consumer-repo \`check-decisions.yml\` failed every PR (diff > threshold + no decision file). Manual workaround was edit-title + close+reopen ritual.

v7 sets the title to \`[skip-logmind] logmind self-update: X.Y.Z → A.B.C\` at workflow-creation time (both \`git commit -m\` and \`gh pr create --title\`). The existing maintainer-override path in check-decisions handles it automatically.

### (c) Self-update template v7 — PyPI CDN-aware retry

The version-check step polls PyPI simple/-index OR JSON API. Both propagate via a CDN that lags 30-60s behind a publish. Workflows fired during the gap saw stale "latest" and silently no-op'd (hit v0.6.12 1/5, v0.6.13 1/5). v7 wraps the lookup in 3-attempt exponential backoff (0/30/60s). Adds 0-90s worst-case; eliminates silent-skip class.

## Files

- \`src/logmind/core/doctor.py\` — \`_probe_post_merge_hook\` + \`_probe_post_rewrite_hook\` extended with content-diff
- \`src/logmind/templates/github/logmind-self-update.yml.template\` — bumped v6 → v7
- \`tests/test_merge_driver.py\` — two new tests (content-drift + byte-identical sanity)
- \`tests/test_v0_2_1_audit_fixes.py\` — two new template-content tests + marker bump
- 3-spot version bump (0.6.13 → 0.6.14)
- CHANGELOG \`[0.6.14]\`

## Test plan

- [x] \`pytest -q\` green: **826 passed, 1 skipped** (+4 over v0.6.13)
- [x] Scoped tests cover the new behaviors (content-drift, title-prefix, retry-loop presence)
- [ ] CI green
- [ ] After merge: tag v0.6.14 → PyPI publish → propagation cycle (paused this session — will run on next)
- [ ] Validation gate: v0.6.15 propagation should be **5/5 first-attempt with no manual title edits, no close+reopen, no silent CDN-race skips** — first pure self-heal cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)