### PR TITLE
feat(doctor): add `logmind doctor --fix` — one-command idempotent repo refresh (Slice 1)

### DIFF
--- a/docs/decisions-branches/fix__doctor-fix.md
+++ b/docs/decisions-branches/fix__doctor-fix.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 15:28 - Add `logmind doctor --fix`: one-command idempotent repo refresh (Slice 1)
+
+**Reasoning:** Consumers whose hooks/workflows/AGENTS.md/merge-driver config drift had no self-service fix — doctor only REPORTED drift. --fix completes the de-friction story (handoff deliverable c): one command brings a drifted repo back to spec. The idempotent installers already existed and init's refresh mode already orchestrated them; doctor just never called them.
+
+**Alternatives considered:** Keep doctor read-only + add a separate fix command — doctor already owns the probe→artifact map, so --fix reuses it, Duplicate the refresh sequence in doctor — extracted a shared applyRefresh so init refresh-mode and doctor --fix share one path
+
+**Implications:**
+- New internal/cli/refresh.go (applyRefresh + refreshResult); doctor.go gains --fix → runDoctorFix (idempotent; quiet 'ok doctor-fix …' line; residual PATH/foreign-hook drift warned not failed; hard write error exits 1). runInitRefresh refactored onto applyRefresh (now also surfaces previously-swallowed AGENTS.md/.gitattributes write errors). Never writes docs/ content, .logmind/config.yml, or a foreign hook. Symlink-following writes are a pre-existing limitation across all installers (noted, not fixed here).
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (91 decisions)
+## 2026-06 (92 decisions)
 
-- **2026-06-29** — Make the derived-doc CI gate advisory (Slice 1 de-friction): never block, never GITHUB_TOKEN-push *(fix/derived-docs-advisory-gate)* — [decisions-branches/fix__derived-docs-advisory-gate.md](decisions-branches/fix__derived-docs-advisory-gate.md)
-- *... 89 more decisions ...*
+- **2026-06-29** — Add `logmind doctor --fix`: one-command idempotent repo refresh (Slice 1) *(fix/doctor-fix)* — [decisions-branches/fix__doctor-fix.md](decisions-branches/fix__doctor-fix.md)
+- *... 90 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,4 +1,4 @@
-// doctor.go — `logmind doctor [--json] [--offline] [--exit-zero]`
+// doctor.go — `logmind doctor [--json] [--offline] [--exit-zero] [--fix]`
 // subcommand.
 //
 // Thin shim over internal/doctor.CollectStatus + RenderStatus. The
@@ -9,36 +9,45 @@
 // Exit semantics:
 //   - overall == "DRIFT" + !--exit-zero → cobra returns ErrSilent so
 //     main exits 1 without re-printing the rendered output.
+//   - --fix applies remediation and exits 0 (residual PATH/version drift
+//     and foreign hooks are warned, not failed); a hard write error during
+//     --fix exits 1.
 //   - All other paths return nil (exit 0).
 //
 // Output:
 //   - Default: human-readable table to stdout.
 //   - --json: report.ToJSON() (2-space indent) to stdout.
-//
-// Network:
-//   - Default: best-effort PyPI probe with 2-second timeout. Failures
-//     degrade to "?" in the latest column.
-//   - --offline: skip the probe entirely; latest column reads
-//     "(offline)".
+//   - --fix: a single quiet `ok doctor-fix …` line to stdout (or the
+//     post-fix report JSON with --fix --json).
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/doctor"
 )
 
 func newDoctorCmd() *cobra.Command {
-	var asJSON, offline, exitZero bool
+	var asJSON, offline, exitZero, fix bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Report installed versions and workflow drift",
+		Short: "Report (and optionally --fix) installed versions and workflow drift",
 		Long: "Report installed versions and workflow drift for logmind +\n" +
 			"clud-bug across .github/workflows/, AGENTS.md, git hooks, and\n" +
-			"merge-driver configuration. Read-only; exits non-zero on drift\n" +
-			"so it's CI-pluggable.",
+			"merge-driver configuration. Read-only by default; exits non-zero\n" +
+			"on drift so it's CI-pluggable.\n\n" +
+			"With --fix, re-installs the drifted on-disk artifacts (workflows,\n" +
+			"AGENTS.md block, .gitattributes, merge-driver config, git hooks) in\n" +
+			"one idempotent pass. --fix never edits docs/ decision content,\n" +
+			"foreign (hand-written) hooks, or your PATH.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if fix {
+				return runDoctorFix(cmd, offline, asJSON)
+			}
 			report := doctor.CollectStatus("", offline)
 			if asJSON {
 				out, err := report.ToJSON()
@@ -58,5 +67,78 @@ func newDoctorCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the report as JSON.")
 	cmd.Flags().BoolVar(&offline, "offline", false, "Skip PyPI / npm probes; use only locally-readable signals.")
 	cmd.Flags().BoolVar(&exitZero, "exit-zero", false, "Always exit 0, even on drift (for informational CI runs).")
+	cmd.Flags().BoolVar(&fix, "fix", false, "Re-install drifted workflows, AGENTS.md block, .gitattributes, merge-driver config, and git hooks (idempotent). Never edits docs/ decisions, foreign hooks, or PATH.")
 	return cmd
+}
+
+// runDoctorFix applies the idempotent remediation pass (applyRefresh) and
+// reports what it changed. It exits 0 even when residual drift remains —
+// PATH/version drift and foreign (markerless) hooks are surfaced as a
+// warning, not a failure, because --fix is an action verb a human runs to
+// clean a repo. A genuine write failure exits 1.
+func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	res, refreshErr := applyRefresh(cwd, refreshOpts{githubActions: true, git: true})
+	if refreshErr != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "error: doctor --fix:", refreshErr)
+		return ErrSilent
+	}
+
+	// Re-probe to compute the residual drift that --fix cannot address.
+	after := doctor.CollectStatus(cwd, offline)
+	residual := residualProbes(after)
+
+	if asJSON {
+		out, err := after.ToJSON()
+		if err != nil {
+			return err
+		}
+		cmd.Println(out)
+		return nil
+	}
+
+	cmd.Println(formatDoctorFixOK(res, residual))
+	for _, name := range residual {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"note: %q still drifted — not auto-fixable by `doctor --fix` "+
+				"(PATH/version, or a hand-written hook). See `logmind doctor`.\n", name)
+	}
+	return nil
+}
+
+// residualProbes returns the names of probes still drifted after a fix pass:
+// PATH/version drift and foreign (markerless) hooks, which --fix
+// deliberately does not touch.
+func residualProbes(r doctor.StatusReport) []string {
+	var out []string
+	for _, t := range r.Tools {
+		for _, wf := range t.Workflows {
+			if wf.Drift == "stale" || wf.Drift == "markerless" {
+				out = append(out, wf.Name)
+			}
+		}
+	}
+	return out
+}
+
+// formatDoctorFixOK renders the single quiet `ok` summary line.
+func formatDoctorFixOK(res refreshResult, residual []string) string {
+	state := func(changed bool, changedWord string) string {
+		if changed {
+			return changedWord
+		}
+		return "current"
+	}
+	return fmt.Sprintf(
+		"ok doctor-fix workflows=%d agents-md=%s gitattributes=%s merge-driver=%s hooks=%d residual=%d",
+		len(res.WorkflowsCreated)+len(res.WorkflowsRefreshed),
+		state(res.AgentsMDMsg != "", "changed"),
+		state(res.GitattrChanged, "written"),
+		state(res.MergeDriverSet, "set"),
+		len(res.HooksRefreshed),
+		len(residual),
+	)
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -330,44 +330,35 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string) erro
 	fmt.Fprintln(out, "logmind is already initialized — running in refresh mode.")
 	fmt.Fprintln(out)
 
+	res, err := applyRefresh(cwd, refreshOpts{githubActions: f.githubActions, git: true})
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: refresh failed:", err)
+	}
+
 	if f.githubActions {
-		created, refreshed, err := installWorkflowTemplates(cwd, true)
-		if err != nil {
-			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: workflow refresh failed:", err)
-		}
-		for _, wf := range created {
+		for _, wf := range res.WorkflowsCreated {
 			fmt.Fprintln(out, "✓ Created", wf)
 		}
-		for _, wf := range refreshed {
+		for _, wf := range res.WorkflowsRefreshed {
 			fmt.Fprintln(out, "↻ Refreshed", wf, "to current template")
 		}
-		if len(created) == 0 && len(refreshed) == 0 {
+		if len(res.WorkflowsCreated) == 0 && len(res.WorkflowsRefreshed) == 0 {
 			fmt.Fprintln(out, "  All workflow templates already current.")
 		}
-		// Dependabot config — same merge semantics as a fresh init;
-		// idempotent so re-running on an already-current file is a
-		// silent no-op.
+		// Dependabot config is init-owned (doctor doesn't probe it, so
+		// applyRefresh leaves it alone); keep init's own merge semantics +
+		// existing-ecosystem nudge here.
 		_ = applyDependabotInit(cmd, cwd)
 	}
 
-	// AGENTS.md refresh — idempotent.
-	if msg, err := inserter.EnsureAgentsMD(cwd); err == nil && msg != "" {
-		fmt.Fprintln(out, msg)
+	if res.AgentsMDMsg != "" {
+		fmt.Fprintln(out, res.AgentsMDMsg)
 	}
-
-	// .gitattributes + merge driver config + hooks.
-	if changed, err := gitattr.EnsureBlock(filepath.Join(cwd, ".gitattributes")); err == nil && changed {
+	if res.GitattrChanged {
 		fmt.Fprintln(out, "✓ Added logmind block to .gitattributes")
 	}
-	_ = gitattr.ConfigureMergeDrivers(cwd)
-	if changed, _ := hooks.InstallPostMerge(cwd); changed {
-		fmt.Fprintln(out, "✓ Refreshed .git/hooks/post-merge")
-	}
-	if changed, _ := hooks.InstallPostRewrite(cwd); changed {
-		fmt.Fprintln(out, "✓ Refreshed .git/hooks/post-rewrite")
-	}
-	if changed, _ := hooks.InstallCommitMsg(cwd); changed {
-		fmt.Fprintln(out, "✓ Refreshed .git/hooks/commit-msg")
+	for _, h := range res.HooksRefreshed {
+		fmt.Fprintln(out, "✓ Refreshed .git/hooks/"+h)
 	}
 
 	fmt.Fprintln(out)

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -1,0 +1,108 @@
+// refresh.go — the shared, idempotent "bring this repo back to spec"
+// remediation sequence, used by both `logmind init` (refresh mode) and
+// `logmind doctor --fix`.
+//
+// It re-installs exactly the on-disk artifacts that `logmind doctor`
+// probes for drift: the workflow templates, the AGENTS.md marker block,
+// the .gitattributes logmind block, the per-clone merge-driver git config,
+// and the three managed git hooks (post-merge / post-rewrite / commit-msg).
+//
+// It deliberately does NOT:
+//   - write or rewrite docs/ decision content, docs/timeline.md, or
+//     docs/file-structure.md (those are content / derived docs, not
+//     install state);
+//   - touch .logmind/config.yml;
+//   - clobber a foreign (markerless) git hook — hooks.Install* refuse to
+//     overwrite a hook that lacks the logmind marker, so a hand-written
+//     hook is left alone and surfaces as residual drift instead;
+//   - manage .github/dependabot.yml (doctor does not probe it; init keeps
+//     its own dependabot UX).
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/thrillmade/logmind/internal/gitattr"
+	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/inserter"
+)
+
+// refreshResult tallies what applyRefresh actually changed. It drives both
+// init's "✓/↻" lines and doctor --fix's quiet `ok` summary.
+type refreshResult struct {
+	WorkflowsCreated   []string // rel paths
+	WorkflowsRefreshed []string // rel paths
+	AgentsMDMsg        string   // "" when no change
+	GitattrChanged     bool
+	MergeDriverSet     bool     // a merge-driver git config key was (re)written
+	HooksRefreshed     []string // subset of {"post-merge","post-rewrite","commit-msg"}
+}
+
+// Changed reports whether applyRefresh wrote anything.
+func (r refreshResult) Changed() bool {
+	return len(r.WorkflowsCreated) > 0 || len(r.WorkflowsRefreshed) > 0 ||
+		r.AgentsMDMsg != "" || r.GitattrChanged || r.MergeDriverSet ||
+		len(r.HooksRefreshed) > 0
+}
+
+// refreshOpts gates the two write surfaces that need a repo/CI context.
+type refreshOpts struct {
+	githubActions bool // install/refresh .github/workflows/*
+	git           bool // configure merge drivers + install hooks (no-op outside a git repo)
+}
+
+// applyRefresh runs every idempotent installer that brings a drifted repo
+// back to spec, reporting what changed. It never writes docs/ content or a
+// foreign hook (the underlying installers enforce the latter).
+//
+// All steps run best-effort; the FIRST hard write error (from the
+// content-bearing installers: workflows, AGENTS.md, .gitattributes) is
+// returned without aborting the remaining steps, so a caller can choose to
+// warn-and-continue (init) or fail (doctor --fix). Merge-driver and hook
+// installers are merge-time optimizations that swallow their own per-item
+// errors, matching the existing init behavior.
+func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
+	var res refreshResult
+	var firstErr error
+	note := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if opts.githubActions {
+		created, refreshed, err := installWorkflowTemplates(cwd, true)
+		res.WorkflowsCreated = created
+		res.WorkflowsRefreshed = refreshed
+		note(err)
+	}
+
+	// AGENTS.md marker block + .gitattributes block are repo-content, not
+	// git-state, so they run regardless of opts.git.
+	msg, err := inserter.EnsureAgentsMD(cwd)
+	if err == nil {
+		res.AgentsMDMsg = msg
+	}
+	note(err)
+
+	changed, err := gitattr.EnsureBlock(filepath.Join(cwd, ".gitattributes"))
+	if err == nil && changed {
+		res.GitattrChanged = true
+	}
+	note(err)
+
+	if opts.git {
+		res.MergeDriverSet = gitattr.ConfigureMergeDrivers(cwd)
+		if c, _ := hooks.InstallPostMerge(cwd); c {
+			res.HooksRefreshed = append(res.HooksRefreshed, "post-merge")
+		}
+		if c, _ := hooks.InstallPostRewrite(cwd); c {
+			res.HooksRefreshed = append(res.HooksRefreshed, "post-rewrite")
+		}
+		if c, _ := hooks.InstallCommitMsg(cwd); c {
+			res.HooksRefreshed = append(res.HooksRefreshed, "commit-msg")
+		}
+	}
+
+	return res, firstErr
+}

--- a/internal/cli/refresh_test.go
+++ b/internal/cli/refresh_test.go
@@ -1,0 +1,164 @@
+// refresh_test.go — exercises `logmind doctor --fix` (the shared
+// applyRefresh remediation pass reached through the doctor command).
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitInitCwd runs `git init` (+ identity) in the current working dir so
+// merge-driver config and hook installation have a real repo to act on.
+func gitInitCwd(t *testing.T) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "logmind-test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func writeRel(t *testing.T, rel, content string, mode os.FileMode) {
+	t.Helper()
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(rel, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readRel(t *testing.T, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// runDoctorFixCmd runs `doctor --fix --offline` in the current cwd and
+// returns (stdout, stderr). Fails on a non-nil error (a hard write fault).
+func runDoctorFixCmd(t *testing.T) (string, string) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs([]string{"doctor", "--fix", "--offline"})
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("doctor --fix: %v\nstderr=%s", err, errOut.String())
+	}
+	return out.String(), errOut.String()
+}
+
+// TestDoctorFix_RefreshesStaleAndIsIdempotent: a stale workflow is brought
+// current, and a second pass changes nothing (no over-reporting).
+func TestDoctorFix_RefreshesStaleAndIsIdempotent(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		// Plant one stale workflow; the other three are absent (so the
+		// first --fix both refreshes and creates).
+		writeRel(t, filepath.Join(".github", "workflows", "regen-timeline.yml"),
+			"# logmind-template-version: v0-FAKE\n# rest\n", 0o644)
+
+		out1, _ := runDoctorFixCmd(t)
+		mustContain(t, out1, "ok doctor-fix")
+		// The stale marker must be gone (refreshed to the bundled template).
+		if got := readRel(t, filepath.Join(".github", "workflows", "regen-timeline.yml")); contains(got, "v0-FAKE") {
+			t.Errorf("--fix left the stale v0-FAKE marker in regen-timeline.yml:\n%s", got)
+		}
+
+		// Second pass: everything is current → no writes anywhere.
+		out2, _ := runDoctorFixCmd(t)
+		mustContain(t, out2, "workflows=0")
+		mustContain(t, out2, "hooks=0")
+		mustContain(t, out2, "agents-md=current")
+		mustContain(t, out2, "gitattributes=current")
+		mustContain(t, out2, "merge-driver=current")
+	})
+}
+
+// TestDoctorFix_LeavesForeignHookAlone: a hand-written (markerless) hook is
+// NEVER clobbered by --fix.
+func TestDoctorFix_LeavesForeignHookAlone(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		foreign := "#!/bin/sh\necho my own custom post-merge hook\n"
+		writeRel(t, filepath.Join(".git", "hooks", "post-merge"), foreign, 0o755)
+
+		_, stderr := runDoctorFixCmd(t)
+
+		if got := readRel(t, filepath.Join(".git", "hooks", "post-merge")); got != foreign {
+			t.Errorf("--fix clobbered a foreign hook:\n got: %q\nwant: %q", got, foreign)
+		}
+		// The untouched foreign hook must surface as residual drift (the
+		// markerless post-merge hook), not be silently ignored.
+		mustContain(t, stderr, "post-merge hook")
+	})
+}
+
+// TestDoctorFix_HardWriteErrorExitsNonZero: a genuine write fault (here,
+// .github is a regular file so .github/workflows/ can't be created) makes
+// --fix exit 1 (ErrSilent) with an error note — distinct from the exit-0
+// residual path.
+func TestDoctorFix_HardWriteErrorExitsNonZero(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		// Block .github/workflows creation by making .github a plain file.
+		writeRel(t, ".github", "not a directory\n", 0o644)
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--fix", "--offline"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		err := root.Execute()
+		if err == nil {
+			t.Fatalf("expected non-nil error on hard write fault; out=%s", out.String())
+		}
+		if !errors.Is(err, ErrSilent) {
+			t.Errorf("err = %v; want ErrSilent", err)
+		}
+		mustContain(t, errOut.String(), "doctor --fix")
+	})
+}
+
+// TestDoctorFix_NeverTouchesDocs: --fix is install-state only; it must not
+// rewrite decision content or derived docs.
+func TestDoctorFix_NeverTouchesDocs(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		sentinels := map[string]string{
+			filepath.Join("docs", "decisions.md"):      "# Decision Log\n\n## 2026-01-01 00:00 - keep me\n\n---\n",
+			filepath.Join("docs", "timeline.md"):       "# Timeline\n\n(hand-written sentinel)\n",
+			filepath.Join("docs", "file-structure.md"): "# File Structure\n\n(hand-written sentinel)\n",
+			filepath.Join(".logmind", "config.yml"):    "git:\n  auto_commit: false\n",
+		}
+		for rel, content := range sentinels {
+			writeRel(t, rel, content, 0o644)
+		}
+
+		runDoctorFixCmd(t)
+
+		for rel, want := range sentinels {
+			if got := readRel(t, rel); got != want {
+				t.Errorf("--fix modified %s:\n got: %q\nwant: %q", rel, got, want)
+			}
+		}
+	})
+}
+
+func contains(haystack, needle string) bool {
+	return bytes.Contains([]byte(haystack), []byte(needle))
+}


### PR DESCRIPTION
## What

Adds `logmind doctor --fix` — a one-command, idempotent "bring this repo back to spec" pass. It re-installs exactly the on-disk artifacts `logmind doctor` probes for drift: the 4 workflow templates, the AGENTS.md marker block, the `.gitattributes` logmind block, the per-clone merge-driver git config, and the 3 managed hooks (post-merge / post-rewrite / commit-msg).

This is Slice 1's "clear a drifted repo" path (handoff deliverable c). With #159's advisory gate, it completes the "stop blocking consumers" story: a drifted repo self-heals in one command instead of hand-clicking through `init`.

## Design

- New `internal/cli/refresh.go::applyRefresh` — the shared remediation sequence. **`init` refresh-mode and `doctor --fix` now share one code path** (no duplication); `runInitRefresh` was refactored onto it.
- `doctor --fix` → `runDoctorFix`: idempotent; emits a single quiet `ok doctor-fix workflows=N agents-md=… gitattributes=… merge-driver=… hooks=N residual=N` line (matches the `init`/`self-update` convention). Residual drift `--fix` can't address — PATH/version, or a hand-written hook — is **warned on stderr, not failed** (exit 0). A genuine hard write fault exits 1.

## Safety — what `--fix` never does

- Never writes `docs/` decision content, `docs/timeline.md`, `docs/file-structure.md`, or `.logmind/config.yml`.
- Never clobbers a **foreign (markerless) hook** — the underlying `hooks.Install*` refuse; `EnsureAgentsMD`/`EnsureBlock` only rewrite their own marker block.

## Notes / follow-ups

- The refactor now **surfaces previously-swallowed** AGENTS.md / `.gitattributes` write errors in `init` refresh mode (warning instead of silence) — intentional improvement; the no-error path output is byte-identical.
- **Pre-existing limitation (not introduced here, out of scope):** all installers write via `os.WriteFile`, which follows symlinks; a managed path symlinked to e.g. `docs/decisions.md` could be clobbered. Tracked as a follow-up (`O_NOFOLLOW`/lstat across installers).

## Tests

`internal/cli/refresh_test.go` pins the contract: refresh-stale + full idempotency (workflows / hooks / agents-md / gitattributes / merge-driver all `current` on a second pass), foreign-hook-left-alone + surfaced as residual, docs/config sentinels untouched, and the hard-write-error → exit 1 path. Full Go suite + vet green; smoke-tested end to end.

## Review status

Reviewed by an adversarial multi-lens panel (correctness/init-parity · safety · regression/conventions) — all three **pass**; test-strengthening findings folded in. **Please do not fast-merge** — awaiting human + clud-bug review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
