### PR TITLE
[skip-logmind] chore(version): refresh stale docstring + SpecVersion 0.1.0 → 0.1.1 (§8.4 + #154)

### DIFF
--- a/internal/cli/testdata/version.golden
+++ b/internal/cli/testdata/version.golden
@@ -1,1 +1,1 @@
-logmind 1.0.0-dev (spec 0.1.0)
+logmind 1.0.0-dev (spec 0.1.1)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,17 +1,15 @@
 // Package version holds the build-time version constants for logmind.
 //
-// During the v1.0 Go rewrite the version string is "1.0.0-dev"; it will
-// be cut to "1.0.0" at the v1-go-rewrite → main cutover PR. The spec
-// version tracks the thrillmade/protocol SPEC.md document and is locked
-// at "0.1.0" — matching the v0.1.0 FINAL tag on thrillmade/protocol
-// (commit 86c2212: "spec(v0.1.0): resolve final 2 judgment calls").
+// v1.0.0 shipped 2026-06-03 via the v1-go-rewrite → main cutover (#132).
+// Local `go build` and `make build` produce a binary reporting the
+// "1.0.0-dev" default; tagged release builds running through
+// `.goreleaser.yaml` override via `-ldflags
+// "-X 'github.com/thrillmade/logmind/internal/version.Version=v1.2.3'"`
+// to inject the actual tag.
 //
-// Wave B7 (distribution): both values are `var` (not `const`) so the
-// GoReleaser build step can inject the released tag via `-ldflags
-// "-X 'github.com/thrillmade/logmind/internal/version.Version=v1.2.3'"`.
-// Local `go build` and `make build` still produce a binary that reports
-// the "1.0.0-dev" default — the override only fires on tagged release
-// builds running through `.goreleaser.yaml`.
+// SpecVersion tracks the thrillmade/protocol SPEC.md document — bumped
+// to "0.1.1" 2026-06-03 (protocol PR #1 + tag v0.1.1: align AGENTS.md
+// marker versions v5→v6 and v7-pointer→v8-pointer per §8.3).
 package version
 
 // Version is the logmind binary's semantic version. Bumped at release.
@@ -22,4 +20,4 @@ var Version = "1.0.0-dev"
 // this binary implements. Reported via `logmind --version` so downstream
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
-var SpecVersion = "0.1.0"
+var SpecVersion = "0.1.1"


### PR DESCRIPTION
Two tiny refresh edits to internal/version/version.go:

1. Docstring referenced the v1-go-rewrite → main cutover as future work; it landed in #132 on 2026-06-03. Updated to reflect post-cutover state.
2. SpecVersion bumped to 0.1.1 to track the just-merged thrillmade/protocol PR #1 (SPEC.md v0.1.1: AGENTS.md marker bumps per §8.3).

After merge + next tag release, `logmind --version` will report `logmind <X.Y.Z> (spec 0.1.1)`.

Closes #154; addresses §8.4 docstring residual.