### PR TITLE
chore(hygiene): gofmt sweep + gofmt/vet CI gate + surface doctor --fix write errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,31 @@ jobs:
       - name: Test
         run: make test
 
+  lint:
+    # gofmt + vet gate. CI previously had no formatting/vet check, so
+    # unformatted files accumulated silently. Runs once (not per matrix
+    # cell); the `test` aggregator below `needs` it, so a lint failure
+    # red-lights the required check.
+    name: lint (gofmt + vet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l . | grep -v '^vendor/' || true)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These Go files are not gofmt-formatted (run: gofmt -w <file>):"
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "All Go files are gofmt-formatted."
+      - name: go vet
+        run: go vet ./...
+
   test:
     # Aggregator under the literal `test` context — the org ruleset's
     # required_status_checks rule pins this exact name. Without this
@@ -63,7 +88,7 @@ jobs:
     # `needs:` blocks until every cell completes; `if: always()` plus the
     # inner `result` check propagates failure correctly when any cell
     # fails.
-    needs: go
+    needs: [go, lint]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -73,4 +98,8 @@ jobs:
             echo "::error::One or more go test matrix cells failed (needs.go.result=${{ needs.go.result }})"
             exit 1
           fi
-          echo "All go test matrix cells passed."
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "::error::lint (gofmt/vet) failed (needs.lint.result=${{ needs.lint.result }})"
+            exit 1
+          fi
+          echo "All go test matrix cells + lint passed."

--- a/docs/decisions-branches/fix__gofmt-sweep-and-ci-gate.md
+++ b/docs/decisions-branches/fix__gofmt-sweep-and-ci-gate.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 12:21 - hygiene: gofmt sweep + gofmt/vet CI gate + surface doctor --fix backfill write errors
+
+**Reasoning:** CI had no gofmt/vet gate, so 8 Go files silently accumulated formatting drift. Separately, doctor --fix backfill dropped writeAtomic errors, making a partial --fix indistinguishable from a clean no-op.
+
+**Alternatives considered:** golangci-lint (heavier; gofmt+vet is the minimal stdlib gate), os.Stderr directly in backfillBranchSummaries (rejected: the codebase threads writers for testability)
+
+**Implications:**
+- gofmt -w'd 8 files (pure whitespace, test-neutral); added a lint job wired into the required 'test' aggregator (needs: [go, lint]) so drift can't recur; backfillBranchSummaries now takes a stderr writer and prints a note per unwritable file (threaded via cmd.ErrOrStderr).
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,13 +56,11 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
-│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   ├── tsconfig.json
-│   └── tsconfig.tsbuildinfo
+│   └── tsconfig.json
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (4 decisions)
+## 2026-07 (5 decisions)
 
-- **2026-07-03** — templates: drop dead Python-API blocks, fix wrong-org URLs + dead required-reading *(fix/templates-dead-python-api-and-links)* — [decisions-branches/fix__templates-dead-python-api-and-links.md](decisions-branches/fix__templates-dead-python-api-and-links.md)
-- *... 2 more decisions ...*
+- **2026-07-03** — hygiene: gofmt sweep + gofmt/vet CI gate + surface doctor --fix backfill write errors *(fix/gofmt-sweep-and-ci-gate)* — [decisions-branches/fix__gofmt-sweep-and-ci-gate.md](decisions-branches/fix__gofmt-sweep-and-ci-gate.md)
+- *... 3 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -17,10 +17,10 @@ import (
 // Behaviour mirror of src/logmind/cli.check_decisions (cli.py:2425-2519).
 // Output strings are byte-identical to Python v0.6.14:
 //
-//   not-a-git-repo:      "Not a git repository, skipping check."  (exit 0)
-//   decision file staged: "✓ A decision log file is staged — changes are documented."
-//   under threshold:     "✓ N lines changed (below T-line threshold)."  (exit 0)
-//   over threshold:      multi-line warning, exit 1 unless --no-fail
+//	not-a-git-repo:      "Not a git repository, skipping check."  (exit 0)
+//	decision file staged: "✓ A decision log file is staged — changes are documented."
+//	under threshold:     "✓ N lines changed (below T-line threshold)."  (exit 0)
+//	over threshold:      multi-line warning, exit 1 unless --no-fail
 //
 // "Decision file" matches the Python predicate:
 //   - exact path "docs/decisions.md"

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -97,7 +97,7 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 	// file (main-canonical only) — the deterministic structural half of the
 	// branch-summary migration. The rich one-sentence summary stays the
 	// agent's job (doctor's advisory lists the placeholders to enrich).
-	summariesBackfilled := backfillBranchSummaries(cwd)
+	summariesBackfilled := backfillBranchSummaries(cwd, cmd.ErrOrStderr())
 
 	// Re-probe to compute the residual drift that --fix cannot address.
 	after := doctor.CollectStatus(cwd, offline)
@@ -162,7 +162,7 @@ func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled
 // returns the count fixed. Best-effort: a per-file read/write error skips that
 // file. Reuses the cli-local marker helpers (buildTimelineMarker /
 // insertMarkerAfterHeader), so no export is needed.
-func backfillBranchSummaries(cwd string) int {
+func backfillBranchSummaries(cwd string, stderr io.Writer) int {
 	cfg, _ := config.Load(cwd)
 	if !cfg.Timeline.IsMainCanonical() {
 		return 0
@@ -187,9 +187,13 @@ func backfillBranchSummaries(cwd string) int {
 		}
 		marker := buildTimelineMarker(entries[0].Date, entries[0].Title, prSuffixFromEnv())
 		updated := string(insertMarkerAfterHeader([]byte(content), marker))
-		if err := writeAtomic(bf, updated); err == nil {
-			n++
+		if err := writeAtomic(bf, updated); err != nil {
+			// Best-effort: surface the failure so a partial --fix is not
+			// silently indistinguishable from a clean no-op.
+			fmt.Fprintf(stderr, "note: could not backfill %s: %v\n", bf, err)
+			continue
 		}
+		n++
 	}
 	return n
 }

--- a/internal/cli/doctor_summary_test.go
+++ b/internal/cli/doctor_summary_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +57,7 @@ func TestBackfillBranchSummaries(t *testing.T) {
 			"← back\n\n## 2026-06-10 09:00 - Old\n\n---\n")
 		mustWriteUnder(t, d, "docs/decisions-branches/feat__has.md",
 			"← back\n\n<!-- logmind-entry-start: 2026-06-11-x -->\n- **2026-06-11** — X\n<!-- logmind-entry-end -->\n\n## 2026-06-11 10:00 - X\n\n---\n")
-		if n := backfillBranchSummaries(d); n != 1 {
+		if n := backfillBranchSummaries(d, io.Discard); n != 1 {
 			t.Errorf("backfillBranchSummaries = %d; want 1 (only the markerless one)", n)
 		}
 	})
@@ -64,7 +65,7 @@ func TestBackfillBranchSummaries(t *testing.T) {
 		t.Errorf("markerless file not backfilled (markers=%d)", n)
 	}
 	// Idempotent: a second pass changes nothing.
-	if n := backfillBranchSummaries(dir); n != 0 {
+	if n := backfillBranchSummaries(dir, io.Discard); n != 0 {
 		t.Errorf("second backfill = %d; want 0 (idempotent)", n)
 	}
 }
@@ -76,7 +77,7 @@ func TestBackfillBranchSummaries_DefaultModeNoop(t *testing.T) {
 		mustWriteUnder(t, d, ".logmind/config.yml", "git:\n  auto_commit: true\n")
 		mustWriteUnder(t, d, "docs/decisions-branches/feat__old.md",
 			"← back\n\n## 2026-06-10 09:00 - Old\n\n---\n")
-		if n := backfillBranchSummaries(d); n != 0 {
+		if n := backfillBranchSummaries(d, io.Discard); n != 0 {
 			t.Errorf("default-mode backfill = %d; want 0", n)
 		}
 	})

--- a/internal/cli/file_structure.go
+++ b/internal/cli/file_structure.go
@@ -15,9 +15,9 @@ import (
 //
 // Behaviour mirror of Python cli.file_structure_cmd (cli.py:2693-2792):
 //
-//   --max-depth N (positive)   → truncate at depth N (root is depth 0)
-//   --max-depth 0              → unbounded (full tree)
-//   --max-depth omitted        → default 2 (DEFAULT_FILE_STRUCTURE_DEPTH)
+//	--max-depth N (positive)   → truncate at depth N (root is depth 0)
+//	--max-depth 0              → unbounded (full tree)
+//	--max-depth omitted        → default 2 (DEFAULT_FILE_STRUCTURE_DEPTH)
 //
 // Output is byte-identical to Python v0.6.14 (stdout messages, sizes,
 // labels). Like timeline, the --check-without-write divergence vs

--- a/internal/cli/install_hook_test.go
+++ b/internal/cli/install_hook_test.go
@@ -180,4 +180,3 @@ func checkGolden(t *testing.T, name, got string) {
 			path, want, got)
 	}
 }
-

--- a/internal/cli/rebase.go
+++ b/internal/cli/rebase.go
@@ -14,9 +14,9 @@ import (
 //
 // Mirror of Python cli.rebase (cli.py:1029-1156). Three-step wrapper:
 //
-//   1. git fetch origin <base>          (unless --no-fetch)
-//   2. git rebase origin/<base>
-//   3. git push --force-with-lease      (unless --no-push)
+//  1. git fetch origin <base>          (unless --no-fetch)
+//  2. git rebase origin/<base>
+//  3. git push --force-with-lease      (unless --no-push)
 //
 // Refuses to run when:
 //   - not in a git repo                        → "Error: not in a git repository."

--- a/internal/linkcheck/linkcheck_test.go
+++ b/internal/linkcheck/linkcheck_test.go
@@ -96,7 +96,7 @@ func TestCheck_DirectoryPrefixAllowlist(t *testing.T) {
 	// docs/decisions-branches/ trailing-slash entry: any .md under
 	// it must be exempt.
 	dir := setupFixture(t, map[string]string{
-		"README.md": "# Project\n",
+		"README.md":                          "# Project\n",
 		"docs/decisions-branches/feature.md": "# Feature branch decisions\n",
 	})
 	_, orphans, err := Check(dir, nil, nil)

--- a/internal/skill/audit_test.go
+++ b/internal/skill/audit_test.go
@@ -47,10 +47,10 @@ func TestAuditSkills_OneSkill(t *testing.T) {
 // TestClassify_Ghost: 0 decisions + over-tight bytes → ghost.
 func TestClassify_Ghost(t *testing.T) {
 	row := AuditRow{
-		Name: "ghost",
-		Bytes: 5000, // > auditTightCap (2000)
+		Name:          "ghost",
+		Bytes:         5000, // > auditTightCap (2000)
 		DecisionCount: 0,
-		LastModified: "2026-06-02",
+		LastModified:  "2026-06-02",
 	}
 	if got := Classify(row, time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)); got != "ghost" {
 		t.Errorf("Classify ghost = %q; want ghost", got)
@@ -60,10 +60,10 @@ func TestClassify_Ghost(t *testing.T) {
 // TestClassify_Aging: last_modified > 90 days ago → aging.
 func TestClassify_Aging(t *testing.T) {
 	row := AuditRow{
-		Name: "old",
-		Bytes: 100,
+		Name:          "old",
+		Bytes:         100,
 		DecisionCount: 5,
-		LastModified: "2025-01-01",
+		LastModified:  "2025-01-01",
 	}
 	if got := Classify(row, time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)); got != "aging" {
 		t.Errorf("Classify aging = %q; want aging", got)
@@ -73,10 +73,10 @@ func TestClassify_Aging(t *testing.T) {
 // TestClassify_Active: small + recent + cited → active.
 func TestClassify_Active(t *testing.T) {
 	row := AuditRow{
-		Name: "ok",
-		Bytes: 100,
+		Name:          "ok",
+		Bytes:         100,
 		DecisionCount: 5,
-		LastModified: "2026-06-01",
+		LastModified:  "2026-06-01",
 	}
 	if got := Classify(row, time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)); got != "active" {
 		t.Errorf("Classify active = %q; want active", got)
@@ -122,8 +122,8 @@ func TestCountWholeWord(t *testing.T) {
 		Name   string
 		Want   int
 	}{
-		{"go to going", "go", 1},     // matches "go", not "going"
-		{"api API APIs", "API", 1},   // matches "API" once, not "APIs"
+		{"go to going", "go", 1},   // matches "go", not "going"
+		{"api API APIs", "API", 1}, // matches "API" once, not "APIs"
 		{"hello world hello", "hello", 2},
 		{"clud-bug-collaboration cited; clud-bug-collaboration again", "clud-bug-collaboration", 2},
 		{"", "anything", 0},

--- a/internal/skill/suggest.go
+++ b/internal/skill/suggest.go
@@ -65,10 +65,10 @@ var suggestStopwords = map[string]struct{}{
 // interestingTokenRE mirrors Python's _INTERESTING_TOKEN_RE — same
 // alternation order, same anchoring. Token kinds (in order):
 //
-//	1. kebab-case multi-word: api-versioning, file-structure-check
-//	2. PascalCase / camelCase: PostgreSQL, AuthHandler
-//	3. acronyms: API, JWT, CI, RPC
-//	4. snake_case multi-word: skill_cli, my_handler
+//  1. kebab-case multi-word: api-versioning, file-structure-check
+//  2. PascalCase / camelCase: PostgreSQL, AuthHandler
+//  3. acronyms: API, JWT, CI, RPC
+//  4. snake_case multi-word: skill_cli, my_handler
 var interestingTokenRE = regexp.MustCompile(
 	`\b(` +
 		`[a-z]+(?:-[a-z]+)+` + // kebab-case multi-word

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -7,12 +7,12 @@
 //
 // Brief-mode algorithm (default since Python v0.5.4):
 //
-//   1. Group entries by year-month, newest-first.
-//   2. For months with < 3 entries: render every entry verbatim.
-//   3. For months with >= 3 entries: render the FIRST (newest) entry,
-//      an italic elision line `- *... N more decisions ...*`, then the
-//      LAST (oldest) entry. The "decision"/"decisions" noun is
-//      singularized when N == 1, plural otherwise.
+//  1. Group entries by year-month, newest-first.
+//  2. For months with < 3 entries: render every entry verbatim.
+//  3. For months with >= 3 entries: render the FIRST (newest) entry,
+//     an italic elision line `- *... N more decisions ...*`, then the
+//     LAST (oldest) entry. The "decision"/"decisions" noun is
+//     singularized when N == 1, plural otherwise.
 //
 // Full mode (`--full`): every entry rendered, one per line, with the
 // month header carrying no count suffix.
@@ -51,7 +51,7 @@ const emptyBody = "\n*(no decisions logged yet)*\n"
 
 // renderEntryLine matches Python timeline._render_entry_line (line 138-143):
 //
-//	- **YYYY-MM-DD** — <title> *(<source_label>)* — [<source_path>](<source_path>)
+//   - **YYYY-MM-DD** — <title> *(<source_label>)* — [<source_path>](<source_path>)
 //
 // source_path is the entry's posix-form path (no backslashes); Iter +
 // Collect already store it that way so no extra transform here.


### PR DESCRIPTION
From the stable-excellent audit — repo hygiene with a guard so it can't rot again.

- **gofmt sweep** — 8 Go files had drifted (pure whitespace/comment-indent/field-alignment; test-neutral): `check_decisions.go`, `file_structure.go`, `rebase.go`, `suggest.go`, `timeline.go`, + 3 test files.
- **New `lint` CI job** (gofmt + `go vet`), wired into the required `test` aggregator (`needs: [go, lint]`) so a formatting/vet regression red-lights the gate. CI previously had **no** gofmt/vet check, which is why the drift accumulated silently.
- **`doctor --fix` signal** — `backfillBranchSummaries` swallowed `writeAtomic` errors, so a partial backfill looked like a clean no-op. It now takes a stderr writer and emits `note: could not backfill <file>: <err>` per failure (threaded via `cmd.ErrOrStderr`).

Full suite green, gofmt clean repo-wide, `test.yml` YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)