### PR TITLE
feat(config): timeline.canonical + file_structure.root_label keys, typed-only (Slice 2 PR2)

### DIFF
--- a/docs/decisions-branches/feat__timeline-config-keys.md
+++ b/docs/decisions-branches/feat__timeline-config-keys.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 18:41 - Slice 2 PR2: timeline.canonical + file_structure.root_label config keys (typed-only)
+
+**Reasoning:** Second of 7 PRs for the main-canonical timeline. Adds the two config gates PR3/PR4/PR5 dispatch on. Typed-only (set in DefaultConfig) — deliberately NOT in DefaultMap, so 'logmind config list' output stays byte-identical to the Python reference (the silent serialized-output change the plan forbids). Surfacing them in config-list rides the v1.0 bump.
+
+**Alternatives considered:** Add to DefaultMap too — rejected: changes config-list bytes, breaks the documented Python<->Go config byte-parity contract
+
+**Implications:**
+- New TimelineConfig{Canonical} + FileStructureConfig.RootLabel. IsMainCanonical() is fail-safe: ONLY the exact 'main-canonical' enables it, so a typo/case-variant can't silently flip output. Absent key -> branch-divergent (DefaultConfig seed + leafwise YAML overlay). Zero behavior change — nothing reads these yet.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (94 decisions)
+## 2026-06 (95 decisions)
 
-- **2026-06-29** — Slice 2 PR1: timeline entry-block primitives (Slugify, extract, detect) — zero wiring *(feat/timeline-canonical-primitives)* — [decisions-branches/feat__timeline-canonical-primitives.md](decisions-branches/feat__timeline-canonical-primitives.md)
-- *... 92 more decisions ...*
+- **2026-06-29** — Slice 2 PR2: timeline.canonical + file_structure.root_label config keys (typed-only) *(feat/timeline-config-keys)* — [decisions-branches/feat__timeline-config-keys.md](decisions-branches/feat__timeline-config-keys.md)
+- *... 93 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,14 +8,14 @@
 //
 //   - Defaults are hard-coded in DefaultConfig(). When the user's
 //     .logmind/config.yml is missing or unparseable, the loader silently
-//     returns the defaults — matching the Python ``except Exception:
-//     return defaults`` branch in core/config.py:104-110. Logmind treats
+//     returns the defaults — matching the Python “except Exception:
+//     return defaults“ branch in core/config.py:104-110. Logmind treats
 //     a broken config as user fixing it later; we never abort a derived-
 //     doc command just because YAML failed.
 //
 //   - Deep merge: user keys override defaults LEAFWISE, not whole-section.
-//     If a user only sets ``file_structure.auto_update: false``, the
-//     ``ignore_patterns`` list still comes from defaults. Matches Python
+//     If a user only sets “file_structure.auto_update: false“, the
+//     “ignore_patterns“ list still comes from defaults. Matches Python
 //     _deep_update (core/config.py:115-127).
 //
 //   - This package never WRITES config — that's `logmind config set`
@@ -37,7 +37,10 @@ type Config struct {
 	Git           GitConfig           `yaml:"git"`
 	Decisions     DecisionsConfig     `yaml:"decisions"`
 	FileStructure FileStructureConfig `yaml:"file_structure"`
-	Agents        map[string]bool     `yaml:"agents"`
+	// Timeline gates the §1.6.4 main-canonical timeline (Slice 2, 0.8.0).
+	// Additive: the default reproduces today's output byte-for-byte.
+	Timeline TimelineConfig  `yaml:"timeline"`
+	Agents   map[string]bool `yaml:"agents"`
 	// CatalogTarget is the default `<owner>/<repo>` slug `logmind skill
 	// push` opens PRs against. Overrideable on the CLI via --catalog.
 	// Per plan §"Skill suggestion cycle §4" + §"Skill catalog
@@ -105,6 +108,29 @@ type DecisionsConfig struct {
 type FileStructureConfig struct {
 	AutoUpdate     bool     `yaml:"auto_update"`
 	IgnorePatterns []string `yaml:"ignore_patterns"`
+	// RootLabel overrides the file-structure tree's root line. Default ""
+	// = the checkout directory's basename (today's behavior); a fixed
+	// string makes file-structure.md deterministic across checkouts /
+	// worktrees, and "auto" resolves to the git remote repo name (wired in
+	// Slice 2 PR5). Additive: "" preserves byte-parity.
+	RootLabel string `yaml:"root_label"`
+}
+
+// TimelineConfig mirrors the `timeline:` section (Slice 2, §1.6.4).
+type TimelineConfig struct {
+	// Canonical selects the timeline assembly model: "branch-divergent"
+	// (default — today's full-regen union, byte-identical to v0.6.14) or
+	// "main-canonical" (deterministic union of §1.6.3 entry-block lines).
+	// Validated fail-safe via IsMainCanonical.
+	Canonical string `yaml:"canonical"`
+}
+
+// IsMainCanonical reports whether main-canonical timeline assembly is
+// enabled. Fail-safe: ONLY the exact string "main-canonical" qualifies, so
+// a typo, empty value, or future/unknown value can never silently flip the
+// timeline's output away from the byte-stable default.
+func (t TimelineConfig) IsMainCanonical() bool {
+	return t.Canonical == "main-canonical"
 }
 
 // DefaultConfig returns a fresh Config populated with the same values
@@ -138,6 +164,14 @@ func DefaultConfig() Config {
 				"build",
 				"*.egg-info",
 			},
+			RootLabel: "",
+		},
+		// Timeline: default "branch-divergent" reproduces today's output
+		// byte-for-byte; the main-canonical opt-in + the eventual default
+		// flip ride later releases. NOT added to DefaultMap (below) — that
+		// would change `logmind config list` bytes and break Python parity.
+		Timeline: TimelineConfig{
+			Canonical: "branch-divergent",
 		},
 		Agents: map[string]bool{
 			"claude":   true,

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTimelineCfg writes content to a temp config.yml and returns its path.
+func writeTimelineCfg(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestTimelineCanonical_DefaultIsBranchDivergent(t *testing.T) {
+	// An absent `timeline` key must yield the DefaultConfig default, with
+	// main-canonical OFF.
+	cfg, err := LoadPath(writeTimelineCfg(t, "git:\n  auto_commit: true\n"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if cfg.Timeline.Canonical != "branch-divergent" {
+		t.Errorf("Canonical = %q; want branch-divergent", cfg.Timeline.Canonical)
+	}
+	if cfg.Timeline.IsMainCanonical() {
+		t.Errorf("IsMainCanonical() = true; want false on the default")
+	}
+	// A wholly missing file degrades to the same default.
+	cfg2, _ := LoadPath(filepath.Join(t.TempDir(), "does-not-exist.yml"))
+	if cfg2.Timeline.IsMainCanonical() {
+		t.Errorf("missing-file default must be branch-divergent (main-canonical OFF)")
+	}
+}
+
+func TestTimelineCanonical_OptIn(t *testing.T) {
+	cfg, err := LoadPath(writeTimelineCfg(t, "timeline:\n  canonical: main-canonical\n"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if !cfg.Timeline.IsMainCanonical() {
+		t.Errorf("IsMainCanonical() = false; want true for `canonical: main-canonical`")
+	}
+}
+
+func TestTimelineCanonical_FailSafeOnUnknownValue(t *testing.T) {
+	// A typo / case-variant / unrelated value must NOT enable main-canonical
+	// — only the exact string qualifies. This is the guard against a silent
+	// output flip from a fat-fingered config.
+	for _, v := range []string{"maincanonical", "main_canonical", "MAIN-CANONICAL", "main-canonical ", "branch-divergent", "", "true"} {
+		cfg, _ := LoadPath(writeTimelineCfg(t, "timeline:\n  canonical: \""+v+"\"\n"))
+		if cfg.Timeline.IsMainCanonical() {
+			t.Errorf("canonical=%q enabled main-canonical; want fail-safe OFF", v)
+		}
+	}
+}
+
+func TestFileStructureRootLabel_DefaultAndRoundTrip(t *testing.T) {
+	if got := DefaultConfig().FileStructure.RootLabel; got != "" {
+		t.Errorf("default RootLabel = %q; want \"\" (basename behavior, byte-parity)", got)
+	}
+	cfg, _ := LoadPath(writeTimelineCfg(t, "file_structure:\n  root_label: my-repo\n"))
+	if cfg.FileStructure.RootLabel != "my-repo" {
+		t.Errorf("RootLabel = %q; want my-repo", cfg.FileStructure.RootLabel)
+	}
+	// Leafwise deep-merge: setting root_label must NOT wipe the default
+	// ignore_patterns (regression guard for the typed-config merge).
+	if len(cfg.FileStructure.IgnorePatterns) == 0 {
+		t.Errorf("ignore_patterns lost when only root_label was set")
+	}
+}
+
+func TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity(t *testing.T) {
+	// THE load-bearing guard for PR2: the new typed keys must NOT appear in
+	// DefaultMap. DefaultMap is what `logmind config list` serializes, and
+	// it round-trips byte-for-byte against the Python reference. Adding
+	// `timeline`/`root_label` here would change that output — the silent
+	// serialized-output change the plan forbids. Surfacing them in
+	// config-list rides the coordinated v1.0 bump, not this slice.
+	m := DefaultMap()
+	if _, ok := m.Get("timeline"); ok {
+		t.Errorf("DefaultMap contains `timeline` — breaks `config list` byte-parity")
+	}
+	fs, ok := m.Get("file_structure")
+	if !ok {
+		t.Fatal("file_structure missing from DefaultMap")
+	}
+	fsMap, ok := fs.(*OrderedMap)
+	if !ok {
+		t.Fatalf("file_structure is %T; want *OrderedMap", fs)
+	}
+	if _, ok := fsMap.Get("root_label"); ok {
+		t.Errorf("DefaultMap file_structure contains `root_label` — breaks byte-parity")
+	}
+}


### PR DESCRIPTION
**PR 2 of 7** for the main-canonical timeline (Slice 2). Adds the two config gates the read-path PRs (PR3/4/5) dispatch on — **typed-only**:
- `timeline.canonical` — `branch-divergent` (default) | `main-canonical`. Fail-safe `IsMainCanonical()`: ONLY the exact `main-canonical` enables it, so a typo/case-variant can never silently flip timeline output.
- `file_structure.root_label` — default `""` (today's basename behavior).

Set in `DefaultConfig()`, **deliberately NOT in `DefaultMap()`** — `DefaultMap` is what `logmind config list` serializes and it round-trips byte-for-byte against the Python reference; adding the keys there would change that output (the silent serialized-output change the plan forbids). Surfacing them in `config list` rides the coordinated v1.0 bump.

**Still zero behavior change** — nothing reads these yet. The load-bearing test (`TestDefaultMap_OmitsNewKeys...`) asserts `DefaultMap` omits both keys (the byte-parity guard); others pin the fail-safe + leafwise-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)