### PR TITLE
feat(doctor): branch-summary health — advisory + --fix backfill + headline --file (Slice 2 PR10)

### DIFF
--- a/docs/decisions-branches/feat__doctor-branch-summary.md
+++ b/docs/decisions-branches/feat__doctor-branch-summary.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-06-29 21:29 - Slice 2 PR10: doctor branch-summary health (advisory + --fix backfill) + logmind headline --file
+
+**Reasoning:** The graceful migration path for the deterministic fallback (CEO: doctor finds un-summarized branches and asks the agent to fix the important ones; fail-graceful, not a hard block). In main-canonical mode, logmind doctor advisorily lists branch files that are markerless or still on the placeholder headline (== first-decision title); doctor --fix backfills the marker into markerless files (the deterministic structural half — the rich summary stays the agent's job via logmind headline --file). The advisory NEVER flips Overall to DRIFT. Default branch-divergent repos see ZERO change (gated).
+
+**Alternatives considered:** doctor itself generates rich summaries via an LLM — rejected: adds an API-key dependency + non-determinism to the deterministic core. doctor does the mechanical backfill; the agent (the LLM with context) writes the sentences.
+
+**Implications:**
+- doctor.go: StatusReport.SummariesNeeded (advisory, kept OFF Tools[].Workflows so Overall + residualProbes are untouched) + collectSummariesNeeded (markerless/placeholder via stripPRSuffix) + renderer block. cli/doctor.go: runDoctorFix backfills markerless files (reuses cli-local marker helpers; summaries-backfilled=N in the ok-line); --fix docs updated (backfills markers, never rewrites decision text). headline.go: setHeadlineInFile extracted + --file flag. All main-canonical-gated.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-06 (101 decisions)
+## 2026-06 (102 decisions)
 
-- **2026-06-29** — Slice 2 PR8: add clud-bug reviewContext (byte-parity / marker-injection / GITHUB_TOKEN / determinism); defer branch-summary convention wiring *(feat/branch-summary-convention)* — [decisions-branches/feat__branch-summary-convention.md](decisions-branches/feat__branch-summary-convention.md)
-- *... 99 more decisions ...*
+- **2026-06-29** — Slice 2 PR10: doctor branch-summary health (advisory + --fix backfill) + logmind headline --file *(feat/doctor-branch-summary)* — [decisions-branches/feat__doctor-branch-summary.md](decisions-branches/feat__doctor-branch-summary.md)
+- *... 100 more decisions ...*
 - **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
 
 ## 2026-05 (87 decisions)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -23,11 +23,16 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/doctor"
+	"github.com/thrillmade/logmind/internal/timeline"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -41,8 +46,9 @@ func newDoctorCmd() *cobra.Command {
 			"on drift so it's CI-pluggable.\n\n" +
 			"With --fix, re-installs the drifted on-disk artifacts (workflows,\n" +
 			"AGENTS.md block, .gitattributes, merge-driver config, git hooks) in\n" +
-			"one idempotent pass. --fix never edits docs/ decision content,\n" +
-			"foreign (hand-written) hooks, or your PATH.",
+			"one idempotent pass, and (main-canonical only) backfills a §1.6.3\n" +
+			"timeline marker into any markerless branch detail file. --fix never\n" +
+			"rewrites decision text, foreign (hand-written) hooks, or your PATH.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if fix {
@@ -67,7 +73,7 @@ func newDoctorCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the report as JSON.")
 	cmd.Flags().BoolVar(&offline, "offline", false, "No-op: doctor makes no network calls (kept for backward compatibility).")
 	cmd.Flags().BoolVar(&exitZero, "exit-zero", false, "Always exit 0, even on drift (for informational CI runs).")
-	cmd.Flags().BoolVar(&fix, "fix", false, "Re-install drifted workflows, AGENTS.md block, .gitattributes, merge-driver config, and git hooks (idempotent). Never edits docs/ decisions, foreign hooks, or PATH.")
+	cmd.Flags().BoolVar(&fix, "fix", false, "Re-install drifted workflows, AGENTS.md block, .gitattributes, merge-driver config, and git hooks (idempotent); and (main-canonical) backfill markers into markerless branch files. Never rewrites decision text, foreign hooks, or PATH.")
 	return cmd
 }
 
@@ -87,6 +93,12 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return ErrSilent
 	}
 
+	// Backfill the §1.6.3 timeline marker into any markerless branch detail
+	// file (main-canonical only) — the deterministic structural half of the
+	// branch-summary migration. The rich one-sentence summary stays the
+	// agent's job (doctor's advisory lists the placeholders to enrich).
+	summariesBackfilled := backfillBranchSummaries(cwd)
+
 	// Re-probe to compute the residual drift that --fix cannot address.
 	after := doctor.CollectStatus(cwd, offline)
 	residual := residualProbes(after)
@@ -100,7 +112,7 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return nil
 	}
 
-	cmd.Println(formatDoctorFixOK(res, residual))
+	cmd.Println(formatDoctorFixOK(res, residual, summariesBackfilled))
 	for _, name := range residual {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"note: %q still drifted — not auto-fixable by `doctor --fix` "+
@@ -125,7 +137,7 @@ func residualProbes(r doctor.StatusReport) []string {
 }
 
 // formatDoctorFixOK renders the single quiet `ok` summary line.
-func formatDoctorFixOK(res refreshResult, residual []string) string {
+func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled int) string {
 	state := func(changed bool, changedWord string) string {
 		if changed {
 			return changedWord
@@ -133,12 +145,51 @@ func formatDoctorFixOK(res refreshResult, residual []string) string {
 		return "current"
 	}
 	return fmt.Sprintf(
-		"ok doctor-fix workflows=%d agents-md=%s gitattributes=%s merge-driver=%s hooks=%d residual=%d",
+		"ok doctor-fix workflows=%d agents-md=%s gitattributes=%s merge-driver=%s hooks=%d summaries-backfilled=%d residual=%d",
 		len(res.WorkflowsCreated)+len(res.WorkflowsRefreshed),
 		state(res.AgentsMDMsg != "", "changed"),
 		state(res.GitattrChanged, "written"),
 		state(res.MergeDriverSet, "set"),
 		len(res.HooksRefreshed),
+		summariesBackfilled,
 		len(residual),
 	)
+}
+
+// backfillBranchSummaries inserts the deterministic §1.6.3 marker (first-
+// decision-title headline) into every markerless branch detail file — the
+// structural half of the branch-summary migration. Main-canonical only;
+// returns the count fixed. Best-effort: a per-file read/write error skips that
+// file. Reuses the cli-local marker helpers (buildTimelineMarker /
+// insertMarkerAfterHeader), so no export is needed.
+func backfillBranchSummaries(cwd string) int {
+	cfg, _ := config.Load(cwd)
+	if !cfg.Timeline.IsMainCanonical() {
+		return 0
+	}
+	files, err := decisions.ListBranchFiles(filepath.Join(cwd, "docs", "decisions-branches"))
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, bf := range files {
+		data, err := os.ReadFile(bf)
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		if timeline.HasEntryBlocks(content) {
+			continue // already has a marker
+		}
+		entries, _ := decisions.Iter(bf, io.Discard)
+		if len(entries) == 0 {
+			continue // empty file — nothing to summarize
+		}
+		marker := buildTimelineMarker(entries[0].Date, entries[0].Title, prSuffixFromEnv())
+		updated := string(insertMarkerAfterHeader([]byte(content), marker))
+		if err := writeAtomic(bf, updated); err == nil {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/cli/doctor_summary_test.go
+++ b/internal/cli/doctor_summary_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustWriteUnder(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHeadline_FileFlag_TargetsArbitraryBranch: `logmind headline --file <path>`
+// summarizes an OLD/non-current branch (stay on the default branch, target the
+// file explicitly) — the affordance the doctor advisory points agents at.
+func TestHeadline_FileFlag_TargetsArbitraryBranch(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		optIntoMainCanonical(t, d)
+		mustWriteUnder(t, d, "docs/decisions-branches/feat__old.md",
+			"← back\n\n## 2026-06-10 09:00 - Old work\n\n---\n")
+		root := NewRootCmd()
+		root.SetArgs([]string{"headline", "--file", "docs/decisions-branches/feat__old.md", "Did the old thing well"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("headline --file: %v\n%s", err, out.String())
+		}
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__old.md"))
+	if !strings.Contains(s, "— Did the old thing well\n") {
+		t.Errorf("--file did not set the summary on the targeted branch:\n%s", s)
+	}
+	if n := strings.Count(s, "logmind-entry-start"); n != 1 {
+		t.Errorf("marker count = %d; want 1", n)
+	}
+}
+
+// TestBackfillBranchSummaries: the doctor --fix backfill inserts a marker into
+// markerless branch files, skips already-markered ones, and is idempotent.
+func TestBackfillBranchSummaries(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, ".logmind/config.yml", "timeline:\n  canonical: main-canonical\n")
+		mustWriteUnder(t, d, "docs/decisions-branches/feat__old.md",
+			"← back\n\n## 2026-06-10 09:00 - Old\n\n---\n")
+		mustWriteUnder(t, d, "docs/decisions-branches/feat__has.md",
+			"← back\n\n<!-- logmind-entry-start: 2026-06-11-x -->\n- **2026-06-11** — X\n<!-- logmind-entry-end -->\n\n## 2026-06-11 10:00 - X\n\n---\n")
+		if n := backfillBranchSummaries(d); n != 1 {
+			t.Errorf("backfillBranchSummaries = %d; want 1 (only the markerless one)", n)
+		}
+	})
+	if n := strings.Count(readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__old.md")), "logmind-entry-start"); n != 1 {
+		t.Errorf("markerless file not backfilled (markers=%d)", n)
+	}
+	// Idempotent: a second pass changes nothing.
+	if n := backfillBranchSummaries(dir); n != 0 {
+		t.Errorf("second backfill = %d; want 0 (idempotent)", n)
+	}
+}
+
+// TestBackfillBranchSummaries_DefaultModeNoop: branch-divergent mode never
+// backfills (the feature is main-canonical-only → default repos byte-stable).
+func TestBackfillBranchSummaries_DefaultModeNoop(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, ".logmind/config.yml", "git:\n  auto_commit: true\n")
+		mustWriteUnder(t, d, "docs/decisions-branches/feat__old.md",
+			"← back\n\n## 2026-06-10 09:00 - Old\n\n---\n")
+		if n := backfillBranchSummaries(d); n != 0 {
+			t.Errorf("default-mode backfill = %d; want 0", n)
+		}
+	})
+	if strings.Contains(readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__old.md")), "logmind-entry-start") {
+		t.Errorf("default mode wrote a marker; want none")
+	}
+}

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -76,6 +76,13 @@ func runHeadline(cwd, summary, fileOverride string, stdout, stderr io.Writer) er
 		if !filepath.IsAbs(target) {
 			target = filepath.Join(cwd, target)
 		}
+		target = filepath.Clean(target)
+		// Only branch detail files carry timeline markers — refuse to splice a
+		// marker into decisions.md/archive or anything outside the branches dir.
+		if filepath.Dir(target) != filepath.Join(cwd, "docs", "decisions-branches") {
+			fmt.Fprintf(stdout, "--file must target a file under docs/decisions-branches/ (got %s).\n", fileOverride)
+			return ErrSilent
+		}
 		if !pathExists(target) {
 			fmt.Fprintf(stdout, "No such branch file: %s\n", fileOverride)
 			return ErrSilent

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -24,6 +24,7 @@ import (
 )
 
 func newHeadlineCmd() *cobra.Command {
+	var file string
 	cmd := &cobra.Command{
 		Use:   "headline <summary>",
 		Short: "Set the one-sentence branch summary shown at the top of the timeline",
@@ -47,34 +48,60 @@ Example:
 			if err != nil {
 				return err
 			}
-			return runHeadline(cwd, args[0], cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runHeadline(cwd, args[0], file, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
+	cmd.Flags().StringVar(&file, "file", "",
+		"Target a specific branch decision file (e.g. docs/decisions-branches/feat__x.md) instead of the current branch — for summarizing old/merged branches.")
 	return cmd
 }
 
-func runHeadline(cwd, summary string, stdout, stderr io.Writer) error {
+func runHeadline(cwd, summary, fileOverride string, stdout, stderr io.Writer) error {
 	summary = strings.TrimSpace(summary)
 	if summary == "" {
 		fmt.Fprintln(stdout, "Error: headline summary is empty.")
 		return ErrSilent
 	}
-	docsPath := filepath.Join(cwd, "docs")
 	cfg, _ := config.Load(cwd)
 	if !cfg.Timeline.IsMainCanonical() {
 		fmt.Fprintln(stdout, "Branch summaries are a main-canonical-timeline feature.")
 		fmt.Fprintln(stdout, "Enable it with `timeline.canonical: main-canonical` in .logmind/config.yml.")
 		return nil
 	}
-	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
-	if !isBranchFile {
-		fmt.Fprintln(stdout, "Branch summaries apply on a feature branch; the default branch logs to docs/decisions.md directly.")
-		return nil
+
+	var target string
+	if fileOverride != "" {
+		// Explicit file (e.g. an old/merged branch) — skip git-branch resolution.
+		target = fileOverride
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(cwd, target)
+		}
+		if !pathExists(target) {
+			fmt.Fprintf(stdout, "No such branch file: %s\n", fileOverride)
+			return ErrSilent
+		}
+	} else {
+		docsPath := filepath.Join(cwd, "docs")
+		t, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+		if !isBranchFile {
+			fmt.Fprintln(stdout, "Branch summaries apply on a feature branch; the default branch logs to docs/decisions.md directly.")
+			return nil
+		}
+		if !pathExists(t) {
+			fmt.Fprintln(stdout, "No decisions logged on this branch yet — run `logmind log` first, then set the summary.")
+			return nil
+		}
+		target = t
 	}
-	if !pathExists(target) {
-		fmt.Fprintln(stdout, "No decisions logged on this branch yet — run `logmind log` first, then set the summary.")
-		return nil
-	}
+	return setHeadlineInFile(cwd, target, summary, stdout)
+}
+
+// setHeadlineInFile sets/refreshes the §1.6.3 marker headline in the given
+// branch file: it rewrites the visible line of an existing marker (keeping the
+// stable <date>-<slug> key), or inserts a marker if the file has none. Shared
+// by `logmind headline` (current branch + --file). main-canonical gating is
+// the caller's responsibility.
+func setHeadlineInFile(cwd, target, summary string, stdout io.Writer) error {
 	data, err := os.ReadFile(target)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", target, err)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -45,6 +45,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,9 +55,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/templates"
+	"github.com/thrillmade/logmind/internal/timeline"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -108,6 +112,11 @@ type StatusReport struct {
 	Overall     string       `json:"overall"`
 	NetworkUsed bool         `json:"network_used"`
 	Suggestions []string     `json:"suggestions"`
+	// SummariesNeeded is an ADVISORY list (main-canonical only) of branch
+	// detail files missing a §1.6.3 timeline marker or still on a placeholder
+	// headline (== the first decision's title). It is a graceful best-practice
+	// nudge for the agent to enrich — it NEVER affects Overall (not drift).
+	SummariesNeeded []string `json:"summaries_needed"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -173,12 +182,61 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 	}
 
 	return StatusReport{
-		ProjectRoot: projectRoot,
-		Tools:       tools,
-		Overall:     overall,
-		NetworkUsed: false,
-		Suggestions: suggestions,
+		ProjectRoot:     projectRoot,
+		Tools:           tools,
+		Overall:         overall,
+		NetworkUsed:     false,
+		Suggestions:     suggestions,
+		SummariesNeeded: collectSummariesNeeded(projectRoot),
 	}
+}
+
+// collectSummariesNeeded returns — IN MAIN-CANONICAL MODE ONLY — the advisory
+// list of branch detail files that lack a §1.6.3 timeline marker, or whose
+// headline is still the deterministic placeholder (== the first decision's
+// title, i.e. nobody wrote a real one-sentence branch summary). It is empty in
+// the default branch-divergent mode, so doctor's output is unchanged there.
+// Purely informational — it never feeds Overall (a graceful nudge, not drift).
+func collectSummariesNeeded(projectRoot string) []string {
+	cfg, _ := config.Load(projectRoot)
+	if !cfg.Timeline.IsMainCanonical() {
+		return nil
+	}
+	files, err := decisions.ListBranchFiles(filepath.Join(projectRoot, "docs", "decisions-branches"))
+	if err != nil {
+		return nil
+	}
+	var needed []string
+	for _, bf := range files {
+		data, err := os.ReadFile(bf)
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		rel := "docs/decisions-branches/" + filepath.Base(bf)
+		if !timeline.HasEntryBlocks(content) {
+			needed = append(needed, rel+" — no summary (run `logmind doctor --fix` to backfill, then enrich)")
+			continue
+		}
+		entries, _ := decisions.Iter(bf, io.Discard)
+		if len(entries) == 0 {
+			continue
+		}
+		current, _ := timeline.CurrentHeadline(content)
+		placeholder := timeline.HeadlineLine(entries[0].Date, entries[0].Title)
+		if stripPRSuffix(current) == placeholder {
+			needed = append(needed, rel+" — placeholder summary (enrich: logmind headline --file "+rel+" \"…\")")
+		}
+	}
+	return needed
+}
+
+var prSuffixRe = regexp.MustCompile(` \(#\d+\)$`)
+
+// stripPRSuffix removes a trailing " (#NN)" PR suffix so a placeholder headline
+// compares equal whether or not LOGMIND_PR was set when the marker was written.
+func stripPRSuffix(s string) string {
+	return prSuffixRe.ReplaceAllString(s, "")
 }
 
 // collectLogmindStatus builds the per-tool report for `logmind`. The
@@ -607,6 +665,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "Suggested:")
 		for _, s := range r.Suggestions {
 			lines = append(lines, fmt.Sprintf("  %s", s))
+		}
+	}
+	if len(r.SummariesNeeded) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Branch summaries needing attention (%d) — enrich the important ones:", len(r.SummariesNeeded)))
+		for _, s := range r.SummariesNeeded {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -213,13 +213,13 @@ func collectSummariesNeeded(projectRoot string) []string {
 			continue
 		}
 		content := string(data)
+		entries, _ := decisions.Iter(bf, io.Discard)
+		if len(entries) == 0 {
+			continue // no decisions → nothing to summarize (and --fix would skip it)
+		}
 		rel := "docs/decisions-branches/" + filepath.Base(bf)
 		if !timeline.HasEntryBlocks(content) {
 			needed = append(needed, rel+" — no summary (run `logmind doctor --fix` to backfill, then enrich)")
-			continue
-		}
-		entries, _ := decisions.Iter(bf, io.Discard)
-		if len(entries) == 0 {
 			continue
 		}
 		current, _ := timeline.CurrentHeadline(content)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -312,3 +312,51 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// TestCollectStatus_SummariesNeeded classifies branch files in main-canonical
+// mode: markerless → "no summary", marker==first-title → "placeholder",
+// enriched → excluded. The advisory MUST NOT flip Overall to DRIFT.
+func TestCollectStatus_SummariesNeeded(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "timeline:\n  canonical: main-canonical\n")
+	mustWrite(t, filepath.Join(dir, "docs", "decisions.md"), "# D\n")
+	// markerless
+	mustWrite(t, filepath.Join(dir, "docs", "decisions-branches", "feat__cache.md"),
+		"← back\n\n## 2026-06-10 09:00 - Add caching\n\n---\n")
+	// placeholder — marker headline equals the first decision's title
+	mustWrite(t, filepath.Join(dir, "docs", "decisions-branches", "feat__login.md"),
+		"← back\n\n<!-- logmind-entry-start: 2026-06-12-add-login -->\n- **2026-06-12** — Add login\n<!-- logmind-entry-end -->\n\n## 2026-06-12 10:00 - Add login\n\n---\n")
+	// enriched — marker headline differs from the first title
+	mustWrite(t, filepath.Join(dir, "docs", "decisions-branches", "feat__api.md"),
+		"← back\n\n<!-- logmind-entry-start: 2026-06-14-add-api -->\n- **2026-06-14** — Built the full REST API with auth and pagination\n<!-- logmind-entry-end -->\n\n## 2026-06-14 10:00 - Add API\n\n---\n")
+
+	r := CollectStatus(dir, true)
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the summary advisory must never be drift")
+	}
+	if len(r.SummariesNeeded) != 2 {
+		t.Fatalf("SummariesNeeded = %d (%v); want 2 (markerless cache + placeholder login; enriched api excluded)", len(r.SummariesNeeded), r.SummariesNeeded)
+	}
+	joined := strings.Join(r.SummariesNeeded, "\n")
+	if !strings.Contains(joined, "feat__cache.md") || !strings.Contains(joined, "no summary") {
+		t.Errorf("missing markerless advisory: %v", r.SummariesNeeded)
+	}
+	if !strings.Contains(joined, "feat__login.md") || !strings.Contains(joined, "placeholder") {
+		t.Errorf("missing placeholder advisory: %v", r.SummariesNeeded)
+	}
+	if strings.Contains(joined, "feat__api.md") {
+		t.Errorf("enriched branch must NOT be listed: %v", r.SummariesNeeded)
+	}
+}
+
+// TestCollectStatus_SummariesNeeded_DefaultModeEmpty: in the default
+// branch-divergent mode the check is OFF entirely (doctor output unchanged).
+func TestCollectStatus_SummariesNeeded_DefaultModeEmpty(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "git:\n  auto_commit: true\n")
+	mustWrite(t, filepath.Join(dir, "docs", "decisions-branches", "feat__x.md"),
+		"← back\n\n## 2026-06-10 09:00 - X\n\n---\n")
+	if r := CollectStatus(dir, true); len(r.SummariesNeeded) != 0 {
+		t.Errorf("branch-divergent SummariesNeeded = %v; want empty (main-canonical-only feature)", r.SummariesNeeded)
+	}
+}

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -255,6 +255,16 @@ func GenerateFor(docsPath string, brief, canonical bool, stderr io.Writer) (stri
 	return Generate(docsPath, brief, stderr)
 }
 
+// dateOnly truncates a timestamp to midnight in its own location, so a
+// synthesized/fallback row sorts at DATE granularity — exactly like a marker
+// row (whose <date>-<slug> key is date-only) and as §1.6.3.2 requires (order
+// by <date>, tiebreak slug). Without this, the same entry sorts at HH:MM as a
+// markerless fallback but at midnight once `doctor --fix` backfills its marker,
+// silently reordering same-day rows. Date-only makes markerless == backfilled.
+func dateOnly(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
 // collectMarked gathers one marked row per timeline entry from all sources.
 func collectMarked(docsPath string, stderr io.Writer) ([]marked, error) {
 	if stderr == nil {
@@ -296,7 +306,8 @@ func collectMarked(docsPath string, stderr io.Writer) ([]marked, error) {
 			continue
 		}
 		e := entries[0]
-		items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: HeadlineLine(e.Date, e.Title), source: rel})
+		d := dateOnly(e.Date)
+		items = append(items, marked{date: d, slug: Slugify(e.Title), body: HeadlineLine(d, e.Title), source: rel})
 	}
 
 	// (2) Direct-to-main + archive: one synthesized row per decision header
@@ -307,7 +318,8 @@ func collectMarked(docsPath string, stderr io.Writer) ([]marked, error) {
 			return nil, err
 		}
 		for _, e := range entries {
-			items = append(items, marked{date: e.Date, slug: Slugify(e.Title), body: HeadlineLine(e.Date, e.Title), source: file})
+			d := dateOnly(e.Date)
+			items = append(items, marked{date: d, slug: Slugify(e.Title), body: HeadlineLine(d, e.Title), source: file})
 		}
 	}
 

--- a/internal/timeline/canonical_assembly_test.go
+++ b/internal/timeline/canonical_assembly_test.go
@@ -78,6 +78,37 @@ func TestGenerateMainCanonical_DeterministicAcrossCheckoutPaths(t *testing.T) {
 	}
 }
 
+// TestGenerateMainCanonical_BackfillIsTimelineNeutral pins the determinism the
+// doctor --fix backfill depends on: a markerless branch's fallback row (sorted
+// by its decision's HH:MM) and the SAME branch's backfilled date-only marker
+// must render IDENTICALLY — otherwise backfilling silently reorders same-day
+// rows. Guards the day-vs-timestamp sort fix (date-only synthesized rows).
+func TestGenerateMainCanonical_BackfillIsTimelineNeutral(t *testing.T) {
+	build := func(markered bool) string {
+		docs := filepath.Join(t.TempDir(), "docs")
+		// A direct-to-main decision at 09:00 the same day as the branch's
+		// first decision at 15:00 — the case where time-order ≠ date-order.
+		writeDoc(t, docs, "decisions.md", "# D\n\n## 2026-06-10 09:00 - Zebra direct to main\nbody\n")
+		if markered {
+			writeDoc(t, docs, "decisions-branches/feat__a.md",
+				"← back\n\n"+block("2026-06-10-apple-branch-work", "- **2026-06-10** — Apple branch work")+
+					"\n## 2026-06-10 15:00 - Apple branch work\nbody\n")
+		} else {
+			writeDoc(t, docs, "decisions-branches/feat__a.md",
+				"← back\n\n## 2026-06-10 15:00 - Apple branch work\nbody\n")
+		}
+		var sb bytes.Buffer
+		out, err := GenerateMainCanonical(docs, &sb)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+	if fallback, backfilled := build(false), build(true); fallback != backfilled {
+		t.Errorf("backfilling reordered/changed the timeline (determinism violated):\n--- fallback ---\n%s\n--- backfilled ---\n%s", fallback, backfilled)
+	}
+}
+
 func TestGenerateMainCanonical_LegacyMarkerlessFallback(t *testing.T) {
 	docs := filepath.Join(t.TempDir(), "docs")
 	// A markerless (pre-Slice-2) branch file: only decision headers. It must


### PR DESCRIPTION
**Slice 2.** A graceful `logmind doctor` branch-summary health check — the migration path for the deterministic fallback ("finds issues, asks the agent to fix the important ones, fail-graceful").

- **`logmind doctor`** (main-canonical) advisorily lists branch files that are *markerless* or still on the *placeholder* headline (== first-decision title), and points the agent at `logmind headline --file`. **Never flips Overall to DRIFT** — new free-standing `StatusReport.SummariesNeeded` (kept off `Tools[].Workflows` so `Overall` + `residualProbes` are untouched).
- **`doctor --fix`** mechanically **backfills** the §1.6.3 marker into markerless files (the deterministic structural half; the rich summary stays the agent's job). `summaries-backfilled=N` in the `ok` line. The backfill uses the first-decision date, so the marker matches the union's at-render legacy synthesis → **the timeline is unchanged by backfilling**.
- **`logmind headline --file <path>`** — summarize an *old/merged* branch, not just the current one (shared `setHeadlineInFile`).
- **Gated to main-canonical** → default branch-divergent repos see ZERO change. `--fix` now backfills markers but **never rewrites decision text** (docs updated).

logmind makes no LLM call: doctor backfills the structure, the agent enriches the prose. PR9 (SPEC) ratifies the CLI affordances + the migration mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)