### PR TITLE
fix(check-doc-links): advisory + no-GITHUB_TOKEN-push self-heal (template v6)

### DIFF
--- a/docs/decisions-branches/fix__check-doc-links-advisory-no-strand.md
+++ b/docs/decisions-branches/fix__check-doc-links-advisory-no-strand.md
@@ -11,3 +11,14 @@
 
 ---
 
+## 2026-07-03 11:20 - Harden check-doc-links self-heal to fully advisory (never red the helper job)
+
+**Reasoning:** The adversarial verifier found two MEDIUMs: mode B's gh pr comment 403s on fork PRs (GitHub caps the token read-only) and set -euo pipefail then reds the self-heal job — contradicting the header's claim that forks take the comment path; mode A similarly reds on a transient API error or an unappliable Claude diff. A non-required helper job going red is noisy and defeats the advisory promise.
+
+**Alternatives considered:** Leave as-is (self-heal is not a required check, so it never blocks the merge), Fix only the mode-B fork 403
+
+**Implications:**
+- Both modes now use set -uo (not -e) and guard their fallible call — if ! python3 (mode A) / if ! gh pr comment (mode B) — degrading to a ::warning:: + exit 0 like regen-timeline; header 'NEVER blocks' scoped to check-links; a test pins both guards so a fork-red can't be reintroduced.
+
+---
+

--- a/docs/decisions-branches/fix__check-doc-links-advisory-no-strand.md
+++ b/docs/decisions-branches/fix__check-doc-links-advisory-no-strand.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 11:01 - check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6)
+
+**Reasoning:** The v5 template stranded consumer PRs three ways, all the class #159 fixed for regen-timeline: (1) the mode-A self-heal pushed a Claude fix to the PR head over GITHUB_TOKEN, moving the head SHA without re-triggering checks, stranding every required check; (2) check-links re-raised the linkcheck exit code, red-blocking the merge on any broken link; (3) it filtered dependabot by actor, and a filtered required check hangs forever.
+
+**Alternatives considered:** Only fix the push; leave the hard-fail and the actor filter as-is, Leave the template; just document that a PAT is required
+
+**Implications:**
+- Bumped v5 to v6 so doctor flags the drift and consumers re-install; mode A now requires LOGMIND_AUTO_REGEN_PAT (not just ANTHROPIC_API_KEY) to push, else it falls through to the mode-B PR comment; added a templates_test invariant block mirroring regen-timeline's; workflow token dropped to contents:read.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -15,6 +15,7 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+- **2026-07-03** — Harden check-doc-links self-heal to fully advisory (never red the helper job) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,6 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
+## 2026-07
+
+- **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
+
 ## 2026-06 (102 decisions)
 
 - **2026-06-29** — Slice 2 PR10: doctor branch-summary health (advisory + --fix backfill) + logmind headline --file *(feat/doctor-branch-summary)* — [decisions-branches/feat__doctor-branch-summary.md](decisions-branches/feat__doctor-branch-summary.md)

--- a/internal/cli/check_links.go
+++ b/internal/cli/check_links.go
@@ -28,7 +28,7 @@ import (
 // projects don't override).
 //
 // `--json` (v1.2.0+): instead of the human-readable report, emit the
-// CheckReport struct as JSON. Used by the v5 check-doc-links workflow
+// CheckReport struct as JSON. Used by the v6 check-doc-links workflow
 // template's mode-B self-heal job (the deterministic PR-comment path
 // that runs when no ANTHROPIC_API_KEY is configured). The JSON shape
 // is intentionally stable so workflow-side consumers don't break on
@@ -54,7 +54,7 @@ default. Configure roots and orphan allowlist via .logmind/config.yml:
 Exits 0 on a clean run, 1 if any broken or orphan links are found.
 
 With --json, emits the agent-readable CheckReport (broken/orphans
-with SuggestedFix strings) used by the v5 check-doc-links workflow's
+with SuggestedFix strings) used by the v6 check-doc-links workflow's
 mode-B self-heal job.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -67,7 +67,7 @@ mode-B self-heal job.`,
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false,
 		"Emit the CheckReport as JSON instead of the human-readable text. "+
-			"Used by the v5 check-doc-links workflow's mode-B self-heal job.")
+			"Used by the v6 check-doc-links workflow's mode-B self-heal job.")
 	return cmd
 }
 

--- a/internal/templates/github/check-doc-links.yml.template
+++ b/internal/templates/github/check-doc-links.yml.template
@@ -5,8 +5,8 @@ name: doc link integrity
 # they follow [link](path.md) references between docs. Installed by
 # `logmind init`.
 #
-# ADVISORY MODEL (v6 — logmind v1.2.0+). This gate NEVER blocks a PR and
-# NEVER pushes with the default GITHUB_TOKEN:
+# ADVISORY MODEL (v6 — logmind v1.2.0+). The check-links gate NEVER blocks
+# a PR, and the self-heal helper NEVER pushes with the default GITHUB_TOKEN:
 #
 #   * check-links runs on every PR / main push and reports link issues as
 #     a `::warning::` — it always EXITS 0, so a broken link never
@@ -14,7 +14,11 @@ name: doc link integrity
 #     blocking form, the advisory derived-doc gate in check-derived-docs;
 #     many link "breaks" are just stale timeline/file-structure regens.)
 #
-#   * self-heal fires only when check-links found issues on a PR:
+#   * self-heal fires only when check-links found issues on a PR. It is a
+#     best-effort HELPER (never a required check): every failure path —
+#     a transient API error, an unappliable diff, or a read-only fork
+#     token — degrades to a `::warning::` and exits 0, so the helper never
+#     red-lights the PR.
 #       - Mode A (auto-fix): requires BOTH `ANTHROPIC_API_KEY` and a
 #         same-repo `LOGMIND_AUTO_REGEN_PAT`. Claude proposes a minimal
 #         markdown-only diff; it is applied, committed, and pushed to the
@@ -23,7 +27,9 @@ name: doc link integrity
 #         gate stays healthy.
 #       - Mode B (deterministic comment): no key, no PAT, or a fork PR.
 #         Posts a PR comment listing each finding + a suggested fix from
-#         `logmind check-links --json`. Comment scope only — no head move.
+#         `logmind check-links --json` (comment scope only — no head move).
+#         On a fork PR the token is read-only, so the comment call is
+#         replaced by a `::warning::` carrying the findings in the job log.
 #
 # It NEVER `git push`es with GITHUB_TOKEN. A GITHUB_TOKEN-authored push
 # moves the PR head SHA but does NOT re-trigger workflows (GitHub's
@@ -130,11 +136,13 @@ jobs:
       - name: Self-heal via Claude (mode A)
         if: ${{ env.ANTHROPIC_API_KEY != '' && env.PAT != '' && env.HEAD_REPO == env.BASE_REPO }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           echo "Mode A: ANTHROPIC_API_KEY + PAT detected — invoking Claude for auto-fix."
           # Constrained prompt; reads the report; produces a unified diff
-          # touching only markdown files; applies via `git apply`.
-          python3 <<'PY'
+          # touching only markdown files; applies via `git apply`. Best-effort:
+          # any failure (transient API, unparseable diff, apply failure) is
+          # caught below and degraded to an advisory warning.
+          if ! python3 <<'PY'
           import json, os, subprocess, sys, urllib.request
 
           report = json.loads(os.environ.get("REPORT_JSON", "{}") or "{}")
@@ -179,12 +187,16 @@ jobs:
               print(diff_text[:500])
               sys.exit(1)
 
-          # Apply via `git apply`. Failure surfaces a real error so the
-          # workflow stays red and a human reviews.
+          # Apply via `git apply`. A failure exits this block non-zero and is
+          # caught below as an advisory warning (the helper never reds).
           with open("/tmp/self-heal.patch", "w") as f:
               f.write(diff_text)
           subprocess.run(["git", "apply", "--whitespace=fix", "/tmp/self-heal.patch"], check=True)
           PY
+          then
+            echo "::warning::Link self-heal (mode A) could not apply an auto-fix (transient API or patch error); the check-links report stands. This does not block the PR."
+            exit 0
+          fi
 
           # Auto-fix common derived-doc cases by re-running the regen
           # commands (idempotent; no-op when content is already correct).
@@ -208,6 +220,7 @@ jobs:
               echo "::warning::Could not push the link self-heal (push race or protected head ref); it reconciles on merge or the next run."
             fi
           fi
+          exit 0
 
       # Mode B — deterministic PR comment. Runs when mode A cannot: no
       # ANTHROPIC_API_KEY, no PAT, or a fork PR. Lists each finding + the
@@ -218,7 +231,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           echo "Mode B: posting deterministic PR comment."
           python3 <<'PY' > /tmp/pr-comment.md
           import json, os
@@ -252,4 +265,11 @@ jobs:
               print()
           print("_Posted by check-doc-links workflow (logmind self-heal, mode B)._")
           PY
-          gh pr comment "$PR_NUMBER" --body-file /tmp/pr-comment.md
+          # `gh pr comment` needs pull-requests:write, which GitHub caps to
+          # read-only on FORK PRs → 403. Degrade to an advisory ::warning:: +
+          # the findings in the job log so the self-heal helper never reds.
+          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/pr-comment.md 2>/dev/null; then
+            echo "::warning::Could not post the link-issues PR comment (the token is read-only on fork PRs). Findings:"
+            cat /tmp/pr-comment.md
+          fi
+          exit 0

--- a/internal/templates/github/check-doc-links.yml.template
+++ b/internal/templates/github/check-doc-links.yml.template
@@ -1,28 +1,40 @@
-# logmind-template-version: v5
+# logmind-template-version: v6
 name: doc link integrity
 
-# Fail PRs that introduce broken or orphaned markdown links so agents stay
-# in context when they follow [link](path.md) references between docs.
-# Installed by `logmind init`.
-
-# Runs unconditionally on every PR / main push — no `paths:` filter.
-# Filtered runs interact badly with `required_status_checks` rules:
-# GitHub treats a filter-skipped check as "expected but missing" and
-# blocks the merge forever. Running unconditionally is cheap (~15s
-# end-to-end) and keeps the gate predictable.
+# Flag broken or orphaned markdown links so agents stay in context when
+# they follow [link](path.md) references between docs. Installed by
+# `logmind init`.
 #
-# v5 (logmind v1.2.0+) — adds a dual-mode self-heal job that fires on
-# pull_request events when `check-links` finds issues. With
-# `secrets.ANTHROPIC_API_KEY` configured, mode A invokes Claude to
-# propose minimal markdown link fixes and pushes them back to the PR
-# head ref via `GITHUB_TOKEN`. Without the key, mode B falls back to a
-# deterministic PR comment listing each finding + a suggested fix
-# (sourced from `logmind check-links --json`). Both modes work out of
-# the box for ANY logmind user — no orchestrator App dependency, no
-# extra config required for mode B. The conditional means the
-# self-heal job is a free upgrade for repos that opt into Anthropic
-# tokens and a no-op for everyone else (mode B always lands a PR
-# comment so the user has actionable feedback regardless).
+# ADVISORY MODEL (v6 — logmind v1.2.0+). This gate NEVER blocks a PR and
+# NEVER pushes with the default GITHUB_TOKEN:
+#
+#   * check-links runs on every PR / main push and reports link issues as
+#     a `::warning::` — it always EXITS 0, so a broken link never
+#     red-lights the merge. (Hard-blocking here would duplicate, in
+#     blocking form, the advisory derived-doc gate in check-derived-docs;
+#     many link "breaks" are just stale timeline/file-structure regens.)
+#
+#   * self-heal fires only when check-links found issues on a PR:
+#       - Mode A (auto-fix): requires BOTH `ANTHROPIC_API_KEY` and a
+#         same-repo `LOGMIND_AUTO_REGEN_PAT`. Claude proposes a minimal
+#         markdown-only diff; it is applied, committed, and pushed to the
+#         PR head THROUGH THE PAT (an explicit credentialed URL, never
+#         persisted). A PAT push re-triggers required checks, so the merge
+#         gate stays healthy.
+#       - Mode B (deterministic comment): no key, no PAT, or a fork PR.
+#         Posts a PR comment listing each finding + a suggested fix from
+#         `logmind check-links --json`. Comment scope only — no head move.
+#
+# It NEVER `git push`es with GITHUB_TOKEN. A GITHUB_TOKEN-authored push
+# moves the PR head SHA but does NOT re-trigger workflows (GitHub's
+# anti-recursion rule), which strands every required status check on the
+# new head ("Expected — Waiting for status to be reported…") and makes the
+# PR permanently unmergeable. The workflow token is kept at
+# `contents: read`; only the optional PAT pushes, and only at push time.
+#
+# The jobs always run (no actor filter). Filtering a required check out
+# for bot/fork PRs would itself strand it as "Expected — Waiting…"; bots
+# and forks simply take the advisory / mode-B comment path.
 
 on:
   pull_request:
@@ -30,13 +42,11 @@ on:
     branches: [main, master]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read          # GITHUB_TOKEN stays read-only; the optional PAT does any push
+  pull-requests: write    # mode-B self-heal posts a PR comment
 
 jobs:
   check-links:
-    # Skip for dependabot PRs — they never touch markdown links.
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       report: ${{ steps.check.outputs.report }}
@@ -44,12 +54,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Self-heal mode A pushes commits back to this PR. Need the
-          # head ref + full history so the push is fast-forward.
+          # Check out the PR head. `repository:` is REQUIRED so fork PRs
+          # work (a fork's head_ref does not exist on the base repo).
+          # persist-credentials:false keeps any token out of .git.
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       # logmind v1.1.0 (2026-06-05) switched from `pip install logmind==X.Y.Z`
       # to the dedicated `thrillmade/setup-logmind` action. The action handles
@@ -59,7 +70,7 @@ jobs:
       # installed by `logmind init`).
       - uses: thrillmade/setup-logmind@v1.0.0
 
-      - name: Check markdown link integrity
+      - name: Check markdown link integrity (advisory)
         id: check
         run: |
           set +e
@@ -74,39 +85,53 @@ jobs:
             echo 'LOGMIND_EOF'
             echo "failed=$rc"
           } >> "$GITHUB_OUTPUT"
-          # Also print human-readable for the job log.
+          # Human-readable for the job log.
           logmind check-links || true
-          exit $rc
+          # ADVISORY: never block the PR. A non-zero linkcheck surfaces as a
+          # warning; the self-heal job (mode A auto-fix / mode B comment) is
+          # the actionable path. Always exit 0 — never strand or red-light.
+          if [ "$rc" != "0" ]; then
+            echo "::warning title=Broken markdown links (advisory — does not block)::logmind check-links found unresolved or orphaned markdown links on this PR. This is ADVISORY and does not fail the check. See the self-heal PR comment, or configure ANTHROPIC_API_KEY + LOGMIND_AUTO_REGEN_PAT for automatic fixes."
+          fi
+          exit 0
 
-  # Self-heal job — only fires when (a) the link check failed AND
-  # (b) the trigger event is a pull_request (push events to main don't
-  # have a writable PR ref to push fixes to).
+  # Self-heal — fires only when check-links found issues on a pull_request.
+  # check-links always exits 0, so this keys off its `failed` output, not
+  # job status (a push event has no writable PR head, so it never runs here).
   self-heal:
     needs: check-links
-    if: failure() && github.event_name == 'pull_request' && needs.check-links.outputs.failed != '0'
+    if: github.event_name == 'pull_request' && needs.check-links.outputs.failed != '0'
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      BASE_REPO: ${{ github.repository }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      REPORT_JSON: ${{ needs.check-links.outputs.report }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v6
         with:
+          # persist-credentials:false — the PAT (mode A) is injected only at
+          # push time via an explicit URL, never persisted into .git.
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: thrillmade/setup-logmind@v1.0.0
 
-      # Mode A — ANTHROPIC_API_KEY is configured: invoke Claude to
-      # propose minimal markdown link fixes, apply, commit, push back to
-      # the PR head ref. The push triggers a fresh `pull_request` run;
-      # if linkcheck passes that run, the PR is unblocked.
+      # Mode A — auto-fix. Requires ANTHROPIC_API_KEY AND a same-repo PAT:
+      # the PAT does the push (GITHUB_TOKEN would strand the PR), so without
+      # it we fall through to the mode-B comment. Claude proposes a minimal
+      # markdown-only diff; it is applied, committed, and PAT-pushed to the
+      # PR head (which re-triggers checks).
       - name: Self-heal via Claude (mode A)
-        if: ${{ env.ANTHROPIC_API_KEY != '' }}
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          REPORT_JSON: ${{ needs.check-links.outputs.report }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' && env.PAT != '' && env.HEAD_REPO == env.BASE_REPO }}
         run: |
           set -euo pipefail
-          echo "Mode A: ANTHROPIC_API_KEY detected — invoking Claude for auto-fix."
+          echo "Mode A: ANTHROPIC_API_KEY + PAT detected — invoking Claude for auto-fix."
           # Constrained prompt; reads the report; produces a unified diff
           # touching only markdown files; applies via `git apply`.
           python3 <<'PY'
@@ -169,28 +194,32 @@ jobs:
           fi
 
           # Commit + push if there's a diff.
-          git config user.name "clud-bug[bot]"
-          git config user.email "clud-bug[bot]@users.noreply.github.com"
+          git config user.name "logmind-auto-regen"
+          git config user.email "logmind-auto-regen@users.noreply.github.com"
           if ! git diff --quiet || ! git diff --cached --quiet; then
             git add -A
             git commit -m "fix(docs): self-heal markdown links
 
           Applied by check-doc-links workflow (mode A, Claude-assisted)."
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            # PAT push (explicit credentialed URL, never persisted). NEVER
+            # GITHUB_TOKEN — that moves the head SHA without re-triggering
+            # checks and strands the PR's required checks forever.
+            if ! git push "https://x-access-token:${PAT}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"; then
+              echo "::warning::Could not push the link self-heal (push race or protected head ref); it reconciles on merge or the next run."
+            fi
           fi
 
-      # Mode B — no ANTHROPIC_API_KEY: post a deterministic PR comment
-      # listing each finding + the SuggestedFix sourced from
-      # `logmind check-links --json`. No tokens, no AI, no extra config.
+      # Mode B — deterministic PR comment. Runs when mode A cannot: no
+      # ANTHROPIC_API_KEY, no PAT, or a fork PR. Lists each finding + the
+      # SuggestedFix from `logmind check-links --json`. `gh pr comment`
+      # only writes a comment (no head move, no strand).
       - name: Self-heal via PR comment (mode B)
-        if: ${{ env.ANTHROPIC_API_KEY == '' }}
+        if: ${{ env.ANTHROPIC_API_KEY == '' || env.PAT == '' || env.HEAD_REPO != env.BASE_REPO }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPORT_JSON: ${{ needs.check-links.outputs.report }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          echo "Mode B: no ANTHROPIC_API_KEY — posting deterministic PR comment."
+          echo "Mode B: posting deterministic PR comment."
           python3 <<'PY' > /tmp/pr-comment.md
           import json, os
           report = json.loads(os.environ.get("REPORT_JSON", "{}") or "{}")
@@ -199,10 +228,11 @@ jobs:
           print("## logmind check-links: link issues detected")
           print()
           print("This PR introduced markdown links that don't resolve, or "
-                "added docs/*.md files that no parent doc references. Please "
-                "address the issues below and push again. (Set "
-                "`ANTHROPIC_API_KEY` as a repo secret to enable automatic "
-                "self-heal via Claude.)")
+                "added docs/*.md files that no parent doc references. This is "
+                "advisory (the check does not block); please address the "
+                "issues below and push again. (Set both `ANTHROPIC_API_KEY` "
+                "and a same-repo `LOGMIND_AUTO_REGEN_PAT` as repo secrets to "
+                "enable automatic self-heal via Claude.)")
           print()
           if broken:
               print(f"### Broken links ({len(broken)})")

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -306,6 +306,17 @@ func TestCheckDocLinksTemplate_V6_AdvisoryNoStrand(t *testing.T) {
 	if !strings.Contains(body, "pull-requests: write") {
 		t.Errorf("check-doc-links v6 missing pull-requests:write permission (mode B comment)")
 	}
+
+	// Both self-heal modes are best-effort advisory: a transient auto-fix
+	// failure (mode A) or a read-only fork token 403 (mode B) MUST degrade
+	// to a ::warning:: and never red-light the helper job. Guarding these is
+	// what keeps the header's "forks take the mode-B path" promise honest.
+	if !strings.Contains(body, "if ! python3") {
+		t.Errorf("check-doc-links v6 mode A must guard the Claude auto-fix (a transient failure must not red the self-heal job)")
+	}
+	if !strings.Contains(body, "if ! gh pr comment") {
+		t.Errorf("check-doc-links v6 mode B must guard `gh pr comment` (a fork 403 must not red the self-heal job)")
+	}
 }
 
 // TestDecisionsBranchHeader_Shape pins the v1.2.0 backlink header

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -213,61 +213,98 @@ func TestRegenTimelineTemplate_V5_Advisory(t *testing.T) {
 	}
 }
 
-// TestCheckDocLinksTemplate_V5_DualModeSelfHeal pins the v1.2.0 Layer
-// 3 self-heal shape (plan §8.7): the workflow template marker bumps
-// to v5, AND it contains both the mode-A (ANTHROPIC_API_KEY auto-fix)
-// and mode-B (deterministic PR comment) conditional branches. Either
-// mode missing means the dual-mode promise is broken.
-func TestCheckDocLinksTemplate_V5_DualModeSelfHeal(t *testing.T) {
+// TestCheckDocLinksTemplate_V6_AdvisoryNoStrand pins the v1.2.0 advisory
+// contract for the doc-link gate: like regen-timeline, it must NEVER
+// hard-block a PR and must NEVER push with the default GITHUB_TOKEN (a
+// GITHUB_TOKEN push moves the PR head SHA without re-triggering checks,
+// stranding every required check). check-links is advisory (warn +
+// exit 0); the dual-mode self-heal either PAT-pushes a Claude fix
+// (mode A) or posts a deterministic PR comment (mode B).
+func TestCheckDocLinksTemplate_V6_AdvisoryNoStrand(t *testing.T) {
 	body := Workflow("check-doc-links.yml.template")
 
-	// Marker bump v4 → v5.
-	if !strings.Contains(body, "# logmind-template-version: v5") {
-		t.Errorf("check-doc-links template missing v5 marker (plan §8.7 / Layer 3)")
+	// Marker bump v5 → v6.
+	if !strings.Contains(body, "# logmind-template-version: v6") {
+		t.Errorf("check-doc-links template missing v6 marker")
 	}
 
-	// Mode A: ANTHROPIC_API_KEY-gated. Must mention the secret + run
-	// some auto-fix machinery + push back to the PR head ref.
-	if !strings.Contains(body, "secrets.ANTHROPIC_API_KEY") {
-		t.Errorf("v5 template missing ANTHROPIC_API_KEY conditional (mode A)")
+	// Advisory: the old `exit $rc` (re-raise the linkcheck exit) red-lit
+	// the PR — it must be gone, replaced by an advisory warning + exit 0.
+	if strings.Contains(body, "exit $rc") {
+		t.Errorf("check-doc-links v6 must not `exit $rc` — check-links is advisory and must never block a PR")
 	}
-	if !strings.Contains(body, "ANTHROPIC_API_KEY != ''") {
-		t.Errorf("v5 template missing mode-A gate (env.ANTHROPIC_API_KEY != '')")
-	}
-	if !strings.Contains(body, "Mode A") {
-		t.Errorf("v5 template missing mode-A label in step name/comment")
+	if !strings.Contains(body, "::warning") {
+		t.Errorf("check-doc-links v6 missing the advisory ::warning:: on broken links")
 	}
 
-	// Mode B: fallback when no key. Must post a PR comment via gh.
-	if !strings.Contains(body, "ANTHROPIC_API_KEY == ''") {
-		t.Errorf("v5 template missing mode-B gate (env.ANTHROPIC_API_KEY == '')")
+	// No GITHUB_TOKEN push: the old `git push origin HEAD:<head-ref>`
+	// (authenticated by GITHUB_TOKEN) stranded the PR. Any push must go
+	// through the explicit PAT-credentialed URL.
+	if strings.Contains(body, "git push origin") {
+		t.Errorf("check-doc-links v6 must not `git push origin` (a GITHUB_TOKEN push strands the PR's required checks)")
 	}
-	if !strings.Contains(body, "Mode B") {
-		t.Errorf("v5 template missing mode-B label in step name/comment")
+	if !strings.Contains(body, "x-access-token:${PAT}") {
+		t.Errorf("check-doc-links v6 mode-A push must use the explicit PAT URL, not a GITHUB_TOKEN credential")
+	}
+
+	// Mode A is PAT-gated: without LOGMIND_AUTO_REGEN_PAT there is no safe
+	// push, so mode A must require it (and fall through to mode B otherwise).
+	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
+		t.Errorf("check-doc-links v6 missing the LOGMIND_AUTO_REGEN_PAT push gate")
+	}
+	if !strings.Contains(body, "env.PAT != ''") {
+		t.Errorf("check-doc-links v6 mode-A must be gated on a configured PAT (env.PAT != '')")
+	}
+
+	// Workflow token stays read-only; the PAT does any push.
+	if !strings.Contains(body, "contents: read") {
+		t.Errorf("check-doc-links v6 must keep the workflow token read-only (contents: read)")
+	}
+	if strings.Contains(body, "contents: write") {
+		t.Errorf("check-doc-links v6 must not grant contents: write (the PAT, not GITHUB_TOKEN, pushes)")
+	}
+
+	// No actor filter: a filtered required check strands as "Expected —
+	// Waiting…". Bots/forks take the advisory / mode-B path.
+	if strings.Contains(body, "github.actor != ") {
+		t.Errorf("check-doc-links v6 must not filter a job by actor (a filtered required check hangs forever)")
+	}
+
+	// Fork PRs must reach the advisory path, not die at checkout.
+	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
+		t.Errorf("check-doc-links v6 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
+	}
+	// No token persisted into .git; the PAT is injected only at push time.
+	if !strings.Contains(body, "persist-credentials: false") {
+		t.Errorf("check-doc-links v6 checkout must set persist-credentials: false")
+	}
+
+	// Dual-mode self-heal preserved: mode A (Claude auto-fix) + mode B
+	// (deterministic PR comment), both keyed off the check-links report.
+	if !strings.Contains(body, "Mode A") || !strings.Contains(body, "Mode B") {
+		t.Errorf("check-doc-links v6 missing a self-heal mode (both mode A and mode B required)")
+	}
+	if !strings.Contains(body, "secrets.ANTHROPIC_API_KEY") || !strings.Contains(body, "ANTHROPIC_API_KEY != ''") {
+		t.Errorf("check-doc-links v6 missing the mode-A ANTHROPIC_API_KEY gate")
 	}
 	if !strings.Contains(body, "gh pr comment") {
-		t.Errorf("v5 template missing `gh pr comment` (mode B deterministic path)")
+		t.Errorf("check-doc-links v6 missing `gh pr comment` (mode B deterministic path)")
 	}
-
-	// Both modes share the `logmind check-links --json` machinery.
 	if !strings.Contains(body, "logmind check-links --json") {
-		t.Errorf("v5 template missing `logmind check-links --json` invocation")
+		t.Errorf("check-doc-links v6 missing `logmind check-links --json` invocation")
 	}
 
-	// Self-heal job is gated on pull_request events to avoid pushing
-	// to main on push triggers.
+	// Self-heal fires on pull_request when check-links reported issues
+	// (keyed off the `failed` output, since check-links now always exits 0).
 	if !strings.Contains(body, "github.event_name == 'pull_request'") {
-		t.Errorf("v5 self-heal job must be gated on pull_request events")
+		t.Errorf("check-doc-links v6 self-heal must be gated on pull_request events")
 	}
-
-	// Permissions: needs contents:write (commit) + pull-requests:write
-	// (comment). Without these the mode-A push and mode-B comment fail
-	// silently.
-	if !strings.Contains(body, "contents: write") {
-		t.Errorf("v5 template missing contents:write permission")
+	if !strings.Contains(body, "needs.check-links.outputs.failed != '0'") {
+		t.Errorf("check-doc-links v6 self-heal must key off the check-links `failed` output")
 	}
+	// pull-requests:write is still needed for the mode-B comment.
 	if !strings.Contains(body, "pull-requests: write") {
-		t.Errorf("v5 template missing pull-requests:write permission")
+		t.Errorf("check-doc-links v6 missing pull-requests:write permission (mode B comment)")
 	}
 }
 


### PR DESCRIPTION
## Problem

The v5 `check-doc-links` workflow template (shipped to every consumer by `logmind init`) could **permanently strand consumer PRs** — three vectors, all the class #159 fixed for `regen-timeline`:

1. **GITHUB_TOKEN push (strands).** The mode-A self-heal pushed a Claude-authored fix to the PR head over `GITHUB_TOKEN`. A `GITHUB_TOKEN` push moves the head SHA but does not re-trigger workflows (GitHub's anti-recursion rule) → every required check is re-expected on the new SHA and never reports → PR permanently unmergeable.
2. **Hard-fail (blocks).** `check-links` re-raised the linkcheck exit code (`exit $rc`), red-blocking the merge on any broken/orphan link — many of which are just stale `timeline`/`file-structure` regens that `check-derived-docs` already treats as advisory.
3. **Actor filter (strands).** `check-links` skipped `dependabot[bot]` PRs — and a filtered required check hangs forever as "Expected — Waiting…".

## Fix (mirror `regen-timeline.yml`, template v5 → v6)

- **`check-links` is advisory**: emits a `::warning::` on broken links, always `exit 0`. Never blocks.
- **No actor filter**: runs unconditionally; bots/forks take the advisory / mode-B path.
- **Self-heal never GITHUB_TOKEN-pushes**: mode A now requires **both** `ANTHROPIC_API_KEY` **and** a same-repo `LOGMIND_AUTO_REGEN_PAT`, and pushes through the explicit PAT-credentialed URL (which re-triggers checks). Without the PAT it falls through to **mode B** (deterministic PR comment). The self-heal trigger keys off the `check-links` `failed` output (since check-links now always exits 0).
- **Token read-only**: workflow `permissions: contents: read` (was `write`); `persist-credentials: false`.

## Tests / propagation

- New `TestCheckDocLinksTemplate_V6_AdvisoryNoStrand` — an **invariant block mirroring `regen-timeline`'s**: asserts no `exit $rc`, no `git push origin`, PAT-URL push only, `contents: read`, no actor filter, dual-mode preserved. (The "invariant-as-executed-test" discipline from clud-bug-app#87, dogfooded.)
- Bumped `v5 → v6`, so `logmind doctor` flags the drift in consumer repos and they re-install to pick it up.

Full suite green (14 pkgs), `go vet` clean, YAML validated (jobs parse, `contents: read` + `pull-requests: write`, no actor filter on `check-links`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
