### PR TITLE
chore(doctor): drop vestigial pip/PyPI machinery (Slice 4 cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ homebrew-tap/
 bin/
 *.test
 *.out
+
+# Browser-automation MCP scratch (console/page dumps) — local-only.
+.playwright-mcp/

--- a/docs/decisions-branches/chore__doctor-drop-vestigial-pypi.md
+++ b/docs/decisions-branches/chore__doctor-drop-vestigial-pypi.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 17:17 - Drop vestigial pip/PyPI machinery from doctor + init (Slice 4 cleanup)
+
+**Reasoning:** Go-era logmind ships via brew/curl + thrillmade/setup-logmind, not pip. But 'logmind doctor' still made a live 2s PyPI network call for a 'latest' version and parsed 'pip install logmind==X' pins that no longer exist in the workflows (→ nil → misleading '(dev install)'); init's refreshPin rewrote those non-existent pins. Dead code producing wrong/slow output.
+
+**Alternatives considered:** Leave it — doctor's network call is slow and its version-drift signal is bogus now that pip pins are gone
+
+**Implications:**
+- doctor makes NO network calls now; InstalledVersion = the running binary's version.Version; drift = workflow/hook/PATH-probe rows only (the PATH probe still catches a stale on-PATH binary). --offline kept as a no-op for compat; JSON shape (installed_version/latest_version/network_used) preserved. Removed logmindPinRe/httpGetJSON/logmindInstalledVersion (doctor) + refreshPin (init). A separate inserter pip-pin rewriter (pinLineRE/UpdateWorkflowPin) + template pip comments remain — flagged as follow-up.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (92 decisions)
+## 2026-06 (93 decisions)
 
-- **2026-06-29** — Add `logmind doctor --fix`: one-command idempotent repo refresh (Slice 1) *(fix/doctor-fix)* — [decisions-branches/fix__doctor-fix.md](decisions-branches/fix__doctor-fix.md)
-- *... 90 more decisions ...*
+- **2026-06-29** — Drop vestigial pip/PyPI machinery from doctor + init (Slice 4 cleanup) *(chore/doctor-drop-vestigial-pypi)* — [decisions-branches/chore__doctor-drop-vestigial-pypi.md](decisions-branches/chore__doctor-drop-vestigial-pypi.md)
+- *... 91 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -65,7 +65,7 @@ func newDoctorCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the report as JSON.")
-	cmd.Flags().BoolVar(&offline, "offline", false, "Skip PyPI / npm probes; use only locally-readable signals.")
+	cmd.Flags().BoolVar(&offline, "offline", false, "No-op: doctor makes no network calls (kept for backward compatibility).")
 	cmd.Flags().BoolVar(&exitZero, "exit-zero", false, "Always exit 0, even on drift (for informational CI runs).")
 	cmd.Flags().BoolVar(&fix, "fix", false, "Re-install drifted workflows, AGENTS.md block, .gitattributes, merge-driver config, and git hooks (idempotent). Never edits docs/ decisions, foreign hooks, or PATH.")
 	return cmd

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -371,7 +371,8 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string) erro
 //
 //   - refresh=false: don't overwrite existing files.
 //   - refresh=true: overwrite when the installed marker differs from the
-//     bundled marker, OR when the pip-install pin needs bumping.
+//     bundled marker. (Go-era workflows use thrillmade/setup-logmind and
+//     carry no pip-install pin, so a matching marker is left as-is.)
 //
 // Returns (created, refreshed, err). Each list is a slice of relative
 // paths from cwd.
@@ -409,13 +410,8 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 			refreshed = append(refreshed, relativePath(repoRoot, target))
 			continue
 		}
-		// Body markers match — check pip-install pin separately.
-		if newBody, prev := refreshPin(string(existing)); prev != "" {
-			if err := os.WriteFile(target, []byte(newBody), 0o644); err != nil {
-				return nil, nil, err
-			}
-			refreshed = append(refreshed, relativePath(repoRoot, target))
-		}
+		// Body marker matches the bundled template — leave the installed
+		// file untouched (no pip-install pin to reconcile anymore).
 	}
 	return created, refreshed, nil
 }
@@ -438,47 +434,6 @@ func extractTemplateVersion(text string) string {
 		}
 	}
 	return ""
-}
-
-// refreshPin updates the `pip install "logmind==X.Y.Z"` line in an
-// installed workflow body to the current binary's version. Returns
-// (newBody, prevPin). prevPin is "" when no rewrite was needed.
-func refreshPin(installed string) (string, string) {
-	// Use the same regex as the doctor's installed-version probe to
-	// avoid two truth sources.
-	// We re-implement the surgical rewrite here without importing the
-	// doctor package (cycle).
-	const needle = `pip install`
-	idx := strings.Index(installed, needle)
-	if idx < 0 {
-		return installed, ""
-	}
-	// Find the `logmind==` substring within ~80 chars.
-	rest := installed[idx:]
-	logmindIdx := strings.Index(rest, "logmind==")
-	if logmindIdx < 0 || logmindIdx > 80 {
-		return installed, ""
-	}
-	verStart := idx + logmindIdx + len("logmind==")
-	// Capture digits + dots until a non-version char.
-	verEnd := verStart
-	for verEnd < len(installed) {
-		c := installed[verEnd]
-		if (c >= '0' && c <= '9') || c == '.' {
-			verEnd++
-			continue
-		}
-		break
-	}
-	if verEnd == verStart {
-		return installed, ""
-	}
-	prev := installed[verStart:verEnd]
-	if prev == version.Version {
-		return installed, ""
-	}
-	newBody := installed[:verStart] + version.Version + installed[verEnd:]
-	return newBody, prev
 }
 
 // enabledAgentList resolves the agents flag. --all-agents wins;

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -22,7 +22,12 @@
 //   - PATH probe (v0.6.16 carry-forward): `which logmind` resolves to a
 //     binary whose `--version` should match the currently-running
 //     process. Drift here is the tokenomics-recurrence root cause.
-//   - PyPI probe is best-effort (2s timeout, swallows all errors).
+//
+// Doctor makes no network calls. The honest "installed version" is the
+// running binary's version.Version; the PATH probe above already catches
+// a stale on-PATH binary, so no version signal is lost. (The legacy
+// best-effort PyPI probe was removed once the Go-era workflows switched
+// to thrillmade/setup-logmind and dropped pip-install pins.)
 //
 // Read-only by design: doctor never writes. The suggested action
 // (`brew install thrillmade/tap/logmind` or curl-pipe-bash from
@@ -40,8 +45,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,7 +71,6 @@ var LogmindWorkflows = []string{
 
 // Marker regexes match Python's compiled patterns at the source.
 var (
-	logmindPinRe          = regexp.MustCompile(`pip install\s+["']?logmind==([\d.]+)["']?`)
 	logmindMarkerRe       = regexp.MustCompile(`^# logmind-template-version:\s*(\S+)`)
 	logmindBlockVersionRe = regexp.MustCompile(`<!--\s*logmind-block-version:\s*(\S+)\s*-->`)
 	logmindVersionLineRe  = regexp.MustCompile(`version\s+(\S+)`)
@@ -78,11 +80,11 @@ var (
 // hook, or other on-disk artifact probe. Reported uniformly so the
 // renderer doesn't care about category.
 type WorkflowStatus struct {
-	Name           string  `json:"name"`
-	Installed      bool    `json:"installed"`
-	Marker         *string `json:"marker"`
-	BundledMarker  *string `json:"bundled_marker"`
-	Drift          string  `json:"drift"`
+	Name          string  `json:"name"`
+	Installed     bool    `json:"installed"`
+	Marker        *string `json:"marker"`
+	BundledMarker *string `json:"bundled_marker"`
+	Drift         string  `json:"drift"`
 }
 
 // ToolStatus aggregates per-tool fields (currently just `logmind`;
@@ -118,52 +120,20 @@ func (r *StatusReport) ToJSON() (string, error) {
 	return string(b), nil
 }
 
-// maxProbeBodyBytes caps the body read for any best-effort probe.
-// PyPI / npm JSON responses are well under this; the cap prevents a
-// rogue server from buffering MB through `io.ReadAll` while the 2s
-// context timeout governs only wall-clock latency (not bytes).
-const maxProbeBodyBytes = 1 << 20 // 1 MiB
-
-// httpGetJSON is a best-effort JSON GET — returns nil on any failure
-// (timeout, network, parse, status>=400). Mirrors Python's
-// _http_get_json semantics: never raises.
-func httpGetJSON(url string, timeout time.Duration) map[string]any {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil
-	}
-	req.Header.Set("User-Agent", "logmind-doctor")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return nil
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes))
-	if err != nil {
-		return nil
-	}
-	var out map[string]any
-	if err := json.Unmarshal(body, &out); err != nil {
-		return nil
-	}
-	return out
-}
-
 // CollectStatus assembles the full StatusReport. project_root may be
 // "" — when empty, the current working directory is used (matches
 // Python's Path.cwd() default).
+//
+// The `offline` parameter is retained for call-site / signature
+// compatibility but is now a no-op: doctor makes no network calls, so
+// NetworkUsed is always false.
 func CollectStatus(projectRoot string, offline bool) StatusReport {
 	if projectRoot == "" {
 		if cwd, err := os.Getwd(); err == nil {
 			projectRoot = cwd
 		}
 	}
-	tools := []ToolStatus{collectLogmindStatus(projectRoot, offline)}
+	tools := []ToolStatus{collectLogmindStatus(projectRoot)}
 
 	overall := "OK"
 	for _, t := range tools {
@@ -206,24 +176,18 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		ProjectRoot: projectRoot,
 		Tools:       tools,
 		Overall:     overall,
-		NetworkUsed: !offline,
+		NetworkUsed: false,
 		Suggestions: suggestions,
 	}
 }
 
-// collectLogmindStatus builds the per-tool report for `logmind`.
-func collectLogmindStatus(projectRoot string, offline bool) ToolStatus {
-	installed := logmindInstalledVersion(projectRoot)
-	var latest *string
-	if !offline {
-		if data := httpGetJSON("https://pypi.org/pypi/logmind/json", 2*time.Second); data != nil {
-			if info, ok := data["info"].(map[string]any); ok {
-				if v, ok := info["version"].(string); ok {
-					latest = &v
-				}
-			}
-		}
-	}
+// collectLogmindStatus builds the per-tool report for `logmind`. The
+// "installed version" is the running binary's version.Version — doctor
+// no longer parses pip-install pins or queries PyPI. The on-PATH probe
+// (probePathResolution) still surfaces a stale binary resolved ahead of
+// this one on PATH, so no version-drift signal is lost.
+func collectLogmindStatus(projectRoot string) ToolStatus {
+	running := version.Version
 
 	var workflows []WorkflowStatus
 	for _, name := range LogmindWorkflows {
@@ -239,11 +203,11 @@ func collectLogmindStatus(projectRoot string, offline bool) ToolStatus {
 	// decides whether to report stale/current/missing.
 	workflows = append(workflows, probePathResolution())
 
-	drift := classifyLogmindDrift(installed, latest, workflows, projectRoot)
+	drift := classifyLogmindDrift(workflows)
 	return ToolStatus{
 		Name:             "logmind",
-		InstalledVersion: installed,
-		LatestVersion:    latest,
+		InstalledVersion: &running,
+		LatestVersion:    nil,
 		Workflows:        workflows,
 		Drift:            drift,
 		Extras:           map[string]string{},
@@ -251,14 +215,11 @@ func collectLogmindStatus(projectRoot string, offline bool) ToolStatus {
 }
 
 // classifyLogmindDrift aggregates per-workflow drift into the tool-level
-// drift. ANY stale workflow OR (installed != latest) flips the tool to
-// "stale"; remaining unknowns flip to "unknown"; otherwise "ok". Mirrors
-// the Python aggregation in collect_logmind_status.
-func classifyLogmindDrift(installed, latest *string, workflows []WorkflowStatus, projectRoot string) string {
-	// Version mismatch (when both known) — stale.
-	if installed != nil && latest != nil && *installed != *latest {
-		return "stale"
-	}
+// drift. ANY stale workflow/hook/probe row flips the tool to "stale";
+// remaining unknowns flip to "unknown"; otherwise "ok". (The version
+// signal now lives entirely in the on-PATH probe row — there's no
+// installed-vs-latest comparison since doctor makes no network calls.)
+func classifyLogmindDrift(workflows []WorkflowStatus) string {
 	for _, wf := range workflows {
 		if wf.Drift == "stale" {
 			return "stale"
@@ -270,19 +231,6 @@ func classifyLogmindDrift(installed, latest *string, workflows []WorkflowStatus,
 		}
 	}
 	return "ok"
-}
-
-func logmindInstalledVersion(projectRoot string) *string {
-	content, err := os.ReadFile(filepath.Join(projectRoot, ".github", "workflows", "regen-timeline.yml"))
-	if err != nil {
-		return nil
-	}
-	m := logmindPinRe.FindStringSubmatch(string(content))
-	if len(m) < 2 {
-		return nil
-	}
-	v := m[1]
-	return &v
 }
 
 func bundledLogmindMarker(workflowName string) *string {
@@ -512,14 +460,14 @@ func probeCommitMsgHook(projectRoot string) WorkflowStatus {
 // src/logmind/core/doctor._probe_path_resolution:
 //
 //   - drift="current"   when `which logmind`'s --version matches the
-//                       running binary.
+//     running binary.
 //   - drift="stale"     when versions differ — marker shows both
-//                       versions + the conflicting path so the user
-//                       can act on it without invoking `which -a`.
+//     versions + the conflicting path so the user
+//     can act on it without invoking `which -a`.
 //   - drift="missing"   when no logmind found on PATH (merge driver
-//                       shell-outs will fail).
+//     shell-outs will fail).
 //   - drift="markerless" when the PATH binary exists but its
-//                       --version is unreadable / unparseable.
+//     --version is unreadable / unparseable.
 //
 // Errors are best-effort: every failure path produces a status row
 // (no panics). This is the v0.6.16 carry-forward that bubbles up
@@ -571,17 +519,13 @@ func probePathResolution() WorkflowStatus {
 	}
 }
 
-// formatVersion renders an optional version pointer with the same
-// Python `?` / `(offline)` placeholder for the "latest" column when the
-// PyPI probe couldn't return a value.
-func formatVersion(v *string, offline bool) string {
+// formatVersion renders an optional version pointer — the dereferenced
+// value when set, else "unknown".
+func formatVersion(v *string) string {
 	if v != nil {
 		return *v
 	}
-	if offline {
-		return "(offline)"
-	}
-	return "?"
+	return "unknown"
 }
 
 func formatDrift(drift string) string {
@@ -605,24 +549,19 @@ func formatDrift(drift string) string {
 // RenderStatus formats a StatusReport for the default (non-JSON)
 // output mode. Mirrors src/logmind/core/doctor.render_status.
 func RenderStatus(r StatusReport) string {
-	offline := !r.NetworkUsed
 	var lines []string
 
 	// Stable iteration: tools were already inserted in order by the
 	// collector; loop preserves it.
 	for _, tool := range r.Tools {
-		installed := formatVersion(tool.InstalledVersion, false)
-		latest := formatVersion(tool.LatestVersion, offline)
-		if tool.InstalledVersion == nil && tool.Name == "logmind" {
-			installed = "(dev install)"
-		}
+		installed := formatVersion(tool.InstalledVersion)
 		statusWord := formatDrift("ok")
 		if tool.Drift != "ok" {
 			statusWord = formatDrift(tool.Drift)
 		}
 		lines = append(lines, fmt.Sprintf(
-			"%s %s installed · %s latest · %s",
-			tool.Name, installed, latest, statusWord,
+			"%s %s · %s",
+			tool.Name, installed, statusWord,
 		))
 
 		for _, wf := range tool.Workflows {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -83,6 +83,19 @@ func TestCollectStatus_FreshRepoListsAllProbes(t *testing.T) {
 	}
 }
 
+// TestCollectStatus_OfflineParamIsNoOp pins the post-cleanup contract:
+// the `offline` parameter is retained for signature/back-compat but doctor
+// no longer makes network calls, so it must NEVER re-enable network use.
+// Without this, a regression re-introducing `NetworkUsed: !offline` would
+// pass every other test (they all call with offline=true).
+func TestCollectStatus_OfflineParamIsNoOp(t *testing.T) {
+	for _, offline := range []bool{true, false} {
+		if r := CollectStatus(t.TempDir(), offline); r.NetworkUsed {
+			t.Errorf("CollectStatus(offline=%v): NetworkUsed=true; want false", offline)
+		}
+	}
+}
+
 func TestCollectStatus_StaleWorkflowFlipsToDrift(t *testing.T) {
 	dir := freshRepo(t)
 	origPath := os.Getenv("PATH")


### PR DESCRIPTION
## What

Removes the dead pip/PyPI machinery so `logmind doctor` makes **no network calls**. Go-era logmind ships via brew/curl + `thrillmade/setup-logmind` (not pip), yet `doctor` still made a live 2s `pypi.org` call for a "latest" version and parsed `pip install logmind==X` pins out of workflows that no longer contain them (→ nil → a misleading `(dev install)` line); `init`'s `refreshPin` rewrote those non-existent pins.

## Change

- **doctor:** removed `logmindPinRe`, `httpGetJSON` (the only network func), `maxProbeBodyBytes`, `logmindInstalledVersion`. `InstalledVersion` is now the running binary's `version.Version`; `LatestVersion`=nil; `NetworkUsed`=false. Drift is the workflow/hook/PATH-probe rows only — **the stale-binary signal is preserved by the existing PATH-resolution probe**. `--offline` kept as a no-op (back-compat); JSON shape (`installed_version`/`latest_version`/`network_used`) unchanged.
- **init:** removed `refreshPin` + its call; a marker-matched workflow is left as-is.
- **+ guard test** pinning the `--offline` no-op contract; **+ gitignore** the `.playwright-mcp/` MCP scratch dir (was leaking into commits).

Net **−106 lines**. Full Go suite + vet + gofmt green.

## Out of scope (flagged)

A *separate* pip-pin rewriter in `internal/inserter` (`pinLineRE`/`UpdateWorkflowPin`) + pip references in template *comments* remain — independent + dormant (Go-era workflows carry no pins). A follow-up can retire them.

## Review

Adversarial verifier: **READY-TO-MERGE** (no regression, no dangling refs, signal preserved). clud-bug: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
