### PR TITLE
feat(hooks): confirm + guard the main-canonical roll-up (Slice 2 PR6)

### DIFF
--- a/docs/decisions-branches/feat__timeline-rollup-confirm.md
+++ b/docs/decisions-branches/feat__timeline-rollup-confirm.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 19:43 - Slice 2 PR6: confirm + guard the main-canonical roll-up (no new mechanism, no push-to-default)
+
+**Reasoning:** Sixth of 7 PRs. The roll-up needs NO new mechanism: the post-merge hook's existing 'logmind timeline --write' dispatches on config (PR3), so a main-canonical repo rebuilds its union on every local merge with no hook-body change and no version bump. The advisory regen-timeline workflow (PR #159) is the server reconciler. This PR documents that and adds an intent guard.
+
+**Alternatives considered:** Add an on-push-to-default workflow that commits the regenerated timeline to main — rejected: it reintroduces the GITHUB_TOKEN-stranding + self-trigger loop the advisory model exists to avoid. Local post-merge hook + server advisory workflow suffice.
+
+**Implications:**
+- Doc note on BuildPostMergeBody (roll-up = local reconciler, inherits config dispatch, branch files KEPT, no push-to-default). TestPostMergeBody_RollupInvariants pins regen-present + no-push as INTENT (survives a golden regen). No behavior change — hook body byte-identical, golden unchanged.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (98 decisions)
+## 2026-06 (99 decisions)
 
-- **2026-06-29** — Slice 2 PR5: deterministic file-structure root label (RenderWithLabel + file_structure.root_label) *(feat/tree-root-label)* — [decisions-branches/feat__tree-root-label.md](decisions-branches/feat__tree-root-label.md)
-- *... 96 more decisions ...*
+- **2026-06-29** — Slice 2 PR6: confirm + guard the main-canonical roll-up (no new mechanism, no push-to-default) *(feat/timeline-rollup-confirm)* — [decisions-branches/feat__timeline-rollup-confirm.md](decisions-branches/feat__timeline-rollup-confirm.md)
+- *... 97 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -86,6 +86,19 @@ func hookVersion() string {
 // pull-up). Local merges that introduce new commits not yet on origin
 // (the multi-branch self-heal case) MUST still trigger regen. See
 // the v0.6.16 inline comment block below for the contract.
+//
+// Slice 2 (main-canonical timeline) roll-up — this hook is the LOCAL
+// reconciler and needs NO change for it. Its `logmind timeline --write`
+// call dispatches on timeline.canonical (internal/cli/timeline.go), so on a
+// repo opted into main-canonical the SAME unchanged body rebuilds the §1.6.4
+// union from the full merged working tree — no hook-body edit, no
+// HookVersionPrefix bump, no fleet-wide "hook updated" churn. Branch detail
+// pages are KEPT (never folded), so the union always has its sources. The
+// server-side reconciler is the advisory regen-timeline.yml workflow (PR
+// #159). We deliberately add NO push-to-default trigger here: it would
+// reintroduce the GITHUB_TOKEN-stranding + self-trigger loop the advisory
+// model exists to avoid. The TestPostMergeBody_RollupInvariants guard pins
+// "regenerates the timeline, never pushes" even across a golden regen.
 func BuildPostMergeBody() string {
 	return "#!/bin/sh\n" +
 		"# logmind post-merge hook\n" +

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -33,6 +33,33 @@ func TestPostRewriteBody_MatchesGolden(t *testing.T) {
 	checkGolden(t, "post-rewrite.golden", BuildPostRewriteBody())
 }
 
+// TestPostMergeBody_RollupInvariants pins the Slice 2 roll-up contract as
+// INTENT (distinct from the byte-golden): the post-merge hook MUST regenerate
+// the timeline + file-structure (so a main-canonical repo rebuilds its §1.6.4
+// union on every local merge — the regen command dispatches on config) and
+// MUST NOT push to a branch (no push-to-default → no GITHUB_TOKEN stranding /
+// self-trigger loop). A golden regen that silently violated either still
+// trips THIS test. (The "leave regens unstaged" v0.6.7 behavior is pinned by
+// the golden + the in-body comment, which itself names `git add`, so we don't
+// substring-match that here.)
+func TestPostMergeBody_RollupInvariants(t *testing.T) {
+	body := BuildPostMergeBody()
+	for _, must := range []string{
+		"logmind timeline --write docs/timeline.md",
+		"logmind file-structure --write docs/file-structure.md",
+	} {
+		if !strings.Contains(body, must) {
+			t.Errorf("post-merge body missing roll-up regen %q", must)
+		}
+	}
+	// Match an actual push invocation, not a stray mention: a `git push` at a
+	// shell-command position (line start, after indentation). The body has
+	// none — the roll-up never pushes.
+	if regexp.MustCompile(`(?m)^\s*git push`).MatchString(body) {
+		t.Errorf("post-merge body issues `git push` — the roll-up must NEVER push to a branch")
+	}
+}
+
 // TestPostMergeBody_ByteIdenticalToPython is THE parity contract for
 // wave B2. It shells to the Python interpreter (skipping the test if
 // Python or the src/logmind package isn't importable), captures


### PR DESCRIPTION
**PR 6 of 7** (the final Go PR) for the main-canonical timeline (Slice 2). Confirms + guards the merge-time roll-up. **No new mechanism, zero behavior change** — the hook body is byte-identical (golden unchanged).

The roll-up needs nothing new: the post-merge hook's existing `logmind timeline --write` dispatches on `timeline.canonical` (PR3), so a main-canonical repo rebuilds its §1.6.4 union on every local merge — no hook-body change, no `HookVersionPrefix` bump. The advisory `regen-timeline.yml` (PR #159) is the server reconciler.

- Doc note on `BuildPostMergeBody` documenting the design: local reconciler, inherits config dispatch, branch detail pages **KEPT**, and deliberately **no push-to-default** (it would reintroduce the GITHUB_TOKEN-stranding + self-trigger loop the advisory model avoids).
- `TestPostMergeBody_RollupInvariants` pins the contract as INTENT: regen-present + no-push (line-anchored regex), surviving a future golden regen.

This completes the **6 Go PRs of Slice 2**. PR7 (SPEC 0.8.0) is the collaborative one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)