### PR TITLE
chore: migrate workflows to setup-logmind action + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      thrillmade:
+        patterns:
+          - "thrillmade/*"

--- a/docs/decisions-branches/chore__migrate-to-setup-logmind.md
+++ b/docs/decisions-branches/chore__migrate-to-setup-logmind.md
@@ -1,0 +1,15 @@
+## 2026-06-05 23:50 - Migrate logmind templates to setup-logmind@v1.0.1 + dependabot group
+
+**Reasoning:** Closes out the v1.1.0 distribution-lock wave by bumping the workflow-template setup-logmind pin from v1.0.0 → v1.0.1 (final immutable ref) and adding the `thrillmade` group to this repo's existing dependabot github-actions ecosystem entry. Future `logmind init` runs scaffold v1.0.1, and Dependabot now bundles all `thrillmade/*` action bumps into one PR per release — same shape we're rolling out to the 6 consumer repos in this same cleanup wave. Last manual setup-logmind version touch on the logmind side; from here Dependabot owns it.
+
+**Alternatives considered:** Leave templates at v1.0.0 and let Dependabot bump them on first install (rejected — new `logmind init` runs would scaffold a stale pin until Dependabot ran, creating a one-cycle drift window for fresh consumers); bump only the action templates without adding the dependabot group here in logmind (rejected — logmind is itself a consumer repo for things like actions/checkout, and the orchestrator-app pattern means it consumes thrillmade/* actions too; the group keeps the propagation pipeline consistent across this repo and the 6 downstreams).
+
+**Implications:**
+- `internal/templates/github/check-doc-links.yml.template`, `regen-timeline.yml.template`, `logmind-self-update.yml.template` bump `thrillmade/setup-logmind@v1.0.0` → `@v1.0.1`. Template-version markers left unchanged (v4 / v4 / v8) — pure pin bumps are Dependabot's job, not the self-update workflow's. Marker bumps only ship when the template BODY shape changes.
+- `.github/dependabot.yml` gains a `groups: thrillmade: patterns: ["thrillmade/*"]` block on the existing `github-actions` ecosystem entry. Bundles future thrillmade/* action bumps (setup-logmind, agent-skills future actions, etc.) into one PR per release.
+- Existing tests pass: `internal/templates/templates_test.go` and `internal/cli/init_test.go` both use prefix matching (`thrillmade/setup-logmind@v`), so they're version-agnostic. No test churn.
+- Companion PRs land in the other 6 consumer repos this same wave (clud-bug, clud-bug-app, agent-skills, tokenomics, reporulez, rezgen). Each replaces the legacy curl-install / pip-install block with `uses: thrillmade/setup-logmind@v1.0.1` and merges the dependabot group block.
+- READMEs (`README.md`, `docs/install.md`) and the installer's CI-advisory message (`installer/install.sh`) still reference `v1.0.0` — intentionally untouched in this PR. They're user-facing docs, not the scaffold path; Dependabot won't bump them. Separate doc-update sweep if/when v1.0.x churns again.
+
+---
+

--- a/internal/templates/github/check-doc-links.yml.template
+++ b/internal/templates/github/check-doc-links.yml.template
@@ -28,7 +28,7 @@ jobs:
       # consumer repos. Dependabot keeps the action ref current via the
       # `github-actions` ecosystem block in `.github/dependabot.yml` (also
       # installed by `logmind init`).
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Check markdown link integrity
         run: logmind check-links

--- a/internal/templates/github/logmind-self-update.yml.template
+++ b/internal/templates/github/logmind-self-update.yml.template
@@ -138,7 +138,7 @@ jobs:
       # `logmind init` (the refresh) runs against the same binary
       # version consumer repos will see after this workflow lands its
       # PR. The action's version tracks the LATEST step output.
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
         if: steps.compare.outputs.skip == 'false'
         with:
           version: ${{ steps.compare.outputs.latest }}

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -63,7 +63,7 @@ jobs:
       # consumer repos. Dependabot keeps the action ref current via the
       # `github-actions` ecosystem block in `.github/dependabot.yml` (also
       # installed by `logmind init`).
-      - uses: thrillmade/setup-logmind@v1.0.0
+      - uses: thrillmade/setup-logmind@v1.0.1
 
       - name: Regenerate derived docs
         run: |


### PR DESCRIPTION
## Summary

Closes out the v1.1.0 distribution-lock wave on the logmind side.

- Bumps `thrillmade/setup-logmind@v1.0.0` → `@v1.0.1` (final immutable ref) in the three workflow templates (`check-doc-links`, `regen-timeline`, `logmind-self-update`). Future `logmind init` runs scaffold v1.0.1.
- Adds `groups: thrillmade: patterns: ["thrillmade/*"]` to the existing `github-actions` ecosystem entry in `.github/dependabot.yml`. Bundles future `thrillmade/*` action bumps into one PR per release.
- Logs the decision at `docs/decisions-branches/chore__migrate-to-setup-logmind.md`.

Last manual setup-logmind version touch — Dependabot owns the pin from here. Companion PRs land in the 6 consumer repos this same wave (clud-bug, clud-bug-app, agent-skills, tokenomics, reporulez, rezgen).

Per locked distribution decision (2026-06-05 §Architectural Decisions): static-pin + Dependabot replaces curl-pinned-version pattern. Industry-standard Go-CLI distribution.

## Test plan

- [x] `go test ./internal/templates/... ./internal/inserter/... ./internal/cli/...` — green
- [x] Template-version markers left unchanged (v4 / v4 / v8) — pin bumps are Dependabot's job, not the self-update workflow's
- [x] READMEs and `installer/install.sh` CI-advisory message intentionally untouched (user-facing docs, not the scaffold path)