### PR TITLE
chore(clud-bug): add reviewContext with logmind's load-bearing invariants (Slice 2 PR8)

### DIFF
--- a/.claude/skills/.clud-bug.json
+++ b/.claude/skills/.clud-bug.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "reviewContext": "logmind is a deterministic Go CLI with a hard byte-parity contract against the frozen Python v0.6.14 reference. On ANY change touching timeline / decisions / config / template output, verify these load-bearing invariants: (1) DEFAULT-PATH BYTE-PARITY — the default branch-divergent timeline and `config list` output stay byte-identical; main-canonical features MUST be gated behind `timeline.canonical` and never alter default output (e.g. new keys go in DefaultConfig but NOT DefaultMap). (2) MARKER-INJECTION SAFETY — any free-text CLI input written into docs/markers (decision summaries, branch headlines) MUST be single-line and unable to forge or break an entry-block marker (`<!-- logmind-entry-start/end -->`); a multi-line value that pushes a marker to column 0 corrupts the union and can evict a real entry. (3) NO GITHUB_TOKEN PUSH — CI self-heal MUST NOT push with GITHUB_TOKEN (it strands required checks → permanently unmergeable); advisory (warn + exit 0) or PAT-push only. (4) DETERMINISM — derived docs (timeline, file-structure) must be byte-identical across checkout paths/worktrees.",
   "installed": [
     {
       "slug": "critical-issues-only",

--- a/docs/decisions-branches/feat__branch-summary-convention.md
+++ b/docs/decisions-branches/feat__branch-summary-convention.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 20:46 - Slice 2 PR8: add clud-bug reviewContext (byte-parity / marker-injection / GITHUB_TOKEN / determinism); defer branch-summary convention wiring
+
+**Reasoning:** The PR7 review caught a MAJOR marker-injection the clud-bug pass had only flagged as a watch-item. Encoding logmind's 4 load-bearing invariants as a trusted reviewContext (read from the base ref, injected into every hosted + local review) bakes the lessons in so every future PR checks them. The branch-summary AGENTS.md-template + canonical-skill wiring is DEFERRED: the convention is dormant until the v1.0 main-canonical default flip; changing the AGENTS.md template would bump the block-version and churn every repo's regenerated block for a dormant instruction; and the load-bearing canonical surface (the agent-skills logmind skill) is another agent's repo.
+
+**Alternatives considered:** Bump the AGENTS.md slim/full templates + in-repo skill now — rejected: dormant convention + a block-version bump pushes churn to every repo's regenerated AGENTS.md; the canonical skill is cross-repo. It rides the v1.0 flip + agent-skills coordination, specced in PR9.
+
+**Implications:**
+- reviewContext added to .claude/skills/.clud-bug.json (4 invariants). Cross-repo follow-up: the canonical agent-skills logmind skill must flip its 'you do not manage this' line to 'maintain the branch summary via logmind headline'; the AGENTS.md templates get the convention at the v1.0 main-canonical flip.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (100 decisions)
+## 2026-06 (101 decisions)
 
-- **2026-06-29** — Slice 2 PR7: agent-authored branch summary — logmind headline + log -H + per-log nudge *(feat/branch-summary-headline)* — [decisions-branches/feat__branch-summary-headline.md](decisions-branches/feat__branch-summary-headline.md)
-- *... 98 more decisions ...*
+- **2026-06-29** — Slice 2 PR8: add clud-bug reviewContext (byte-parity / marker-injection / GITHUB_TOKEN / determinism); defer branch-summary convention wiring *(feat/branch-summary-convention)* — [decisions-branches/feat__branch-summary-convention.md](decisions-branches/feat__branch-summary-convention.md)
+- *... 99 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)


### PR DESCRIPTION
**PR 8 of 9** (Slice 2). **Config + docs, no code.**

Adds a clud-bug `reviewContext` to `.claude/skills/.clud-bug.json` encoding logmind's **4 load-bearing invariants** — default-path byte-parity, marker-injection safety, no-GITHUB_TOKEN-push, determinism. It's trusted standing guidance injected into every hosted + local review, so the lessons from this slice (especially the **PR7 marker-injection MAJOR** the adversarial panel caught) are checked on every future PR.

**Defers the branch-summary convention wiring** (AGENTS.md templates + the canonical agent-skills skill): the convention is dormant until the v1.0 main-canonical flip; changing the AGENTS.md template would bump the block-version and churn every repo's regenerated block for a dormant instruction; and the canonical skill is a cross-repo (another agent's) surface. It rides the v1.0 flip + agent-skills coordination, and **PR9 (SPEC)** specifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)