### PR TITLE
v0.6.16: multi-branch self-heal + PATH probe + commit-msg hook + AGENTS.md v6/v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.16] - 2026-06-02
+
+Tokenomics-agent verification-report follow-up (Concerns 2/3 + dogfood enforcement + multi-branch self-heal regression). Three changes, one release — all bridge directly into the v1.0 Go rewrite parity matrix.
+
+### Fixed — multi-branch self-heal contract restored
+
+The v0.6.15 blanket default-branch skip in the post-merge hook fixed the `gh pr merge --squash --delete-branch` unstaged-docs case, but broke local-merge regen on main. Concrete failure mode: when agent A merges `feat/agent-a` locally and agent B merges `feat/agent-b` against the same main, the merge driver fires for `docs/timeline.md` with a partial working tree (B's `decisions-branches/feat__agent-b.md` not yet checked out), producing a timeline missing B's content. The post-merge hook was supposed to sweep — but the v0.6.15 skip made it a no-op on main, freezing the partial output.
+
+v0.6.16 tightens the skip: instead of "skip whenever current branch == default," the hook skips only when `HEAD` already matches `origin/<default>` (the actual fast-forward / pull-up case where `regen-timeline.yml` server-side is authoritative). Local merges that introduce new commits not yet on origin run regen normally, so the working tree reflects the merged-in decision content.
+
+Surfaced by three new regression tests in `tests/test_merge_driver.py` (two-branch, three-branch, squash-then-merge variants). All exercise real `git` + `logmind` subprocess calls — no mocks. The whole dogfood loop assumes this contract holds; without it, every concurrent-PR cycle would silently lose decisions on local merges.
+
+### Added — `logmind doctor` PATH-resolution probe (Concern 3)
+
+Tokenomics-agent's 2026-06-01 recurrence had a non-obvious root cause: `logmind doctor` reported `current` for the post-merge hook, but `logmind init` (invoked from the user's shell, via PATH) was writing a v0.3.4 hook body. The discrepancy: doctor was running via `python -m logmind` (PYENV_VERSION=3.11.8 → v0.6.13), while `logmind` typed at the shell prompt resolved through the pyenv shim to an older active pyenv → v0.3.4.
+
+v0.6.16 adds `_probe_path_resolution()` in `core/doctor.py`. The probe runs `shutil.which("logmind")` + `<path> --version` and compares the resolved binary's version against the currently-running version. Drift surfaces as `stale` with a marker showing both versions + the conflicting path, so doctor exits non-zero on PATH-conflict (`Stack status: DRIFT`).
+
+### Added — commit-msg hook (dogfood enforcement)
+
+Tokenomics-session feedback "why git add instead of logmind" revealed that even with AGENTS.md guidance, agents fall back to raw `git commit` on substantive code changes. v0.6.16 adds a `commit-msg` hook installed by `logmind init` (alongside post-merge + post-rewrite) that warns when:
+
+1. Commit message's first line does NOT start with one of the exempt prefixes (`logmind:`, `Revert `, `Merge `, `Bump version`, `chore(release):`, `fixup!`, `squash!`)
+2. Staged diff exceeds 20 lines across code-bearing extensions (`.py .go .ts .tsx .js .jsx .sh .yaml .yml .toml .rs .rb`)
+
+WARN by default. STRICT mode (exits 1, rejecting the commit) when `.logmind/config.yml` contains `commit_msg_hook: strict: true`. Bypass via `git commit --no-verify` for intentional overrides. The hook reads strict mode at runtime so users flip without re-installing.
+
+### Changed — AGENTS.md template bumps + strengthened framing
+
+- `AGENTS.md.template`: v5 → v6 — heading reframed to "REQUIRED for substantive commits" + new blockquote with "DO NOT run raw `git add` / `git commit` / `git push`" warning that references the commit-msg hook
+- `AGENTS.md.slim.template`: v7-pointer → v8-pointer — same strengthening with the contract sentence preserved verbatim ("`logmind log` replaces `git add` + `git commit` + `git push`")
+
+The contract sentence stays load-bearing for `tests/test_agents_consolidation.py` discovery; new `v0.6.16` framing is additive on top.
+
+### Validation gate
+
+- `pytest -q` green: **846 passed, 1 skipped** (+17 over v0.6.15 — 3 self-heal + 9 commit-msg-hook + 5 PATH-probe).
+- After propagation: tokenomics agent's next `logmind doctor` should surface PATH-conflict if their pyenv shim still resolves to v0.3.4. Their next substantive `git commit` (without `logmind log`) will fire the warning. Multi-branch self-heal test guards regression for the v1.0 Go rewrite parity gate.
+
+### Go v1.0 parity carry-forward
+
+Every v0.6.16 change is a parity item for the Go rewrite waves:
+- B2 (hooks): port `_build_commit_msg_hook_body()` to `internal/hooks/commit_msg_body.go` with byte-identical hook body
+- B3 (timeline): port the multi-branch self-heal tests to `internal/timeline/merge_driver_test.go`
+- B4 (templates): bump embedded `AGENTS.md.template` + slim variant in `embed.FS`
+- B6 (doctor): port `_probe_path_resolution()` to `internal/doctor/probe_path.go`
+- Phase 2 convergence: cross-binary parity test (Python v0.6.16 vs Go v1.0 timeline.md byte-identical) is a release gate
+
 ## [0.6.15] - 2026-06-02
 
 Hotfix surfaced by the tokenomics agent's v0.6.14 verification cycle.

--- a/docs/decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md
+++ b/docs/decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md
@@ -1,0 +1,13 @@
+## 2026-06-02 13:38 - v0.6.16: multi-branch self-heal + PATH probe + commit-msg hook + AGENTS.md v6/v8
+
+**Reasoning:** tokenomics agent verification report Concerns 2/3 + the bug surfaced by writing the multi-branch self-heal test: v0.6.15 default-branch skip was over-aggressive, dropping decisions on local merges. v0.6.16 tightens skip to HEAD==origin/<default> (true pull-up case) + adds doctor PATH-conflict probe to surface tokenomics-style stale-binary cases + adds commit-msg hook for dogfood enforcement + bumps AGENTS.md templates with REQUIRED framing. Every change has Go v1.0 parity carry-forward mapped to B-wave waves.
+
+**Alternatives considered:** ship Concern 3 (doctor PATH) + commit-msg hook + AGENTS.md bump as separate v0.6.16/v0.6.17/v0.6.18 — rejected: bundling lets multi-branch test gate all four end-to-end in one PR; the dogfood loop validates the cohesion, revert v0.6.15 default-branch skip entirely and accept the unstaged-docs-on-main pain — rejected: v0.6.15 fix is real for the gh-pr-merge-squash pull-up case; need both behaviors, make merge driver smarter (read git index instead of working tree) — rejected: requires substantial logmind timeline rewrite + breaks the byte-identical CLI contract for the Go rewrite parity gate
+
+**Implications:**
+- consumer repos must re-run logmind init or logmind self-update to pick up the new commit-msg hook + refreshed post-merge hook body
+- AGENTS.md template auto-migrates on logmind self-update when slot 1 between markers is unchanged (existing _replace_marker_block guard)
+- Go v1.0 parity items B2/B3/B4/B6 must absorb the v0.6.16 changes; cross-binary parity test gates v1.0 release
+- PATH probe firing STALE in CI/test environments needed an autouse stub in tests/test_doctor.py — real-environment behavior unaffected
+
+---

--- a/docs/decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md
+++ b/docs/decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md
@@ -11,3 +11,13 @@
 - PATH probe firing STALE in CI/test environments needed an autouse stub in tests/test_doctor.py — real-environment behavior unaffected
 
 ---
+## 2026-06-02 14:06 - fix: address clud-bug-review threads on PR #123 (unused import + test fallback)
+
+**Reasoning:** clud-bug-review flagged two real issues: (1) sys import in _probe_path_resolution is unused — only shutil/subprocess/__version__ get referenced; (2) fake_run pass-through used real_subprocess.run.__wrapped__ which doesn't exist on a plain function, silently returning None and masking future probes that access .returncode
+
+**Alternatives considered:** leave sys import — rejected: real unused import, linter would flag eventually, use functools.wraps trick on fake_run so __wrapped__ exists — rejected: that's a hack; capturing the real run before patching is the conventional pattern
+
+**Implications:**
+- test now properly exercises real subprocess fall-through for git/gh probes that collect_status calls; new probes won't silently break this test
+
+---

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (25 decisions)
+## 2026-06 (26 decisions)
 
-- **2026-06-02** — fix(v0.6.15): unreachable || fallback in default-branch resolution (clud-bug PR #122) *(feat/v0.6.15-default-branch-hook-skip)* — [decisions-branches/feat__v0.6.15-default-branch-hook-skip.md](decisions-branches/feat__v0.6.15-default-branch-hook-skip.md)
-- *... 23 more decisions ...*
+- **2026-06-02** — v0.6.16: multi-branch self-heal + PATH probe + commit-msg hook + AGENTS.md v6/v8 *(feat/v0.6.16-doctor-path-commit-msg-hook)* — [decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md](decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md)
+- *... 24 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (26 decisions)
+## 2026-06 (27 decisions)
 
-- **2026-06-02** — v0.6.16: multi-branch self-heal + PATH probe + commit-msg hook + AGENTS.md v6/v8 *(feat/v0.6.16-doctor-path-commit-msg-hook)* — [decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md](decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md)
-- *... 24 more decisions ...*
+- **2026-06-02** — fix: address clud-bug-review threads on PR #123 (unused import + test fallback) *(feat/v0.6.16-doctor-path-commit-msg-hook)* — [decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md](decisions-branches/feat__v0.6.16-doctor-path-commit-msg-hook.md)
+- *... 25 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logmind"
-version = "0.6.15"
+version = "0.6.16"
 description = "Decision logging for AI-assisted development - automatic tracking, git integration, and context for AI agents"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/logmind/__init__.py
+++ b/src/logmind/__init__.py
@@ -1,6 +1,6 @@
 """logmind - AI decision logging system for development projects."""
 
-__version__ = "0.6.15"
+__version__ = "0.6.16"
 
 from logmind.core.logger import log
 from logmind.decorators import log_choice, log_decision

--- a/src/logmind/cli.py
+++ b/src/logmind/cli.py
@@ -14,6 +14,7 @@ from logmind.core.git_handler import commit_and_push, is_git_repo
 from logmind.core.gitattributes import (
     configure_merge_drivers,
     ensure_block as ensure_gitattributes_block,
+    install_commit_msg_hook,
     install_post_merge_hook,
     install_post_rewrite_hook,
 )
@@ -183,7 +184,7 @@ def _install_skdd_via_npx() -> None:
 
 
 @click.group()
-@click.version_option(version="0.6.15", prog_name="logmind")
+@click.version_option(version="0.6.16", prog_name="logmind")
 @click.option(
     "--quiet",
     "-q",
@@ -506,6 +507,7 @@ def init(
         configure_merge_drivers(root_path)
         install_post_merge_hook(root_path)
         install_post_rewrite_hook(root_path)
+        install_commit_msg_hook(root_path)
 
         click.echo()
         click.secho("Done. docs/ and .logmind/ left untouched.", fg="green")
@@ -631,6 +633,7 @@ def init(
         configure_merge_drivers(root_path)
         install_post_merge_hook(root_path)
         install_post_rewrite_hook(root_path)
+        install_commit_msg_hook(root_path)
 
     # Log first decision
     log_first_decision(docs_path)
@@ -2907,6 +2910,7 @@ def self_update_cmd():
         current binary's body (closes the v0.6.10 drift loop)
     """
     from logmind.core.gitattributes import (
+        install_commit_msg_hook,
         install_post_merge_hook,
         install_post_rewrite_hook,
     )
@@ -2923,6 +2927,8 @@ def self_update_cmd():
             click.echo("✓ Refreshed .git/hooks/post-merge")
         if install_post_rewrite_hook(root_path):
             click.echo("✓ Refreshed .git/hooks/post-rewrite")
+        if install_commit_msg_hook(root_path):
+            click.echo("✓ Refreshed .git/hooks/commit-msg")
 
     if not sync_messages:
         click.secho("✓ logmind templates are up to date.", fg="green")

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -533,6 +533,62 @@ def check_clud_bug_skill_usage_integration(project_root: Path) -> Optional[str]:
     return None
 
 
+def _probe_commit_msg_hook(project_root: Path) -> WorkflowStatus:
+    """v0.6.16 — dogfood enforcement hook. Surfaces drift between the
+    binary that wrote the hook and the binary currently running, same
+    pattern as post-merge / post-rewrite probes. The commit-msg hook
+    enforces `logmind log`-vs-`git commit` discipline for substantive
+    changes; stale hook body means the discipline is mis-enforced.
+    """
+    from logmind.core.gitattributes import (
+        _build_commit_msg_hook_body,
+        _COMMIT_MSG_HOOK_MARKER,
+        commit_msg_hook_installed,
+        installed_commit_msg_hook_version,
+    )
+    from logmind import __version__ as current_version
+
+    if not (project_root / ".git").exists():
+        return WorkflowStatus(
+            name="commit-msg hook", installed=False,
+            marker=None, bundled_marker=None, drift="missing",
+        )
+    if not commit_msg_hook_installed(project_root):
+        return WorkflowStatus(
+            name="commit-msg hook", installed=False,
+            marker=None, bundled_marker=current_version, drift="missing",
+        )
+    hook_version = installed_commit_msg_hook_version(project_root)
+    if hook_version is None:
+        return WorkflowStatus(
+            name="commit-msg hook", installed=True,
+            marker="markerless", bundled_marker=current_version,
+            drift="markerless",
+        )
+    if hook_version != current_version:
+        return WorkflowStatus(
+            name="commit-msg hook", installed=True,
+            marker=hook_version, bundled_marker=current_version, drift="stale",
+        )
+    bundled_body = _build_commit_msg_hook_body()
+    try:
+        installed_body = (project_root / ".git" / "hooks" / "commit-msg").read_text(
+            encoding="utf-8", errors="ignore"
+        )
+    except OSError:
+        installed_body = bundled_body
+    if installed_body != bundled_body:
+        return WorkflowStatus(
+            name="commit-msg hook", installed=True,
+            marker=f"{hook_version} (content drift)",
+            bundled_marker=current_version, drift="stale",
+        )
+    return WorkflowStatus(
+        name="commit-msg hook", installed=True,
+        marker=hook_version, bundled_marker=current_version, drift="current",
+    )
+
+
 def _probe_post_rewrite_hook(project_root: Path) -> WorkflowStatus:
     """v0.5.11 / issue #58: .git/hooks/post-rewrite installed by logmind.
     Companion to the post-merge hook. Fires after `git rebase` or
@@ -746,6 +802,106 @@ def _probe_auto_regen_pat(project_root: Path) -> WorkflowStatus:
     )
 
 
+# ---------------------------------------------------------------------------
+# v0.6.16 — PATH-resolution conflict probe
+#
+# The tokenomics-agent's 2026-06-01 failure recurrence had a non-obvious
+# root cause: `logmind doctor` reported `current` for the post-merge hook,
+# but `logmind init` (invoked from the user's shell, via PATH) was writing
+# a v0.3.4 hook body. The discrepancy: doctor was running via `python -m
+# logmind` from the test runner (PYENV_VERSION=3.11.8 → v0.6.13), while
+# `logmind` typed at the shell prompt resolved through the pyenv shim to
+# a different active pyenv → an older logmind version.
+#
+# This probe detects the gap proactively:
+#   - The currently-running binary's __version__ is the source of truth
+#     for doctor's report.
+#   - `shutil.which("logmind")` resolves the first PATH entry the user's
+#     SHELL hits — what their interactive `logmind log` actually invokes.
+#   - Run `<path> --version` and compare. If different, the user's shell
+#     uses a STALE binary that doctor's report doesn't reflect.
+#
+# This is the kind of bug that surfaces months later as "doctor says
+# current but the hook body looks like an older version." Surfacing it
+# at `logmind doctor` time saves a debugging round-trip.
+# ---------------------------------------------------------------------------
+
+
+_LOGMIND_VERSION_LINE_RE = re.compile(r"version\s+(\S+)")
+
+
+def _probe_path_resolution() -> "WorkflowStatus":
+    """v0.6.16: surface mismatch between currently-running logmind and
+    the binary that the user's shell PATH resolves to.
+
+    Returns a WorkflowStatus row:
+    - drift="current" when PATH binary's version matches running version
+      OR when no PATH binary is found (latter is a different signal we
+      surface separately as drift="missing")
+    - drift="stale" when PATH binary's version differs from running
+      version — the tokenomics-recurrence signal. Marker includes both
+      versions + the conflicting path for one-glance remediation.
+    - drift="markerless" when the PATH binary exists but its --version
+      can't be read (timeout, permission, malformed output). Informational.
+    """
+    import shutil
+    import subprocess
+    import sys
+
+    from logmind import __version__ as running_version
+
+    path_logmind = shutil.which("logmind")
+    if path_logmind is None:
+        # No `logmind` on PATH at all. Merge driver shell-out will fail.
+        return WorkflowStatus(
+            name="logmind on PATH", installed=False, marker=None,
+            bundled_marker=running_version, drift="missing",
+        )
+
+    try:
+        result = subprocess.run(
+            [path_logmind, "--version"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return WorkflowStatus(
+            name="logmind on PATH", installed=True,
+            marker=f"{path_logmind} (cannot exec --version)",
+            bundled_marker=running_version, drift="markerless",
+        )
+
+    out = (result.stdout or "").strip() or (result.stderr or "").strip()
+    m = _LOGMIND_VERSION_LINE_RE.search(out)
+    path_version = m.group(1) if m else None
+    if path_version is None:
+        return WorkflowStatus(
+            name="logmind on PATH", installed=True,
+            marker=f"{path_logmind} (no version parsed from {out!r})",
+            bundled_marker=running_version, drift="markerless",
+        )
+
+    # Strip a trailing comma if --version output is `logmind, version X.Y.Z`
+    # (click's default format puts the comma BEFORE 'version', so the
+    # captured group is already clean — defensive only).
+    path_version = path_version.rstrip(",")
+
+    if path_version == running_version:
+        return WorkflowStatus(
+            name="logmind on PATH", installed=True,
+            marker=f"{path_logmind} ({path_version})",
+            bundled_marker=running_version, drift="current",
+        )
+
+    return WorkflowStatus(
+        name="logmind on PATH", installed=True,
+        marker=(
+            f"{path_logmind} ({path_version}) — STALE; running binary is "
+            f"{running_version}. `which -a logmind` shows full PATH order."
+        ),
+        bundled_marker=running_version, drift="stale",
+    )
+
+
 def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     installed = _logmind_installed_version(project_root)
     latest: Optional[str] = None
@@ -769,10 +925,15 @@ def collect_logmind_status(project_root: Path, *, offline: bool) -> ToolStatus:
     workflows.append(_probe_merge_driver_config(project_root))
     workflows.append(_probe_post_merge_hook(project_root))
     workflows.append(_probe_post_rewrite_hook(project_root))
+    workflows.append(_probe_commit_msg_hook(project_root))
     # v0.6.12: surface PAT secret status for repos whose workflows depend on it.
     pat_status = _probe_auto_regen_pat(project_root)
     if pat_status.installed or pat_status.marker is not None:
         workflows.append(pat_status)
+    # v0.6.16: surface PATH-conflict cases (tokenomics-agent 2026-06-01
+    # recurrence root cause). Always added — the probe itself decides
+    # whether to report "current" (no signal) or "stale" (real drift).
+    workflows.append(_probe_path_resolution())
 
     # Drift = any installed workflow with a marker that's stale,
     # OR installed version != latest version (when both known),

--- a/src/logmind/core/doctor.py
+++ b/src/logmind/core/doctor.py
@@ -846,7 +846,6 @@ def _probe_path_resolution() -> "WorkflowStatus":
     """
     import shutil
     import subprocess
-    import sys
 
     from logmind import __version__ as running_version
 

--- a/src/logmind/core/gitattributes.py
+++ b/src/logmind/core/gitattributes.py
@@ -207,22 +207,26 @@ def _build_post_merge_hook_body() -> str:
         "      exit 0\n"
         "    fi\n"
         "  fi\n"
-        "  # v0.6.15 / tokenomics-agent feedback: default-branch skip. After\n"
-        "  # `gh pr merge --squash --delete-branch`, the hook fires on main;\n"
-        "  # if it regens locally the output differs from origin/main (squash\n"
-        "  # compressed history), leaving docs/timeline.md + docs/file-structure.md\n"
-        "  # unstaged every merge. regen-timeline.yml handles main server-side;\n"
-        "  # local main converges on next pull. Trade 'immediate local view of\n"
-        "  # new entry' for 'main matches origin/main' — users want the latter.\n"
-        "  # Resolve default branch via --short. The prior pipeline\n"
-        "  # `... | sed ... || echo main` had an unreachable fallback because\n"
-        "  # sed's exit (0) masked git's failure — flagged by clud-bug-review\n"
-        "  # on PR #122. --short gives the bare branch name directly.\n"
+        "  # v0.6.16 (replaces v0.6.15's blanket default-branch skip): on the\n"
+        "  # default branch, only skip when HEAD already matches origin/<default>\n"
+        "  # — i.e., a fast-forward pull-up from server where regen-timeline.yml\n"
+        "  # has already produced the authoritative timeline. For local merges\n"
+        "  # that introduced new commits not yet on origin (the multi-branch\n"
+        "  # self-heal case: `git merge feat-branch` on main), regen MUST fire\n"
+        "  # so the working tree reflects the merged-in decision files. v0.6.15's\n"
+        "  # blanket skip dropped Decision-B-style entries from local main; the\n"
+        "  # multi-branch self-heal regression test in tests/test_merge_driver.py\n"
+        "  # catches this. Surfaces the bug PRE-merge instead of in a downstream\n"
+        "  # check-derived-docs failure weeks later.\n"
         "  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)\n"
         "  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)\n"
         "  [ -z \"$default\" ] && default=main\n"
         "  if [ -n \"$current\" ] && [ \"$current\" = \"$default\" ]; then\n"
-        "    exit 0\n"
+        "    head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n"
+        "    origin_sha=$(git rev-parse \"origin/$default\" 2>/dev/null || true)\n"
+        "    if [ -n \"$origin_sha\" ] && [ \"$head_sha\" = \"$origin_sha\" ]; then\n"
+        "      exit 0\n"
+        "    fi\n"
         "  fi\n"
         "  if [ -d docs ]; then\n"
         "    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true\n"
@@ -321,6 +325,148 @@ def installed_post_rewrite_hook_version(repo_root: Path) -> Optional[str]:
         return None
     content = hook.read_text(encoding="utf-8", errors="ignore")
     if _POST_REWRITE_HOOK_MARKER not in content:
+        return None
+    match = _HOOK_VERSION_RE.search(content)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# v0.6.16 — commit-msg hook (dogfood enforcement)
+#
+# The tokenomics-agent session's "why git add instead of logmind" feedback
+# revealed that even with AGENTS.md guidance + skill docs, agents reflexively
+# fall back to raw `git commit` on substantive code changes. The commit-msg
+# hook adds a client-side check: when a commit's first line doesn't carry
+# the `logmind:` prefix AND the staged diff exceeds a threshold of
+# code-bearing lines, the hook prints a warning (default) or rejects the
+# commit (STRICT mode via `.logmind/config.yml`: commit_msg_hook.strict).
+#
+# Exempt patterns (always allowed without warning):
+#   - `logmind:*` — produced by `logmind log`
+#   - `Revert `, `Merge ` — git-generated
+#   - `Bump version`, `chore(release):` — release-bot patterns
+#   - `fixup!`, `squash!` — interactive rebase intermediates
+#
+# Threshold: 20 staged lines across `.py .go .ts .tsx .js .jsx .sh .yaml
+# .yml .toml`. Below threshold = trivial change (typo, formatting,
+# dep-bump) → exit 0 silently.
+# ---------------------------------------------------------------------------
+
+_COMMIT_MSG_HOOK_MARKER = "# logmind commit-msg hook"
+
+
+def _build_commit_msg_hook_body() -> str:
+    """Build the canonical commit-msg hook body for the current binary
+    version. v0.6.16+: embed binary version marker for doctor drift
+    detection. WARN-vs-STRICT behavior is selected at runtime from
+    `.logmind/config.yml` so users can flip the mode without re-installing
+    the hook.
+    """
+    return (
+        "#!/bin/sh\n"
+        "# logmind commit-msg hook\n"
+        f"{HOOK_VERSION_PREFIX}{_current_logmind_version()}\n"
+        "# Installed by `logmind init` (v0.6.16+). Enforces dogfood discipline:\n"
+        "# substantive code commits should be produced via `logmind log` so the\n"
+        "# decision tree captures the reasoning, alternatives, and implications.\n"
+        "# Raw `git commit` for substantive changes loses that signal.\n"
+        "#\n"
+        "# WARN by default. STRICT mode (reject commit) when .logmind/config.yml\n"
+        "# contains `commit_msg_hook: strict: true` in a top-level key. Users\n"
+        "# can bypass either mode with `git commit --no-verify` when the\n"
+        "# bypass is intentional.\n"
+        "#\n"
+        "# Exempt patterns (no check applied):\n"
+        "#   logmind:*    — written by `logmind log`\n"
+        "#   Revert       — git-generated revert message\n"
+        "#   Merge        — git-generated merge message\n"
+        "#   Bump version — release bot\n"
+        "#   chore(release): — release bot (conventional commits)\n"
+        "#   fixup!, squash! — interactive rebase intermediates\n"
+        "\n"
+        'msg=$(head -n1 "$1" 2>/dev/null || echo "")\n'
+        'case "$msg" in\n'
+        "  logmind:*|\"Revert \"*|\"Merge \"*|\"Bump version\"*|\"chore(release):\"*|fixup!*|squash!*)\n"
+        "    exit 0\n"
+        "    ;;\n"
+        "esac\n"
+        "\n"
+        "# Count staged additions+deletions across code-bearing extensions.\n"
+        "staged=$(git diff --cached --numstat -- \\\n"
+        "  '*.py' '*.go' '*.ts' '*.tsx' '*.js' '*.jsx' '*.sh' \\\n"
+        "  '*.yaml' '*.yml' '*.toml' '*.rs' '*.rb' 2>/dev/null \\\n"
+        "  | awk '$1 != \"-\" { s+=$1+$2 } END { print s+0 }')\n"
+        "\n"
+        "threshold=20\n"
+        'if [ "${staged:-0}" -lt "$threshold" ] 2>/dev/null; then\n'
+        "  exit 0\n"
+        "fi\n"
+        "\n"
+        "# Best-effort grep for strict mode in .logmind/config.yml.\n"
+        "# Matches a `commit_msg_hook:` block with a nested `strict: true`.\n"
+        'strict=""\n'
+        'if [ -f .logmind/config.yml ]; then\n'
+        '  strict=$(awk \'/^commit_msg_hook:/{in_block=1; next} /^[a-zA-Z_]/ && !/^  /{in_block=0} in_block && /^  +strict:[[:space:]]*true/{print "yes"; exit}\' .logmind/config.yml 2>/dev/null || true)\n'
+        "fi\n"
+        "\n"
+        'echo "⚠ logmind: substantive commit ($staged lines staged in code) not produced via \\`logmind log\\`." >&2\n'
+        'echo "  Use:   logmind log \\"summary\\" -r \\"why\\" -a \\"alt\\" -i \\"impl\\"" >&2\n'
+        'echo "  Skip:  git commit --no-verify  (intentional override)" >&2\n'
+        "\n"
+        'if [ "$strict" = "yes" ]; then\n'
+        '  echo "  STRICT mode (commit_msg_hook.strict in .logmind/config.yml): rejecting commit." >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n"
+    )
+
+
+def install_commit_msg_hook(repo_root: Path) -> bool:
+    """Write `.git/hooks/commit-msg`. Returns True if the hook was created
+    or updated, False if logmind's hook with the CURRENT body was already
+    in place. Refuses to overwrite a non-logmind hook (some users have
+    custom commit-msg hooks for conventional commits / linting; we don't
+    trample them — doctor reports the foreign-hook state instead).
+    """
+    hooks_dir = repo_root / ".git" / "hooks"
+    if not hooks_dir.exists():
+        return False
+    hook = hooks_dir / "commit-msg"
+    body = _build_commit_msg_hook_body()
+    if hook.exists():
+        existing = hook.read_text(encoding="utf-8", errors="ignore")
+        if _COMMIT_MSG_HOOK_MARKER in existing:
+            if existing == body:
+                return False
+            hook.write_text(body, encoding="utf-8")
+            hook.chmod(0o755)
+            return True
+        return False  # foreign hook — preserve
+    hook.write_text(body, encoding="utf-8")
+    hook.chmod(0o755)
+    return True
+
+
+def commit_msg_hook_installed(repo_root: Path) -> bool:
+    hook = repo_root / ".git" / "hooks" / "commit-msg"
+    if not hook.exists():
+        return False
+    try:
+        return _COMMIT_MSG_HOOK_MARKER in hook.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def installed_commit_msg_hook_version(repo_root: Path) -> Optional[str]:
+    """Read the `# logmind-hook-version: …` marker from the installed
+    commit-msg hook. Returns the version string when present + ours;
+    None for missing / foreign / unmarked hooks.
+    """
+    hook = repo_root / ".git" / "hooks" / "commit-msg"
+    if not hook.exists():
+        return None
+    content = hook.read_text(encoding="utf-8", errors="ignore")
+    if _COMMIT_MSG_HOOK_MARKER not in content:
         return None
     match = _HOOK_VERSION_RE.search(content)
     return match.group(1) if match else None

--- a/src/logmind/templates/AGENTS.md.slim.template
+++ b/src/logmind/templates/AGENTS.md.slim.template
@@ -7,10 +7,15 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v7-pointer -->
-## Decision logging — `logmind log` is the commit primitive
+<!-- logmind-block-version: v8-pointer -->
+## Decision logging — `logmind log` is REQUIRED for substantive commits
 
 **`logmind log` replaces `git add` + `git commit` + `git push` for any change that carries a decision** — do not run those git commands directly.
+
+> **DO NOT run raw `git add` / `git commit` / `git push` for substantive code changes.**
+> The commit-msg hook installed by `logmind init` warns when raw git is used on
+> a substantive commit; the intent is to prevent the warning, not bypass it via
+> `--no-verify`. Typo / whitespace / dep-bump-only commits MAY use raw git.
 
 ```bash
 logmind log "summary" -r "why" -a "alternative" -i "implication"

--- a/src/logmind/templates/AGENTS.md.template
+++ b/src/logmind/templates/AGENTS.md.template
@@ -7,8 +7,14 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v5 -->
-## Decision Logging (logmind)
+<!-- logmind-block-version: v6 -->
+## Decision Logging (logmind) — REQUIRED for substantive commits
+
+> **DO NOT run `git add` / `git commit` / `git push` for substantive code changes.**
+> `logmind log` is the commit primitive. Raw git commands for non-trivial changes
+> bypass the decision tree, leaving future agents (and humans) without context.
+> The commit-msg hook installed by `logmind init` warns when this happens; the
+> intent here is to prevent the warning, not bypass it via `--no-verify`.
 
 **This project uses [logmind](https://logmind.dev). `logmind log` is the commit primitive — it replaces `git add`, `git commit`, and `git push` for any change that carries a decision. Do not run those git commands directly when logging a decision.**
 

--- a/tests/test_agents_consolidation.py
+++ b/tests/test_agents_consolidation.py
@@ -121,11 +121,13 @@ def test_get_agents_md_template_returns_slim_when_skills_available(monkeypatch):
 
     monkeypatch.setattr(skill_install, "is_skills_available", lambda: True)
     slim = get_agents_md_template()
-    assert "logmind-block-version: v7-pointer" in slim
+    assert "logmind-block-version: v8-pointer" in slim
     # The load-bearing contract — "logmind log replaces git add+commit+push"
     # — must survive every future trim. If this assertion fails, the
     # block was over-trimmed and agents will fall back to direct git.
-    assert "logmind log` is the commit primitive" in slim
+    # v0.6.16: the heading shifted from "is the commit primitive" to
+    # "is REQUIRED for substantive commits" but the contract sentence
+    # — `replaces git add + commit + push` — is preserved verbatim.
     assert "replaces `git add` + `git commit` + `git push`" in slim
     # Skill pointer is the authority delegation — without it, agents
     # have no way to find the full procedure when this block trims it out.
@@ -172,7 +174,7 @@ def test_get_agents_md_template_returns_full_when_skills_absent(monkeypatch):
     # Match exact marker (v4 — not v4-slim, which is a different file). Use
     # the line-exact match so a future v4-extended variant wouldn't also
     # satisfy this assertion accidentally.
-    assert "logmind-block-version: v5 " in full or "logmind-block-version: v5\n" in full
+    assert "logmind-block-version: v6 " in full or "logmind-block-version: v6\n" in full
     # Full template carries the inline procedure
     assert "When you MUST log" in full or "REQUIREMENT" in full or "skill is also embedded" in full
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -19,6 +19,32 @@ def project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def _stub_path_probe_in_clean_state(monkeypatch, request):
+    """Tests in this file generally assert on workflow drift, NOT on the
+    PATH-resolution probe. In the editable-install + pyenv-shim test
+    environment, `shutil.which("logmind")` resolves to a shim that may
+    invoke a SLIGHTLY OLDER version (the previous editable rebuild)
+    than what the running Python module reports — a real signal in
+    production but a noisy false-positive in tests that aren't about it.
+
+    Tests opt OUT by including "path_probe" or "path_stale" in their
+    name; those tests want the real probe to run.
+    """
+    if "path_probe" in request.node.name or "path_stale" in request.node.name:
+        return
+    from logmind.core import doctor as doctor_mod
+    from logmind.core.doctor import WorkflowStatus
+
+    def _stubbed_probe():
+        return WorkflowStatus(
+            name="logmind on PATH", installed=True,
+            marker="(stubbed for test)", bundled_marker="(stubbed)",
+            drift="current",
+        )
+    monkeypatch.setattr(doctor_mod, "_probe_path_resolution", _stubbed_probe)
+
+
 def _write_workflow(project: Path, name: str, content: str) -> None:
     (project / ".github" / "workflows" / name).write_text(content, encoding="utf-8")
 
@@ -47,6 +73,10 @@ def test_offline_no_workflows_reports_clean_unknown_versions(project: Path):
     # (v0.3.0: gitattributes block, git config, post-merge; v0.5.11:
     # post-rewrite) are reported as missing. None should be `stale` —
     # that would false-positive every fresh fixture.
+    # v0.6.16: the `logmind on PATH` probe is also added unconditionally
+    # (it surfaces tokenomics-style stale-binary cases). In a fresh test
+    # fixture it typically reports `current` (running matches PATH) — it
+    # isn't a "missing" row and shouldn't be counted as drift.
     names = {w.name for w in logmind.workflows}
     expected = (
         set(doctor.LOGMIND_WORKFLOWS)
@@ -56,10 +86,14 @@ def test_offline_no_workflows_reports_clean_unknown_versions(project: Path):
             "git config (merge driver)",
             "post-merge hook",
             "post-rewrite hook",
+            "commit-msg hook",
+            "logmind on PATH",
         }
     )
     assert names == expected
-    assert all(w.drift == "missing" for w in logmind.workflows)
+    # All probes EXCEPT the PATH probe report `missing` in this fixture.
+    non_path = [w for w in logmind.workflows if w.name != "logmind on PATH"]
+    assert all(w.drift == "missing" for w in non_path)
 
 
 def test_pinned_workflow_with_matching_marker_is_current(project: Path, monkeypatch):
@@ -377,3 +411,136 @@ def test_cli_json_output_parses(project: Path, monkeypatch):
     assert "overall" in payload
     assert "network_used" in payload
     assert payload["network_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# v0.6.16 — PATH-resolution conflict probe (tokenomics-agent 2026-06-01
+# recurrence root cause: stale `logmind` ahead on shell PATH while doctor
+# inspects a different binary via `python -m logmind`).
+# ---------------------------------------------------------------------------
+
+
+def test_path_probe_returns_current_when_path_matches_running(monkeypatch, tmp_path: Path):
+    """Common case: `shutil.which("logmind")` resolves to a binary whose
+    --version matches the currently-running version. Drift = "current"."""
+    from logmind import __version__ as running_version
+    from logmind.core.doctor import _probe_path_resolution
+    import subprocess as real_subprocess
+
+    fake_path = "/usr/local/bin/logmind"
+    monkeypatch.setattr("shutil.which", lambda _name: fake_path)
+
+    def fake_run(cmd, *args, **kwargs):
+        class R:
+            returncode = 0
+            stdout = f"logmind, version {running_version}\n"
+            stderr = ""
+        return R()
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    status = _probe_path_resolution()
+    assert status.installed is True
+    assert status.drift == "current"
+    assert running_version in (status.marker or "")
+
+
+def test_path_probe_flags_stale_when_path_version_differs(monkeypatch):
+    """Tokenomics-recurrence scenario: PATH binary reports an OLDER version
+    than the currently-running binary. drift="stale" so doctor exits non-
+    zero. Marker must include both versions + path for one-glance fix."""
+    from logmind import __version__ as running_version
+    from logmind.core.doctor import _probe_path_resolution
+    import subprocess as real_subprocess
+
+    fake_path = "/Users/x/local/bin/logmind"
+    monkeypatch.setattr("shutil.which", lambda _name: fake_path)
+
+    def fake_run(cmd, *args, **kwargs):
+        class R:
+            returncode = 0
+            stdout = "logmind, version 0.3.4\n"
+            stderr = ""
+        return R()
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    status = _probe_path_resolution()
+    assert status.installed is True
+    assert status.drift == "stale", (
+        f"PATH-conflict must surface as stale so doctor exits non-zero; "
+        f"got drift={status.drift!r}"
+    )
+    marker = status.marker or ""
+    assert "0.3.4" in marker, "marker must include PATH binary's version"
+    assert running_version in marker, "marker must include currently-running version"
+    assert fake_path in marker, "marker must include the conflicting path"
+
+
+def test_path_probe_reports_missing_when_logmind_not_on_path(monkeypatch):
+    """No `logmind` on PATH at all → drift="missing". The merge driver
+    shell-out would fail in this state. Not as severe as stale, but worth
+    surfacing."""
+    from logmind.core.doctor import _probe_path_resolution
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    status = _probe_path_resolution()
+    assert status.installed is False
+    assert status.drift == "missing"
+
+
+def test_path_probe_tolerates_unparseable_version_output(monkeypatch):
+    """Defensive: PATH binary exists but --version emits something we
+    can't parse (truncated, mangled, foreign CLI named `logmind`).
+    Drift = "markerless" so we report the binary's existence without
+    falsely claiming drift OR claiming current."""
+    from logmind.core.doctor import _probe_path_resolution
+    import subprocess as real_subprocess
+
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/logmind")
+
+    def fake_run(cmd, *args, **kwargs):
+        class R:
+            returncode = 0
+            stdout = "(garbled output: no semver here)\n"
+            stderr = ""
+        return R()
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    status = _probe_path_resolution()
+    assert status.installed is True
+    assert status.drift == "markerless"
+
+
+def test_doctor_overall_flips_to_drift_when_path_stale(monkeypatch, project: Path):
+    """End-to-end: a PATH-stale probe flows through collect_logmind_status
+    → ToolStatus.drift = "stale" → overall = "DRIFT" → cli exits 1."""
+    from logmind import __version__ as running_version
+    from logmind.core import doctor as doctor_mod
+    import subprocess as real_subprocess
+
+    monkeypatch.setattr(doctor_mod, "_http_get_json", lambda *_a, **_kw: None)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/logmind")
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[1] == "--version":
+            class R:
+                returncode = 0
+                stdout = "logmind, version 0.3.4\n"
+                stderr = ""
+            return R()
+        # Pass-through for all other subprocess.run calls
+        return real_subprocess.run.__wrapped__(cmd, *args, **kwargs) if hasattr(real_subprocess.run, "__wrapped__") else None
+
+    # We don't actually need to call real subprocess for this test — just
+    # for the --version probe. Other subprocess calls in collect_status
+    # may happen (git remote, gh secret list); they all degrade gracefully.
+    monkeypatch.setattr(real_subprocess, "run", fake_run)
+
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--offline"])
+    assert "Stack status: DRIFT" in result.output, (
+        f"PATH-stale must drive overall=DRIFT.\nOutput:\n{result.output}"
+    )
+    assert result.exit_code != 0, (
+        f"Doctor must exit non-zero on PATH-stale drift; got exit_code={result.exit_code}"
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -520,6 +520,15 @@ def test_doctor_overall_flips_to_drift_when_path_stale(monkeypatch, project: Pat
     monkeypatch.setattr(doctor_mod, "_http_get_json", lambda *_a, **_kw: None)
     monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/logmind")
 
+    # Capture the real subprocess.run BEFORE patching so the fallback
+    # pass-through actually executes real subprocesses (git remote, gh
+    # secret list, etc. — they all degrade gracefully on failure but
+    # need a real run, not None). Prior implementation used
+    # `real_subprocess.run.__wrapped__` which never exists on a plain
+    # function and silently returned None, masking any new probe that
+    # accesses `.returncode` on the result.
+    real_run = real_subprocess.run
+
     def fake_run(cmd, *args, **kwargs):
         if isinstance(cmd, list) and len(cmd) >= 2 and cmd[1] == "--version":
             class R:
@@ -527,12 +536,8 @@ def test_doctor_overall_flips_to_drift_when_path_stale(monkeypatch, project: Pat
                 stdout = "logmind, version 0.3.4\n"
                 stderr = ""
             return R()
-        # Pass-through for all other subprocess.run calls
-        return real_subprocess.run.__wrapped__(cmd, *args, **kwargs) if hasattr(real_subprocess.run, "__wrapped__") else None
+        return real_run(cmd, *args, **kwargs)
 
-    # We don't actually need to call real subprocess for this test — just
-    # for the --version probe. Other subprocess calls in collect_status
-    # may happen (git remote, gh secret list); they all degrade gracefully.
     monkeypatch.setattr(real_subprocess, "run", fake_run)
 
     monkeypatch.chdir(project)

--- a/tests/test_merge_driver.py
+++ b/tests/test_merge_driver.py
@@ -13,12 +13,15 @@ from logmind.core import doctor
 from logmind.core.gitattributes import (
     LOGMIND_GITATTRIBUTES_START,
     MERGE_DRIVER_CONFIG,
+    commit_msg_hook_installed,
     configure_merge_drivers,
     driver_configured,
     ensure_block,
     has_block,
+    install_commit_msg_hook,
     install_post_merge_hook,
     install_post_rewrite_hook,
+    installed_commit_msg_hook_version,
     post_merge_hook_installed,
     post_rewrite_hook_installed,
 )
@@ -898,3 +901,562 @@ def test_doctor_reports_post_rewrite_current_when_marker_and_body_match(
         f"Expected freshly-installed post-rewrite hook to be current; "
         f"got drift={status.drift!r} marker={status.marker!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# v0.6.16 — multi-branch self-heal regression tests (the keystone)
+#
+# What we are proving: when two (or three) agents work on independent
+# branches off main, each running `logmind log`, then merging them back
+# sequentially, the merge driver auto-resolves `docs/timeline.md` AND
+# `docs/file-structure.md` without conflict markers, without manual
+# intervention, and final main carries ALL decisions.
+#
+# Why this matters: every concurrent-PR cycle in the dogfood loop and
+# every consumer-repo cycle depends on this contract. If the driver
+# silently breaks (binary off PATH, config not configured per-clone,
+# fresh-clone hook gap), trailing PRs go DIRTY immediately after the
+# leading PR merges, requiring `logmind rebase` per branch. That was
+# the tokenomics-agent pain — preventable by surfacing the contract
+# break in a regression test instead of a check-derived-docs failure
+# weeks later.
+#
+# The tests use real subprocess `git` + real subprocess `logmind`
+# calls — no mocks. The whole point is to exercise the live driver.
+# We skip when `logmind` isn't on PATH (the merge driver shells out
+# to it; without it, every test would spuriously fail).
+# ---------------------------------------------------------------------------
+
+
+_LOGMIND_BIN = None
+
+
+def _logmind_on_path():
+    """Memoized shutil.which check for `logmind`. The merge driver shells
+    out to `logmind timeline --write %A`, so if logmind isn't on PATH
+    these tests can only spuriously fail. Skip cleanly when missing."""
+    global _LOGMIND_BIN
+    if _LOGMIND_BIN is None:
+        import shutil
+        _LOGMIND_BIN = shutil.which("logmind") or ""
+    return bool(_LOGMIND_BIN)
+
+
+def _setup_logmind_repo(tmp_path: Path) -> Path:
+    """Set up a temp dir as a git repo with logmind init applied. Returns
+    the repo root. Disables auto_push (no remote in tests)."""
+    import os
+
+    env = {**os.environ, "LOGMIND_QUIET": "1"}
+
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"], cwd=tmp_path, check=True
+    )
+
+    (tmp_path / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "initial"], cwd=tmp_path, check=True
+    )
+
+    result = subprocess.run(
+        ["logmind", "init", "--no-skill-install"],
+        cwd=tmp_path, capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 0, (
+        f"logmind init failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    # No remote in tests → disable auto_push so `logmind log` doesn't fail
+    # at the push step. The merge driver + hooks still install + fire.
+    cfg = tmp_path / ".logmind" / "config.yml"
+    cfg.write_text(
+        cfg.read_text(encoding="utf-8").replace("auto_push: true", "auto_push: false"),
+        encoding="utf-8",
+    )
+
+    # Stage everything logmind init scaffolded into the initial commit.
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "logmind init scaffolding"],
+        cwd=tmp_path, check=True,
+    )
+
+    return tmp_path
+
+
+def _logmind_log(
+    repo: Path,
+    summary: str,
+    reasoning: str,
+    alternative: str,
+    implication: str,
+) -> subprocess.CompletedProcess:
+    """Run `logmind log` in `repo`. Returns the CompletedProcess for
+    callers that want to assert on output; caller decides whether to
+    `check=True`."""
+    import os
+
+    env = {**os.environ, "LOGMIND_QUIET": "1"}
+    return subprocess.run(
+        [
+            "logmind", "log", summary,
+            "-r", reasoning,
+            "-a", alternative,
+            "-i", implication,
+        ],
+        cwd=repo, capture_output=True, text=True, env=env,
+    )
+
+
+def _assert_no_conflict_markers(text: str, label: str):
+    """The whole point of the merge driver is to leave NO conflict
+    markers in derived docs. If any survive, the driver didn't fire (or
+    fired wrong) and the test must fail loudly."""
+    assert "<<<<<<< " not in text, (
+        f"{label}: merge driver left conflict marker '<<<<<<< ' — driver did NOT auto-resolve."
+    )
+    assert ">>>>>>> " not in text, (
+        f"{label}: merge driver left conflict marker '>>>>>>> ' — driver did NOT auto-resolve."
+    )
+    assert "=======" not in text, (
+        f"{label}: merge driver left conflict marker '=======' — driver did NOT auto-resolve."
+    )
+
+
+# ---------------------------------------------------------------------------
+# v0.6.16 — commit-msg hook (dogfood enforcement: substantive commits must
+# go through `logmind log`, not raw `git commit`)
+# ---------------------------------------------------------------------------
+
+
+def test_install_commit_msg_hook_creates_executable_hook(git_repo: Path):
+    """v0.6.16: hook is written under .git/hooks/commit-msg and (on POSIX)
+    executable. Same pattern as post-merge / post-rewrite installers."""
+    import os
+    changed = install_commit_msg_hook(git_repo)
+    assert changed is True
+    hook = git_repo / ".git" / "hooks" / "commit-msg"
+    assert hook.exists()
+    if os.name != "nt":
+        assert hook.stat().st_mode & 0o111
+    body = hook.read_text(encoding="utf-8")
+    # The hook must implement the exempt-prefix carve-out and the
+    # threshold check. Both are part of the user-facing contract.
+    assert "logmind:*" in body
+    assert "Revert " in body
+    assert "Merge " in body
+    assert "fixup!" in body
+    assert "threshold=20" in body
+
+
+def test_install_commit_msg_hook_is_idempotent(git_repo: Path):
+    install_commit_msg_hook(git_repo)
+    assert install_commit_msg_hook(git_repo) is False
+
+
+def test_install_commit_msg_hook_preserves_foreign_hook(git_repo: Path):
+    """A user-authored commit-msg hook (e.g., conventional commits linter)
+    is preserved untouched — same contract as the other hooks."""
+    hook = git_repo / ".git" / "hooks" / "commit-msg"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho 'custom commit-msg'\n", encoding="utf-8")
+    hook.chmod(0o755)
+    changed = install_commit_msg_hook(git_repo)
+    assert changed is False
+    assert "custom commit-msg" in hook.read_text(encoding="utf-8")
+
+
+def test_commit_msg_hook_installed_detects_logmind_hook(git_repo: Path):
+    install_commit_msg_hook(git_repo)
+    assert commit_msg_hook_installed(git_repo) is True
+
+
+def test_installed_commit_msg_hook_version_returns_current(git_repo: Path):
+    from logmind import __version__ as current_version
+    assert installed_commit_msg_hook_version(git_repo) is None  # not installed yet
+    install_commit_msg_hook(git_repo)
+    assert installed_commit_msg_hook_version(git_repo) == current_version
+
+
+def test_commit_msg_hook_warns_on_substantive_raw_commit(git_repo: Path):
+    """End-to-end: a raw `git commit` of >20 staged code lines under a
+    non-exempt message prints the dogfood warning but doesn't reject
+    the commit (WARN mode default)."""
+    install_commit_msg_hook(git_repo)
+    # Substantive change: write a 25-line .py file.
+    target = git_repo / "module.py"
+    target.write_text("\n".join(f"x_{i} = {i}" for i in range(25)) + "\n", encoding="utf-8")
+    subprocess.run(["git", "add", "module.py"], cwd=git_repo, check=True)
+
+    # Need .logmind/config.yml so the hook's strict-mode probe doesn't error
+    # (the hook tolerates missing config — defaults to WARN — but explicit
+    # presence exercises the realistic install state).
+    cfg_dir = git_repo / ".logmind"
+    cfg_dir.mkdir(exist_ok=True)
+    (cfg_dir / "config.yml").write_text(
+        "# logmind config\ngit:\n  auto_commit: true\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "feat: add module without logmind log"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        f"WARN mode: hook must exit 0 even when warning fires. stderr={result.stderr}"
+    )
+    assert "substantive commit" in result.stderr, (
+        "WARN mode: warning must be visible to user. "
+        f"stderr was:\n{result.stderr}"
+    )
+    assert "logmind log" in result.stderr
+
+
+def test_commit_msg_hook_silent_on_logmind_prefix(git_repo: Path):
+    """Hook must NOT warn for messages with the `logmind:` prefix even on
+    substantive changes — `logmind log` produces those messages and we
+    don't want to spam its own commits."""
+    install_commit_msg_hook(git_repo)
+    target = git_repo / "module.py"
+    target.write_text("\n".join(f"x_{i} = {i}" for i in range(25)) + "\n", encoding="utf-8")
+    subprocess.run(["git", "add", "module.py"], cwd=git_repo, check=True)
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "logmind: Use new module"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "substantive commit" not in result.stderr, (
+        "Hook fired warning on `logmind:` commit — exempt-prefix check failed."
+    )
+
+
+def test_commit_msg_hook_silent_on_small_diff(git_repo: Path):
+    """Below-threshold changes (typos, dep bumps) should pass without warning."""
+    install_commit_msg_hook(git_repo)
+    target = git_repo / "module.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "module.py"], cwd=git_repo, check=True)
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "fix: tiny change"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "substantive commit" not in result.stderr, (
+        "Hook fired warning on below-threshold change. "
+        f"stderr was:\n{result.stderr}"
+    )
+
+
+def test_commit_msg_hook_strict_mode_rejects_raw_commit(git_repo: Path):
+    """STRICT mode (commit_msg_hook.strict: true in .logmind/config.yml)
+    rejects the commit instead of warning. v0.6.16 ships WARN as default
+    but supports STRICT for high-discipline repos."""
+    install_commit_msg_hook(git_repo)
+    target = git_repo / "module.py"
+    target.write_text("\n".join(f"x_{i} = {i}" for i in range(25)) + "\n", encoding="utf-8")
+    subprocess.run(["git", "add", "module.py"], cwd=git_repo, check=True)
+
+    cfg_dir = git_repo / ".logmind"
+    cfg_dir.mkdir(exist_ok=True)
+    (cfg_dir / "config.yml").write_text(
+        "commit_msg_hook:\n  strict: true\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "feat: add module"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert result.returncode != 0, (
+        f"STRICT mode: hook must exit non-zero. stderr={result.stderr}"
+    )
+    assert "STRICT mode" in result.stderr or "rejecting" in result.stderr
+
+
+def _amend_pending_regen(repo: Path):
+    """The post-merge hook regens docs/timeline.md + docs/file-structure.md
+    AFTER git completes the merge commit. v0.6.7's no-stage contract leaves
+    those regens as UNSTAGED modifications in the working tree. Subsequent
+    `git merge` operations refuse to proceed while the working tree is
+    dirty. To simulate the realistic multi-merge workflow, fold the regen
+    into the just-created merge commit via `git commit --amend --no-edit`.
+    Real users would either amend here, push as-is and let server-side
+    regen-timeline.yml fix it, or accept the unstaged state until their
+    next commit.
+    """
+    subprocess.run(
+        ["git", "add", "docs/timeline.md", "docs/file-structure.md"],
+        cwd=repo, capture_output=True,
+    )
+    has_staged_diff = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=repo, capture_output=True,
+    ).returncode == 1
+    if has_staged_diff:
+        subprocess.run(
+            ["git", "commit", "--amend", "--no-edit", "-q"],
+            cwd=repo, check=True,
+        )
+
+
+def _assert_decision_branches_present(repo: Path, branches: list, label: str):
+    """Both decision-branches files must exist post-merge AND the timeline
+    must reflect them (either inline or via the `(N decisions)` count when
+    brief-mode elides middle rows).
+    """
+    for branch in branches:
+        path = repo / "docs" / "decisions-branches" / f"feat__{branch}.md"
+        assert path.exists(), (
+            f"{label}: docs/decisions-branches/feat__{branch}.md missing — "
+            f"merge did not bring in branch {branch!r}'s decision file."
+        )
+        # The file itself records the title used in `logmind log`.
+        # Defensive — confirms the file isn't a stub.
+        assert path.read_text(encoding="utf-8").strip(), (
+            f"{label}: decision-branches/feat__{branch}.md is empty"
+        )
+
+
+def _assert_timeline_has_decision_count(repo: Path, expected_count: int, label: str):
+    """Brief mode collapses middle decisions but always renders an accurate
+    count in the month header: `## 2026-06 (N decisions)`. The count is
+    the durable signal that the timeline regen saw ALL decision sources."""
+    timeline = (repo / "docs" / "timeline.md").read_text(encoding="utf-8")
+    # Look for any month header with the expected count
+    import re
+    match = re.search(rf"## \d{{4}}-\d{{2}} \({expected_count} decisions\)", timeline)
+    # In months with < 3 decisions, no count is rendered. Fall back to
+    # checking direct title presence.
+    if match is None and expected_count < 3:
+        return  # short month uses no-count rendering; caller asserts titles separately
+    assert match is not None, (
+        f"{label}: expected timeline to show `(N decisions)` count = "
+        f"{expected_count}, got:\n{timeline}"
+    )
+
+
+@pytest.mark.skipif(
+    not _logmind_on_path(),
+    reason="`logmind` not on PATH; merge driver can't shell out",
+)
+def test_merge_driver_self_heals_two_concurrent_branches(tmp_path: Path):
+    """Two agents on independent branches off main, both run `logmind log`,
+    both merge to main sequentially. The merge driver + post-merge hook
+    MUST cooperatively produce a final main where both decision files are
+    present, no conflict markers leak, and the timeline reflects all
+    three entries (init + A + B).
+
+    THIS IS THE KEYSTONE TEST. The whole dogfood loop assumes this works.
+    Without it, every concurrent-PR cycle hits a check-derived-docs failure
+    and the user has to `logmind rebase` per branch.
+    """
+    repo = _setup_logmind_repo(tmp_path)
+
+    # Agent A's branch
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feat/agent-a"], cwd=repo, check=True
+    )
+    r = _logmind_log(
+        repo,
+        "Decision A: pick PostgreSQL",
+        reasoning="ACID + complex joins",
+        alternative="MongoDB",
+        implication="connection pooling required",
+    )
+    assert r.returncode == 0, f"logmind log on agent-a failed: {r.stderr}"
+
+    # Agent B's branch (OFF main, not off A)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feat/agent-b"], cwd=repo, check=True
+    )
+    r = _logmind_log(
+        repo,
+        "Decision B: pick Redis for cache",
+        reasoning="fast session storage",
+        alternative="Memcached",
+        implication="run Redis server",
+    )
+    assert r.returncode == 0, f"logmind log on agent-b failed: {r.stderr}"
+
+    # Merge A first (no concurrent conflict — only A's branch ever wrote
+    # timeline with content).
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    result_a = subprocess.run(
+        ["git", "merge", "feat/agent-a", "--no-ff", "-m", "merge a"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert result_a.returncode == 0, (
+        f"merge of agent-a failed:\nstdout={result_a.stdout}\nstderr={result_a.stderr}"
+    )
+
+    # THIS IS THE SELF-HEAL MOMENT.
+    # Branch B's timeline.md was regen'd off main BEFORE A landed — its
+    # "Recent decisions" lines contain only B. Main's timeline (post-A)
+    # contains only A. Textual merge would conflict; the merge driver +
+    # post-merge hook must cooperate to produce a clean tree with both.
+    result_b = subprocess.run(
+        ["git", "merge", "feat/agent-b", "--no-ff", "-m", "merge b"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert result_b.returncode == 0, (
+        "merge driver MUST auto-resolve timeline.md on concurrent-branch merge.\n"
+        f"git merge exit code: {result_b.returncode}\n"
+        f"stdout:\n{result_b.stdout}\n"
+        f"stderr:\n{result_b.stderr}\n"
+        "Likely cause: merge driver not configured per-clone (`logmind init` "
+        "didn't run `git config merge.logmind-timeline.driver`), or `logmind` "
+        "binary not on PATH for the driver shell-out. Re-run `logmind init` "
+        "and `logmind doctor` to surface the gap."
+    )
+
+    # Working tree contract — both branches' decision files survive merge.
+    _assert_decision_branches_present(repo, ["agent-a", "agent-b"], "two-branch self-heal")
+
+    # Timeline contract — no conflict markers + decision count = 3 (init+A+B).
+    final_timeline = (repo / "docs" / "timeline.md").read_text(encoding="utf-8")
+    _assert_no_conflict_markers(final_timeline, "docs/timeline.md after B merge")
+    _assert_timeline_has_decision_count(repo, 3, "two-branch self-heal")
+
+
+@pytest.mark.skipif(
+    not _logmind_on_path(),
+    reason="`logmind` not on PATH; merge driver can't shell out",
+)
+def test_merge_driver_self_heals_three_concurrent_branches(tmp_path: Path):
+    """N=3 generalization. Three branches off main, three sequential merges.
+    Validates the driver scales beyond pairwise — each merge regenerates
+    timeline from the cumulative decisions-branches/ tree."""
+    repo = _setup_logmind_repo(tmp_path)
+
+    # Each agent writes on a separate branch off main
+    for name, summary, alt in [
+        ("a", "Decision A: use REST", "GraphQL"),
+        ("b", "Decision B: use Redis", "Memcached"),
+        ("c", "Decision C: use Pytest", "unittest"),
+    ]:
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", f"feat/agent-{name}"],
+            cwd=repo, check=True,
+        )
+        r = _logmind_log(
+            repo,
+            summary,
+            reasoning=f"reasoning for {name}",
+            alternative=alt,
+            implication=f"implication {name}",
+        )
+        assert r.returncode == 0, f"logmind log on agent-{name} failed: {r.stderr}"
+
+    # Merge sequentially: a → b → c. After 'a', timeline has just A. After
+    # 'b', driver must merge B's regen (only B) into main's (only A) → both.
+    # After 'c', driver must do the same dance against the existing A+B.
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    for name in ("a", "b", "c"):
+        result = subprocess.run(
+            ["git", "merge", f"feat/agent-{name}", "--no-ff", "-m", f"merge {name}"],
+            cwd=repo, capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"merge of agent-{name} failed — driver didn't auto-resolve:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        # Fold the post-merge regen into the merge commit so the next
+        # iteration's `git merge` doesn't refuse on dirty working tree.
+        _amend_pending_regen(repo)
+
+    # Working tree + timeline contracts.
+    _assert_decision_branches_present(repo, ["agent-a", "agent-b", "agent-c"], "3-branch self-heal")
+    final_timeline = (repo / "docs" / "timeline.md").read_text(encoding="utf-8")
+    _assert_no_conflict_markers(final_timeline, "docs/timeline.md after 3-branch merge")
+    # init + A + B + C = 4
+    _assert_timeline_has_decision_count(repo, 4, "3-branch self-heal")
+
+
+@pytest.mark.skipif(
+    not _logmind_on_path(),
+    reason="`logmind` not on PATH; merge driver can't shell out",
+)
+def test_merge_driver_self_heals_squash_merge(tmp_path: Path):
+    """Squash-merge variant. Agent A squash-merges (the GitHub default for
+    PR merges); agent B's branch was forked BEFORE the squash. When B
+    merges to the post-squash main, git replays B's timeline regen
+    against a main whose history was compressed — the driver must still
+    fire on the textual conflict and emit a clean final tree.
+
+    Composes with the v0.6.13 + v0.6.15 fixes (orphan-branch skip +
+    default-branch skip). If those skips fire incorrectly, the regen
+    would silently no-op and we'd lose decisions; the test catches that
+    by asserting both decisions land in the final timeline.
+    """
+    repo = _setup_logmind_repo(tmp_path)
+
+    # Agent A's branch
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feat/agent-a"], cwd=repo, check=True
+    )
+    r = _logmind_log(
+        repo,
+        "Decision A: pick Postgres",
+        reasoning="ACID",
+        alternative="MongoDB",
+        implication="pool connections",
+    )
+    assert r.returncode == 0, f"logmind log on agent-a failed: {r.stderr}"
+
+    # Agent B forks from main BEFORE A is merged (a parallel agent)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feat/agent-b"], cwd=repo, check=True
+    )
+    r = _logmind_log(
+        repo,
+        "Decision B: pick pytest",
+        reasoning="fixtures",
+        alternative="unittest",
+        implication="adopt fixtures pattern",
+    )
+    assert r.returncode == 0, f"logmind log on agent-b failed: {r.stderr}"
+
+    # Squash-merge A into main (replicates `gh pr merge --squash`)
+    subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+    sq = subprocess.run(
+        ["git", "merge", "--squash", "feat/agent-a"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert sq.returncode == 0, f"squash --merge failed: {sq.stderr}"
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "squash merge a"], cwd=repo, check=True
+    )
+
+    # Now merge B's branch (forked off pre-squash main). Timeline conflict
+    # is unavoidable textually — driver must auto-resolve.
+    result_b = subprocess.run(
+        ["git", "merge", "feat/agent-b", "--no-ff", "-m", "merge b"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert result_b.returncode == 0, (
+        "merge driver MUST auto-resolve timeline.md on the squash-then-merge "
+        "case — this is the common GitHub PR cycle pattern.\n"
+        f"stdout:\n{result_b.stdout}\nstderr:\n{result_b.stderr}"
+    )
+
+    # Working tree + timeline contracts — squash-merge variant.
+    _assert_decision_branches_present(repo, ["agent-a", "agent-b"], "squash + merge")
+    final_timeline = (repo / "docs" / "timeline.md").read_text(encoding="utf-8")
+    _assert_no_conflict_markers(final_timeline, "docs/timeline.md after squash + merge")
+    _assert_timeline_has_decision_count(repo, 3, "squash + merge")


### PR DESCRIPTION
Tokenomics-agent follow-up bundle. Three changes + one bug fix surfaced by writing the multi-branch self-heal test.

## Summary

- **Fixed multi-branch self-heal**: v0.6.15's blanket default-branch skip dropped decisions on local merges (driver fires on partial working tree → hook can't sweep). v0.6.16 tightens skip to `HEAD == origin/<default>` (real pull-up case only).
- **Added `logmind doctor` PATH probe** (Concern 3): surfaces stale-binary cases where `shutil.which("logmind")` resolves to a different version than the running module — tokenomics-recurrence root cause.
- **Added commit-msg hook** (dogfood enforcement): warns when raw `git commit` is used on substantive code changes (>20 lines, non-exempt prefix). WARN by default; STRICT mode opt-in via `.logmind/config.yml`.
- **Bumped AGENTS.md templates**: v5→v6 + v7-pointer→v8-pointer with REQUIRED framing + explicit DO-NOT-git-commit warning.

## Validation

- `pytest` green: **846 passed, 1 skipped** (+17 over v0.6.15: 3 self-heal + 9 commit-msg + 5 PATH probe).
- New regression tests use real subprocess `git` + `logmind` calls — no mocks.

## Go v1.0 parity

Every change has a B-wave parity item: B2 (commit-msg hook body), B3 (multi-branch test), B4 (templates), B6 (PATH probe). Cross-binary parity test is the v1.0 release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)