### PR TITLE
fix(templates): drop dead Python-API blocks + fix wrong-org URLs + dead required-reading

### DIFF
--- a/docs/ai-agent-files.md
+++ b/docs/ai-agent-files.md
@@ -43,19 +43,17 @@ This file provides guidance to Claude Code...
 <!-- logmind-start -->
 ## Decision Logging (logmind)
 
-This project uses [logmind](https://github.com/logmind/logmind) for decision tracking.
+This project uses [logmind](https://logmind.dev) for decision tracking.
 
 ### For AI Agents
 
 When making significant decisions or writing important code:
 
-```python
-from logmind import log
-
-log("Decision summary",
-    reasoning="Why this approach",
-    alternatives=["Option A", "Option B"],
-    implications=["Impact 1", "Impact 2"])
+```bash
+logmind log "Decision summary" \
+  -r "Why this approach" \
+  -a "Option A" -a "Option B" \
+  -i "Impact 1" -i "Impact 2"
 ```
 
 ### Context Files

--- a/docs/decisions-branches/fix__templates-dead-python-api-and-links.md
+++ b/docs/decisions-branches/fix__templates-dead-python-api-and-links.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 12:03 - templates: drop dead Python-API blocks, fix wrong-org URLs + dead required-reading
+
+**Reasoning:** The consumer-facing templates shipped by 'logmind init' contained a 'from logmind import log' Python-API block (the Go binary has no importable module), a wrong-org github.com/logmind/logmind URL (dead), and CLAUDE.md.template listed a nonexistent docs/logmind-readme.md as REQUIRED reading — which, post-#172, actively trips consumers' check-links. Audit finding.
+
+**Alternatives considered:** Also bump AGENTS.md.template's Python-API removal + block version (deferred: it's governed v6, coupled to the §8.3 marker-alignment work in the SPEC pass)
+
+**Implications:**
+- Scoped to the ungoverned templates (CLAUDE.md.template, logmind-section.md — bare logmind-start, no version marker) + the repo doc docs/ai-agent-files.md; Python examples replaced with the real 'logmind log' CLI; new inits get correct templates. AGENTS.md.template's cleanup + marker bump deferred to the coordinated marker work.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,11 +56,13 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
+│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   └── tsconfig.json
+│   ├── tsconfig.json
+│   └── tsconfig.tsbuildinfo
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,13 +56,11 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
-│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   ├── tsconfig.json
-│   └── tsconfig.tsbuildinfo
+│   └── tsconfig.json
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,9 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07
+## 2026-07 (3 decisions)
 
-- **2026-07-03** — Harden check-doc-links self-heal to fully advisory (never red the helper job) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
+- **2026-07-03** — templates: drop dead Python-API blocks, fix wrong-org URLs + dead required-reading *(fix/templates-dead-python-api-and-links)* — [decisions-branches/fix__templates-dead-python-api-and-links.md](decisions-branches/fix__templates-dead-python-api-and-links.md)
+- *... 1 more decision ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/templates/CLAUDE.md.template
+++ b/internal/templates/CLAUDE.md.template
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 <!-- logmind-start -->
 ## Decision Logging (logmind)
 
-**IMPORTANT:** This project uses [logmind](https://github.com/logmind/logmind) for decision tracking.
+**IMPORTANT:** This project uses [logmind](https://logmind.dev) for decision tracking.
 
 ### REQUIREMENT: AI Agents MUST Log All Decisions
 
@@ -19,13 +19,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **How to log:**
 
-```python
-from logmind import log
-
-log("Decision summary",
-    reasoning="Why this approach",
-    alternatives=["Option A", "Option B"],
-    implications=["Impact 1", "Impact 2"])
+```bash
+logmind log "Decision summary" \
+  -r "Why this approach" \
+  -a "Option A" -a "Option B" \
+  -i "Impact 1" -i "Impact 2"
 ```
 
 **BEFORE writing code, ask yourself: "Should this be logged?" If yes, log it IMMEDIATELY.**
@@ -33,7 +31,6 @@ log("Decision summary",
 ### Required Reading
 
 **READ THESE FILES FIRST** before starting any work:
-- **[docs/logmind-readme.md](docs/logmind-readme.md)** - Complete logmind documentation and usage guide (REQUIRED)
 - **[docs/decisions.md](docs/decisions.md)** - 20 most recent decisions (REQUIRED)
 - **[docs/file-structure.md](docs/file-structure.md)** - Current project structure (REQUIRED)
 

--- a/internal/templates/logmind-section.md
+++ b/internal/templates/logmind-section.md
@@ -2,7 +2,7 @@
 <!-- logmind-start -->
 ## Decision Logging (logmind)
 
-**IMPORTANT:** This project uses [logmind](https://github.com/logmind/logmind) for decision tracking.
+**IMPORTANT:** This project uses [logmind](https://logmind.dev) for decision tracking.
 
 ### REQUIREMENT: AI Agents MUST Log All Decisions
 
@@ -17,16 +17,6 @@
 **BEFORE writing code, ask yourself: "Should this be logged?" If yes, log it IMMEDIATELY.**
 
 ### How to Log Decisions
-
-**Python API (example):**
-```python
-from logmind import log
-
-log("Decision summary",
-    reasoning="Why this approach",
-    alternatives=["Option A", "Option B"],
-    implications=["Impact 1", "Impact 2"])
-```
 
 **CLI (example for shell commands):**
 ```bash


### PR DESCRIPTION
Consumer-facing templates shipped by `logmind init` carried Python-era dead content. From the stable-excellent audit:

- **Dead Python API** — `from logmind import log(...)` in `CLAUDE.md.template`, `logmind-section.md`, and `docs/ai-agent-files.md`. The Go binary has no importable module; replaced each with the real `logmind log` CLI form.
- **Wrong-org URL** — `github.com/logmind/logmind` (dead) → `logmind.dev` in all three.
- **Dead required-reading** — `CLAUDE.md.template` listed `docs/logmind-readme.md` (nonexistent) as REQUIRED reading. Post-#172 that actively trips a consumer's `check-links`. Dropped it (the local `decisions.md` + `file-structure.md` remain).

**Scope:** the two ungoverned templates (bare `<!-- logmind-start -->`, no `logmind-block-version`) + the repo doc. **Deferred:** `AGENTS.md.template` carries a governed `logmind-block-version: v6`, so its Python-API removal needs a coordinated marker bump (tied to the §8.3 marker-alignment work in the SPEC pass) — left for that PR.

New `logmind init` runs get correct templates. Full suite green, `check-links` clean, byte-parity gate unaffected (dormant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)