### PR TITLE
fix(skill): drop the dead Python-API section from the logmind skill

### DIFF
--- a/docs/decisions-branches/fix__skill-drop-python-api.md
+++ b/docs/decisions-branches/fix__skill-drop-python-api.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 13:22 - skill: drop the dead Python-API section from the logmind skill (off-Python completeness)
+
+**Reasoning:** skill/SKILL.md — the canonical logmind agent skill (source-of-truth for the agent-skills catalog, auto-loaded by agents) — still showed a 'from logmind import log' Python section: the same Go-binary-misleading cruft #177 removed from the templates, flagged by the #177 review. The CLI is the real interface.
+
+**Alternatives considered:** Leave it (rejected — it's the skill agents AUTO-LOAD; advertising a nonexistent Python API is actively misleading)
+
+**Implications:**
+- skill/SKILL.md is now Python-free; the 'logmind log' CLI is the sole how-to-log; propagates to the agent-skills catalog on the next skill push. Completes the off-Python tail (item 1 of the build-all-then-flip v1.0 plan). docs/plan.md's copies are historical planning prose, left as-is.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (7 decisions)
+## 2026-07 (8 decisions)
 
-- **2026-07-03** — templates: drop the last dead Python-API block from AGENTS.md.template (completes the off-Python template purge) *(fix/agents-template-drop-python-api)* — [decisions-branches/fix__agents-template-drop-python-api.md](decisions-branches/fix__agents-template-drop-python-api.md)
-- *... 5 more decisions ...*
+- **2026-07-03** — skill: drop the dead Python-API section from the logmind skill (off-Python completeness) *(fix/skill-drop-python-api)* — [decisions-branches/fix__skill-drop-python-api.md](decisions-branches/fix__skill-drop-python-api.md)
+- *... 6 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -34,19 +34,6 @@ context months later is not.
 
 ## How to log
 
-### Python
-
-```python
-from logmind import log
-
-log("Use PostgreSQL for primary database",
-    reasoning="Need ACID compliance and complex joins",
-    alternatives=["MongoDB", "SQLite"],
-    implications=["Connection pooling required", "Schema migrations needed"])
-```
-
-### CLI
-
 ```bash
 logmind log "Use PostgreSQL for primary database" \
   -r "Need ACID compliance and complex joins" \


### PR DESCRIPTION
Off-Python completeness (v1.0 plan, item 1). `skill/SKILL.md` — the canonical logmind agent skill agents auto-load, and the source that publishes to the agent-skills catalog — still carried a `from logmind import log` section. Same Go-binary-misleading cruft #177 removed from the templates; the #177 review flagged it.

Removed the `### Python` block; the `logmind log` CLI is now the sole how-to-log. Skill is grep-clean for `from logmind import`, fences balanced, full suite green. Propagates to the catalog on the next skill push.

(A pure dead-content deletion mirroring #177, which reviewed clean for the identical pattern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)