### PR TITLE
fix(log): route the main-canonical non-TTY headline nudge to stderr (§3.1.1)

### DIFF
--- a/docs/decisions-branches/fix__nudge-stderr-conformance.md
+++ b/docs/decisions-branches/fix__nudge-stderr-conformance.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 11:25 - Route the main-canonical non-TTY headline nudge to stderr (§3.1.1 conformance)
+
+**Reasoning:** nudgeBranchSummary wrote its non-TTY advisory to stdout, appending a 4th line after the three required logmind log lines under main-canonical — violating the §3.1.1 contract that non-TTY stdout is EXACTLY the three lines, byte-identical to the §6.6 fixtures. The adversarial red-team of the SPEC 0.8.0 pass caught it; latent today (main-canonical isn't the default, no fixture covers it) but it blocks the 0.8.0 conformance claim.
+
+**Alternatives considered:** Keep it on stdout and drop the byte-parity claim for main-canonical non-TTY (forfeits the core guarantee)
+
+**Implications:**
+- Non-TTY nudge now writes to stderr; the interactive TTY path is unchanged (§3.1.1 permits TTY-on-stdout). The test now splits stdout/stderr (the old one merged them, so it couldn't catch contamination) and asserts the nudge is stderr-only + absent from stdout. Pairs with SPEC 0.8.0 Edit 14.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,11 +56,13 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
+│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   └── tsconfig.json
+│   ├── tsconfig.json
+│   └── tsconfig.tsbuildinfo
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (3 decisions)
+## 2026-07 (4 decisions)
 
 - **2026-07-03** — templates: drop dead Python-API blocks, fix wrong-org URLs + dead required-reading *(fix/templates-dead-python-api-and-links)* — [decisions-branches/fix__templates-dead-python-api-and-links.md](decisions-branches/fix__templates-dead-python-api-and-links.md)
-- *... 1 more decision ...*
+- *... 2 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -176,7 +176,7 @@ func TestLog_HeadlineFlag_SetsAndUpdatesKeepingKey(t *testing.T) {
 }
 
 func TestLog_NudgeAdvisoryOnNonTTY(t *testing.T) {
-	var out string
+	var outStr, errStr string
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
@@ -185,17 +185,23 @@ func TestLog_NudgeAdvisoryOnNonTTY(t *testing.T) {
 		withFakeTTY(t, false, func() {
 			root := NewRootCmd()
 			root.SetArgs([]string{"log", "decision", "-r", "why", "--no-commit", "--no-interactive"})
-			var b bytes.Buffer
-			root.SetOut(&b)
-			root.SetErr(&b)
+			var outBuf, errBuf bytes.Buffer
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
 			if err := root.Execute(); err != nil {
-				t.Fatalf("%v\n%s", err, b.String())
+				t.Fatalf("%v\nout:%s\nerr:%s", err, outBuf.String(), errBuf.String())
 			}
-			out = b.String()
+			outStr, errStr = outBuf.String(), errBuf.String()
 		})
 	})
-	if !strings.Contains(out, "📝 Branch summary:") || !strings.Contains(out, "logmind headline") {
-		t.Errorf("expected the non-TTY advisory nudge; got:\n%s", out)
+	// The non-TTY advisory nudge MUST land on stderr...
+	if !strings.Contains(errStr, "📝 Branch summary:") || !strings.Contains(errStr, "logmind headline") {
+		t.Errorf("expected the non-TTY advisory nudge on stderr; got stderr:\n%s", errStr)
+	}
+	// ...and MUST NOT contaminate stdout (SPEC §3.1.1: stdout stays the
+	// three log lines, byte-identical to the §6.6 fixtures).
+	if strings.Contains(outStr, "📝 Branch summary:") {
+		t.Errorf("the nudge must not appear on stdout (breaks the §3.1.1 three-line contract); got stdout:\n%s", outStr)
 	}
 }
 

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -298,7 +298,7 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 	// commit so a TTY edit lands in the same commit. Gated to a main-canonical
 	// branch file. Best-effort: never fails the log.
 	if isBranchFile && cfg.Timeline.IsMainCanonical() && f.headline == "" {
-		nudgeBranchSummary(target, f.noInteractive, stdin, stdout)
+		nudgeBranchSummary(target, f.noInteractive, stdin, stdout, stderr)
 	}
 
 	// Commit (unless --no-commit OR not in a git repo).
@@ -463,7 +463,7 @@ func insertMarkerAfterHeader(existing []byte, marker string) []byte {
 // refresh it — a blocking prompt can't reach a non-TTY caller, so the agent
 // acts asynchronously via `logmind headline`. Best-effort: any IO error just
 // skips the nudge; it never fails the log.
-func nudgeBranchSummary(target string, forceNonInteractive bool, stdin io.Reader, stdout io.Writer) {
+func nudgeBranchSummary(target string, forceNonInteractive bool, stdin io.Reader, stdout, stderr io.Writer) {
 	data, err := os.ReadFile(target)
 	if err != nil {
 		return
@@ -474,9 +474,11 @@ func nudgeBranchSummary(target string, forceNonInteractive bool, stdin io.Reader
 	}
 
 	if forceNonInteractive || !isTerminalFunc() {
-		// Agent / CI: advisory only — never block on stdin.
-		fmt.Fprintf(stdout, "\n📝 Branch summary: %s\n", current)
-		fmt.Fprintln(stdout, "   Keep it a one-sentence summary of the whole branch — refresh with: logmind headline \"<one sentence>\"")
+		// Agent / CI: advisory only — never block on stdin, and the nudge
+		// MUST go to stderr so stdout stays byte-identical to the three §3.1
+		// log lines (SPEC §3.1.1: the non-TTY headline nudge is stderr-only).
+		fmt.Fprintf(stderr, "\n📝 Branch summary: %s\n", current)
+		fmt.Fprintln(stderr, "   Keep it a one-sentence summary of the whole branch — refresh with: logmind headline \"<one sentence>\"")
 		return
 	}
 


### PR DESCRIPTION
Under `timeline.canonical: main-canonical`, `logmind log`'s branch-summary nudge was written to **stdout** (`nudgeBranchSummary`), appending a line after the three required `logmind log` lines — violating SPEC §3.1.1: non-TTY stdout must be **exactly** the three lines, byte-identical to the §6.6 fixtures.

Latent today (main-canonical isn't the default and no fixture covers it), but it blocks the 0.8.0 conformance claim. The adversarial red-team of the SPEC 0.8.0 main-canonical pass surfaced it; confirmed stderr direction.

**Fix:** the non-TTY advisory nudge now writes to **stderr**; stdout stays the three log lines in every mode. The interactive TTY path is unchanged (§3.1.1 permits the TTY advisory on stdout).

**Test:** `TestLog_NudgeAdvisoryOnNonTTY` now splits stdout/stderr (the old test merged them into one buffer, so it couldn't catch stream contamination) and asserts the nudge is on stderr **and** absent from stdout.

Pairs with protocol SPEC 0.8.0 Edit 14 (§3.1.1). Full suite green, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)