### PR TITLE
fix(install): document Homebrew 6.0.0 tap-trust cleanup for stale thrillmot/logmind tap

### DIFF
--- a/docs/decisions-branches/fix__homebrew-tap-trust.md
+++ b/docs/decisions-branches/fix__homebrew-tap-trust.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 22:52 - Document Homebrew 6.0.0 tap-trust cleanup for the stale thrillmot/logmind personal tap
+
+**Reasoning:** Homebrew 6.0.0 (Jun 2026) added client-side tap trust; the pre-migration personal tap thrillmot/logmind is now flagged untrusted and ignored, tripping users with a warning. The canonical thrillmade/tap is already correct in README, install.md, and .goreleaser.yaml (owner thrillmade/homebrew-tap), and a fully-qualified 'brew install thrillmade/tap/logmind' auto-trusts the cask, so no repo/goreleaser change is needed — only user-facing cleanup docs.
+
+**Implications:**
+- docs/install.md gains a Troubleshooting entry (brew untap thrillmot/logmind + canonical install auto-trusts, optional brew trust thrillmade/tap for unqualified installs) plus an inline pointer in the Homebrew section. No goreleaser/attestation change: tap trust is purely client-side. The two remaining thrillmot mentions are historical decision-log/changelog records and are intentionally left untouched.
+
+---
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,11 +21,20 @@ This installs the latest signed + notarized release from
 keyed to your CPU architecture (Apple Silicon, Intel, ARM64 Linux, x86_64
 Linux). Brew handles `$PATH` setup for you.
 
+The fully-qualified name (`thrillmade/tap/logmind`) auto-trusts the cask
+under Homebrew 6.0.0's [tap trust](https://docs.brew.sh/Tap-Trust) rules,
+so no extra `brew trust` step is needed.
+
 To upgrade later:
 
 ```bash
 brew upgrade thrillmade/tap/logmind
 ```
+
+> **Seeing a "tap trust is required" warning about `thrillmot/logmind`?**
+> That's a stale personal tap from before the `thrillmade` org migration.
+> Run `brew untap thrillmot/logmind` — see
+> [Troubleshooting](#troubleshooting).
 
 ## curl one-liner
 
@@ -167,6 +176,48 @@ A full consumer-repo migration recipe lands alongside the v1.0 cutover
 PR (Phase 3) — it will live in `docs/migrate-from-pip.md` once published.
 
 ## Troubleshooting
+
+- **"Homebrew is currently ignoring formulae, casks and commands from
+  these taps because tap trust is required" (mentions
+  `thrillmot/logmind`)**
+  Homebrew 6.0.0 (June 2026) added [tap
+  trust](https://docs.brew.sh/Tap-Trust): non-official third-party taps
+  must be explicitly trusted before their Ruby code runs, and any tap
+  that isn't trusted is ignored with this warning. The offender here is
+  the **stale personal tap** `thrillmot/logmind` — a pre-v0.3.1 install
+  path that predates the org migration to `thrillmade`. It was never the
+  canonical tap and nothing installs from it anymore. Remove it:
+
+  ```bash
+  brew untap thrillmot/logmind
+  ```
+
+  Then install (or reinstall) from the canonical tap:
+
+  ```bash
+  brew install thrillmade/tap/logmind
+  ```
+
+  **You do not need to run `brew trust` for the canonical path.** A
+  fully-qualified install (`brew install thrillmade/tap/logmind`)
+  auto-trusts that cask before installing — that's why the command above
+  Just Works under the new rules, and it's the form we document
+  everywhere. Tap trust is entirely client-side: the tap publisher signs
+  or attests nothing, so there is nothing for `thrillmade/homebrew-tap`
+  to change on its end.
+
+  Only if you prefer to tap first and install by the short name do you
+  need an explicit trust step:
+
+  ```bash
+  brew tap thrillmade/tap
+  brew trust thrillmade/tap   # required for the UNqualified `brew install logmind`
+  brew install logmind
+  ```
+
+  (`export HOMEBREW_NO_REQUIRE_TAP_TRUST=1` disables the check globally,
+  but Homebrew warns it's unsafe and slated for removal — untap the stale
+  tap instead.)
 
 - **"command not found: logmind" after install**
   Your install prefix's `bin/` directory isn't on `$PATH`. The curl

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (11 decisions)
+## 2026-07 (12 decisions)
 
-- **2026-07-03** — context: make the missing-doc note strict-XML-safe (self-closing element, review fix) *(feat/token-killer-phase1-context)* — [decisions-branches/feat__token-killer-phase1-context.md](decisions-branches/feat__token-killer-phase1-context.md)
-- *... 9 more decisions ...*
+- **2026-07-03** — Document Homebrew 6.0.0 tap-trust cleanup for the stale thrillmot/logmind personal tap *(fix/homebrew-tap-trust)* — [decisions-branches/fix__homebrew-tap-trust.md](decisions-branches/fix__homebrew-tap-trust.md)
+- *... 10 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)


### PR DESCRIPTION
## Symptom

Homebrew now ignores untrusted third-party taps:

> Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required. Untap them with: `brew untap thrillmot/logmind`

## Root cause — the tap-trust mechanism

**Homebrew 6.0.0** (June 2026) shipped [**tap trust**](https://docs.brew.sh/Tap-Trust): non-official third-party taps must be *explicitly trusted* before their Ruby code is evaluated, and any untrusted tap is ignored with the warning above.

Key properties:
- Trust is **purely client-side**. The tap publisher signs/attests **nothing** — there is nothing for `thrillmade/homebrew-tap` to change.
- A **fully-qualified install** auto-trusts the item: `brew install thrillmade/tap/logmind` trusts the cask before installing, so the canonical path Just Works under the new rules with no `brew trust` step.
- The trigger is the **stale personal tap** `thrillmot/logmind` — a pre-v0.3.1 path from before the `thrillmade` org migration — still present on affected machines. It was never canonical and nothing installs from it.

## The fix

Cleanup is **user-side**, not repo-side:

```bash
brew untap thrillmot/logmind
brew install thrillmade/tap/logmind   # fully-qualified name auto-trusts the cask
```

## What changed

- **`docs/install.md`** — new Troubleshooting entry (untap the stale tap, canonical install auto-trusts, optional `brew trust thrillmade/tap` only for the *unqualified* `brew install logmind`, note on `HOMEBREW_NO_REQUIRE_TAP_TRUST`), plus an inline pointer in the Homebrew section.

## What deliberately did **not** change

- **`.goreleaser.yaml`** — already targets `thrillmade/homebrew-tap` (owner `thrillmade`). Tap trust is client-side, so no attestation/trust config is possible or needed here.
- **README / install.md install commands** — already canonical (`thrillmade/tap/logmind`).
- The two remaining `thrillmot` + tap mentions (`docs/changelog-python.md`, `docs/decisions-branches/chore__migrate-to-thrillmade.md`) are **historical records** of the past migration and are intentionally left untouched.

## Verification

`go build ./...` and `go test ./...` both green (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG