### PR TITLE
ci: fix recurring macOS go-test abort-trap (pin macos-14 + MallocNanoZone)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
     # jobs replace the job-id-based context with the `name:` template.
     name: go (${{ matrix.os }} / go${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
+    env:
+      # Guard against the macOS "signal: abort trap" SIGABRT that crashes
+      # go test binaries on startup on newer runner images (no-op on Linux).
+      MallocNanoZone: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +38,11 @@ jobs:
         os: [ubuntu-latest]
         go-version: ["1.22", "1.24"]
         include:
-          - os: macos-latest
+          # Pinned to macos-14: macos-latest rolled to an image where go1.22
+          # test binaries abort on startup ("signal: abort trap"), red-lighting
+          # every PR. macos-14 is a known-good image for the go1.22 floor.
+          # Revisit when the go floor moves past 1.22.
+          - os: macos-14
             go-version: "1.22"
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The `go (macos-latest / go1.22)` cell has been red-lighting **every** PR (#160, #161) with `signal: abort trap` — go1.22 test binaries aborting on startup on the newer `macos-latest` runner image (cli + skill packages abort at 0.004s, i.e. before any test runs — not code-related).

Fix: pin the macOS cell to **macos-14** (known-good for the go1.22 floor) + set **MallocNanoZone=0** (the standard guard for the macOS go SIGABRT; no-op on Linux). Self-validating — this PR's own macOS cell proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)