### PR TITLE
feat(log): write the §1.6.3 timeline marker; union computes the detail link (Slice 2 PR4)

### DIFF
--- a/docs/decisions-branches/feat__timeline-log-marker.md
+++ b/docs/decisions-branches/feat__timeline-log-marker.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 19:20 - Slice 2 PR4: logmind log writes the §1.6.3 timeline marker; union computes the detail link
+
+**Reasoning:** Fourth of 7 PRs. logmind log opens a main-canonical branch file with its entry-block headline (written once, preserved on append, inserted if absent for pre-opt-in files). The marker body is LINK-FREE; the union (renderCanonical) computes the detail link from the source path — because check-links resolves links relative to the source file's dir, a docs/-relative link baked into a branch file would be broken there.
+
+**Alternatives considered:** Bake the detail link into the marker body — rejected: it would fail check-links from the branch file's own directory. Compute at render time from the known source path instead.
+
+**Implications:**
+- log.go: buildTimelineMarker (key excludes the (#NN) suffix per §1.6.3.1; visible line includes it) + insertMarkerAfterHeader + prSuffixFromEnv (LOGMIND_PR, offline — no gh call on the hot path). canonical.go: HeadlineLine single-sources the link-free body; renderCanonical appends a detail link built from the source path. Gated on isBranchFile + IsMainCanonical so default branch files stay byte-identical. FOR PR7 SPEC: the link-free marker body + union-computed link convention to ratify.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (96 decisions)
+## 2026-06 (97 decisions)
 
-- **2026-06-29** — Slice 2 PR3: main-canonical timeline read path (GenerateMainCanonical) + single-point config dispatch *(feat/timeline-main-canonical-readpath)* — [decisions-branches/feat__timeline-main-canonical-readpath.md](decisions-branches/feat__timeline-main-canonical-readpath.md)
-- *... 94 more decisions ...*
+- **2026-06-29** — Slice 2 PR4: logmind log writes the §1.6.3 timeline marker; union computes the detail link *(feat/timeline-log-marker)* — [decisions-branches/feat__timeline-log-marker.md](decisions-branches/feat__timeline-log-marker.md)
+- *... 95 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -66,6 +66,7 @@ import (
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/linkcheck"
 	"github.com/thrillmade/logmind/internal/templates"
+	"github.com/thrillmade/logmind/internal/timeline"
 )
 
 // isTerminalFunc is the indirection seam used by tests to fake TTY
@@ -109,12 +110,12 @@ func isStdinTerminal() bool {
 // the Python click signature but skips fields not yet ported (see
 // file-level docstring "Out of scope" list).
 type logFlags struct {
-	reasoning      string
-	alternatives   []string
-	implications   []string
-	noCommit       bool
-	noInteractive  bool
-	stage          string
+	reasoning     string
+	alternatives  []string
+	implications  []string
+	noCommit      bool
+	noInteractive bool
+	stage         string
 }
 
 // newLogCmd wires the `logmind log <summary>` subcommand.
@@ -235,12 +236,26 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 		existing = data
 	}
 
-	// Compose: header (if first-creation branch file) + existing +
-	// entry. Header is the templates.DecisionsBranchHeader() POSIX-
-	// terminated single line + trailing blank line.
+	// Compose: header (if first-creation branch file) + the §1.6.3 timeline
+	// marker (main-canonical only) + existing + entry. Header is the
+	// templates.DecisionsBranchHeader() POSIX-terminated single line +
+	// trailing blank line.
 	var body strings.Builder
 	if firstCreation {
 		body.WriteString(templates.DecisionsBranchHeader())
+	}
+	// Main-canonical: open the branch detail page with its timeline marker
+	// (the PR headline the union consumes). First creation emits it right
+	// after the header; a later append inserts one only if the file has none
+	// yet (e.g. it predates the opt-in). Gated on isBranchFile + the config
+	// flag, so the default branch-divergent path writes byte-identical files.
+	if isBranchFile && cfg.Timeline.IsMainCanonical() {
+		now := time.Now()
+		if firstCreation {
+			body.WriteString(buildTimelineMarker(now, summary, prSuffixFromEnv()))
+		} else if !timeline.HasEntryBlocks(string(existing)) {
+			existing = insertMarkerAfterHeader(existing, buildTimelineMarker(now, summary, prSuffixFromEnv()))
+		}
 	}
 	body.Write(existing)
 	body.WriteString(entry)
@@ -374,6 +389,41 @@ func buildDecisionEntry(summary, reasoning string, alternatives, implications []
 
 	b.WriteString("---\n\n")
 	return b.String()
+}
+
+// buildTimelineMarker renders the §1.6.3 entry-block headline that opens a
+// branch detail page — the one per-PR row the main-canonical timeline unions.
+// The body is timeline.HeadlineLine (link-free; the union adds the detail
+// link from the source path). Per §1.6.3.1 the (#NN) PR suffix appears in the
+// visible line ONLY, never in the <date>-<slug> key. A trailing blank line
+// separates the marker from the decision entries below.
+func buildTimelineMarker(date time.Time, headline, prSuffix string) string {
+	key := date.Format("2006-01-02") + "-" + timeline.Slugify(headline)
+	line := timeline.HeadlineLine(date, headline+prSuffix)
+	return fmt.Sprintf("<!-- logmind-entry-start: %s -->\n%s\n<!-- logmind-entry-end -->\n\n", key, line)
+}
+
+// prSuffixFromEnv returns " (#NN)" when LOGMIND_PR is set (CI exports it),
+// else "". Tolerates a leading "#". Kept env-only so `logmind log` stays
+// fast + offline — no `gh` network call on the hot path.
+func prSuffixFromEnv() string {
+	v := strings.TrimPrefix(strings.TrimSpace(os.Getenv("LOGMIND_PR")), "#")
+	if v == "" {
+		return ""
+	}
+	return " (#" + v + ")"
+}
+
+// insertMarkerAfterHeader splices marker in right after the branch-file
+// backlink header, preserving the rest of the file. If the header isn't found
+// (a hand-edited file), the marker is prepended — never silently dropped.
+func insertMarkerAfterHeader(existing []byte, marker string) []byte {
+	header := templates.DecisionsBranchHeader()
+	s := string(existing)
+	if strings.HasPrefix(s, header) {
+		return []byte(s[:len(header)] + marker + s[len(header):])
+	}
+	return append([]byte(marker), existing...)
 }
 
 // commitDecision stages the relevant files and creates the commit.

--- a/internal/cli/log_marker_test.go
+++ b/internal/cli/log_marker_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// optIntoMainCanonical overwrites the scaffolded config to enable the
+// main-canonical timeline. Call after scaffoldDocs, before the first log.
+func optIntoMainCanonical(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".logmind", "config.yml"),
+		[]byte("timeline:\n  canonical: main-canonical\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func logOnce(t *testing.T, summary string) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs([]string{"log", summary, "-r", "Why", "--no-commit", "--no-interactive"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("log %q: %v\n%s", summary, err, out.String())
+	}
+}
+
+// TestLog_MainCanonical_WritesAndPreservesMarker: the first log on a branch
+// writes ONE §1.6.3 marker between the header and the first entry; a second
+// log preserves it (no duplicate).
+func TestLog_MainCanonical_WritesAndPreservesMarker(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		cmd := exec.Command("git", "checkout", "-b", "feat/login")
+		cmd.Dir = d
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("checkout: %v\n%s", err, out)
+		}
+		withFakeTTY(t, false, func() {
+			logOnce(t, "Add JWT session auth")
+			logOnce(t, "Refresh token rotation")
+		})
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__login.md"))
+
+	if n := strings.Count(s, "<!-- logmind-entry-start: "); n != 1 {
+		t.Fatalf("marker count = %d; want 1 (written once, preserved on append)\n%s", n, s)
+	}
+	// Key slug derives from the FIRST summary.
+	if !strings.Contains(s, "-add-jwt-session-auth -->") {
+		t.Errorf("marker key missing slug add-jwt-session-auth\n%s", s)
+	}
+	// Visible line is the link-free headline (no detail link baked into the
+	// branch file — that would break check-links from this dir).
+	if !strings.Contains(s, "— Add JWT session auth\n") {
+		t.Errorf("marker line missing/!link-free\n%s", s)
+	}
+	if strings.Contains(s[:strings.Index(s, "logmind-entry-end")], "[detail]") {
+		t.Errorf("marker body must NOT carry a detail link (check-links)\n%s", s)
+	}
+	// Ordering: header < marker < first decision entry.
+	hdr := strings.Index(s, "← back to")
+	mark := strings.Index(s, "<!-- logmind-entry-start:")
+	entry := strings.Index(s, "\n## ")
+	if !(hdr >= 0 && hdr < mark && mark < entry) {
+		t.Errorf("expected header < marker < first-entry; got %d,%d,%d\n%s", hdr, mark, entry, s)
+	}
+}
+
+// TestLog_DefaultMode_NoMarker: with no opt-in, branch files are byte-stable
+// — NO entry-block marker is written (the parity guard at the log layer).
+func TestLog_DefaultMode_NoMarker(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t) // default config — branch-divergent
+		cmd := exec.Command("git", "checkout", "-b", "feat/plain")
+		cmd.Dir = d
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("checkout: %v\n%s", err, out)
+		}
+		withFakeTTY(t, false, func() { logOnce(t, "Plain decision") })
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__plain.md"))
+	if strings.Contains(s, "logmind-entry-start") {
+		t.Errorf("default mode wrote a marker; want none\n%s", s)
+	}
+}
+
+// TestLog_MainCanonical_InsertsMarkerWhenAbsent: a branch file created before
+// the opt-in (no marker) gets one inserted after the header on the next log.
+func TestLog_MainCanonical_InsertsMarkerWhenAbsent(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		cmd := exec.Command("git", "checkout", "-b", "feat/upgrade")
+		cmd.Dir = d
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("checkout: %v\n%s", err, out)
+		}
+		// First log in DEFAULT mode → markerless branch file.
+		withFakeTTY(t, false, func() { logOnce(t, "Pre-opt-in decision") })
+		// Now opt in and log again → marker must be inserted.
+		optIntoMainCanonical(t, d)
+		withFakeTTY(t, false, func() { logOnce(t, "Post-opt-in decision") })
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__upgrade.md"))
+	if n := strings.Count(s, "<!-- logmind-entry-start: "); n != 1 {
+		t.Fatalf("marker count = %d; want 1 inserted on the post-opt-in log\n%s", n, s)
+	}
+	// Inserted right after the header, before any decision entry.
+	hdr := strings.Index(s, "← back to")
+	mark := strings.Index(s, "<!-- logmind-entry-start:")
+	entry := strings.Index(s, "\n## ")
+	if !(hdr < mark && mark < entry) {
+		t.Errorf("inserted marker mis-positioned; got %d,%d,%d\n%s", hdr, mark, entry, s)
+	}
+}
+
+func TestBuildTimelineMarker(t *testing.T) {
+	d := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	got := buildTimelineMarker(d, "Add JWT session auth", " (#42)")
+	// Key excludes the PR suffix (§1.6.3.1); visible line includes it.
+	if !strings.Contains(got, "<!-- logmind-entry-start: 2026-06-29-add-jwt-session-auth -->") {
+		t.Errorf("key wrong (PR suffix must NOT be in the key):\n%s", got)
+	}
+	if !strings.Contains(got, "- **2026-06-29** — Add JWT session auth (#42)\n") {
+		t.Errorf("visible line wrong (must carry the #42 suffix):\n%s", got)
+	}
+	if strings.Contains(got, "[detail]") {
+		t.Errorf("marker body must be link-free:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "<!-- logmind-entry-end -->\n\n") {
+		t.Errorf("marker must end with the close marker + blank line:\n%q", got)
+	}
+}
+
+func TestPrSuffixFromEnv(t *testing.T) {
+	for in, want := range map[string]string{"": "", "42": " (#42)", "#42": " (#42)", "  7 ": " (#7)"} {
+		t.Setenv("LOGMIND_PR", in)
+		if got := prSuffixFromEnv(); got != want {
+			t.Errorf("prSuffixFromEnv(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestInsertMarkerAfterHeader(t *testing.T) {
+	hdr := "← back to [docs/timeline.md](../timeline.md)\n\n"
+	got := string(insertMarkerAfterHeader([]byte(hdr+"## body\n"), "MARK\n"))
+	if got != hdr+"MARK\n## body\n" {
+		t.Errorf("insert-after-header wrong:\n%q", got)
+	}
+	// No header → prepend (never drop).
+	got2 := string(insertMarkerAfterHeader([]byte("hand-edited\n"), "MARK\n"))
+	if got2 != "MARK\nhand-edited\n" {
+		t.Errorf("no-header prepend wrong:\n%q", got2)
+	}
+}
+
+func readFileStr(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -179,9 +179,10 @@ func extractEntryBlocks(content string, stderr io.Writer) []entryBlock {
 // `timeline.canonical: main-canonical` is set; the default branch-divergent
 // path (Generate/Render) is untouched, so v0.6.14 output is byte-stable.
 
-// marked is one timeline row: its date+slug identity, the verbatim body
-// rendered between the entry-block markers, and its source path (used only
-// for the deterministic collision tiebreak — never rendered).
+// marked is one timeline row: its date+slug identity, the link-free headline
+// body rendered between the entry-block markers, and its source path (the
+// detail-page link target, AND the deterministic collision tiebreak — both
+// relative to docs/, e.g. "decisions-branches/feat__x.md" or "decisions.md").
 type marked struct {
 	date   time.Time
 	slug   string
@@ -207,12 +208,16 @@ func splitKey(key string) (date time.Time, slug string, ok bool) {
 	return d, slug, true
 }
 
-// branchLabel reverses _sanitize_branch for the legacy fallback's source
-// label (feat__auth.md → feat/auth). Mirrors decisions.branchLabelFromFilename
-// (unexported there); kept tiny + local rather than widening that package's
-// surface.
-func branchLabel(base string) string {
-	return strings.ReplaceAll(strings.TrimSuffix(base, ".md"), "__", "/")
+// HeadlineLine renders the deterministic visible line for a timeline row —
+// the body that lives BETWEEN the entry-block markers — WITHOUT a detail
+// link. The link is appended by renderCanonical from the row's source path,
+// so it is correct relative to docs/timeline.md regardless of where the
+// marker physically lives (a docs/-relative link baked into a branch file
+// would resolve wrong from that file's own directory and fail check-links).
+// Single-sourced here so `logmind log` (the marker writer) and the synthesized
+// rows share one exact byte format.
+func HeadlineLine(date time.Time, title string) string {
+	return fmt.Sprintf("- **%s** — %s", date.Format("2006-01-02"), title)
 }
 
 // GenerateMainCanonical builds the §1.6.4 deterministic-union timeline from
@@ -278,25 +283,18 @@ func collectMarked(docsPath string, stderr io.Writer) ([]marked, error) {
 			continue
 		}
 		e := entries[0]
-		e.SourcePath = rel
-		e.SourceLabel = branchLabel(base)
-		items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: renderEntryLine(e), source: rel})
+		items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: HeadlineLine(e.Date, e.Title), source: rel})
 	}
 
 	// (2) Direct-to-main + archive: one synthesized row per decision header
 	// (these sources carry no entry-block markers under the newspaper model).
-	for _, src := range []struct{ file, label string }{
-		{"decisions.md", "main"},
-		{"decisions-archive.md", "archive"},
-	} {
-		entries, err := decisions.Iter(filepath.Join(docsPath, src.file), stderr)
+	for _, file := range []string{"decisions.md", "decisions-archive.md"} {
+		entries, err := decisions.Iter(filepath.Join(docsPath, file), stderr)
 		if err != nil {
 			return nil, err
 		}
 		for _, e := range entries {
-			e.SourcePath = src.file
-			e.SourceLabel = src.label
-			items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: renderEntryLine(e), source: src.file})
+			items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: HeadlineLine(e.Date, e.Title), source: file})
 		}
 	}
 
@@ -423,8 +421,13 @@ func renderCanonical(items []marked) string {
 		b.WriteString(it.date.Format("2006-01-02") + "-" + it.slug)
 		b.WriteString(entryStartSuffix)
 		b.WriteString("\n")
+		// Body (the headline, link-free) + the detail link computed from the
+		// source path — correct relative to docs/timeline.md, where this row
+		// lands, not relative to the branch file the marker may live in.
 		b.WriteString(it.body)
-		b.WriteString("\n")
+		b.WriteString(" → [detail](")
+		b.WriteString(it.source)
+		b.WriteString(")\n")
 		b.WriteString(entryEndMarker)
 		b.WriteString("\n")
 	}

--- a/internal/timeline/canonical_assembly_test.go
+++ b/internal/timeline/canonical_assembly_test.go
@@ -50,9 +50,10 @@ func TestGenerateMainCanonical_UnionNewestFirst(t *testing.T) {
 			t.Errorf("block[%d].Key = %q; want %q (newest-first)", i, blocks[i].Key, w)
 		}
 	}
-	// The markered branch body is copied VERBATIM.
-	if blocks[0].Body != "- **2026-06-29** — Add A" {
-		t.Errorf("block[0].Body = %q; want the verbatim marker body", blocks[0].Body)
+	// The markered headline + the detail link computed from the source path.
+	wantBody := "- **2026-06-29** — Add A → [detail](decisions-branches/feat__a.md)"
+	if blocks[0].Body != wantBody {
+		t.Errorf("block[0].Body = %q; want %q", blocks[0].Body, wantBody)
 	}
 }
 
@@ -113,10 +114,13 @@ func TestGenerateMainCanonical_CollisionGetsStableSuffix(t *testing.T) {
 		t.Errorf("keys = %v; want {2026-06-29-dup, 2026-06-29-dup-2}", got)
 	}
 	// The bare slug goes to the lexicographically-smallest source path
-	// (feat__a.md < feat__b.md), so it carries body-from-A.
+	// (feat__a.md < feat__b.md), so it carries body-from-A + its detail link.
 	for _, b := range blocks {
-		if b.Key == "2026-06-29-dup" && b.Body != "- body from A" {
-			t.Errorf("bare-slug body = %q; want body-from-A (smallest source path)", b.Body)
+		if b.Key == "2026-06-29-dup" {
+			want := "- body from A → [detail](decisions-branches/feat__a.md)"
+			if b.Body != want {
+				t.Errorf("bare-slug body = %q; want %q (smallest source path)", b.Body, want)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**PR 4 of 7** for the main-canonical timeline (Slice 2). `logmind log` writes the per-PR §1.6.3 "headline" marker into the branch detail page; the union computes the detail link.

**Key design — branch markers are LINK-FREE.** `check-links` resolves a link relative to the *source file's* dir (`linkcheck.go:142`), so a `docs/`-relative link baked into a branch file would resolve wrong from that file's own directory and fail CI. So the marker body is just the headline, and `renderCanonical` appends the `→ [detail](source)` link computed from the source path — correct in `docs/timeline.md`, where the row actually lands.

- **`log.go`**: `buildTimelineMarker` (key excludes the `(#NN)` suffix per §1.6.3.1; visible line includes it), written on first-creation (`header < marker < entry`), **preserved on append**, **inserted-if-absent** so files created before the opt-in upgrade on their next log. `prSuffixFromEnv` reads `LOGMIND_PR` (offline — no `gh` on the hot path).
- **`canonical.go`**: `HeadlineLine` single-sources the link-free body (the marker writer + synthesized rows share one byte format); `renderCanonical` appends the computed link.
- **Gated on `isBranchFile` + `IsMainCanonical`** → default branch files stay byte-identical (`TestLog_DefaultMode_NoMarker`).

**Flagged for the PR7 SPEC brainstorm:** the link-free marker-body convention + the union-computed `→ [detail]` format to ratify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)