### PR TITLE
fix(templates): drop the last dead Python-API block from AGENTS.md.template

### DIFF
--- a/docs/decisions-branches/fix__agents-template-drop-python-api.md
+++ b/docs/decisions-branches/fix__agents-template-drop-python-api.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 13:00 - templates: drop the last dead Python-API block from AGENTS.md.template (completes the off-Python template purge)
+
+**Reasoning:** AGENTS.md.template — the canonical agent-instruction file init writes to every consumer — still showed a 'from logmind import log' Python-API block, dead and misleading for the Go binary (there is no importable module). This was the LAST logmind-is-Python cruft in the shipped templates; the 'logmind log' CLI form directly above it is the real interface.
+
+**Alternatives considered:** Also bump the block marker v6→v7 to force-propagate to existing installs (deferred: the SPEC hardcodes v6 as the full-variant marker, so a bump needs coordinated SPEC + agent-skills convention work — that rides the v1.0 flip; the content removal itself needs no bump)
+
+**Implications:**
+- Shipped templates are now Python-API-free (grep-clean). Marker stays v6 (a within-variant content refresh, not a variant change; the v6-pinned test strings are untouched). KEPT as intentional: the polyglot file-structure ignore patterns (.pytest_cache etc. — for Python/JS/Go CONSUMER repos) and the pip→Go migration off-ramp (self-update pip-detection + the live inserter.UpdateWorkflowPin).
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (6 decisions)
+## 2026-07 (7 decisions)
 
-- **2026-07-03** — docs: repo version consistency — SpecVersion 0.1.1→0.8.0, README badges/version, AGENTS.md Python-era dedup *(fix/repo-docs-version-consistency)* — [decisions-branches/fix__repo-docs-version-consistency.md](decisions-branches/fix__repo-docs-version-consistency.md)
-- *... 4 more decisions ...*
+- **2026-07-03** — templates: drop the last dead Python-API block from AGENTS.md.template (completes the off-Python template purge) *(fix/agents-template-drop-python-api)* — [decisions-branches/fix__agents-template-drop-python-api.md](decisions-branches/fix__agents-template-drop-python-api.md)
+- *... 5 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/templates/AGENTS.md.template
+++ b/internal/templates/AGENTS.md.template
@@ -80,16 +80,6 @@ logmind log "Use PostgreSQL for primary database" \
   -i "Schema migrations via alembic"
 ```
 
-**Python API:**
-```python
-from logmind import log
-
-log("Use PostgreSQL for primary database",
-    reasoning="Need ACID compliance and complex joins",
-    alternatives=["MongoDB", "SQLite"],
-    implications=["Connection pooling required", "Schema migrations via alembic"])
-```
-
 ### Branch-aware routing (automatic)
 
 On a feature branch, the entry lands in


### PR DESCRIPTION
Completes the off-Python purge of the shipped templates. `AGENTS.md.template` — the canonical agent-instruction file `logmind init` writes to **every** consumer repo — still carried a `from logmind import log` block. The Go binary has no importable module, so it's dead + misleading; the `logmind log` CLI form directly above it is the real interface.

**After this, shipped templates are Python-API-free** (grep-clean for `from logmind import` / `import logmind`).

Scoped to the content removal only. The block **marker stays `v6`** — the SPEC hardcodes `v6` as the full-variant marker, so a `v6→v7` bump (to force-propagate the cleanup to *existing* installs) needs coordinated SPEC + agent-skills convention work, which rides the v1.0 flip. New `init` runs get the clean block now.

**Deliberately kept** (not Python cruft): the polyglot file-structure ignore patterns (`.pytest_cache`, `__pycache__`, `venv` … — these ignore noise in Python/JS/Go *consumer* repos) and the pip→Go migration off-ramp (`logmind-self-update.yml` pip-detection + the live `inserter.UpdateWorkflowPin`, called by `agents.go`), which upgrade old pip-installed consumers.

Full suite green; `TestAgentsTemplate_HasV6Marker` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)