### PR TITLE
feat(log): agent-authored branch summary — logmind headline + log -H + nudge (Slice 2 PR7)

### DIFF
--- a/docs/decisions-branches/feat__branch-summary-headline.md
+++ b/docs/decisions-branches/feat__branch-summary-headline.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 20:28 - Slice 2 PR7: agent-authored branch summary — logmind headline + log -H + per-log nudge
+
+**Reasoning:** The timeline headline becomes a one-sentence summary of the WHOLE branch, authored by the agent (the LLM with full context; logmind makes no LLM call). New 'logmind headline' command + bundled 'logmind log -H' flag set it; the per-log nudge steers toward keeping it current (interactive at a TTY; a printed advisory for a non-TTY agent, which it acts on via logmind headline). First-decision title stays the deterministic fallback. Gated to main-canonical, so the default path is byte-stable.
+
+**Alternatives considered:** logmind shells out to an LLM to summarize each branch — rejected: breaks determinism, adds an API-key dependency, costs tokens on every regen. The agent is already the LLM with context; it authors the sentence once, logmind persists it, the dumb union copies it.
+
+**Implications:**
+- New timeline.CurrentHeadline + ReplaceFirstHeadline (keep the date-slug key stable; refine only the visible line). New internal/cli/headline.go. log.go: -H flag + marker-block refactor (headlineText) + nudgeBranchSummary (reuses the runSelfHealLayer1 TTY gate; non-TTY never blocks). Key stable across refinements (tested). PR8 wires the convention into the skill + AGENTS.md templates; PR9 specs it.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (99 decisions)
+## 2026-06 (100 decisions)
 
-- **2026-06-29** — Slice 2 PR6: confirm + guard the main-canonical roll-up (no new mechanism, no push-to-default) *(feat/timeline-rollup-confirm)* — [decisions-branches/feat__timeline-rollup-confirm.md](decisions-branches/feat__timeline-rollup-confirm.md)
-- *... 97 more decisions ...*
+- **2026-06-29** — Slice 2 PR7: agent-authored branch summary — logmind headline + log -H + per-log nudge *(feat/branch-summary-headline)* — [decisions-branches/feat__branch-summary-headline.md](decisions-branches/feat__branch-summary-headline.md)
+- *... 98 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -1,0 +1,112 @@
+// headline.go — `logmind headline <summary>` subcommand.
+//
+// Sets the branch's one-sentence "headline" summary: the plain-English line
+// the main-canonical timeline shows for this branch (the §1.6.3 marker at the
+// top of docs/decisions-branches/<branch>.md). The timeline copies it
+// verbatim; the next agent reads it first. The <date>-<slug> KEY stays stable
+// — only the visible sentence is refined (logmind makes no LLM call; the agent
+// authors the sentence). See also `logmind log --headline` (the bundled form)
+// and the per-log nudge in log.go.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/timeline"
+)
+
+func newHeadlineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "headline <summary>",
+		Short: "Set the one-sentence branch summary shown at the top of the timeline",
+		Long: `Set the branch's one-sentence summary — the "headline" the main-canonical
+timeline shows for this branch, and the first thing the next agent reads.
+
+Write a plain-English sentence describing what the WHOLE branch did (not just
+one decision). It's stored in the §1.6.3 marker at the top of the branch's
+decision file and copied verbatim into docs/timeline.md. The <date>-<slug>
+key stays stable — only the sentence changes, so you can refine it as the
+branch grows.
+
+Requires timeline.canonical: main-canonical (a no-op otherwise, and on the
+default branch). Set LOGMIND_PR to append a (#NN) suffix to the visible line.
+
+Example:
+    logmind headline "Added JWT session auth with refresh-token rotation"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runHeadline(cwd, args[0], cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	return cmd
+}
+
+func runHeadline(cwd, summary string, stdout, stderr io.Writer) error {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		fmt.Fprintln(stdout, "Error: headline summary is empty.")
+		return ErrSilent
+	}
+	docsPath := filepath.Join(cwd, "docs")
+	cfg, _ := config.Load(cwd)
+	if !cfg.Timeline.IsMainCanonical() {
+		fmt.Fprintln(stdout, "Branch summaries are a main-canonical-timeline feature.")
+		fmt.Fprintln(stdout, "Enable it with `timeline.canonical: main-canonical` in .logmind/config.yml.")
+		return nil
+	}
+	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+	if !isBranchFile {
+		fmt.Fprintln(stdout, "Branch summaries apply on a feature branch; the default branch logs to docs/decisions.md directly.")
+		return nil
+	}
+	if !pathExists(target) {
+		fmt.Fprintln(stdout, "No decisions logged on this branch yet — run `logmind log` first, then set the summary.")
+		return nil
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", target, err)
+	}
+	content := string(data)
+	prSuffix := prSuffixFromEnv()
+
+	updated, replaced := timeline.ReplaceFirstHeadline(content, summary, prSuffix)
+	if !replaced {
+		// Markerless (pre-opt-in) branch file — insert a marker now.
+		updated = string(insertMarkerAfterHeader([]byte(content), buildTimelineMarker(time.Now(), summary, prSuffix)))
+	}
+	rel := relForOk(cwd, target)
+	if updated == content {
+		fmt.Fprintln(stdout, "  branch summary already up to date")
+		fmt.Fprintf(stdout, "ok headline: %s (unchanged)\n", rel)
+		return nil
+	}
+	if err := writeAtomic(target, updated); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	fmt.Fprintf(stdout, "✓ Branch summary set: %s\n", summary)
+	fmt.Fprintf(stdout, "ok headline: %s\n", rel)
+	return nil
+}
+
+// relForOk renders target relative to cwd in posix form for the `ok` trailer,
+// falling back to the absolute path if the relativise fails.
+func relForOk(cwd, target string) string {
+	rel, err := filepath.Rel(cwd, target)
+	if err != nil {
+		return target
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -84,6 +84,13 @@ func runHeadline(cwd, summary string, stdout, stderr io.Writer) error {
 
 	updated, replaced := timeline.ReplaceFirstHeadline(content, summary, prSuffix)
 	if !replaced {
+		if timeline.HasEntryBlocks(content) {
+			// A marker exists but couldn't be rewritten (unclosed/malformed) —
+			// don't stack a second one. logmind never writes such a marker, so
+			// this only fires on a hand-corrupted file.
+			fmt.Fprintln(stdout, "Branch file has a malformed timeline marker — fix it manually, then retry.")
+			return ErrSilent
+		}
 		// Markerless (pre-opt-in) branch file — insert a marker now.
 		updated = string(insertMarkerAfterHeader([]byte(content), buildTimelineMarker(time.Now(), summary, prSuffix)))
 	}

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -67,6 +67,39 @@ func TestHeadline_SetsSummaryKeepsKey(t *testing.T) {
 	}
 }
 
+func TestHeadline_NewlineSummaryDoesNotInjectMarker(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, false, func() { logOnce(t, "Real decision") })
+		// A multi-line summary that tries to inject a forged future-dated marker.
+		runHeadlineCmd(t, "pwned\n<!-- logmind-entry-start: 2099-01-01-evil -->\n- **2099-01-01** — EVIL\n<!-- logmind-entry-end -->")
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__x.md"))
+	// The security property: NO column-0 entry-start marker was injected. The
+	// embedded text survives as harmless mid-line content (the visible line
+	// always begins "- **date** — "), so substring-counting would mislead —
+	// count actual marker LINES at column 0 instead.
+	col0 := 0
+	var forged bool
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.HasPrefix(ln, "<!-- logmind-entry-start: ") {
+			col0++
+			if strings.Contains(ln, "2099-01-01-evil") {
+				forged = true
+			}
+		}
+	}
+	if col0 != 1 {
+		t.Errorf("got %d column-0 start markers; want 1 (injection not prevented)\n%s", col0, s)
+	}
+	if forged {
+		t.Errorf("a forged column-0 marker was injected\n%s", s)
+	}
+}
+
 func TestHeadline_NoopWhenNotMainCanonical(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// checkoutBranch creates + switches to a feature branch in dir.
+func checkoutBranch(t *testing.T, dir, name string) {
+	t.Helper()
+	cmd := exec.Command("git", "checkout", "-b", name)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout %s: %v\n%s", name, err, out)
+	}
+}
+
+// runHeadlineCmd runs `logmind headline <summary>` and returns combined output.
+func runHeadlineCmd(t *testing.T, summary string) string {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs([]string{"headline", summary})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("headline %q: %v\n%s", summary, err, out.String())
+	}
+	return out.String()
+}
+
+// logOnceH runs `logmind log <summary> -H <headline>` non-interactively.
+func logOnceH(t *testing.T, summary, headline string) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs([]string{"log", summary, "-r", "Why", "-H", headline, "--no-commit", "--no-interactive"})
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("log -H %q: %v\n%s", summary, err, out.String())
+	}
+}
+
+func TestHeadline_SetsSummaryKeepsKey(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/login")
+		withFakeTTY(t, false, func() { logOnce(t, "Add JWT auth") })
+		runHeadlineCmd(t, "Added the full JWT session lifecycle")
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__login.md"))
+	if !strings.Contains(s, "— Added the full JWT session lifecycle\n") {
+		t.Errorf("summary not set:\n%s", s)
+	}
+	// Key derives from the FIRST decision and stays stable.
+	if !strings.Contains(s, "-add-jwt-auth -->") {
+		t.Errorf("key not stable:\n%s", s)
+	}
+	if n := strings.Count(s, "logmind-entry-start"); n != 1 {
+		t.Errorf("marker count = %d; want 1", n)
+	}
+}
+
+func TestHeadline_NoopWhenNotMainCanonical(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t) // default config → branch-divergent
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, false, func() { logOnce(t, "decision") })
+		out := runHeadlineCmd(t, "some summary")
+		if !strings.Contains(out, "main-canonical") {
+			t.Errorf("expected a main-canonical opt-in notice; got:\n%s", out)
+		}
+	})
+}
+
+func TestHeadline_EmptyRejected(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, false, func() { logOnce(t, "decision") })
+		root := NewRootCmd()
+		root.SetArgs([]string{"headline", "   "})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err == nil {
+			t.Errorf("empty summary should error; output:\n%s", out.String())
+		}
+	})
+}
+
+func TestHeadline_InsertsMarkerOnMarkerlessFile(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		checkoutBranch(t, d, "feat/legacy")
+		// Log in DEFAULT mode → a markerless branch file.
+		withFakeTTY(t, false, func() { logOnce(t, "Pre-opt-in decision") })
+		// Opt in, then set the summary → marker must be inserted.
+		optIntoMainCanonical(t, d)
+		runHeadlineCmd(t, "The branch summary")
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__legacy.md"))
+	if n := strings.Count(s, "logmind-entry-start"); n != 1 {
+		t.Fatalf("marker count = %d; want 1 inserted\n%s", n, s)
+	}
+	if !strings.Contains(s, "— The branch summary\n") {
+		t.Errorf("inserted marker missing the summary:\n%s", s)
+	}
+}
+
+func TestLog_HeadlineFlag_SetsAndUpdatesKeepingKey(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/login")
+		withFakeTTY(t, false, func() {
+			logOnceH(t, "Add JWT auth", "JWT auth added")
+			logOnceH(t, "Add logout", "JWT auth + logout — full lifecycle")
+		})
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__login.md"))
+	if !strings.Contains(s, "— JWT auth + logout — full lifecycle\n") {
+		t.Errorf("-H did not update the headline on append:\n%s", s)
+	}
+	if n := strings.Count(s, "logmind-entry-start"); n != 1 {
+		t.Errorf("marker count = %d; want 1", n)
+	}
+	// Key from the FIRST -H headline ("JWT auth added"), stable across updates.
+	if !strings.Contains(s, "-jwt-auth-added -->") {
+		t.Errorf("key not stable across -H updates:\n%s", s)
+	}
+}
+
+func TestLog_NudgeAdvisoryOnNonTTY(t *testing.T) {
+	var out string
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "decision", "-r", "why", "--no-commit", "--no-interactive"})
+			var b bytes.Buffer
+			root.SetOut(&b)
+			root.SetErr(&b)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("%v\n%s", err, b.String())
+			}
+			out = b.String()
+		})
+	})
+	if !strings.Contains(out, "📝 Branch summary:") || !strings.Contains(out, "logmind headline") {
+		t.Errorf("expected the non-TTY advisory nudge; got:\n%s", out)
+	}
+}
+
+func TestLog_NudgeSkippedWithHeadlineFlag(t *testing.T) {
+	var out string
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "decision", "-r", "why", "-H", "the summary", "--no-commit", "--no-interactive"})
+			var b bytes.Buffer
+			root.SetOut(&b)
+			root.SetErr(&b)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("%v\n%s", err, b.String())
+			}
+			out = b.String()
+		})
+	})
+	if strings.Contains(out, "📝 Branch summary:") {
+		t.Errorf("nudge must be skipped when -H is provided; got:\n%s", out)
+	}
+}
+
+func TestLog_NudgeInteractiveEditOnTTY(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		checkoutBranch(t, d, "feat/x")
+		withFakeTTY(t, true, func() { // pretend stdin is a TTY
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "decision", "-r", "why", "--no-commit"})
+			root.SetIn(strings.NewReader("y\nThe edited branch summary\n"))
+			var b bytes.Buffer
+			root.SetOut(&b)
+			root.SetErr(&b)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("%v\n%s", err, b.String())
+			}
+		})
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__x.md"))
+	if !strings.Contains(s, "— The edited branch summary\n") {
+		t.Errorf("interactive nudge edit did not apply:\n%s", s)
+	}
+}

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -116,6 +116,10 @@ type logFlags struct {
 	noCommit      bool
 	noInteractive bool
 	stage         string
+	// headline, when set, becomes the branch's one-sentence timeline summary
+	// (the §1.6.3 marker headline) — the bundled form of `logmind headline`.
+	// Empty leaves the marker on its deterministic default / prior value.
+	headline string
 }
 
 // newLogCmd wires the `logmind log <summary>` subcommand.
@@ -170,6 +174,8 @@ Example:
 		"Skip the Layer 1 interactive retry prompt; print advisory + exit 0 when linkcheck has issues.")
 	cmd.Flags().StringVar(&f.stage, "stage", "all",
 		"What to stage in the decision commit: 'all' (default) sweeps the working tree, 'scoped' stages only the decision file(s).")
+	cmd.Flags().StringVarP(&f.headline, "headline", "H", "",
+		"Set/refresh the branch's one-sentence timeline summary (main-canonical only). Bundled form of `logmind headline`.")
 	return cmd
 }
 
@@ -251,10 +257,25 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 	// flag, so the default branch-divergent path writes byte-identical files.
 	if isBranchFile && cfg.Timeline.IsMainCanonical() {
 		now := time.Now()
-		if firstCreation {
-			body.WriteString(buildTimelineMarker(now, summary, prSuffixFromEnv()))
-		} else if !timeline.HasEntryBlocks(string(existing)) {
-			existing = insertMarkerAfterHeader(existing, buildTimelineMarker(now, summary, prSuffixFromEnv()))
+		prSuffix := prSuffixFromEnv()
+		// The headline is the branch SUMMARY when --headline is given, else the
+		// decision summary (the deterministic default until the agent refines
+		// it via the nudge or `logmind headline`).
+		headlineText := summary
+		if f.headline != "" {
+			headlineText = f.headline
+		}
+		switch {
+		case firstCreation:
+			body.WriteString(buildTimelineMarker(now, headlineText, prSuffix))
+		case !timeline.HasEntryBlocks(string(existing)):
+			existing = insertMarkerAfterHeader(existing, buildTimelineMarker(now, headlineText, prSuffix))
+		case f.headline != "":
+			// Marker already present + an explicit --headline → refresh the
+			// visible line, keeping the stable <date>-<slug> key.
+			if replaced, ok := timeline.ReplaceFirstHeadline(string(existing), f.headline, prSuffix); ok {
+				existing = []byte(replaced)
+			}
 		}
 	}
 	body.Write(existing)
@@ -270,6 +291,15 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 	}
 	relTarget = filepath.ToSlash(relTarget)
 	fmt.Fprintf(stdout, "✓ Logged decision to %s\n", relTarget)
+
+	// Branch-summary nudge — steer the author toward a clean one-sentence
+	// summary of the WHOLE branch (the timeline headline the next agent reads).
+	// Skipped when --headline was just set (already current). Runs BEFORE the
+	// commit so a TTY edit lands in the same commit. Gated to a main-canonical
+	// branch file. Best-effort: never fails the log.
+	if isBranchFile && cfg.Timeline.IsMainCanonical() && f.headline == "" {
+		nudgeBranchSummary(target, f.noInteractive, stdin, stdout)
+	}
 
 	// Commit (unless --no-commit OR not in a git repo).
 	committed := false
@@ -424,6 +454,56 @@ func insertMarkerAfterHeader(existing []byte, marker string) []byte {
 		return []byte(s[:len(header)] + marker + s[len(header):])
 	}
 	return append([]byte(marker), existing...)
+}
+
+// nudgeBranchSummary steers the author toward a clean one-sentence branch
+// summary after a log. At a TTY it offers an interactive edit (the new summary
+// is written before the caller commits, so it lands in the same commit). For
+// an agent (non-TTY) it prints an advisory with the current summary + how to
+// refresh it — a blocking prompt can't reach a non-TTY caller, so the agent
+// acts asynchronously via `logmind headline`. Best-effort: any IO error just
+// skips the nudge; it never fails the log.
+func nudgeBranchSummary(target string, forceNonInteractive bool, stdin io.Reader, stdout io.Writer) {
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return
+	}
+	current, ok := timeline.CurrentHeadline(string(data))
+	if !ok {
+		return
+	}
+
+	if forceNonInteractive || !isTerminalFunc() {
+		// Agent / CI: advisory only — never block on stdin.
+		fmt.Fprintf(stdout, "\n📝 Branch summary: %s\n", current)
+		fmt.Fprintln(stdout, "   Keep it a one-sentence summary of the whole branch — refresh with: logmind headline \"<one sentence>\"")
+		return
+	}
+
+	// Interactive TTY: offer an inline edit.
+	reader := bufio.NewReader(stdin)
+	fmt.Fprintf(stdout, "\nBranch summary: %s\n", current)
+	fmt.Fprint(stdout, "Update it to a one-sentence summary of the whole branch? [y to edit / N to keep]: ")
+	line, _ := reader.ReadString('\n')
+	if strings.ToLower(strings.TrimSpace(line)) != "y" {
+		return
+	}
+	fmt.Fprint(stdout, "New summary: ")
+	newSummary, _ := reader.ReadString('\n')
+	newSummary = strings.TrimSpace(newSummary)
+	if newSummary == "" {
+		fmt.Fprintln(stdout, "  (empty — kept the current summary)")
+		return
+	}
+	updated, replaced := timeline.ReplaceFirstHeadline(string(data), newSummary, prSuffixFromEnv())
+	if !replaced {
+		return
+	}
+	if err := writeAtomic(target, updated); err != nil {
+		fmt.Fprintf(stdout, "  (could not write summary: %v)\n", err)
+		return
+	}
+	fmt.Fprintln(stdout, "✓ Branch summary updated.")
 }
 
 // commitDecision stages the relevant files and creates the commit.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -75,6 +75,9 @@ func NewRootCmd() *cobra.Command {
 	// Layer 1 of markdown self-healing on top (linkcheck-driven
 	// interactive retry loop). See internal/cli/log.go.
 	root.AddCommand(newLogCmd())
+	// Slice 2: set the branch's one-sentence timeline headline (the
+	// main-canonical summary line). Companion to `logmind log --headline`.
+	root.AddCommand(newHeadlineCmd())
 
 	// Top-level --version flag mirrors `logmind version` so both
 	// `logmind --version` and `logmind version` produce the same line.

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -433,3 +433,45 @@ func renderCanonical(items []marked) string {
 	}
 	return b.String()
 }
+
+// CurrentHeadline returns the verbatim body of the FIRST entry-block in
+// content (the branch's visible headline line), and ok=false when content has
+// no marker. Used to show "[current: …]" in the per-log summary nudge.
+func CurrentHeadline(content string) (headline string, ok bool) {
+	blocks := extractEntryBlocks(content, io.Discard)
+	if len(blocks) == 0 {
+		return "", false
+	}
+	return blocks[0].Body, true
+}
+
+// ReplaceFirstHeadline rewrites the visible body of the FIRST entry-block to a
+// fresh HeadlineLine built from `summary` + `prSuffix`, while KEEPING the
+// existing <date>-<slug> key (the stable identity — only the sentence is
+// refined) and the marker dates. Returns (newContent, true) when a marker was
+// found and rewritten; (content, false) when there is no marker, an unclosed
+// marker, or a malformed key — so the caller can fall back to inserting one.
+func ReplaceFirstHeadline(content, summary, prSuffix string) (string, bool) {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		key, ok := parseStartMarker(line)
+		if !ok {
+			continue
+		}
+		date, _, ok := splitKey(key)
+		if !ok {
+			return content, false // malformed key — don't touch it
+		}
+		for j := i + 1; j < len(lines); j++ {
+			if isEndMarker(lines[j]) {
+				out := make([]string, 0, len(lines))
+				out = append(out, lines[:i+1]...)                       // through the start marker
+				out = append(out, HeadlineLine(date, summary+prSuffix)) // the new single body line
+				out = append(out, lines[j:]...)                         // from the end marker on
+				return strings.Join(out, "\n"), true
+			}
+		}
+		return content, false // unclosed marker
+	}
+	return content, false // no marker
+}

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -216,8 +216,21 @@ func splitKey(key string) (date time.Time, slug string, ok bool) {
 // would resolve wrong from that file's own directory and fail check-links).
 // Single-sourced here so `logmind log` (the marker writer) and the synthesized
 // rows share one exact byte format.
+//
+// The title is collapsed to a SINGLE line (any CR/LF/tab run → one space):
+// the headline is a one-line field by contract, and an un-collapsed multi-line
+// title would push a forged `<!-- logmind-entry-start: … -->` line to column 0
+// of the branch file — corrupting the union and silently dropping the real
+// entry. This is the single chokepoint for every write path (the marker
+// writers + the synthesized rows), so sanitizing here covers them all.
 func HeadlineLine(date time.Time, title string) string {
-	return fmt.Sprintf("- **%s** — %s", date.Format("2006-01-02"), title)
+	return fmt.Sprintf("- **%s** — %s", date.Format("2006-01-02"), collapseToLine(title))
+}
+
+// collapseToLine replaces every run of whitespace (including CR/LF) with a
+// single space and trims the ends, guaranteeing a single-line result.
+func collapseToLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // GenerateMainCanonical builds the §1.6.4 deterministic-union timeline from

--- a/internal/timeline/headline_test.go
+++ b/internal/timeline/headline_test.go
@@ -3,7 +3,25 @@ package timeline
 import (
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestHeadlineLine_CollapsesToSingleLine(t *testing.T) {
+	d := time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC)
+	// A newline-laden title must NOT yield a multi-line body or a column-0
+	// forged marker (the PR7 review's MAJOR injection finding).
+	got := HeadlineLine(d, "pwned\n<!-- logmind-entry-start: 2099-01-01-evil -->\n- **2099** — EVIL")
+	if strings.Contains(got, "\n") {
+		t.Errorf("HeadlineLine produced a multi-line body:\n%q", got)
+	}
+	if strings.Contains(got, "\n<!-- logmind-entry-start") {
+		t.Errorf("a forged marker line survived:\n%q", got)
+	}
+	// Normal interior whitespace is collapsed but content preserved.
+	if got := HeadlineLine(d, "Add   JWT\tauth"); got != "- **2026-06-29** — Add JWT auth" {
+		t.Errorf("whitespace collapse wrong: %q", got)
+	}
+}
 
 func TestCurrentHeadline(t *testing.T) {
 	content := "← back\n\n" + block("2026-06-29-add-jwt", "- **2026-06-29** — Add JWT") +

--- a/internal/timeline/headline_test.go
+++ b/internal/timeline/headline_test.go
@@ -1,0 +1,77 @@
+package timeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCurrentHeadline(t *testing.T) {
+	content := "← back\n\n" + block("2026-06-29-add-jwt", "- **2026-06-29** — Add JWT") +
+		"\n## 2026-06-29 10:00 - decision\nbody\n"
+	got, ok := CurrentHeadline(content)
+	if !ok || got != "- **2026-06-29** — Add JWT" {
+		t.Errorf("CurrentHeadline = %q, %v; want the first block's body", got, ok)
+	}
+	if _, ok := CurrentHeadline("# no markers here\n"); ok {
+		t.Errorf("CurrentHeadline on markerless content must be ok=false")
+	}
+}
+
+func TestReplaceFirstHeadline_KeepsKeyReplacesLine(t *testing.T) {
+	content := "← back\n\n" + block("2026-06-29-add-jwt", "- **2026-06-29** — Add JWT") +
+		"\n## 2026-06-29 10:00 - decision\nbody\n"
+	updated, ok := ReplaceFirstHeadline(content, "Added the full JWT session lifecycle", " (#42)")
+	if !ok {
+		t.Fatal("ReplaceFirstHeadline ok=false on a valid marker")
+	}
+	// Key preserved (slug from the original); the (#NN) suffix is NOT in the key.
+	if !strings.Contains(updated, "<!-- logmind-entry-start: 2026-06-29-add-jwt -->") {
+		t.Errorf("key not preserved:\n%s", updated)
+	}
+	// Visible line replaced, suffix in the visible line only.
+	if !strings.Contains(updated, "- **2026-06-29** — Added the full JWT session lifecycle (#42)\n") {
+		t.Errorf("visible line not replaced as expected:\n%s", updated)
+	}
+	if strings.Contains(updated, "— Add JWT\n") {
+		t.Errorf("old headline still present:\n%s", updated)
+	}
+	// The decision body below the marker is untouched, and exactly one block remains.
+	if !strings.Contains(updated, "## 2026-06-29 10:00 - decision") {
+		t.Errorf("decision body below the marker disturbed:\n%s", updated)
+	}
+	if n := strings.Count(updated, "<!-- logmind-entry-start: "); n != 1 {
+		t.Errorf("block count = %d; want 1", n)
+	}
+}
+
+func TestReplaceFirstHeadline_DateFromKeyNotToday(t *testing.T) {
+	// The rewritten line's date MUST come from the (stable) key, not from now.
+	content := block("2025-01-15-old-entry", "- **2025-01-15** — Old")
+	updated, ok := ReplaceFirstHeadline(content, "A refined summary", "")
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if !strings.Contains(updated, "- **2025-01-15** — A refined summary") {
+		t.Errorf("date not preserved from the key:\n%s", updated)
+	}
+}
+
+func TestReplaceFirstHeadline_NoMarkerLeavesContent(t *testing.T) {
+	content := "# just decisions\n\n## 2026-06-29 10:00 - x\nbody\n"
+	got, ok := ReplaceFirstHeadline(content, "summary", "")
+	if ok {
+		t.Errorf("ok=true on markerless content; want false")
+	}
+	if got != content {
+		t.Errorf("content mutated on the no-marker path")
+	}
+}
+
+func TestReplaceFirstHeadline_MalformedKeyUntouched(t *testing.T) {
+	// A start marker with an unparseable key must be left exactly as-is.
+	content := entryStartPrefix + "not-a-date-key" + entryStartSuffix + "\n- body\n" + entryEndMarker + "\n"
+	got, ok := ReplaceFirstHeadline(content, "summary", "")
+	if ok || got != content {
+		t.Errorf("malformed key: want (content unchanged, false); got ok=%v changed=%v", ok, got != content)
+	}
+}


### PR DESCRIPTION
**PR 7 of 9** for the main-canonical timeline (Slice 2). Makes the timeline headline a **one-sentence summary of the whole branch**, authored by the agent — the rich edge-of-inference payload the next agent reads.

**Authored at the edge:** distilling a branch into one sentence is a synthesis task; the agent that did the work is the LLM with full context. It writes the sentence; logmind persists it in the §1.6.3 marker; the dumb union copies it verbatim. **logmind makes no LLM call.** The first-decision title stays the deterministic fallback.

- **`timeline.CurrentHeadline` / `ReplaceFirstHeadline`** — refine the visible line, **keep the `<date>-<slug>` key stable** (the identity).
- **`logmind headline "…"`** (new `internal/cli/headline.go`) + bundled **`logmind log -H/--headline "…"`**.
- **Per-log nudge** (`nudgeBranchSummary`, reuses the `runSelfHealLayer1` TTY gate): at a TTY → interactive edit (written before commit, lands in the same commit); for an agent (non-TTY → never blocks) → a printed advisory it acts on via `logmind headline`. Skipped when `-H` was just set.
- **Gated** on `isBranchFile` + main-canonical → default branch files byte-identical.

Verified end-to-end: the key `2026-06-29-add-jwt-auth` stayed stable across three progressively-richer summary refinements.

PR8 wires the convention into the skill + AGENTS.md templates; PR9 (SPEC) ratifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)