### PR TITLE
[skip-logmind] chore(notify): port off Python import + idempotent fallback (§8.3)

### DIFF
--- a/.github/scripts/parse_changelog.py
+++ b/.github/scripts/parse_changelog.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Standalone CHANGELOG section extractor — vendored for
+`notify-agent-skills.yml` after PR #137 deleted the Python source tree
+(including `logmind.core.changelog`).
+
+This script reproduces ONLY what the workflow needed from the deleted
+`extract_sections_between` function: slice the CHANGELOG markdown to
+the `## [X.Y.Z]` sections between a `--after` tag and a `--up-to` tag.
+
+Long-term migration path: add `logmind changelog --since v<prev>` as a
+Go subcommand registered in `internal/cli/root.go`, then replace this
+script + the `python3` invocation in `notify-agent-skills.yml` with a
+single binary call. Tracked as a follow-up — this script is the
+stopgap for the v1.0.x release wave.
+
+Input file resolution:
+  1. Prefer `docs/changelog-python.md` (PR #137's new home).
+  2. Fall back to top-level `CHANGELOG.md` (pre-#137 location) so the
+     script remains correct on older refs the workflow might still
+     check out via `actions/checkout` (e.g. re-running on an older
+     tag).
+
+Usage:
+  python3 .github/scripts/parse_changelog.py \\
+    --since v0.6.16 \\
+    --up-to v1.0.0 \\
+    --out /tmp/notify/changelog-section.md
+
+  # --since may be omitted on the very first release; the script will
+  # then emit every section up to and including --up-to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Mirrors logmind.core.changelog._VERSION_HEADER_RE. Matches the
+# `## [X.Y.Z]` header at the start of a line; trailing date suffix
+# (` - 2026-06-03`) is ignored. Pre-release suffixes like `1.0.0-rc1`
+# are accepted via the optional `[\w.+\-]*` tail.
+_VERSION_HEADER_RE = re.compile(r"^##\s*\[(\d+\.\d+\.\d+(?:[\w.+\-]*)?)\]")
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a semver-ish string into a comparable tuple. Non-numeric
+    components (pre-release suffixes) collapse to a -1 sentinel so e.g.
+    0.2.10-rc1 sorts before 0.2.10. Mirrors the deleted Python helper.
+    """
+    parts: list[int] = []
+    for chunk in v.split("."):
+        try:
+            parts.append(int(chunk))
+        except ValueError:
+            # First non-int chunk → stop comparing numerically; treat
+            # as a pre-release suffix that sorts before the stable.
+            return tuple(parts) + (-1,)
+    return tuple(parts)
+
+
+def extract_sections_between(
+    changelog_text: str, *, after: str | None, up_to: str
+) -> str:
+    """Return the substring of CHANGELOG containing every `## [X.Y.Z]`
+    section S such that ``after < S.version <= up_to``.
+
+    `after=None` means "everything up to and including up_to".
+
+    Sections are emitted in source order. The CHANGELOG is laid out
+    most-recent-first, so once we step OUT of the included range we
+    can break — earlier sections are necessarily older.
+    """
+    if after is not None and _parse_version(up_to) <= _parse_version(after):
+        return ""  # caller is on or ahead of the target
+
+    lines = changelog_text.splitlines(keepends=True)
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        m = _VERSION_HEADER_RE.match(line)
+        if m:
+            version = m.group(1)
+            v_tuple = _parse_version(version)
+            include = v_tuple <= _parse_version(up_to) and (
+                after is None or v_tuple > _parse_version(after)
+            )
+            if include:
+                in_section = True
+                out.append(line)
+                continue
+            # Stepped OUT of the included range after collecting at
+            # least one section → done (sections are descending).
+            if out:
+                break
+            in_section = False
+            continue
+        if in_section:
+            out.append(line)
+    return "".join(out).rstrip() + "\n" if out else ""
+
+
+def _resolve_changelog_path(repo_root: Path) -> Path:
+    """Prefer the new docs/changelog-python.md location (PR #137);
+    fall back to top-level CHANGELOG.md for older checkouts. Fail
+    loudly if neither exists — the workflow should not silently
+    produce an empty section.
+    """
+    candidates = (
+        repo_root / "docs" / "changelog-python.md",
+        repo_root / "CHANGELOG.md",
+    )
+    for path in candidates:
+        if path.exists():
+            return path
+    paths_str = ", ".join(str(p) for p in candidates)
+    raise FileNotFoundError(
+        f"CHANGELOG file not found at any of: {paths_str}. "
+        "Did the file move again? Update _resolve_changelog_path."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract CHANGELOG sections between two version tags."
+    )
+    parser.add_argument(
+        "--since",
+        default="",
+        help=(
+            "Previous version tag (e.g. v0.6.16). Sections strictly newer "
+            "than this are included. Omit / empty string = include "
+            "everything up to --up-to (first-release case)."
+        ),
+    )
+    parser.add_argument(
+        "--up-to",
+        required=True,
+        help="Current version tag (e.g. v1.0.0). Inclusive upper bound.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="File path to write the extracted section to.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help=(
+            "Repository root to search for the CHANGELOG file. "
+            "Defaults to the current working directory (matches "
+            "actions/checkout's default workspace)."
+        ),
+    )
+    args = parser.parse_args()
+
+    # Strip leading `v` from both tags before passing into the version
+    # comparator, which expects bare X.Y.Z (matches the Python
+    # workflow's prior behavior).
+    after = args.since.lstrip("v") if args.since else None
+    up_to = args.up_to.lstrip("v")
+
+    changelog_path = _resolve_changelog_path(args.repo_root)
+    text = changelog_path.read_text(encoding="utf-8")
+    section = extract_sections_between(text, after=after, up_to=up_to)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(section, encoding="utf-8")
+    print(
+        f"  Read CHANGELOG from: {changelog_path}\n"
+        f"  Extracted {len(section)} chars of CHANGELOG section "
+        f"(after={after or '<none>'}, up_to={up_to})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/notify-agent-skills.yml
+++ b/.github/workflows/notify-agent-skills.yml
@@ -39,23 +39,20 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install logmind + anthropic SDK
+      - name: Install anthropic SDK
         run: |
           set -euo pipefail
-          # Install the just-released logmind from PyPI. The notify
-          # workflow runs AFTER publish.yml in the release chain, so
-          # the version is available. Pin to the tagged version so
-          # this step's behavior matches what consumers will see.
-          VERSION="${TAG#v}"
-          # Wait briefly for PyPI propagation — publish.yml also
-          # waits, but the GitHub-Actions runner's view of PyPI is
-          # sometimes behind. Best-effort.
-          for i in $(seq 1 18); do
-            if pip install "logmind==${VERSION}" 2>/dev/null; then break; fi
-            echo "  pip install logmind==${VERSION} attempt ${i}/18 — retrying in 10s"
-            sleep 10
-          done
-          pip install logmind=="${VERSION}"  # final attempt; fail loud if still unavailable
+          # v1.0 cutover note: PR #137 deleted the Python source tree
+          # including `logmind.core.changelog`, so we no longer
+          # `pip install logmind==<TAG>` here — the changelog slice is
+          # now produced by the vendored `parse_changelog.py` script
+          # below, which has zero non-stdlib deps. Only the anthropic
+          # SDK remains (still used by `.github/scripts/propose_skill_update.py`
+          # to call Claude for the SKILL.md diff proposal).
+          #
+          # The PyPI propagation/retry dance we used to need also goes
+          # away as a side effect: there's no `pip install logmind` to
+          # race against publish.yml anymore.
           pip install anthropic
 
       - name: Determine previous tag (for CHANGELOG slice)
@@ -80,23 +77,20 @@ jobs:
           PREV_TAG: ${{ steps.prev.outputs.tag }}
         run: |
           set -euo pipefail
-          # Strip leading v from version tags before passing to
-          # extract_sections_between, which expects bare X.Y.Z.
-          AFTER="${PREV_TAG#v}"
-          UP_TO="${TAG#v}"
+          # Calls the vendored standalone script (zero non-stdlib deps)
+          # that replaced `from logmind.core.changelog import
+          # extract_sections_between` after PR #137 deleted the Python
+          # source tree. Script resolves the CHANGELOG file from
+          # `docs/changelog-python.md` (new home) with a fallback to
+          # top-level `CHANGELOG.md` for older checkouts.
+          #
+          # Long-term: replace with `logmind changelog --since <prev>`
+          # once that Go subcommand exists (tracked as a follow-up).
           mkdir -p /tmp/notify
-          python3 - <<PY
-          from pathlib import Path
-          from logmind.core.changelog import extract_sections_between
-          text = Path("CHANGELOG.md").read_text(encoding="utf-8")
-          section = extract_sections_between(
-              text,
-              after="${AFTER}" or None,
-              up_to="${UP_TO}",
-          )
-          Path("/tmp/notify/changelog-section.md").write_text(section, encoding="utf-8")
-          print(f"  Extracted {len(section)} chars of CHANGELOG section")
-          PY
+          python3 .github/scripts/parse_changelog.py \
+            --since "${PREV_TAG}" \
+            --up-to "${TAG}" \
+            --out /tmp/notify/changelog-section.md
 
       - name: Fetch current SKILL.md from agent-skills
         env:
@@ -181,11 +175,14 @@ jobs:
           git checkout -b "$BRANCH"
 
           # Always write the stub TODO file with full context.
+          # CHANGELOG file moved to docs/changelog-python.md in PR #137
+          # (Python source removal). The path here is rendered into
+          # markdown reviewers click — point at the new location.
           mkdir -p .skill-update-todo
           {
             echo "# logmind ${TAG} — skill update context"
             echo
-            echo "**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md"
+            echo "**CHANGELOG diff**: https://github.com/thrillmade/logmind/blob/${TAG}/docs/changelog-python.md"
             echo "**Release URL**: https://github.com/thrillmade/logmind/releases/tag/${TAG}"
             echo
             echo "## Claude's reasoning"
@@ -212,7 +209,7 @@ jobs:
           PR_BODY=$(cat <<EOF
           Automated notification from \`thrillmade/logmind\` — ${TAG} shipped.
 
-          **CHANGELOG**: [\`${TAG}\` on logmind](https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md)
+          **CHANGELOG**: [\`${TAG}\` on logmind](https://github.com/thrillmade/logmind/blob/${TAG}/docs/changelog-python.md)
           **Release**: https://github.com/thrillmade/logmind/releases/tag/${TAG}
 
           ## Shape of this PR
@@ -245,6 +242,27 @@ jobs:
   # Fallback job: if the propose-skill-update job above failed (Anthropic
   # API down, PAT missing, etc.), open the v0.3.x-style issue so the
   # release still gets acknowledged.
+  #
+  # Idempotency rules (added 2026-06-03 after the v1.0.0 release wave
+  # — rc1 → rc2 → rc3 → v1.0.0 — produced 11 stale fallback issues on
+  # thrillmade/agent-skills):
+  #
+  #   1. Same-skill check (any age): if ANY open issue tagged
+  #      `from-logmind` already mentions this SKILL ("skills/logmind/SKILL.md"),
+  #      append a comment instead of opening a new one. This collapses
+  #      cascaded failures across a release wave onto a single tracker
+  #      until a maintainer triages it.
+  #
+  #   2. Daily-cap (rolling 24h): if any open `from-logmind` issue with
+  #      the canonical fallback title was opened in the last 24h,
+  #      comment instead of opening. Catches the case where rule #1
+  #      somehow misses (e.g. label not yet applied because a prior
+  #      run failed mid-create) but the workflow is still firing on
+  #      consecutive release attempts within a day.
+  #
+  # Both checks degrade gracefully — if `gh` rate-limits or the API
+  # returns nothing, we fall through to opening a fresh issue rather
+  # than silently swallowing the signal.
   fallback-issue:
     runs-on: ubuntu-latest
     needs: propose-skill-update
@@ -252,9 +270,11 @@ jobs:
     env:
       TAG: ${{ github.ref_name }}
     steps:
-      - name: Open fallback issue on agent-skills
+      - name: Open or update fallback issue on agent-skills
         env:
           GH_TOKEN: ${{ secrets.AGENT_SKILLS_NOTIFY_PAT }}
+          RUN_ID: ${{ github.run_id }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
@@ -262,15 +282,17 @@ jobs:
             exit 0
           fi
 
+          TITLE="logmind ${TAG} shipped — review skills/logmind/SKILL.md (PR-shape notify failed, fallback)"
+
           BODY=$(cat <<EOF
           logmind \`${TAG}\` shipped but the v0.4.0 PR-shape notify workflow failed.
 
           Falling back to the v0.3.x issue notification. Review \`skills/logmind/SKILL.md\` manually for any user-facing changes:
 
-          - CHANGELOG: https://github.com/thrillmade/logmind/blob/${TAG}/CHANGELOG.md
+          - CHANGELOG: https://github.com/thrillmade/logmind/blob/${TAG}/docs/changelog-python.md
           - SKILL.md:  https://github.com/thrillmade/agent-skills/blob/main/skills/logmind/SKILL.md
 
-          The workflow run (for debugging): https://github.com/thrillmade/logmind/actions/runs/\${{ github.run_id }}
+          The workflow run (for debugging): https://github.com/thrillmade/logmind/actions/runs/${RUN_ID}
 
           Close as a no-op if this release is internal-only with no skill-relevant changes.
           EOF
@@ -282,12 +304,59 @@ jobs:
             --description "Auto-opened by logmind release notifier" \
             --force || true
 
+          # Idempotency rule #1: same-skill check (any age).
+          # The fallback is currently a single-skill notifier (skills/logmind/SKILL.md),
+          # so any open from-logmind issue is by-definition for the same skill.
+          # Pick the most recently updated one to comment on.
+          EXISTING_SAME_SKILL=$(gh issue list \
+            --repo thrillmade/agent-skills \
+            --state open \
+            --label from-logmind \
+            --search "skills/logmind/SKILL.md in:body" \
+            --json number,updatedAt \
+            --jq 'sort_by(.updatedAt) | reverse | .[0].number // ""' \
+            2>/dev/null || echo "")
+
+          # Idempotency rule #2: daily-cap (rolling 24h).
+          # Cutoff is "now minus 24h" in ISO-8601 UTC; gh's --search uses
+          # GitHub's date-comparison syntax (`created:>YYYY-MM-DDTHH:MM:SSZ`).
+          # Brace-quoted title substring matches GitHub issue search phrase syntax.
+          CUTOFF=$(date -u -d "24 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+                   date -u -v-24H "+%Y-%m-%dT%H:%M:%SZ")
+          EXISTING_RECENT=$(gh issue list \
+            --repo thrillmade/agent-skills \
+            --state open \
+            --search "\"PR-shape notify failed, fallback\" in:title created:>${CUTOFF}" \
+            --json number,createdAt \
+            --jq 'sort_by(.createdAt) | reverse | .[0].number // ""' \
+            2>/dev/null || echo "")
+
+          # Prefer same-skill match; fall through to daily-cap match.
+          TARGET="${EXISTING_SAME_SKILL:-${EXISTING_RECENT}}"
+
+          if [ -n "${TARGET}" ]; then
+            echo "::notice::Fallback already tracked in issue #${TARGET} — appending comment instead of opening a new one."
+            COMMENT=$(cat <<EOF
+          Fallback fired again at HEAD \`${HEAD_SHA}\` for tag \`${TAG}\`.
+
+          Workflow run: https://github.com/thrillmade/logmind/actions/runs/${RUN_ID}
+
+          (Idempotency rule active — see \`notify-agent-skills.yml\` \`fallback-issue\` job. Close this thread once the underlying issue is resolved; subsequent fallbacks will open a fresh tracker.)
+          EOF
+          )
+            gh issue comment "${TARGET}" \
+              --repo thrillmade/agent-skills \
+              --body "${COMMENT}"
+            exit 0
+          fi
+
+          # No existing tracker — open a fresh issue.
           gh issue create \
             --repo thrillmade/agent-skills \
-            --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md (PR-shape notify failed, fallback)" \
+            --title "${TITLE}" \
             --label "from-logmind" \
             --body "$BODY" \
             || gh issue create \
               --repo thrillmade/agent-skills \
-              --title "logmind ${TAG} shipped — review skills/logmind/SKILL.md (PR-shape notify failed, fallback)" \
+              --title "${TITLE}" \
               --body "$BODY"

--- a/.github/workflows/notify-agent-skills.yml
+++ b/.github/workflows/notify-agent-skills.yml
@@ -344,10 +344,18 @@ jobs:
           (Idempotency rule active — see \`notify-agent-skills.yml\` \`fallback-issue\` job. Close this thread once the underlying issue is resolved; subsequent fallbacks will open a fresh tracker.)
           EOF
           )
-            gh issue comment "${TARGET}" \
-              --repo thrillmade/agent-skills \
-              --body "${COMMENT}"
-            exit 0
+            # Per clud-bug-review on PR #140: `gh issue comment` failure
+            # (network blip, API outage, transient 5xx) must not silently
+            # drop the signal. Fall through to opening a fresh issue if
+            # the comment attempt fails — losing the signal entirely would
+            # let a stuck workflow go unnoticed for days. Idempotency rule
+            # 2 (daily-cap) still bounds duplicate-open noise.
+            if gh issue comment "${TARGET}" \
+                 --repo thrillmade/agent-skills \
+                 --body "${COMMENT}"; then
+              exit 0
+            fi
+            echo "::warning::Comment on #${TARGET} failed; falling through to fresh issue (signal preservation per PR #140 review)."
           fi
 
           # No existing tracker — open a fresh issue.


### PR DESCRIPTION
Per master plan §8.3. Two-deliverables-in-one: port `.github/workflows/notify-agent-skills.yml` off the now-dead `logmind.core.changelog` Python module (PR #137 deleted it) AND add idempotency to the `fallback-issue` job so a flapping API can't accumulate dozens of duplicate issues on `thrillmade/agent-skills` (the v1.0.0 release wave generated 12 such fallback issues — already closed in parallel).

**Changes:**

1. `.github/workflows/notify-agent-skills.yml`:
   - Stops importing `logmind.core.changelog` (gone after #137 merge).
   - Calls vendored `scripts/parse_changelog.py` (~120 LOC) that reads `docs/changelog-python.md` (new path after #137) with fallback to top-level `CHANGELOG.md` for backward compat. Same extract-sections semantics as the old Python module.
   - Adds fallback-issue idempotency: rolling-24h daily-cap via `created:>${CUTOFF}` issue search + same-skill check (open `from-logmind` issues with `skills/logmind/SKILL.md in:body`). If a recent or open fallback for the same skill exists, comment on it rather than opening a new one.

2. `.github/scripts/parse_changelog.py`:
   - New file. Docstring calls out the Option-A migration path: add `logmind changelog --since <tag>` Go subcommand in next release, replace this script + `python3` call with single binary invocation.
   - Tested locally against `docs/changelog-python.md`:
     - `--since v0.6.13 --up-to v0.6.14` → 3,535 chars
     - `--since "" --up-to v0.5.10` → 58,357 chars (first-release case)
     - `--since v0.7.0 --up-to v0.6.0` → 0 chars (caller-ahead edge)

**Parallel deliverable — 12 stale fallback issues closed on `thrillmade/agent-skills`:**
#98 #99 #100 #101 #102 #103 #104 #105 #106 #107 #108 #109 (v1.0.0 release wave: rc1 → rc2 → rc3 → v1.0.0).

**Verification:**
- yaml.safe_load + actionlint both clean on the edited workflow.
- Script tested locally with three representative inputs (above).

URGENT: must land before next logmind tag release; without this, the next tag fires `notify-agent-skills.yml` which then breaks on the missing Python module and re-opens the fallback issue noise pattern.