### PR TITLE
chore: bump dependabot-auto-merge caller pin to 6e1f9df (major-bump support)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
-# Auto-approve + squash-merge Dependabot patch/minor PRs once required CI passes.
-# Major bumps are left for human review. See §8.1 for org-level rationale.
+# Auto-approve + squash-merge Dependabot PRs once required CI passes.
+# Patch/minor/major all eligible — CI gates breakage. See §8.1 for org-level rationale.
 #
 # Calls the reusable workflow at thrillmade/.github.
 
@@ -16,8 +16,8 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    # Pinned to thrillmade/.github commit b208d22 for supply-chain immutability (§8.6 orchestrator App approval (was GHA token, blocked by policy)). Bump via dependabot or manual edit.
-    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@b208d22652d2585efb106e99e543113a113b101f
+    # Pinned to thrillmade/.github commit 6e1f9df for supply-chain immutability (§8.6 orchestrator App approval (was GHA token, blocked by policy)). Bump via dependabot or manual edit.
+    uses: thrillmade/.github/.github/workflows/dependabot-auto-merge.yml@6e1f9dfd2695396d5ae2b14af9a84ca132784a94
     secrets:
       orchestrator-app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
       orchestrator-private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}

--- a/docs/decisions-branches/chore__bump-dabm-pin-6e1f9df.md
+++ b/docs/decisions-branches/chore__bump-dabm-pin-6e1f9df.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-10 11:29 - Bump dependabot-auto-merge caller pin to 6e1f9df
+
+**Reasoning:** Picks up thrillmade/.github PR #3 which drops the major-bump early-stop step. CI gates breakage; trust the bots.
+
+**Alternatives considered:** Stay on b208d22 and continue blocking major bumps from auto-merge — rejected, contradicts org direction 2026-06-10
+
+**Implications:**
+- Major dependabot bumps in this repo will now auto-merge on required-CI pass like patch/minor already do
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -132,6 +132,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-06-29** — Add `logmind doctor --fix`: one-command idempotent repo refresh (Slice 1) → [detail](decisions-branches/fix__doctor-fix.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-06-10-bump-dependabot-auto-merge-caller-pin-to-6e1f9df -->
+- **2026-06-10** — Bump dependabot-auto-merge caller pin to 6e1f9df → [detail](decisions-branches/chore__bump-dabm-pin-6e1f9df.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-06-07-v1-2-0-port-logmind-log-to-go-and-add-3-layer-markdown-self- -->
 - **2026-06-07** — v1.2.0: Port logmind log to Go and add 3-layer markdown self-healing → [detail](decisions-branches/feat__v1.2.0-log-go-port-self-heal.md)
 <!-- logmind-entry-end -->


### PR DESCRIPTION
Bumps the reusable workflow pin to pick up the change from PR #3 on `thrillmade/.github` (drops the major-bump early-stop step). After merge, major dependabot bumps in this repo will auto-merge on CI pass like patch/minor already do.