### PR TITLE
docs: repo version consistency (SpecVersion→0.8.0, README + AGENTS.md cleanup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,90 +54,22 @@ permissions, ruleset bypass details, and rotation procedure.
 
 ## Project Overview
 
-<!-- Replace with a short description of what this project does. -->
+**logmind** is a decision-logging CLI (Go) — the commit primitive for this
+repo and its consumers. It scaffolds `docs/` structure via `logmind init`,
+records the "why" behind changes via `logmind log`, and keeps the derived
+`docs/timeline.md` + `docs/file-structure.md` in sync as agent-readable
+context. One leg of the thrillmade SkDD toolchain (with clud-bug = review,
+agent-skills = catalog). Entry point `cmd/logmind/main.go`; code under
+`internal/`. See [docs/plan.md](docs/plan.md) for architecture + roadmap.
 
 ## Development Commands
 
-<!-- Common commands a contributor needs (build, test, lint, run). -->
-
-## From Claude Code
-
-# CLAUDE.md
-
-
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-**logmind** is an AI decision logging system that scaffolds documentation structure and tracks development decisions automatically.
-
-**Key concept:** A pip-installable package that runs `logmind init` to create standardized docs, then serves as the decision logging engine.
-
-## Essential Documentation
-
-- **[docs/plan.md](docs/plan.md)** - Complete architecture, approach, and roadmap
-- **[README.md](README.md)** - User-facing overview and quick start
-
-## Development Commands
-
-This is a Python package. Standard commands:
-
 ```bash
-# Setup development environment
-python3 -m venv venv
-source venv/bin/activate
-pip install -e ".[dev]"
-
-# Run tests
-pytest                    # All tests
-pytest tests/test_*.py -v # Specific test file
-
-# Build package
-python -m build
+go build ./cmd/logmind      # build the binary
+go test ./...               # run the full suite
+go vet ./...                # static checks
+gofmt -l .                  # list any unformatted files
 ```
-
-## logmind CLI Commands
-
-You can use logmind via CLI or Python API:
-
-```bash
-# View recent decisions
-logmind show
-logmind show --all  # Include archive
-
-# Search decisions
-logmind search "postgres"
-logmind search "API" --case-sensitive
-logmind search "config" --no-archive
-
-# Log decision via CLI
-logmind log "Use Redis for caching" \
-  -r "Need fast session storage" \
-  -a "Memcached" -a "In-memory dict" \
-  -i "Need to run Redis server"
-```
-
-## Current Status
-
-**Phase 2 Complete** - Configuration system and search functionality implemented
-
-✅ Phase 1: Core package (init, log, show)
-✅ Phase 2: Configuration + search
-🔲 Phase 3: AI integrations (decorators, plugins)
-
-See [docs/plan.md](docs/plan.md) for complete roadmap.
-
-## From Cursor
-
-# Cursor Rules
-
-
-
-
-## Project Rules
-
-[Add your Cursor rules here]
 
 <!-- clud-bug-start -->
 <!-- clud-bug-block-version: v3-app -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # logmind
 
-[![PyPI](https://img.shields.io/pypi/v/logmind.svg)](https://pypi.org/project/logmind/)
-[![Python versions](https://img.shields.io/pypi/pyversions/logmind.svg)](https://pypi.org/project/logmind/)
 [![CI](https://github.com/thrillmade/logmind/actions/workflows/test.yml/badge.svg)](https://github.com/thrillmade/logmind/actions/workflows/test.yml)
 [![skills.sh](https://www.skills.sh/b/thrillmade/agent-skills/logmind)](https://www.skills.sh/thrillmade/agent-skills/logmind)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -41,7 +39,7 @@ LOGMIND_VERSION=v1.0.0 curl -fsSL https://logmind.dev/install.sh | bash
 Verify the install:
 
 ```bash
-logmind --version  # logmind 1.1.0 (spec 0.1.1)
+logmind --version  # logmind 1.2.0 (spec 0.8.0)
 ```
 
 The curl installer is idempotent — re-running it when the same version

--- a/docs/decisions-branches/fix__repo-docs-version-consistency.md
+++ b/docs/decisions-branches/fix__repo-docs-version-consistency.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 12:27 - docs: repo version consistency — SpecVersion 0.1.1→0.8.0, README badges/version, AGENTS.md Python-era dedup
+
+**Reasoning:** Version-consistency audit: version.go SpecVersion lagged at 0.1.1 while protocol is now 0.8.0 (merged in #26) and logmind implements the surface; README headlined PyPI/pyversions badges + a stale '1.1.0 (spec 0.1.1)' --version example; the repo's own AGENTS.md carried a Python-era concat tail (empty stubs + an embedded CLAUDE.md with pip/pytest/python -m build commands + a 'Phase 2 Complete' roadmap + an empty Cursor Rules section).
+
+**Alternatives considered:** Keep SpecVersion 0.1.1 until every pre-existing SPEC-vs-code divergence is fixed (rejected: SpecVersion declares the TARGETED spec version; 0.1.1 is absurdly stale; the §3.1/isatty divergences are separate bugs)
+
+**Implications:**
+- SpecVersion → 0.8.0 (regenerated version.golden + updated the docstring); README drops the PyPI badges + shows '1.2.0 (spec 0.8.0)'; AGENTS.md gets a clean Go Project Overview + Development Commands. Left untouched: the managed clud-bug block, and the version-pin examples (floor/mechanism references, judgment call).
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,11 +56,13 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
+│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   └── tsconfig.json
+│   ├── tsconfig.json
+│   └── tsconfig.tsbuildinfo
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -56,13 +56,11 @@ logmind
 │   ├── app
 │   ├── public
 │   ├── .gitignore
-│   ├── next-env.d.ts
 │   ├── next.config.ts
 │   ├── package-lock.json
 │   ├── package.json
 │   ├── postcss.config.mjs
-│   ├── tsconfig.json
-│   └── tsconfig.tsbuildinfo
+│   └── tsconfig.json
 ├── skill
 │   └── SKILL.md
 ├── .cursorrules

--- a/docs/install.md
+++ b/docs/install.md
@@ -140,7 +140,7 @@ same path as macOS) cover the trust gap.
 
 ```bash
 logmind --version
-# logmind 1.1.0 (spec 0.1.1)
+# logmind 1.2.0 (spec 0.8.0)
 ```
 
 The `--version` line is the protocol contract — downstream tooling

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (5 decisions)
+## 2026-07 (6 decisions)
 
-- **2026-07-03** — hygiene: gofmt sweep + gofmt/vet CI gate + surface doctor --fix backfill write errors *(fix/gofmt-sweep-and-ci-gate)* — [decisions-branches/fix__gofmt-sweep-and-ci-gate.md](decisions-branches/fix__gofmt-sweep-and-ci-gate.md)
-- *... 3 more decisions ...*
+- **2026-07-03** — docs: repo version consistency — SpecVersion 0.1.1→0.8.0, README badges/version, AGENTS.md Python-era dedup *(fix/repo-docs-version-consistency)* — [decisions-branches/fix__repo-docs-version-consistency.md](decisions-branches/fix__repo-docs-version-consistency.md)
+- *... 4 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/testdata/version.golden
+++ b/internal/cli/testdata/version.golden
@@ -1,1 +1,1 @@
-logmind 1.2.0-dev (spec 0.1.1)
+logmind 1.2.0-dev (spec 0.8.0)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,8 +8,10 @@
 // to inject the actual tag.
 //
 // SpecVersion tracks the thrillmade/protocol SPEC.md document — bumped
-// to "0.1.1" 2026-06-03 (protocol PR #1 + tag v0.1.1: align AGENTS.md
-// marker versions v5→v6 and v7-pointer→v8-pointer per §8.3).
+// to "0.8.0" 2026-07-03 (protocol #26: the Slice-2 main-canonical
+// timeline pass — §1.6.4 union assembly, the agent-authored headline
+// convention, the headline/doctor CLI, and the §5.1.2 advisory-first
+// regen-timeline template).
 package version
 
 // Version is the logmind binary's semantic version. Bumped at release.
@@ -43,4 +45,4 @@ var Version = "1.2.0-dev"
 // this binary implements. Reported via `logmind --version` so downstream
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
-var SpecVersion = "0.1.1"
+var SpecVersion = "0.8.0"


### PR DESCRIPTION
Final polish from the stable-excellent audit.

- **SpecVersion 0.1.1 → 0.8.0** (`internal/version/version.go`) — now that protocol SPEC **0.8.0** is merged (#26) and logmind implements its opt-in surface, `logmind --version` declares the targeted contract honestly (`logmind 1.2.0-dev (spec 0.8.0)`). Regenerated `testdata/version.golden` + updated the docstring.
- **README** — dropped the PyPI/pyversions badges (they headlined the frozen Python wheel on a Go binary; the `pip install logmind==0.6.16` legacy section stays), and bumped the `--version` example `1.1.0 (spec 0.1.1)` → `1.2.0 (spec 0.8.0)`.
- **AGENTS.md** — removed the Python-era concat tail (empty `## Project Overview`/`## Development Commands` stubs + an embedded CLAUDE.md with `pip install`/`pytest`/`python -m build` + a stale 'Phase 2 Complete' roadmap + an empty Cursor Rules block); replaced with a real Go overview + `go build`/`go test`/`go vet`/`gofmt` commands. Kept the managed logmind + clud-bug blocks and the Release-infra section.

Full suite green, `check-links` clean (docs/plan.md link resolves), `--version` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)