### PR TITLE
feat: logmind context — one-read agent cold-start payload

### DIFF
--- a/docs/decisions-branches/feat__context-command.md
+++ b/docs/decisions-branches/feat__context-command.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 14:42 - feat: logmind context — one-read agent cold-start payload (timeline + file-structure)
+
+**Reasoning:** The thesis is a repo self-describing on the edge of inference: an agent should orient in ONE read, not by reconstructing context from git log / ls / grep. 'logmind context' concatenates the two pre-baked derived docs (timeline = the why, file-structure = the what) with headings. v1.0 thesis-extra (plan item 3).
+
+**Alternatives considered:** Just tell agents to read the two files directly (rejected — a command is discoverable, handles a missing doc gracefully, and gives AGENTS.md/the skill a stable 'run logmind context at task start' entry point)
+
+**Implications:**
+- Read-only; a missing derived doc is noted with a regenerate hint, never an error; no flags in v1 (--json etc. can follow). Registered alongside the derived-doc commands; full suite green, gofmt-clean, smoke-verified.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (8 decisions)
+## 2026-07 (9 decisions)
 
-- **2026-07-03** — skill: drop the dead Python-API section from the logmind skill (off-Python completeness) *(fix/skill-drop-python-api)* — [decisions-branches/fix__skill-drop-python-api.md](decisions-branches/fix__skill-drop-python-api.md)
-- *... 6 more decisions ...*
+- **2026-07-03** — feat: logmind context — one-read agent cold-start payload (timeline + file-structure) *(feat/context-command)* — [decisions-branches/feat__context-command.md](decisions-branches/feat__context-command.md)
+- *... 7 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// newContextCmd wires `logmind context`.
+//
+// Prints the agent cold-start payload — the two pre-baked derived docs
+// (docs/timeline.md = the "why", docs/file-structure.md = the "what") — to
+// stdout in one read. This is the single command an agent runs at the start
+// of a task to orient, instead of burning tokens reconstructing context from
+// `git log` / `ls -R` / `grep`. It is the practical expression of the
+// logmind thesis: a repo self-describing on the edge of inference.
+//
+// Read-only. A missing derived doc is noted (with how to regenerate), never
+// an error — `context` is a convenience, not a gate.
+func newContextCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Print the agent cold-start context (timeline + file-structure) in one read",
+		Long: `Print the agent cold-start context in one read.
+
+Concatenates the two pre-baked derived docs an agent reads to orient:
+
+    docs/timeline.md         the WHY — the decision timeline
+    docs/file-structure.md   the WHAT — the repo tree
+
+Run it at the start of a task instead of piecing context together from
+git log / ls / grep. A missing derived doc is noted (with how to
+regenerate it), not treated as an error.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runContext(cwd, cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+// contextDoc is one section of the cold-start payload.
+type contextDoc struct {
+	rel   string // repo-relative path to the derived doc
+	label string // section heading
+	regen string // command to regenerate it when missing
+}
+
+func runContext(cwd string, stdout io.Writer) error {
+	fmt.Fprint(stdout, "# logmind context\n\n"+
+		"The pre-baked cold-start payload for this repo: the decision timeline\n"+
+		"(the \"why\") and the file structure (the \"what\"). Read this to orient\n"+
+		"instead of reconstructing context from git log / ls / grep.\n")
+
+	docs := []contextDoc{
+		{"docs/timeline.md", "Decision timeline — the why", "logmind timeline --write docs/timeline.md"},
+		{"docs/file-structure.md", "File structure — the what", "logmind file-structure --write docs/file-structure.md"},
+	}
+	for _, d := range docs {
+		fmt.Fprintf(stdout, "\n## %s (%s)\n\n", d.label, d.rel)
+		data, err := os.ReadFile(filepath.Join(cwd, d.rel))
+		if err != nil {
+			fmt.Fprintf(stdout, "(%s not found — regenerate with: %s)\n", d.rel, d.regen)
+			continue
+		}
+		stdout.Write(data)
+		// Guarantee a trailing newline so the next section separates cleanly.
+		if n := len(data); n == 0 || data[n-1] != '\n' {
+			fmt.Fprintln(stdout)
+		}
+	}
+	return nil
+}

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestContext_PrintsBothDocs: `logmind context` concatenates the two
+// derived docs (why + what) in order, with headings, in one read.
+func TestContext_PrintsBothDocs(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/timeline.md", "TIMELINE_CONTENT_MARKER\n")
+		mustWriteUnder(t, d, "docs/file-structure.md", "FILESTRUCTURE_CONTENT_MARKER\n")
+		root := NewRootCmd()
+		root.SetArgs([]string{"context"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("context: %v\n%s", err, out.String())
+		}
+		s := out.String()
+		if !strings.Contains(s, "TIMELINE_CONTENT_MARKER") || !strings.Contains(s, "FILESTRUCTURE_CONTENT_MARKER") {
+			t.Errorf("context missing a doc's content:\n%s", s)
+		}
+		// Order: the why (timeline) before the what (file-structure).
+		iT := strings.Index(s, "docs/timeline.md")
+		iF := strings.Index(s, "docs/file-structure.md")
+		if iT < 0 || iF < 0 || iT > iF {
+			t.Errorf("sections missing or out of order (timeline before file-structure):\n%s", s)
+		}
+	})
+}
+
+// TestContext_MissingDocNoted_NotError: a missing derived doc is noted
+// with a regenerate hint, never an error (context is read-only convenience).
+func TestContext_MissingDocNoted_NotError(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		// docs/file-structure.md intentionally absent.
+		root := NewRootCmd()
+		root.SetArgs([]string{"context"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("context must not error on a missing doc: %v", err)
+		}
+		s := out.String()
+		if !strings.Contains(s, "docs/file-structure.md not found") || !strings.Contains(s, "regenerate with") {
+			t.Errorf("missing doc not noted with a regen hint:\n%s", s)
+		}
+	})
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,7 @@ func NewRootCmd() *cobra.Command {
 	// B3: derived doc generators + rebase wrapper.
 	root.AddCommand(newTimelineCmd())
 	root.AddCommand(newFileStructureCmd())
+	root.AddCommand(newContextCmd())
 	root.AddCommand(newTreeCmd())
 	root.AddCommand(newRebaseCmd())
 	// B4: agent file templating subcommand tree.


### PR DESCRIPTION
The practical expression of the thesis (v1.0 plan, thesis extras). `logmind context` prints the agent cold-start payload in **one read** — the two pre-baked derived docs an agent reads to orient:

- `docs/timeline.md` — the **why** (decision timeline)
- `docs/file-structure.md` — the **what** (repo tree)

…with markdown headings, so an agent runs `logmind context` at task start instead of reconstructing context from `git log` / `ls -R` / `grep`. Read-only; a missing derived doc is **noted with a regenerate hint, never an error**. No flags in v1 (`--json` etc. can follow).

New: `internal/cli/context.go` + `context_test.go`; registered in `root.go` with the derived-doc commands. Full suite green, gofmt-clean, smoke-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)