### PR TITLE
feat(context): cache-optimal cold-start payload + --stats token receipt (token-killer Phase 1a/1c)

### DIFF
--- a/docs/decisions-branches/feat__token-killer-phase1-context.md
+++ b/docs/decisions-branches/feat__token-killer-phase1-context.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 22:37 - feat(context): cache-optimal cold-start payload + --stats token receipt (token-killer Phase 1a/1c)
+
+**Reasoning:** Research: the ~10x token lever is prompt caching, and logmind's byte-stable re-read context is the ideal cache target. Re-architected 'logmind context': cut the human-facing boilerplate to one machine preface; wrapped the two docs in Anthropic's <document><source><document_content> envelope; reordered file-structure-first (stable) / timeline-last (volatile) so the cache prefix stays byte-identical longest; guaranteed byte-determinism (the property caching depends on). Added --stats: a deterministic ceil(len/4) token receipt (payload size + how much denser the timeline is than the raw decision logs — 115.8x on this repo).
+
+**Alternatives considered:** Keep the prose format (rejected: boilerplate + volatile-first ordering waste tokens and bust the cache), An ML/LLMLingua compressor (rejected: lossy + requires shipping a model)
+
+**Implications:**
+- context.go is non-byte-gated (the free surface); new internal/tokens estimator = the toolchain's shared ceil/4 per the coming protocol §Token-efficiency contract; the Long help documents the caching placement (system-prompt, breakpoint, 1h TTL, pre-warm, above-the-task). Byte-stability now has a determinism test. The derived docs' OWN headers stay (byte-gated → 1d/Phase 2 / v1.0 flip).
+
+---
+

--- a/docs/decisions-branches/feat__token-killer-phase1-context.md
+++ b/docs/decisions-branches/feat__token-killer-phase1-context.md
@@ -11,3 +11,12 @@
 
 ---
 
+## 2026-07-03 22:43 - context: make the missing-doc note strict-XML-safe (self-closing element, review fix)
+
+**Reasoning:** The clud-bug review noted the missing-doc XML comment held a '--' double-hyphen (from '--write'), which strict XML forbids inside <!-- -->. Since the PR's pitch is unambiguous parsing, replaced the comment with a self-closing <document ... status="absent" regenerate="..."/> element — well-formed (the command lives in an attribute value) and still carries what's absent + how to restore it.
+
+**Implications:**
+- Only the degraded doc-absent path changes; the present-doc envelope is unchanged; test updated to assert the self-closing form.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -48,6 +48,7 @@ logmind
 │   ├── skill
 │   ├── templates
 │   ├── timeline
+│   ├── tokens
 │   ├── tree
 │   └── version
 ├── scripts

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (9 decisions)
+## 2026-07 (10 decisions)
 
-- **2026-07-03** — feat: logmind context — one-read agent cold-start payload (timeline + file-structure) *(feat/context-command)* — [decisions-branches/feat__context-command.md](decisions-branches/feat__context-command.md)
-- *... 7 more decisions ...*
+- **2026-07-03** — feat(context): cache-optimal cold-start payload + --stats token receipt (token-killer Phase 1a/1c) *(feat/token-killer-phase1-context)* — [decisions-branches/feat__token-killer-phase1-context.md](decisions-branches/feat__token-killer-phase1-context.md)
+- *... 8 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (10 decisions)
+## 2026-07 (11 decisions)
 
-- **2026-07-03** — feat(context): cache-optimal cold-start payload + --stats token receipt (token-killer Phase 1a/1c) *(feat/token-killer-phase1-context)* — [decisions-branches/feat__token-killer-phase1-context.md](decisions-branches/feat__token-killer-phase1-context.md)
-- *... 8 more decisions ...*
+- **2026-07-03** — context: make the missing-doc note strict-XML-safe (self-closing element, review fix) *(feat/token-killer-phase1-context)* — [decisions-branches/feat__token-killer-phase1-context.md](decisions-branches/feat__token-killer-phase1-context.md)
+- *... 9 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -108,10 +108,11 @@ func contextPayload(cwd string) string {
 	for _, d := range contextDocs {
 		data, err := os.ReadFile(filepath.Join(cwd, d.rel))
 		if err != nil {
-			// Note a missing doc as a comment (kept out of the <document> set)
-			// so the agent knows it exists + how to regenerate, without an
-			// error and without breaking the envelope.
-			fmt.Fprintf(&b, "<!-- %s absent — regenerate: %s -->\n", d.rel, d.regen)
+			// A missing doc becomes a self-closing element carrying the
+			// regenerate command in an attribute — well-formed (an XML comment
+			// would hit the "--" double-hyphen rule via `--write`) and still
+			// tells the agent what's absent and how to restore it.
+			fmt.Fprintf(&b, "<document type=%q source=%q status=\"absent\" regenerate=%q/>\n", d.typ, d.rel, d.regen)
 			continue
 		}
 		fmt.Fprintf(&b, "<document type=%q>\n<source>%s</source>\n<document_content>\n", d.typ, d.rel)

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -5,76 +5,170 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/tokens"
 )
 
-// newContextCmd wires `logmind context`.
+// newContextCmd wires `logmind context [--stats]`.
 //
 // Prints the agent cold-start payload — the two pre-baked derived docs
-// (docs/timeline.md = the "why", docs/file-structure.md = the "what") — to
-// stdout in one read. This is the single command an agent runs at the start
-// of a task to orient, instead of burning tokens reconstructing context from
-// `git log` / `ls -R` / `grep`. It is the practical expression of the
-// logmind thesis: a repo self-describing on the edge of inference.
+// (docs/file-structure.md = the "what", docs/timeline.md = the "why") — to
+// stdout in one read, structured for prompt caching. This is the single
+// command an agent runs at the start of a task to orient, instead of burning
+// tokens reconstructing context from `git log` / `ls -R` / `grep`. It is the
+// practical expression of the logmind thesis (and the token-killer): a repo
+// self-describing on the edge of inference.
 //
-// Read-only. A missing derived doc is noted (with how to regenerate), never
-// an error — `context` is a convenience, not a gate.
+// TOKEN-SAVING DESIGN (grounded in the research in the plan):
+//   - Byte-stable + deterministic → an ideal prompt-cache prefix; cached
+//     re-reads cost ~0.1× (≈90% off).
+//   - Stable content first (file-structure), volatile last (the newest-first
+//     timeline) → the cache prefix stays byte-identical longest (a churning
+//     top would bust the cache from the first breakpoint).
+//   - Both docs in the Anthropic-prescribed
+//     <document><source><document_content> envelope (unambiguous parsing;
+//     denser than stacked markdown prose).
+//   - The framing is ONE machine line, not human-facing boilerplate.
+//
+// Read-only. A missing derived doc is noted as a comment and omitted, never an
+// error — `context` is a convenience, not a gate.
 func newContextCmd() *cobra.Command {
+	var stats bool
 	cmd := &cobra.Command{
 		Use:   "context",
-		Short: "Print the agent cold-start context (timeline + file-structure) in one read",
-		Long: `Print the agent cold-start context in one read.
+		Short: "Print the cache-optimal agent cold-start context (file-structure + timeline) in one read",
+		Long: `Print the agent cold-start context in one read, structured for prompt caching.
 
-Concatenates the two pre-baked derived docs an agent reads to orient:
+Emits the two pre-baked derived docs an agent reads to orient:
 
-    docs/timeline.md         the WHY — the decision timeline
-    docs/file-structure.md   the WHAT — the repo tree
+    docs/file-structure.md   the WHAT — the repo tree    (stable → cache prefix)
+    docs/timeline.md         the WHY  — decision timeline (newest-first)
 
-Run it at the start of a task instead of piecing context together from
-git log / ls / grep. A missing derived doc is noted (with how to
-regenerate it), not treated as an error.`,
+wrapped in a <document><source><document_content> envelope. Run it at the start
+of a task instead of piecing context together from git log / ls / grep; open a
+linked source file for full reasoning on demand.
+
+Caching (the ~10x lever): this output is byte-stable and re-read across turns,
+so treat it as a cacheable PREFIX —
+  - place it ABOVE your task/query (long stable context first improves quality
+    up to ~30% and is what caches),
+  - set a prompt-cache breakpoint at the end of this block (cache_control),
+  - use the 1-hour TTL for multi-step / multi-agent sessions, and pre-warm it,
+  - read it ONCE per task; byte-identical re-reads hit the cache at ~0.1x input.
+
+--stats prints a deterministic token receipt (est. ~4 chars/token) instead of
+the payload.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
 			}
+			if stats {
+				return runContextStats(cwd, cmd.OutOrStdout())
+			}
 			return runContext(cwd, cmd.OutOrStdout())
 		},
 	}
+	cmd.Flags().BoolVar(&stats, "stats", false,
+		"Print a deterministic token receipt (payload size + density vs. raw sources) instead of the payload.")
 	return cmd
 }
 
-// contextDoc is one section of the cold-start payload.
+// contextDoc is one document in the cold-start payload.
 type contextDoc struct {
 	rel   string // repo-relative path to the derived doc
-	label string // section heading
+	typ   string // <document type=…> — machine label
 	regen string // command to regenerate it when missing
 }
 
-func runContext(cwd string, stdout io.Writer) error {
-	fmt.Fprint(stdout, "# logmind context\n\n"+
-		"The pre-baked cold-start payload for this repo: the decision timeline\n"+
-		"(the \"why\") and the file structure (the \"what\"). Read this to orient\n"+
-		"instead of reconstructing context from git log / ls / grep.\n")
+// contextDocs is the ordered payload: the stable "what" (file-structure)
+// before the volatile "why" (newest-first timeline), so the cacheable prefix
+// stays byte-identical for as long as possible.
+var contextDocs = []contextDoc{
+	{"docs/file-structure.md", "file-structure", "logmind file-structure --write docs/file-structure.md"},
+	{"docs/timeline.md", "decision-timeline", "logmind timeline --write docs/timeline.md"},
+}
 
-	docs := []contextDoc{
-		{"docs/timeline.md", "Decision timeline — the why", "logmind timeline --write docs/timeline.md"},
-		{"docs/file-structure.md", "File structure — the what", "logmind file-structure --write docs/file-structure.md"},
-	}
-	for _, d := range docs {
-		fmt.Fprintf(stdout, "\n## %s (%s)\n\n", d.label, d.rel)
+const contextPreface = "Pre-baked repo cold-start context: the file map (what) + the decision " +
+	"timeline (why). Read this to orient instead of running git log / ls / grep; " +
+	"open a linked source file for detail. Byte-stable — cache it as a prefix ABOVE your task.\n"
+
+// contextPayload builds the deterministic, cache-optimal payload: the machine
+// preface + the two derived docs in an XML document envelope, stable-first.
+// Deterministic by construction (fixed strings + on-disk doc bytes, stable
+// order) — the property prompt caching depends on.
+func contextPayload(cwd string) string {
+	var b strings.Builder
+	b.WriteString(contextPreface)
+	b.WriteString("\n<repo_context>\n")
+	for _, d := range contextDocs {
 		data, err := os.ReadFile(filepath.Join(cwd, d.rel))
 		if err != nil {
-			fmt.Fprintf(stdout, "(%s not found — regenerate with: %s)\n", d.rel, d.regen)
+			// Note a missing doc as a comment (kept out of the <document> set)
+			// so the agent knows it exists + how to regenerate, without an
+			// error and without breaking the envelope.
+			fmt.Fprintf(&b, "<!-- %s absent — regenerate: %s -->\n", d.rel, d.regen)
 			continue
 		}
-		stdout.Write(data)
-		// Guarantee a trailing newline so the next section separates cleanly.
+		fmt.Fprintf(&b, "<document type=%q>\n<source>%s</source>\n<document_content>\n", d.typ, d.rel)
+		b.Write(data)
 		if n := len(data); n == 0 || data[n-1] != '\n' {
-			fmt.Fprintln(stdout)
+			b.WriteByte('\n')
 		}
+		b.WriteString("</document_content>\n</document>\n")
 	}
+	b.WriteString("</repo_context>\n")
+	return b.String()
+}
+
+func runContext(cwd string, stdout io.Writer) error {
+	_, err := io.WriteString(stdout, contextPayload(cwd))
+	return err
+}
+
+// runContextStats prints a deterministic token receipt: the payload size and
+// how much denser the timeline is than the raw decision logs it distills.
+func runContextStats(cwd string, stdout io.Writer) error {
+	payload := contextPayload(cwd)
+	fsTok := tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, "docs", "file-structure.md")))
+	tlTok := tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, "docs", "timeline.md")))
+	rawWhy := rawDecisionTokens(cwd)
+
+	fmt.Fprint(stdout, "logmind context — token receipt (est. ~4 chars/token, deterministic)\n\n")
+	fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + timeline %d + framing)\n",
+		tokens.Estimate(payload), fsTok, tlTok)
+	if rawWhy > 0 && tlTok > 0 {
+		fmt.Fprintf(stdout, "  the timeline distills %d tok of raw decision logs -> %.1fx denser.\n",
+			rawWhy, float64(rawWhy)/float64(tlTok))
+	}
+	fmt.Fprint(stdout, "  reading this pre-baked payload replaces a git log / ls -R / grep cold-start.\n")
+	fmt.Fprint(stdout, "  cache it as a stable prefix -> every re-read costs ~0.1x (about 90% off).\n")
 	return nil
+}
+
+func ctxReadOrEmpty(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// rawDecisionTokens estimates the tokens of the raw decision sources the
+// timeline distills (decisions.md + archive + every branch log) — the "why" an
+// agent would otherwise reconstruct from git log.
+func rawDecisionTokens(cwd string) int {
+	total := 0
+	for _, p := range []string{"decisions.md", "decisions-archive.md"} {
+		total += tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, "docs", p)))
+	}
+	branches, _ := filepath.Glob(filepath.Join(cwd, "docs", "decisions-branches", "*.md"))
+	for _, p := range branches {
+		total += tokens.Estimate(ctxReadOrEmpty(p))
+	}
+	return total
 }

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -6,50 +6,85 @@ import (
 	"testing"
 )
 
-// TestContext_PrintsBothDocs: `logmind context` concatenates the two
-// derived docs (why + what) in order, with headings, in one read.
-func TestContext_PrintsBothDocs(t *testing.T) {
+func runContextCapture(t *testing.T, args ...string) string {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(append([]string{"context"}, args...))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("context %v: %v\n%s", args, err, out.String())
+	}
+	return out.String()
+}
+
+// TestContext_XMLEnvelope_StableFirst: the payload wraps both docs in the
+// <document><source><document_content> envelope, with the stable file-structure
+// BEFORE the volatile (newest-first) timeline — the cache-prefix ordering.
+func TestContext_XMLEnvelope_StableFirst(t *testing.T) {
 	withTempCwd(t, func(d string) {
-		mustWriteUnder(t, d, "docs/timeline.md", "TIMELINE_CONTENT_MARKER\n")
-		mustWriteUnder(t, d, "docs/file-structure.md", "FILESTRUCTURE_CONTENT_MARKER\n")
-		root := NewRootCmd()
-		root.SetArgs([]string{"context"})
-		var out bytes.Buffer
-		root.SetOut(&out)
-		root.SetErr(&out)
-		if err := root.Execute(); err != nil {
-			t.Fatalf("context: %v\n%s", err, out.String())
+		mustWriteUnder(t, d, "docs/file-structure.md", "FSMARKER\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "TLMARKER\n")
+		s := runContextCapture(t)
+		for _, want := range []string{
+			"<repo_context>", `<document type="file-structure">`,
+			`<document type="decision-timeline">`, "<source>docs/file-structure.md</source>",
+			"FSMARKER", "TLMARKER", "</repo_context>",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("payload missing %q:\n%s", want, s)
+			}
 		}
-		s := out.String()
-		if !strings.Contains(s, "TIMELINE_CONTENT_MARKER") || !strings.Contains(s, "FILESTRUCTURE_CONTENT_MARKER") {
-			t.Errorf("context missing a doc's content:\n%s", s)
-		}
-		// Order: the why (timeline) before the what (file-structure).
-		iT := strings.Index(s, "docs/timeline.md")
-		iF := strings.Index(s, "docs/file-structure.md")
-		if iT < 0 || iF < 0 || iT > iF {
-			t.Errorf("sections missing or out of order (timeline before file-structure):\n%s", s)
+		// Stable-first: file-structure precedes timeline (cache-prefix stability).
+		if strings.Index(s, "FSMARKER") > strings.Index(s, "TLMARKER") {
+			t.Errorf("file-structure must precede timeline (cache-stable ordering):\n%s", s)
 		}
 	})
 }
 
-// TestContext_MissingDocNoted_NotError: a missing derived doc is noted
-// with a regenerate hint, never an error (context is read-only convenience).
+// TestContext_Deterministic: byte-identical across runs — the property prompt
+// caching depends on (a single changed byte busts the whole cache prefix).
+func TestContext_Deterministic(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "tree\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "why\n")
+		a := runContextCapture(t)
+		b := runContextCapture(t)
+		if a != b {
+			t.Errorf("context not byte-deterministic (breaks prompt caching):\n--- a ---\n%s\n--- b ---\n%s", a, b)
+		}
+	})
+}
+
+// TestContext_MissingDocNoted_NotError: a missing derived doc is noted as a
+// comment and omitted from the <document> set, never an error.
 func TestContext_MissingDocNoted_NotError(t *testing.T) {
 	withTempCwd(t, func(d string) {
-		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "why\n")
 		// docs/file-structure.md intentionally absent.
-		root := NewRootCmd()
-		root.SetArgs([]string{"context"})
-		var out bytes.Buffer
-		root.SetOut(&out)
-		root.SetErr(&out)
-		if err := root.Execute(); err != nil {
-			t.Fatalf("context must not error on a missing doc: %v", err)
+		s := runContextCapture(t)
+		if !strings.Contains(s, "docs/file-structure.md absent") || !strings.Contains(s, "regenerate:") {
+			t.Errorf("missing doc not noted as a comment:\n%s", s)
 		}
-		s := out.String()
-		if !strings.Contains(s, "docs/file-structure.md not found") || !strings.Contains(s, "regenerate with") {
-			t.Errorf("missing doc not noted with a regen hint:\n%s", s)
+		if strings.Contains(s, `<document type="file-structure">`) {
+			t.Errorf("an absent doc must not emit a <document> block:\n%s", s)
+		}
+	})
+}
+
+// TestContext_Stats: --stats prints the token receipt, not the payload.
+func TestContext_Stats(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "tree\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "why\n")
+		mustWriteUnder(t, d, "docs/decisions.md", "## 2026-01-01 12:00 - X\n\nrationale\n")
+		s := runContextCapture(t, "--stats")
+		if !strings.Contains(s, "token receipt") || !strings.Contains(s, "payload total:") {
+			t.Errorf("--stats missing the receipt:\n%s", s)
+		}
+		if strings.Contains(s, "<repo_context>") {
+			t.Errorf("--stats must not print the payload:\n%s", s)
 		}
 	})
 }

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -64,11 +64,11 @@ func TestContext_MissingDocNoted_NotError(t *testing.T) {
 		mustWriteUnder(t, d, "docs/timeline.md", "why\n")
 		// docs/file-structure.md intentionally absent.
 		s := runContextCapture(t)
-		if !strings.Contains(s, "docs/file-structure.md absent") || !strings.Contains(s, "regenerate:") {
-			t.Errorf("missing doc not noted as a comment:\n%s", s)
+		if !strings.Contains(s, `source="docs/file-structure.md" status="absent"`) || !strings.Contains(s, "regenerate=") {
+			t.Errorf("absent file-structure not noted as a self-closing element:\n%s", s)
 		}
-		if strings.Contains(s, `<document type="file-structure">`) {
-			t.Errorf("an absent doc must not emit a <document> block:\n%s", s)
+		if strings.Contains(s, "<source>docs/file-structure.md</source>") {
+			t.Errorf("an absent doc must not emit a full <document>…<source>…</document> block:\n%s", s)
 		}
 	})
 }

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -1,0 +1,18 @@
+// Package tokens provides a deterministic, dependency-free token estimate for
+// logmind's token-efficiency surfaces (`logmind context --stats`, and future
+// `gain`/receipt output). It is the toolchain's shared estimator per the
+// protocol § Token-efficiency contract: the common ~4-bytes-per-token proxy,
+// never a billed count — just a stable, no-network approximation so token
+// savings are auditable the same way across tools.
+package tokens
+
+// Estimate returns a rough token count for s using ceil(len(s)/4) — the widely
+// used ~4-bytes-per-token heuristic. Deterministic; makes no network/LLM call.
+// It intentionally counts bytes (not runes): token count tracks bytes closely
+// for English/code, and byte-length keeps the estimate stable and cheap.
+func Estimate(s string) int {
+	if len(s) == 0 {
+		return 0
+	}
+	return (len(s) + 3) / 4
+}

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -1,0 +1,22 @@
+package tokens
+
+import "testing"
+
+func TestEstimate(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"a", 1},        // ceil(1/4)
+		{"abcd", 1},     // ceil(4/4)
+		{"abcde", 2},    // ceil(5/4)
+		{"12345678", 2}, // ceil(8/4)
+		{"123456789", 3},
+	}
+	for _, c := range cases {
+		if got := Estimate(c.in); got != c.want {
+			t.Errorf("Estimate(%q) = %d; want %d", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
First increment of the token-killer pillar — the high-leverage proactive wins, on the non-byte-gated `context.go` surface.

**Why (research):** the ~10× token lever is **prompt caching** — cached re-reads cost 0.1×, and logmind's byte-stable, re-read context is the ideal cache target. The waste was prose boilerplate + a volatile-first layout that busts the cache.

**1a — cache-optimal `logmind context`:**
- Cut the ~13 lines of human-facing boilerplate → **one machine preface**.
- Wrap both docs in the Anthropic-prescribed `<document><source><document_content>` envelope.
- **Reorder file-structure first (stable) / timeline last (volatile)** so the cacheable prefix stays byte-identical longest.
- **Byte-determinism** guaranteed + tested (a changed byte busts the whole cache prefix).
- The `--help` documents the caching placement (system-prompt, breakpoint at the boundary, 1h TTL, pre-warm, put it above your task).

**1c — `logmind context --stats`:** a deterministic `ceil(len/4)` token receipt — payload size + how much denser the timeline is than the raw decision logs. On this repo: payload ~1,228 tok; **the timeline is 115.8× denser** than the 63k tok of raw decision logs it distills.

New `internal/tokens` (the toolchain's shared estimator per the coming protocol § Token-efficiency contract). Full suite green, gofmt-clean, smoke-verified. The derived docs' own headers stay (byte-gated → a later phase / the v1.0 flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)