### PR TITLE
feat(timeline): entry-block primitives — Slugify + extract + detect (Slice 2 PR1)

### DIFF
--- a/docs/decisions-branches/feat__timeline-canonical-primitives.md
+++ b/docs/decisions-branches/feat__timeline-canonical-primitives.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 18:27 - Slice 2 PR1: timeline entry-block primitives (Slugify, extract, detect) — zero wiring
+
+**Reasoning:** First of 7 additive PRs for the main-canonical timeline. These implement SPEC §1.6.3 (slug derivation §1.6.3.1, entry-block stack scan §1.6.3.3, format detection) that PR3 (union generation) and PR4 (logmind log marker writing) build on. Shipped alone so the byte-critical slug algorithm is reviewed in isolation against the spec.
+
+**Alternatives considered:** Inline the primitives into PR3 — split out so a wrong slug (= wrong union keys downstream) gets focused review
+
+**Implications:**
+- New internal/timeline/canonical.go: Slugify (§1.6.3.1 4-step), HasEntryBlocks (§1.6.3.3 detection), extractEntryBlocks (stack scan; tolerate-and-warn on unclosed/nested). NOTHING wired — default branch-divergent timeline (Generate/Render) untouched, byte-parity preserved. Slug truncation follows spec order (trim then truncate, so a truncated slug MAY end in '-').
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (93 decisions)
+## 2026-06 (94 decisions)
 
-- **2026-06-29** — Drop vestigial pip/PyPI machinery from doctor + init (Slice 4 cleanup) *(chore/doctor-drop-vestigial-pypi)* — [decisions-branches/chore__doctor-drop-vestigial-pypi.md](decisions-branches/chore__doctor-drop-vestigial-pypi.md)
-- *... 91 more decisions ...*
+- **2026-06-29** — Slice 2 PR1: timeline entry-block primitives (Slugify, extract, detect) — zero wiring *(feat/timeline-canonical-primitives)* — [decisions-branches/feat__timeline-canonical-primitives.md](decisions-branches/feat__timeline-canonical-primitives.md)
+- *... 92 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -106,7 +106,7 @@ func parseStartMarker(line string) (key string, ok bool) {
 		return "", false
 	}
 	// Allow trailing whitespace after the suffix but require the suffix.
-	trimmed := strings.TrimRight(line, " \t")
+	trimmed := strings.TrimRight(line, " \t\r")
 	if !strings.HasSuffix(trimmed, entryStartSuffix) {
 		return "", false
 	}
@@ -120,7 +120,7 @@ func parseStartMarker(line string) (key string, ok bool) {
 // isEndMarker reports whether line is the closing marker (at column 0,
 // trailing whitespace tolerated).
 func isEndMarker(line string) bool {
-	return strings.TrimRight(line, " \t") == entryEndMarker
+	return strings.TrimRight(line, " \t\r") == entryEndMarker
 }
 
 // extractEntryBlocks scans content for matched §1.6.3 entry-blocks and

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -1,0 +1,166 @@
+// canonical.go — primitives for the main-canonical ("newspaper") timeline.
+//
+// These are the building blocks for SPEC §1.6.3's HTML-marker entry-block
+// format and the §1.6.4 deterministic-union timeline (Slice 2). This file
+// is PRIMITIVES ONLY — nothing here is wired into timeline generation yet;
+// the default branch-divergent path (Generate/Render in timeline.go) is
+// untouched, so output stays byte-identical until a later PR opts in via
+// config. See docs/plan / the protocol SPEC §1.6.3.
+package timeline
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Entry-block markers (SPEC §1.6.3.1). Each marker occupies its own line,
+// starting at column 0. The opening marker carries the `<date>-<slug>`
+// identity; the closing marker carries only the terminator.
+const (
+	entryStartPrefix = "<!-- logmind-entry-start: "
+	entryStartSuffix = " -->"
+	entryEndMarker   = "<!-- logmind-entry-end -->"
+)
+
+// slugMaxBytes is the §1.6.3.1 truncation bound. The slug is pure
+// [a-z0-9-] after step 2, so a byte bound is also a rune bound; we still
+// truncate on a rune boundary to honor the spec's "UTF-8 safe" note.
+const slugMaxBytes = 60
+
+// Slugify derives a kebab-case slug from an entry title per SPEC §1.6.3.1:
+//
+//  1. lowercase
+//  2. replace any run of chars not in [a-z0-9] with a single "-"
+//  3. strip leading/trailing "-"
+//  4. truncate to 60 bytes (UTF-8 safe — never split a codepoint)
+//
+// Steps are applied in order; per the spec, truncation (4) happens after
+// trimming (3), so a truncated slug MAY end in "-".
+func Slugify(title string) string {
+	var b strings.Builder
+	b.Grow(len(title))
+	prevDash := false
+	for _, r := range strings.ToLower(title) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+			continue
+		}
+		if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if len(slug) > slugMaxBytes {
+		// slug is ASCII here, but truncate on a rune boundary defensively.
+		slug = truncateRunes(slug, slugMaxBytes)
+	}
+	return slug
+}
+
+// truncateRunes returns s truncated to at most maxBytes, never splitting a
+// multi-byte rune.
+func truncateRunes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	end := maxBytes
+	// Back off to a rune boundary (a continuation byte is 0b10xxxxxx).
+	for end > 0 && (s[end]&0xC0) == 0x80 {
+		end--
+	}
+	return s[:end]
+}
+
+// entryBlock is one parsed §1.6.3 entry-block: its `<date>-<slug>` key and
+// the verbatim body lines between (exclusive of) the markers.
+type entryBlock struct {
+	Key  string
+	Body string
+}
+
+// HasEntryBlocks reports whether content is in entry-block format, per the
+// §1.6.3.3 detection rule: any line beginning with
+// `<!-- logmind-entry-start: ` within the first 200 lines indicates
+// entry-block format; otherwise the file is brief mode.
+func HasEntryBlocks(content string) bool {
+	lines := strings.SplitN(content, "\n", 201)
+	limit := len(lines)
+	if limit > 200 {
+		limit = 200
+	}
+	for _, line := range lines[:limit] {
+		if strings.HasPrefix(line, entryStartPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseStartMarker returns the `<date>-<slug>` key if line is a well-formed
+// opening marker at column 0, else ok=false.
+func parseStartMarker(line string) (key string, ok bool) {
+	if !strings.HasPrefix(line, entryStartPrefix) {
+		return "", false
+	}
+	// Allow trailing whitespace after the suffix but require the suffix.
+	trimmed := strings.TrimRight(line, " \t")
+	if !strings.HasSuffix(trimmed, entryStartSuffix) {
+		return "", false
+	}
+	key = strings.TrimSpace(trimmed[len(entryStartPrefix) : len(trimmed)-len(entryStartSuffix)])
+	if key == "" {
+		return "", false
+	}
+	return key, true
+}
+
+// isEndMarker reports whether line is the closing marker (at column 0,
+// trailing whitespace tolerated).
+func isEndMarker(line string) bool {
+	return strings.TrimRight(line, " \t") == entryEndMarker
+}
+
+// extractEntryBlocks scans content for matched §1.6.3 entry-blocks and
+// returns them in document order. Per §1.6.3.3 markers are consumed as a
+// stack: each opening marker opens a frame, the next closing marker closes
+// it. Bodies MUST NOT nest (§1.6.3.1); an opening marker encountered before
+// the current frame closes, or an unclosed frame at EOF, is malformed — the
+// offending block is skipped and a diagnostic is written to stderr (mirrors
+// decisions.Iter's tolerate-and-warn posture). It never panics.
+func extractEntryBlocks(content string, stderr io.Writer) []entryBlock {
+	var out []entryBlock
+	lines := strings.Split(content, "\n")
+	i := 0
+	for i < len(lines) {
+		key, ok := parseStartMarker(lines[i])
+		if !ok {
+			i++
+			continue
+		}
+		// Find the matching close, rejecting a nested open first.
+		j := i + 1
+		nested := false
+		for j < len(lines) && !isEndMarker(lines[j]) {
+			if _, isStart := parseStartMarker(lines[j]); isStart {
+				nested = true
+				break
+			}
+			j++
+		}
+		switch {
+		case nested:
+			fmt.Fprintf(stderr, "logmind: skipping entry-block %q: nested opening marker before close (§1.6.3.1)\n", key)
+			i++ // resume at the nested opener
+		case j >= len(lines):
+			fmt.Fprintf(stderr, "logmind: skipping entry-block %q: unclosed at end of file\n", key)
+			i++
+		default:
+			out = append(out, entryBlock{Key: key, Body: strings.Join(lines[i+1:j], "\n")})
+			i = j + 1
+		}
+	}
+	return out
+}

--- a/internal/timeline/canonical_test.go
+++ b/internal/timeline/canonical_test.go
@@ -1,0 +1,135 @@
+package timeline
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		title string
+		want  string
+	}{
+		{"Add JWT session auth", "add-jwt-session-auth"},
+		{"Use Redis for caching!", "use-redis-for-caching"},
+		{"  Leading / trailing  ", "leading-trailing"},
+		{"C++ & Go", "c-go"},
+		{"already-kebab-case", "already-kebab-case"},
+		{"Multiple   spaces\tand\ntabs", "multiple-spaces-and-tabs"},
+		{"café résumé", "caf-r-sum"}, // non-ASCII runs collapse to a single '-'
+		{"", ""},
+		{"!!!", ""}, // all punctuation → empty after trim
+		{"v1.2.0 release", "v1-2-0-release"},
+	}
+	for _, c := range cases {
+		if got := Slugify(c.title); got != c.want {
+			t.Errorf("Slugify(%q) = %q; want %q", c.title, got, c.want)
+		}
+	}
+}
+
+func TestSlugify_TruncatesTo60Bytes(t *testing.T) {
+	// Step 4: truncate to 60 bytes. Input is pure ASCII so 60 bytes = 60 chars.
+	got := Slugify(strings.Repeat("a", 70))
+	if len(got) != 60 {
+		t.Errorf("len = %d; want 60", len(got))
+	}
+	// A hyphen-dense title must still truncate at ≤60 bytes.
+	got2 := Slugify(strings.Repeat("ab cd ", 20)) // → "ab-cd-ab-cd-..."
+	if len(got2) > 60 {
+		t.Errorf("len = %d; want ≤60", len(got2))
+	}
+}
+
+func TestSlugify_NeverSplitsCodepoint(t *testing.T) {
+	// Defensive: truncateRunes must not split a multi-byte rune. Build a
+	// raw string whose byte-60 boundary lands mid-rune and feed it directly
+	// to the truncator (Slugify itself ASCII-izes before truncating).
+	s := strings.Repeat("a", 59) + "é" // 'é' = 2 bytes; byte index 60 is a continuation byte
+	got := truncateRunes(s, 60)
+	if !utf8.ValidString(got) {
+		t.Errorf("truncateRunes split a codepoint: %q", got)
+	}
+	if len(got) != 59 { // the 2-byte rune is dropped whole, not split
+		t.Errorf("len = %d; want 59 (dropped the split rune whole)", len(got))
+	}
+}
+
+func TestHasEntryBlocks(t *testing.T) {
+	withMarker := "# Timeline\n\n" + entryStartPrefix + "2026-06-29-x" + entryStartSuffix + "\nbody\n" + entryEndMarker + "\n"
+	if !HasEntryBlocks(withMarker) {
+		t.Errorf("HasEntryBlocks = false; want true for entry-block content")
+	}
+	brief := "# Timeline\n\n## 2026-06\n\n- **2026-06-29** — something\n"
+	if HasEntryBlocks(brief) {
+		t.Errorf("HasEntryBlocks = true; want false for brief-mode content")
+	}
+	// A marker only after line 200 must NOT be detected (§1.6.3.3 scans the
+	// first 200 lines).
+	deep := strings.Repeat("filler\n", 250) + entryStartPrefix + "2026-06-29-x" + entryStartSuffix + "\n"
+	if HasEntryBlocks(deep) {
+		t.Errorf("HasEntryBlocks = true; want false for a marker past line 200")
+	}
+}
+
+func block(key, body string) string {
+	return entryStartPrefix + key + entryStartSuffix + "\n" + body + "\n" + entryEndMarker + "\n"
+}
+
+func TestExtractEntryBlocks_WellFormed(t *testing.T) {
+	content := "# Timeline\n\n" +
+		block("2026-06-29-add-jwt", "- **2026-06-29** — Add JWT") +
+		"\n## 2026-05\n\n" +
+		block("2026-05-01-init", "- **2026-05-01** — Init")
+	var stderr bytes.Buffer
+	got := extractEntryBlocks(content, &stderr)
+	if len(got) != 2 {
+		t.Fatalf("got %d blocks; want 2 (%s)", len(got), stderr.String())
+	}
+	if got[0].Key != "2026-06-29-add-jwt" || got[1].Key != "2026-05-01-init" {
+		t.Errorf("keys = %q, %q", got[0].Key, got[1].Key)
+	}
+	if got[0].Body != "- **2026-06-29** — Add JWT" {
+		t.Errorf("body[0] = %q (markers must be excluded, body verbatim)", got[0].Body)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("unexpected stderr on well-formed input: %s", stderr.String())
+	}
+}
+
+func TestExtractEntryBlocks_UnclosedSkippedLoudly(t *testing.T) {
+	content := entryStartPrefix + "2026-06-29-x" + entryStartSuffix + "\nbody never closes\n"
+	var stderr bytes.Buffer
+	got := extractEntryBlocks(content, &stderr)
+	if len(got) != 0 {
+		t.Errorf("got %d; want 0 (unclosed must be skipped)", len(got))
+	}
+	if !strings.Contains(stderr.String(), "unclosed") {
+		t.Errorf("expected an 'unclosed' diagnostic on stderr; got %q", stderr.String())
+	}
+}
+
+func TestExtractEntryBlocks_NestedSkippedLoudly(t *testing.T) {
+	content := entryStartPrefix + "2026-06-29-outer" + entryStartSuffix + "\n" +
+		entryStartPrefix + "2026-06-29-inner" + entryStartSuffix + "\n" +
+		"body\n" + entryEndMarker + "\n"
+	var stderr bytes.Buffer
+	got := extractEntryBlocks(content, &stderr)
+	// The outer is malformed (nested open); the inner is well-formed and recovered.
+	if len(got) != 1 || got[0].Key != "2026-06-29-inner" {
+		t.Errorf("got %+v; want just the recovered inner block", got)
+	}
+	if !strings.Contains(stderr.String(), "nested") {
+		t.Errorf("expected a 'nested' diagnostic; got %q", stderr.String())
+	}
+}
+
+func TestExtractEntryBlocks_NoMarkers(t *testing.T) {
+	var stderr bytes.Buffer
+	got := extractEntryBlocks("# Timeline\n\njust prose, no markers\n", &stderr)
+	if len(got) != 0 {
+		t.Errorf("got %d; want 0", len(got))
+	}
+}

--- a/internal/timeline/canonical_test.go
+++ b/internal/timeline/canonical_test.go
@@ -43,6 +43,17 @@ func TestSlugify_TruncatesTo60Bytes(t *testing.T) {
 	}
 }
 
+func TestSlugify_TruncateMayEndInDash(t *testing.T) {
+	// Step 4 truncates AFTER step-3 trim; the spec defines no re-trim, so a
+	// truncated slug MAY end in '-'. This locks the exact byte output the
+	// <date>-<slug> union key depends on — a future "tidy the slug" refactor
+	// that re-trimmed would silently change every colliding key downstream.
+	got := Slugify(strings.Repeat("a", 59) + " bbb")
+	if want := strings.Repeat("a", 59) + "-"; got != want {
+		t.Errorf("Slugify trailing-dash truncation = %q; want %q", got, want)
+	}
+}
+
 func TestSlugify_NeverSplitsCodepoint(t *testing.T) {
 	// Defensive: truncateRunes must not split a multi-byte rune. Build a
 	// raw string whose byte-60 boundary lands mid-rune and feed it directly
@@ -131,5 +142,21 @@ func TestExtractEntryBlocks_NoMarkers(t *testing.T) {
 	got := extractEntryBlocks("# Timeline\n\njust prose, no markers\n", &stderr)
 	if len(got) != 0 {
 		t.Errorf("got %d; want 0", len(got))
+	}
+}
+
+func TestExtractEntryBlocks_TolerateCRLF(t *testing.T) {
+	// On a CRLF (Windows autocrlf) checkout the marker lines end in "\r".
+	// The detector (HasEntryBlocks) and the parser must AGREE — otherwise
+	// the detector says "entry-block format" while the parser silently
+	// extracts nothing.
+	content := entryStartPrefix + "2026-06-29-x" + entryStartSuffix + "\r\nbody\r\n" + entryEndMarker + "\r\n"
+	if !HasEntryBlocks(content) {
+		t.Errorf("HasEntryBlocks = false on CRLF content")
+	}
+	var stderr bytes.Buffer
+	got := extractEntryBlocks(content, &stderr)
+	if len(got) != 1 || got[0].Key != "2026-06-29-x" {
+		t.Errorf("got %+v (stderr=%s); want 1 block keyed 2026-06-29-x", got, stderr.String())
 	}
 }


### PR DESCRIPTION
**PR 1 of 7** for the main-canonical "newspaper" timeline (Slice 2). **Pure primitives, zero wiring** — the default `branch-divergent` timeline is untouched, so output stays byte-identical (the byte-parity guard: existing `timeline_test.go` goldens stay green).

Adds `internal/timeline/canonical.go`:
- **`Slugify`** — SPEC §1.6.3.1 slug derivation (lowercase → collapse `[^a-z0-9]`→`-` → trim → 60-byte UTF-8-safe truncate).
- **`HasEntryBlocks`** — §1.6.3.3 format detection (`^<!-- logmind-entry-start: ` in the first 200 lines).
- **`extractEntryBlocks`** — §1.6.3.3 stack scan; tolerate-and-warn on unclosed/nested (mirrors `decisions.Iter`).

Table-driven tests against the spec cases (slug edge cases incl. 60-byte truncation + no-codepoint-split; extraction of well-formed / unclosed / nested). Full Go suite + vet + gofmt green.

These back PR3 (union generation) and PR4 (`logmind log` marker writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)