### PR TITLE
feat(tree): deterministic file-structure root label (Slice 2 PR5)

### DIFF
--- a/docs/decisions-branches/feat__tree-root-label.md
+++ b/docs/decisions-branches/feat__tree-root-label.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 19:34 - Slice 2 PR5: deterministic file-structure root label (RenderWithLabel + file_structure.root_label)
+
+**Reasoning:** Fifth of 7 PRs. tree.Render hardcoded the root line to the checkout-dir basename, so the same repo in two different checkout paths produced a different first line and a perpetually-stale file-structure.md. RenderWithLabel takes an explicit label; an empty label reproduces today's basename behavior byte-for-byte (the default), a set label is checkout-independent.
+
+**Alternatives considered:** Auto-derive from the git remote always — rejected: the remote name is itself non-deterministic (fork vs upstream, missing in shallow CI), so only an explicit config label is fully stable. root_label auto is an opt-in convenience that degrades to the basename.
+
+**Implications:**
+- tree.RenderWithLabel (Render delegates with an empty label for byte-parity); GenerateFileStructure threads cfg.FileStructure.RootLabel via resolveRootLabel (auto resolves through new gitcli.RemoteRepoName, else verbatim). Default empty root_label preserves all bytes; the default flip rides v1.0.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (97 decisions)
+## 2026-06 (98 decisions)
 
-- **2026-06-29** — Slice 2 PR4: logmind log writes the §1.6.3 timeline marker; union computes the detail link *(feat/timeline-log-marker)* — [decisions-branches/feat__timeline-log-marker.md](decisions-branches/feat__timeline-log-marker.md)
-- *... 95 more decisions ...*
+- **2026-06-29** — Slice 2 PR5: deterministic file-structure root label (RenderWithLabel + file_structure.root_label) *(feat/tree-root-label)* — [decisions-branches/feat__tree-root-label.md](decisions-branches/feat__tree-root-label.md)
+- *... 96 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -136,6 +136,31 @@ func RemoteHEAD(repoRoot string) string {
 	return out
 }
 
+// RemoteRepoName returns the repository name parsed from origin's URL — the
+// last path segment with any ".git" suffix stripped. Handles both scp-style
+// ("git@github.com:thrillmade/logmind.git" → "logmind") and URL-style
+// ("https://github.com/thrillmade/logmind" → "logmind"). Empty string on any
+// failure (no origin, parse miss). Used only for the OPTIONAL
+// file_structure.root_label: "auto" convenience, which falls back to the
+// checkout basename when this is empty.
+func RemoteRepoName(repoRoot string) string {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	url := strings.TrimSpace(stdout.String())
+	url = strings.TrimSuffix(url, "/")
+	url = strings.TrimSuffix(url, ".git")
+	if i := strings.LastIndexAny(url, "/:"); i >= 0 {
+		url = url[i+1:]
+	}
+	return url
+}
+
 // DiffCachedNames returns the list of staged file paths
 // (`git diff --cached --name-only`). Empty slice on any failure or
 // when nothing is staged.
@@ -256,12 +281,12 @@ func StatusPorcelain(repoRoot, path string) string {
 // DefaultBranch resolves the repo's default branch following the same
 // 5-step search Python's git_handler.default_branch uses:
 //
-//   1. refs/remotes/origin/HEAD                  (set by `git clone` or
-//                                                 `git remote set-head`)
-//   2. local `main` if it exists, else `master`
-//   3. single-branch repo: that branch IS the default
-//   4. `git config init.defaultBranch`
-//   5. hard fallback: "main"
+//  1. refs/remotes/origin/HEAD                  (set by `git clone` or
+//     `git remote set-head`)
+//  2. local `main` if it exists, else `master`
+//  3. single-branch repo: that branch IS the default
+//  4. `git config init.defaultBranch`
+//  5. hard fallback: "main"
 //
 // Used by `logmind rebase` (B3) when --base isn't supplied. Same
 // resolution order as Python so a consuming repo configured to point

--- a/internal/gitcli/gitcli_remote_test.go
+++ b/internal/gitcli/gitcli_remote_test.go
@@ -1,0 +1,42 @@
+package gitcli
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestRemoteRepoName(t *testing.T) {
+	// All these origin URL shapes must parse to the bare repo name.
+	for _, url := range []string{
+		"git@github.com:thrillmade/logmind.git",
+		"https://github.com/thrillmade/logmind.git",
+		"https://github.com/thrillmade/logmind",
+		"ssh://git@github.com/thrillmade/logmind.git",
+		"https://github.com/thrillmade/logmind/",
+	} {
+		dir := t.TempDir()
+		git := func(args ...string) {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+		git("init")
+		git("remote", "add", "origin", url)
+		if got := RemoteRepoName(dir); got != "logmind" {
+			t.Errorf("RemoteRepoName(%q) = %q; want logmind", url, got)
+		}
+	}
+
+	// No origin remote → "" (resolveRootLabel falls back to the basename).
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	if got := RemoteRepoName(dir); got != "" {
+		t.Errorf("no-origin RemoteRepoName = %q; want empty", got)
+	}
+}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/gitcli"
 )
 
 // DefaultFileStructureDepth mirrors Python's DEFAULT_FILE_STRUCTURE_DEPTH.
@@ -58,9 +59,9 @@ const fileStructureTemplateTail = "\n```\n" +
 //
 // Patterns are stored as raw strings; matching happens at the leaf via
 // filepath.Match. Per pattern we test three targets per item:
-//   1. full repo-relative path (e.g. "site/.next/cache")
-//   2. each path component individually
-//   3. the basename
+//  1. full repo-relative path (e.g. "site/.next/cache")
+//  2. each path component individually
+//  3. the basename
 //
 // First match wins for ignore-vs-negate (negate beats ignore — matches
 // gitignore precedence).
@@ -223,10 +224,22 @@ func dedup(in []string) []string {
 // excludes them. Both are matched against the entry's repo-relative
 // posix path (e.g. "site/.next/cache").
 func Render(rootPath string, rules IgnoreRules, maxDepth int) (string, error) {
+	return RenderWithLabel(rootPath, rules, maxDepth, "")
+}
+
+// RenderWithLabel is Render with an explicit root label. label=="" reproduces
+// Render's basename behavior EXACTLY (byte-parity with v0.6.14). A non-empty
+// label makes the root line deterministic across checkouts/worktrees —
+// fixing the churn where /tmp/foo and /work/logmind-pr otherwise produced
+// different first lines (and thus a perpetually-"stale" file-structure.md).
+func RenderWithLabel(rootPath string, rules IgnoreRules, maxDepth int, label string) (string, error) {
 	rootPath = filepath.Clean(rootPath)
-	rootName := filepath.Base(rootPath)
-	if rootName == "" || rootName == "/" {
-		rootName = "."
+	rootName := label
+	if rootName == "" {
+		rootName = filepath.Base(rootPath)
+		if rootName == "" || rootName == "/" {
+			rootName = "."
+		}
 	}
 	var b strings.Builder
 	b.WriteString(rootName)
@@ -354,11 +367,23 @@ func GenerateFileStructure(repoRoot string, maxDepth int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tree, err := Render(repoRoot, rules, maxDepth)
+	tree, err := RenderWithLabel(repoRoot, rules, maxDepth, resolveRootLabel(repoRoot, cfg.FileStructure.RootLabel))
 	if err != nil {
 		return "", err
 	}
 	return fileStructureTemplateHead + tree + fileStructureTemplateTail, nil
+}
+
+// resolveRootLabel maps the config value to the literal root label.
+// Empty (default) → "" (RenderWithLabel falls back to the checkout basename,
+// byte-parity). "auto" → the git remote repo name, or "" when it can't be
+// resolved (shallow/fork CI, no origin) so it degrades to the basename. Any
+// other value is used verbatim.
+func resolveRootLabel(repoRoot, configured string) string {
+	if configured == "auto" {
+		return gitcli.RemoteRepoName(repoRoot)
+	}
+	return configured
 }
 
 // WriteFileStructure atomically writes the rendered file-structure to

--- a/internal/tree/tree_rootlabel_test.go
+++ b/internal/tree/tree_rootlabel_test.go
@@ -1,0 +1,82 @@
+package tree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustWriteTree(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRenderWithLabel_DeterministicAcrossDirNames is the churn fix: the same
+// content in two differently-named checkout dirs + the same label produces
+// identical bytes (without a label, the root line would differ).
+func TestRenderWithLabel_DeterministicAcrossDirNames(t *testing.T) {
+	build := func(name string) string {
+		dir := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		mustWriteTree(t, filepath.Join(dir, "a.txt"), "x")
+		mustWriteTree(t, filepath.Join(dir, "sub", "b.txt"), "y")
+		out, err := RenderWithLabel(dir, IgnoreRules{}, -1, "myrepo")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+	a := build("checkout-one")
+	b := build("a-completely-different-name")
+	if a != b {
+		t.Errorf("not deterministic across dir names:\n--- A ---\n%s\n--- B ---\n%s", a, b)
+	}
+	if !strings.HasPrefix(a, "myrepo\n") {
+		t.Errorf("root line = %q; want it to start with the label", a)
+	}
+}
+
+// TestRenderWithLabel_EmptyLabelMatchesRender is the byte-parity guard:
+// label=="" must reproduce Render's basename behavior exactly.
+func TestRenderWithLabel_EmptyLabelMatchesRender(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "somerepo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTree(t, filepath.Join(dir, "a.txt"), "x")
+
+	withEmpty, err := RenderWithLabel(dir, IgnoreRules{}, -1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	viaRender, err := Render(dir, IgnoreRules{}, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withEmpty != viaRender {
+		t.Errorf("label=\"\" diverged from Render (byte-parity broken):\n%q\nvs\n%q", withEmpty, viaRender)
+	}
+	if !strings.HasPrefix(viaRender, "somerepo\n") {
+		t.Errorf("default root line = %q; want the basename 'somerepo'", viaRender)
+	}
+}
+
+// TestResolveRootLabel covers the config→label mapping (auto resolution is
+// exercised in the gitcli RemoteRepoName test).
+func TestResolveRootLabel(t *testing.T) {
+	if got := resolveRootLabel(t.TempDir(), ""); got != "" {
+		t.Errorf("empty → %q; want \"\"", got)
+	}
+	if got := resolveRootLabel(t.TempDir(), "fixed-name"); got != "fixed-name" {
+		t.Errorf("verbatim → %q; want fixed-name", got)
+	}
+	// "auto" in a non-git dir → "" (degrades to basename downstream).
+	if got := resolveRootLabel(t.TempDir(), "auto"); got != "" {
+		t.Errorf("auto in non-git dir → %q; want \"\"", got)
+	}
+}


### PR DESCRIPTION
**PR 5 of 7** for the main-canonical timeline (Slice 2). Fixes the `file-structure.md` churn: `tree.Render` hardcoded the tree's root line to the checkout-dir basename (`filepath.Base(rootPath)`), so the same repo checked out at different paths (CI worktree vs local) produced a different first line and a perpetually-"stale" `file-structure.md`.

- **`tree.RenderWithLabel(rootPath, rules, maxDepth, label)`** — `label==""` reproduces `Render`'s basename behavior byte-for-byte (`Render` now delegates); a set label is checkout-independent.
- **`GenerateFileStructure`** threads `cfg.FileStructure.RootLabel` via `resolveRootLabel`: `"auto"` resolves through new `gitcli.RemoteRepoName` (degrades to the basename on shallow/fork/no-origin), any other value verbatim.
- **Default `root_label: ""` preserves all bytes** (existing tree goldens pass). The default flip rides v1.0.

Determinism proven: same content in two differently-named dirs + a label → identical bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)