### PR TITLE
feat(cli): LOGMIND_QUIET output discipline — one chainable `ok <k=v>` per verb (token-killer Phase 1b)

### DIFF
--- a/docs/decisions-branches/feat__token-killer-1b-quiet.md
+++ b/docs/decisions-branches/feat__token-killer-1b-quiet.md
@@ -9,3 +9,14 @@
 
 ---
 
+## 2026-07-03 23:20 - 1b review-fixes: --help flag placeholder, --quiet=false precedence, headline default-receipt test
+
+**Reasoning:** Two local reviews (adversarial byte-parity + clud-bug-lens) returned CLEAN; three release-quality nits both flagged: pflag rendered the back-quoted 'ok <k=v>' in the --quiet usage as a bogus value placeholder; quietEnabled ignored flag.Changed so an explicit --quiet=false couldn't override LOGMIND_QUIET=1; headline's default-mode receipt lines had no assertion.
+
+**Alternatives considered:** Ship as-is — all three were non-blocking; rejected because the fixes are tiny and this is the release-quality bar.
+
+**Implications:**
+- --help reads correctly for a boolean flag; explicit CLI flag now beats env (12-factor precedence); the headline default receipt is golden-guarded against future regression.
+
+---
+

--- a/docs/decisions-branches/feat__token-killer-1b-quiet.md
+++ b/docs/decisions-branches/feat__token-killer-1b-quiet.md
@@ -1,0 +1,11 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-03 23:03 - token-killer Phase 1b: LOGMIND_QUIET output discipline across log/timeline/file-structure/doctor/headline
+
+**Reasoning:** Agents pay tokens to read and skip multi-line ✓ progress chatter; a single chainable 'ok <k=v>' receipt per verb (borrowed from clud-bug's CLUD_BUG_QUIET) is far cheaper and still machine-parseable
+
+**Implications:**
+- New opt-in quiet MODE only (--quiet flag OR LOGMIND_QUIET env); default output stays byte-identical so timeline/tree/cli goldens pass unchanged; errors + hints always route to stderr under quiet, never suppressed
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (13 decisions)
+## 2026-07 (14 decisions)
 
-- **2026-07-03** — token-killer Phase 1b: LOGMIND_QUIET output discipline across log/timeline/file-structure/doctor/headline *(feat/token-killer-1b-quiet)* — [decisions-branches/feat__token-killer-1b-quiet.md](decisions-branches/feat__token-killer-1b-quiet.md)
-- *... 11 more decisions ...*
+- **2026-07-03** — 1b review-fixes: --help flag placeholder, --quiet=false precedence, headline default-receipt test *(feat/token-killer-1b-quiet)* — [decisions-branches/feat__token-killer-1b-quiet.md](decisions-branches/feat__token-killer-1b-quiet.md)
+- *... 12 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (12 decisions)
+## 2026-07 (13 decisions)
 
-- **2026-07-03** — Document Homebrew 6.0.0 tap-trust cleanup for the stale thrillmot/logmind personal tap *(fix/homebrew-tap-trust)* — [decisions-branches/fix__homebrew-tap-trust.md](decisions-branches/fix__homebrew-tap-trust.md)
-- *... 10 more decisions ...*
+- **2026-07-03** — token-killer Phase 1b: LOGMIND_QUIET output discipline across log/timeline/file-structure/doctor/headline *(feat/token-killer-1b-quiet)* — [decisions-branches/feat__token-killer-1b-quiet.md](decisions-branches/feat__token-killer-1b-quiet.md)
+- *... 11 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -51,17 +51,29 @@ func newDoctorCmd() *cobra.Command {
 			"rewrites decision text, foreign (hand-written) hooks, or your PATH.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			quiet := quietEnabled(cmd)
 			if fix {
+				// --fix is already quiet-shaped: it emits exactly one
+				// `ok doctor-fix …` line to stdout and routes residual notes to
+				// stderr, so it satisfies the QUIET discipline in both modes.
 				return runDoctorFix(cmd, offline, asJSON)
 			}
 			report := doctor.CollectStatus("", offline)
-			if asJSON {
+			switch {
+			case asJSON:
+				// --json is an explicit format request that wins over quiet's
+				// terse line — an agent that asked for the full JSON report
+				// gets it.
 				out, err := report.ToJSON()
 				if err != nil {
 					return err
 				}
 				cmd.Println(out)
-			} else {
+			case quiet:
+				// Suppress the human table; emit the single chainable receipt.
+				fmt.Fprintf(cmd.OutOrStdout(), "ok doctor overall=%s drift=%d\n",
+					report.Overall, driftCount(report))
+			default:
 				cmd.Println(doctor.RenderStatus(report))
 			}
 			if report.Overall == "DRIFT" && !exitZero {
@@ -119,6 +131,23 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 				"(PATH/version, or a hand-written hook). See `logmind doctor`.\n", name)
 	}
 	return nil
+}
+
+// driftCount counts probe rows that are "stale" — the drift signal that flips
+// Overall to DRIFT (see doctor.CollectStatus). "missing" (benign in a fresh
+// repo) and "markerless" (a main-canonical migration advisory, not a hard
+// drift) are excluded so the QUIET `ok doctor …` receipt stays consistent
+// with `overall` (e.g. overall=OK never pairs with drift>0).
+func driftCount(r doctor.StatusReport) int {
+	n := 0
+	for _, t := range r.Tools {
+		for _, wf := range t.Workflows {
+			if wf.Drift == "stale" {
+				n++
+			}
+		}
+	}
+	return n
 }
 
 // residualProbes returns the names of probes still drifted after a fix pass:

--- a/internal/cli/file_structure.go
+++ b/internal/cli/file_structure.go
@@ -63,7 +63,7 @@ Examples:
 					effective = maxDepth
 				}
 			}
-			return runFileStructure(cwd, writePath, check, effective, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runFileStructure(cwd, writePath, check, effective, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().StringVar(&writePath, "write", "",
@@ -79,7 +79,8 @@ Examples:
 	return cmd
 }
 
-func runFileStructure(cwd, writePath string, check bool, effective int, stdout, stderr io.Writer) error {
+func runFileStructure(cwd, writePath string, check bool, effective int, quiet bool, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
 	// File-structure doesn't insist on docs/ existing for stdout mode.
 	// Python's file-structure has no docs/-existence check either.
 	depthLabel := fmt.Sprintf("depth=%d", effective)
@@ -89,7 +90,7 @@ func runFileStructure(cwd, writePath string, check bool, effective int, stdout, 
 
 	if check {
 		if writePath == "" {
-			fmt.Fprintln(stdout, "Error: --check requires --write PATH to compare against.")
+			q.fail("Error: --check requires --write PATH to compare against.\n")
 			return ErrSilent
 		}
 		rendered, err := tree.GenerateFileStructure(cwd, effective)
@@ -98,11 +99,15 @@ func runFileStructure(cwd, writePath string, check bool, effective int, stdout, 
 		}
 		existing, _ := os.ReadFile(writePath)
 		if string(existing) != rendered {
-			fmt.Fprintf(stdout, "✗ %s is stale — re-run `logmind file-structure --write %s` and commit.\n", writePath, writePath)
+			q.fail("✗ %s is stale — re-run `logmind file-structure --write %s` and commit.\n", writePath, writePath)
 			return ErrSilent
 		}
-		fmt.Fprintf(stdout, "✓ %s is up to date\n", writePath)
-		fmt.Fprintf(stdout, "ok file-structure: %s up to date\n", writePath)
+		q.chat("✓ %s is up to date\n", writePath)
+		if quiet {
+			q.ok("file-structure path=%s %s state=up-to-date", writePath, depthLabel)
+		} else {
+			fmt.Fprintf(stdout, "ok file-structure: %s up to date\n", writePath)
+		}
 		return nil
 	}
 
@@ -111,8 +116,12 @@ func runFileStructure(cwd, writePath string, check bool, effective int, stdout, 
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(stdout, rendered)
-		fmt.Fprintf(stdout, "ok file-structure: %d bytes, %s (stdout)\n", len(rendered), depthLabel)
+		if !quiet {
+			fmt.Fprint(stdout, rendered)
+			fmt.Fprintf(stdout, "ok file-structure: %d bytes, %s (stdout)\n", len(rendered), depthLabel)
+		} else {
+			q.ok("file-structure bytes=%d %s sink=stdout", len(rendered), depthLabel)
+		}
 		return nil
 	}
 
@@ -121,15 +130,19 @@ func runFileStructure(cwd, writePath string, check bool, effective int, stdout, 
 		return err
 	}
 	if changed {
-		fmt.Fprintf(stdout, "✓ Regenerated %s\n", writePath)
+		q.chat("✓ Regenerated %s\n", writePath)
 	} else {
-		fmt.Fprintf(stdout, "  %s already up to date\n", writePath)
+		q.chat("  %s already up to date\n", writePath)
 	}
 	st, err := os.Stat(writePath)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "ok %s (%d bytes, %s)\n", writePath, st.Size(), depthLabel)
+	if quiet {
+		q.ok("file-structure path=%s bytes=%d %s changed=%t", writePath, st.Size(), depthLabel, changed)
+	} else {
+		fmt.Fprintf(stdout, "ok %s (%d bytes, %s)\n", writePath, st.Size(), depthLabel)
+	}
 	return nil
 }
 

--- a/internal/cli/file_structure_test.go
+++ b/internal/cli/file_structure_test.go
@@ -46,7 +46,7 @@ func TestFileStructureStdoutDefault(t *testing.T) {
 		"sub/d.txt": "d",
 	})
 	var stdout, stderr bytes.Buffer
-	if err := runFileStructure(cwd, "", false, tree.DefaultFileStructureDepth, &stdout, &stderr); err != nil {
+	if err := runFileStructure(cwd, "", false, tree.DefaultFileStructureDepth, false, &stdout, &stderr); err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	out := stdout.String()
@@ -68,7 +68,7 @@ func TestFileStructureStdoutUnbounded(t *testing.T) {
 	})
 	var stdout, stderr bytes.Buffer
 	// effective = -1 (unbounded)
-	if err := runFileStructure(cwd, "", false, -1, &stdout, &stderr); err != nil {
+	if err := runFileStructure(cwd, "", false, -1, false, &stdout, &stderr); err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if !strings.Contains(stdout.String(), "unbounded (stdout)") {
@@ -87,7 +87,7 @@ func TestFileStructureWriteIdempotent(t *testing.T) {
 	// stays content-equal to the first.
 	target := filepath.Join(t.TempDir(), "out.md")
 	var stdout, stderr bytes.Buffer
-	if err := runFileStructure(cwd, target, false, -1, &stdout, &stderr); err != nil {
+	if err := runFileStructure(cwd, target, false, -1, false, &stdout, &stderr); err != nil {
 		t.Fatalf("first run: %v", err)
 	}
 	if !strings.Contains(stdout.String(), "✓ Regenerated") {
@@ -95,7 +95,7 @@ func TestFileStructureWriteIdempotent(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if err := runFileStructure(cwd, target, false, -1, &stdout, &stderr); err != nil {
+	if err := runFileStructure(cwd, target, false, -1, false, &stdout, &stderr); err != nil {
 		t.Fatalf("second run: %v", err)
 	}
 	if !strings.Contains(stdout.String(), "already up to date") {
@@ -112,7 +112,7 @@ func TestFileStructureCheckStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	err := runFileStructure(cwd, target, true, -1, &stdout, &stderr)
+	err := runFileStructure(cwd, target, true, -1, false, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Errorf("stale check err = %v; want ErrSilent", err)
 	}
@@ -124,7 +124,7 @@ func TestFileStructureCheckStale(t *testing.T) {
 func TestFileStructureCheckRequiresWrite(t *testing.T) {
 	cwd := makeRepoForTree(t, nil)
 	var stdout, stderr bytes.Buffer
-	err := runFileStructure(cwd, "", true, -1, &stdout, &stderr)
+	err := runFileStructure(cwd, "", true, -1, false, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Errorf("err = %v; want ErrSilent", err)
 	}

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -48,7 +48,7 @@ Example:
 			if err != nil {
 				return err
 			}
-			return runHeadline(cwd, args[0], file, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runHeadline(cwd, args[0], file, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().StringVar(&file, "file", "",
@@ -56,16 +56,20 @@ Example:
 	return cmd
 }
 
-func runHeadline(cwd, summary, fileOverride string, stdout, stderr io.Writer) error {
+func runHeadline(cwd, summary, fileOverride string, quiet bool, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
 	summary = strings.TrimSpace(summary)
 	if summary == "" {
-		fmt.Fprintln(stdout, "Error: headline summary is empty.")
+		q.fail("Error: headline summary is empty.\n")
 		return ErrSilent
 	}
 	cfg, _ := config.Load(cwd)
 	if !cfg.Timeline.IsMainCanonical() {
-		fmt.Fprintln(stdout, "Branch summaries are a main-canonical-timeline feature.")
-		fmt.Fprintln(stdout, "Enable it with `timeline.canonical: main-canonical` in .logmind/config.yml.")
+		q.chat("Branch summaries are a main-canonical-timeline feature.\n")
+		q.chat("Enable it with `timeline.canonical: main-canonical` in .logmind/config.yml.\n")
+		if quiet {
+			q.ok("headline state=skipped reason=not-main-canonical")
+		}
 		return nil
 	}
 
@@ -80,27 +84,33 @@ func runHeadline(cwd, summary, fileOverride string, stdout, stderr io.Writer) er
 		// Only branch detail files carry timeline markers — refuse to splice a
 		// marker into decisions.md/archive or anything outside the branches dir.
 		if filepath.Dir(target) != filepath.Join(cwd, "docs", "decisions-branches") {
-			fmt.Fprintf(stdout, "--file must target a file under docs/decisions-branches/ (got %s).\n", fileOverride)
+			q.fail("--file must target a file under docs/decisions-branches/ (got %s).\n", fileOverride)
 			return ErrSilent
 		}
 		if !pathExists(target) {
-			fmt.Fprintf(stdout, "No such branch file: %s\n", fileOverride)
+			q.fail("No such branch file: %s\n", fileOverride)
 			return ErrSilent
 		}
 	} else {
 		docsPath := filepath.Join(cwd, "docs")
 		t, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
 		if !isBranchFile {
-			fmt.Fprintln(stdout, "Branch summaries apply on a feature branch; the default branch logs to docs/decisions.md directly.")
+			q.chat("Branch summaries apply on a feature branch; the default branch logs to docs/decisions.md directly.\n")
+			if quiet {
+				q.ok("headline state=skipped reason=default-branch")
+			}
 			return nil
 		}
 		if !pathExists(t) {
-			fmt.Fprintln(stdout, "No decisions logged on this branch yet — run `logmind log` first, then set the summary.")
+			q.chat("No decisions logged on this branch yet — run `logmind log` first, then set the summary.\n")
+			if quiet {
+				q.ok("headline state=skipped reason=no-decisions")
+			}
 			return nil
 		}
 		target = t
 	}
-	return setHeadlineInFile(cwd, target, summary, stdout)
+	return setHeadlineInFile(cwd, target, summary, q)
 }
 
 // setHeadlineInFile sets/refreshes the §1.6.3 marker headline in the given
@@ -108,7 +118,7 @@ func runHeadline(cwd, summary, fileOverride string, stdout, stderr io.Writer) er
 // stable <date>-<slug> key), or inserts a marker if the file has none. Shared
 // by `logmind headline` (current branch + --file). main-canonical gating is
 // the caller's responsibility.
-func setHeadlineInFile(cwd, target, summary string, stdout io.Writer) error {
+func setHeadlineInFile(cwd, target, summary string, q qout) error {
 	data, err := os.ReadFile(target)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", target, err)
@@ -122,7 +132,7 @@ func setHeadlineInFile(cwd, target, summary string, stdout io.Writer) error {
 			// A marker exists but couldn't be rewritten (unclosed/malformed) —
 			// don't stack a second one. logmind never writes such a marker, so
 			// this only fires on a hand-corrupted file.
-			fmt.Fprintln(stdout, "Branch file has a malformed timeline marker — fix it manually, then retry.")
+			q.fail("Branch file has a malformed timeline marker — fix it manually, then retry.\n")
 			return ErrSilent
 		}
 		// Markerless (pre-opt-in) branch file — insert a marker now.
@@ -130,15 +140,23 @@ func setHeadlineInFile(cwd, target, summary string, stdout io.Writer) error {
 	}
 	rel := relForOk(cwd, target)
 	if updated == content {
-		fmt.Fprintln(stdout, "  branch summary already up to date")
-		fmt.Fprintf(stdout, "ok headline: %s (unchanged)\n", rel)
+		q.chat("  branch summary already up to date\n")
+		if q.quiet {
+			q.ok("headline path=%s state=unchanged", rel)
+		} else {
+			fmt.Fprintf(q.stdout, "ok headline: %s (unchanged)\n", rel)
+		}
 		return nil
 	}
 	if err := writeAtomic(target, updated); err != nil {
 		return fmt.Errorf("write %s: %w", target, err)
 	}
-	fmt.Fprintf(stdout, "✓ Branch summary set: %s\n", summary)
-	fmt.Fprintf(stdout, "ok headline: %s\n", rel)
+	q.chat("✓ Branch summary set: %s\n", summary)
+	if q.quiet {
+		q.ok("headline path=%s state=set", rel)
+	} else {
+		fmt.Fprintf(q.stdout, "ok headline: %s\n", rel)
+	}
 	return nil
 }
 

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -159,7 +159,7 @@ Example:
 			if err != nil {
 				return err
 			}
-			return runLog(cwd, args[0], f, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runLog(cwd, args[0], f, quietEnabled(cmd), cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().StringVarP(&f.reasoning, "reasoning", "r", "",
@@ -185,15 +185,16 @@ Example:
 //
 // Returns nil on success, ErrSilent for user-facing errors already
 // printed to stdout, or a regular error for plumbing failures.
-func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io.Writer) error {
+func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
 	docsPath := filepath.Join(cwd, "docs")
 	if !pathExists(docsPath) {
-		fmt.Fprintln(stdout, "Error: docs/ directory not found. Run 'logmind init' first.")
+		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
 		return ErrSilent
 	}
 
 	if strings.TrimSpace(summary) == "" {
-		fmt.Fprintln(stdout, "Error: decision summary is empty.")
+		q.fail("Error: decision summary is empty.\n")
 		return ErrSilent
 	}
 
@@ -201,7 +202,7 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 	// Python click.Choice behavior: print the actual user input + the
 	// allowed set so a typo is easy to fix.
 	if f.stage != "all" && f.stage != "scoped" {
-		fmt.Fprintf(stdout, "Error: invalid --stage %q (allowed: all, scoped).\n", f.stage)
+		q.fail("Error: invalid --stage %q (allowed: all, scoped).\n", f.stage)
 		return ErrSilent
 	}
 
@@ -290,14 +291,15 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 		relTarget = target
 	}
 	relTarget = filepath.ToSlash(relTarget)
-	fmt.Fprintf(stdout, "✓ Logged decision to %s\n", relTarget)
+	q.chat("✓ Logged decision to %s\n", relTarget)
 
 	// Branch-summary nudge — steer the author toward a clean one-sentence
 	// summary of the WHOLE branch (the timeline headline the next agent reads).
 	// Skipped when --headline was just set (already current). Runs BEFORE the
 	// commit so a TTY edit lands in the same commit. Gated to a main-canonical
-	// branch file. Best-effort: never fails the log.
-	if isBranchFile && cfg.Timeline.IsMainCanonical() && f.headline == "" {
+	// branch file. Best-effort: never fails the log. Suppressed under QUIET —
+	// an agent that opted into terse output doesn't want the multi-line nudge.
+	if isBranchFile && cfg.Timeline.IsMainCanonical() && f.headline == "" && !quiet {
 		nudgeBranchSummary(target, f.noInteractive, stdin, stdout, stderr)
 	}
 
@@ -312,21 +314,29 @@ func runLog(cwd, summary string, f *logFlags, stdin io.Reader, stdout, stderr io
 			fmt.Fprintf(stderr, "Warning: auto-commit failed: %v\n", err)
 		} else {
 			committed = true
-			fmt.Fprintln(stdout, "✓ Committed decision")
+			q.chat("✓ Committed decision\n")
 		}
 	} else if !f.noCommit {
 		fmt.Fprintln(stderr, "Warning: not inside a git repo; skipping auto-commit.")
 	}
-	_ = committed // future use: gate the post-commit advisory message
 
 	// Layer 1 self-heal — runs whether we committed or not. The file is
 	// on disk either way, so a stale link introduced by this decision
-	// should surface immediately.
-	if err := runSelfHealLayer1(cwd, f.noInteractive, stdin, stdout, stderr); err != nil {
+	// should surface immediately. Under QUIET the advisory is routed to
+	// stderr (never onto the single-ok-line stdout) and the prompt is
+	// skipped.
+	if err := runSelfHealLayer1(cwd, f.noInteractive, quiet, stdin, stdout, stderr); err != nil {
 		// runSelfHealLayer1 returns ErrSilent on user abort (`q` reply)
 		// or three failed retries. Propagate so the CLI exits non-zero
 		// and the agent sees the abort signal.
 		return err
+	}
+
+	// QUIET receipt — the single chainable summary line. Default mode keeps
+	// its historical multi-line ✓ output (no `ok` trailer) for byte parity;
+	// this line is the quiet MODE's sole stdout output.
+	if quiet {
+		q.ok("logged path=%s committed=%t", relTarget, committed)
 	}
 	return nil
 }
@@ -563,7 +573,7 @@ func commitDecision(cwd, targetAbs, targetRel, stage, summary string, cfg config
 //	    → fix: ...
 //	Fix the issues above, then reply [y] to re-check, [n] to skip, [q] to abort:
 //	>
-func runSelfHealLayer1(cwd string, forceNonInteractive bool, stdin io.Reader, stdout, stderr io.Writer) error {
+func runSelfHealLayer1(cwd string, forceNonInteractive, quiet bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	report, err := linkcheck.CheckWithReport(cwd, nil, nil)
 	if err != nil {
 		// Linkcheck plumbing failure isn't a self-heal-able error;
@@ -572,6 +582,15 @@ func runSelfHealLayer1(cwd string, forceNonInteractive bool, stdin io.Reader, st
 		return nil
 	}
 	if !report.HasIssues() {
+		return nil
+	}
+
+	// QUIET: the link advisory is a recovery hint, not chatter — emit it to
+	// stderr (never onto the single-ok-line stdout) and skip the prompt. The
+	// decision is saved; CI's Layer 3 will catch any leftover issues.
+	if quiet {
+		printAdvisory(stderr, report)
+		fmt.Fprintln(stderr, "Non-interactive/quiet context — decision is saved but docs may be stale.")
 		return nil
 	}
 

--- a/internal/cli/quiet.go
+++ b/internal/cli/quiet.go
@@ -1,0 +1,113 @@
+// quiet.go — the LOGMIND_QUIET output discipline (token-killer Phase 1b).
+//
+// Borrowed from clud-bug's proven CLI pattern (CLUD_BUG_QUIET): an agent
+// that invokes a verb wants ONE chainable, machine-parseable line — not a
+// paragraph of ✓-progress chatter it has to pay tokens to read and skip.
+//
+// Under QUIET (the `--quiet` persistent root flag OR LOGMIND_QUIET in the
+// environment) each wired verb:
+//
+//   - SUPPRESSES its progress/chatter lines (the ✓ / "already up to date"
+//     lines) — chat().
+//   - Emits EXACTLY ONE chainable `ok <k=v ...>` summary line to stdout —
+//     ok().
+//   - Routes errors + recovery hints to stderr, NEVER suppressed — fail()
+//     lands them on stderr under QUIET (clud-bug's own regression lesson:
+//     a quiet mode that swallows errors is worse than useless).
+//
+// QUIET is strictly OPT-IN. The default (no flag, no env) path keeps every
+// byte of the historical output — chat(), fail(), and the legacy `ok`
+// trailers all write to stdout exactly as before — so the timeline / tree /
+// cli goldens stay green. The quiet MODE is additive; it never rewrites the
+// default MODE.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// quietEnvVar is the environment opt-in, the output-side twin of clud-bug's
+// CLUD_BUG_QUIET. Any non-empty value other than a falsey word enables it,
+// so `LOGMIND_QUIET=1` (the documented form) and `LOGMIND_QUIET=true` both
+// work while `LOGMIND_QUIET=0` / unset stay in the byte-stable default.
+const quietEnvVar = "LOGMIND_QUIET"
+
+// quietFlagName is the persistent root flag registered in root.go.
+const quietFlagName = "quiet"
+
+// quietEnabled reports whether QUIET output discipline is active for this
+// invocation: the persistent --quiet flag (inherited by every subcommand)
+// OR LOGMIND_QUIET in the environment. Opt-in only.
+func quietEnabled(cmd *cobra.Command) bool {
+	if cmd != nil {
+		if f := cmd.Flags().Lookup(quietFlagName); f != nil {
+			if b, err := cmd.Flags().GetBool(quietFlagName); err == nil && b {
+				return true
+			}
+		}
+	}
+	return quietEnvSet()
+}
+
+// quietEnvSet reads LOGMIND_QUIET and reports whether it opts in. Falsey
+// words ("", "0", "false", "no", "off") stay in the default; anything else
+// enables quiet.
+func quietEnvSet() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(quietEnvVar))) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// qout bundles a verb's stdout + stderr with the resolved quiet flag and
+// gives every wired verb one uniform way to emit the three output classes.
+// Threaded in place of raw io.Writer pairs so the quiet/non-quiet split
+// lives in one place instead of being re-derived at each call.
+type qout struct {
+	stdout io.Writer
+	stderr io.Writer
+	quiet  bool
+}
+
+// newQout builds the writer bundle for a verb.
+func newQout(quiet bool, stdout, stderr io.Writer) qout {
+	return qout{stdout: stdout, stderr: stderr, quiet: quiet}
+}
+
+// chat writes a human-facing progress/chatter line to stdout. Suppressed
+// entirely under QUIET (that is the whole point); in the default mode it is
+// a plain Fprintf to stdout, so byte-parity holds.
+func (q qout) chat(format string, a ...any) {
+	if q.quiet {
+		return
+	}
+	fmt.Fprintf(q.stdout, format, a...)
+}
+
+// ok writes the single chainable `ok <k=v ...>` summary line to stdout. The
+// caller passes the trailer WITHOUT the leading "ok " and WITHOUT the
+// newline. Always emitted — it is the machine receipt an agent chains on.
+func (q qout) ok(format string, a ...any) {
+	fmt.Fprintf(q.stdout, "ok "+format+"\n", a...)
+}
+
+// fail writes a user-facing error/diagnostic line. In the default mode it
+// preserves the historical stdout destination (several logmind verbs print
+// their "Error: …" diagnostics to stdout — matching the Python CLI — and
+// the goldens/tests pin that). Under QUIET it routes to stderr instead, so
+// quiet stdout carries ONLY the ok summary (or nothing, on error) and the
+// diagnostic is never swallowed.
+func (q qout) fail(format string, a ...any) {
+	w := q.stdout
+	if q.quiet {
+		w = q.stderr
+	}
+	fmt.Fprintf(w, format, a...)
+}

--- a/internal/cli/quiet.go
+++ b/internal/cli/quiet.go
@@ -43,11 +43,22 @@ const quietFlagName = "quiet"
 // quietEnabled reports whether QUIET output discipline is active for this
 // invocation: the persistent --quiet flag (inherited by every subcommand)
 // OR LOGMIND_QUIET in the environment. Opt-in only.
+//
+// Precedence: an EXPLICIT flag on the command line wins over the env var
+// (standard 12-factor precedence — explicit flag > environment). So
+// `--quiet=false` deliberately turns quiet OFF even when LOGMIND_QUIET=1,
+// and `--quiet` turns it ON regardless of the env. The env var only decides
+// when the flag was not passed at all.
 func quietEnabled(cmd *cobra.Command) bool {
 	if cmd != nil {
 		if f := cmd.Flags().Lookup(quietFlagName); f != nil {
-			if b, err := cmd.Flags().GetBool(quietFlagName); err == nil && b {
-				return true
+			if b, err := cmd.Flags().GetBool(quietFlagName); err == nil {
+				if f.Changed {
+					return b
+				}
+				if b {
+					return true
+				}
 			}
 		}
 	}

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -1,0 +1,232 @@
+// quiet_test.go — the LOGMIND_QUIET output discipline (token-killer Phase 1b).
+//
+// Per wired verb we assert the three invariants:
+//
+//   - QUIET emits EXACTLY ONE `ok <k=v>` line to stdout and suppresses the
+//     ✓-progress chatter / rendered body.
+//   - Errors still land on stderr under QUIET (never swallowed).
+//   - The DEFAULT (non-quiet) path is unchanged — the legacy trailer + body
+//     are still there. (The timeline/tree/cli goldens are the byte-parity
+//     guard; these are belt-and-suspenders contrast checks.)
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// assertSingleOK checks that out is exactly one line, an `ok ` receipt whose
+// trailer contains each wanted key=value token.
+func assertSingleOK(t *testing.T, out string, wantTokens ...string) {
+	t.Helper()
+	trimmed := strings.TrimRight(out, "\n")
+	if strings.Contains(trimmed, "\n") {
+		t.Fatalf("quiet stdout has >1 line:\n%q", out)
+	}
+	if !strings.HasPrefix(trimmed, "ok ") {
+		t.Fatalf("quiet stdout is not an `ok` line: %q", out)
+	}
+	for _, tok := range wantTokens {
+		if !strings.Contains(trimmed, tok) {
+			t.Errorf("quiet ok line %q missing token %q", trimmed, tok)
+		}
+	}
+}
+
+func TestQuietEnvSet(t *testing.T) {
+	cases := map[string]bool{
+		"1": true, "true": true, "TRUE": true, "yes": true, "on": true, "anything": true,
+		"": false, "0": false, "false": false, "no": false, "off": false, "  ": false,
+	}
+	for v, want := range cases {
+		t.Setenv(quietEnvVar, v)
+		if got := quietEnvSet(); got != want {
+			t.Errorf("quietEnvSet(%q) = %v; want %v", v, got, want)
+		}
+	}
+}
+
+func TestQuiet_Timeline_StdoutSingleOK(t *testing.T) {
+	cwd := makeDocs(t,
+		"## 2026-06-04 14:00 - Newest\n## 2026-06-01 08:00 - Oldest\n", "", nil)
+	var out, errBuf bytes.Buffer
+	if err := runTimeline(cwd, "", false, false, true, &out, &errBuf); err != nil {
+		t.Fatalf("runTimeline quiet: %v", err)
+	}
+	assertSingleOK(t, out.String(), "timeline", "bytes=", "mode=brief")
+	if strings.Contains(out.String(), "Newest") || strings.Contains(out.String(), "✓") {
+		t.Errorf("quiet stdout leaked the rendered body / chatter: %q", out.String())
+	}
+}
+
+func TestQuiet_Timeline_DefaultUnchanged(t *testing.T) {
+	cwd := makeDocs(t,
+		"## 2026-06-04 14:00 - Newest\n## 2026-06-01 08:00 - Oldest\n", "", nil)
+	var out, errBuf bytes.Buffer
+	if err := runTimeline(cwd, "", false, false, false, &out, &errBuf); err != nil {
+		t.Fatalf("runTimeline default: %v", err)
+	}
+	// Default mode keeps the legacy trailer AND the rendered body.
+	if !strings.Contains(out.String(), "ok timeline: ") {
+		t.Errorf("default mode dropped the legacy `ok timeline:` trailer: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "Newest") {
+		t.Errorf("default mode dropped the rendered body: %q", out.String())
+	}
+}
+
+func TestQuiet_Timeline_ErrorToStderr(t *testing.T) {
+	cwd := t.TempDir() // no docs/
+	var out, errBuf bytes.Buffer
+	if err := runTimeline(cwd, "", false, false, true, &out, &errBuf); err == nil {
+		t.Fatal("expected ErrSilent when docs/ missing")
+	}
+	if out.Len() != 0 {
+		t.Errorf("quiet error path wrote to stdout: %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "Error: docs/ directory not found") {
+		t.Errorf("error not routed to stderr under quiet: %q", errBuf.String())
+	}
+}
+
+func TestQuiet_FileStructure_StdoutSingleOK(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	if err := runFileStructure(cwd, "", false, 2, true, &out, &errBuf); err != nil {
+		t.Fatalf("runFileStructure quiet: %v", err)
+	}
+	assertSingleOK(t, out.String(), "file-structure", "bytes=", "depth=2")
+}
+
+func TestQuiet_FileStructure_DefaultUnchanged(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	if err := runFileStructure(cwd, "", false, 2, false, &out, &errBuf); err != nil {
+		t.Fatalf("runFileStructure default: %v", err)
+	}
+	if !strings.Contains(out.String(), "ok file-structure: ") {
+		t.Errorf("default mode dropped the legacy trailer: %q", out.String())
+	}
+}
+
+func TestQuiet_Headline_SkippedSingleOK(t *testing.T) {
+	cwd := t.TempDir() // no main-canonical config
+	var out, errBuf bytes.Buffer
+	if err := runHeadline(cwd, "A summary", "", true, &out, &errBuf); err != nil {
+		t.Fatalf("runHeadline quiet: %v", err)
+	}
+	assertSingleOK(t, out.String(), "headline", "state=skipped", "reason=not-main-canonical")
+}
+
+func TestQuiet_Headline_DefaultUnchanged(t *testing.T) {
+	cwd := t.TempDir()
+	var out, errBuf bytes.Buffer
+	if err := runHeadline(cwd, "A summary", "", false, &out, &errBuf); err != nil {
+		t.Fatalf("runHeadline default: %v", err)
+	}
+	if strings.Contains(out.String(), "ok ") {
+		t.Errorf("default mode emitted an ok line it never had before: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "main-canonical-timeline feature") {
+		t.Errorf("default mode dropped its guidance line: %q", out.String())
+	}
+}
+
+func TestQuiet_Headline_SetSingleOK(t *testing.T) {
+	cwd := t.TempDir()
+	branchDir := filepath.Join(cwd, "docs", "decisions-branches")
+	if err := os.MkdirAll(branchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(branchDir, "feat__x.md")
+	// Markerless branch file → setHeadlineInFile inserts a marker (state=set).
+	if err := os.WriteFile(target, []byte("## 2026-07-01 10:00 - First\n\n---\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	q := newQout(true, &out, &errBuf)
+	if err := setHeadlineInFile(cwd, target, "Whole-branch summary", q); err != nil {
+		t.Fatalf("setHeadlineInFile quiet: %v", err)
+	}
+	assertSingleOK(t, out.String(), "headline", "state=set", "docs/decisions-branches/feat__x.md")
+	if strings.Contains(out.String(), "✓") {
+		t.Errorf("quiet leaked the ✓ chatter: %q", out.String())
+	}
+}
+
+func TestQuiet_Doctor_ReportSingleOK(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--quiet", "--offline", "--exit-zero"})
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor quiet: %v\n%s", err, errBuf.String())
+		}
+		assertSingleOK(t, out.String(), "doctor", "overall=", "drift=")
+		if strings.Contains(out.String(), "Stack status:") {
+			t.Errorf("quiet doctor leaked the human table: %q", out.String())
+		}
+	})
+}
+
+func TestQuiet_Doctor_EnvVarEnables(t *testing.T) {
+	t.Setenv(quietEnvVar, "1")
+	withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline", "--exit-zero"})
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor env-quiet: %v\n%s", err, errBuf.String())
+		}
+		assertSingleOK(t, out.String(), "doctor", "overall=")
+	})
+}
+
+func TestQuiet_Log_SingleOK(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "Quiet decision", "-r", "Why", "--quiet", "--no-commit"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log quiet: %v\n%s", err, errBuf.String())
+			}
+			assertSingleOK(t, out.String(), "logged", "path=docs/decisions.md", "committed=false")
+			if strings.Contains(out.String(), "✓ Logged") {
+				t.Errorf("quiet log leaked the ✓ chatter to stdout: %q", out.String())
+			}
+		})
+	})
+}
+
+func TestQuiet_Log_ErrorToStderr(t *testing.T) {
+	cwd := t.TempDir() // no docs/ → error path
+	f := &logFlags{stage: "all"}
+	var out, errBuf bytes.Buffer
+	if err := runLog(cwd, "x", f, true, strings.NewReader(""), &out, &errBuf); err == nil {
+		t.Fatal("expected ErrSilent when docs/ missing")
+	}
+	if out.Len() != 0 {
+		t.Errorf("quiet log error path wrote to stdout: %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "Error: docs/ directory not found") {
+		t.Errorf("error not routed to stderr under quiet: %q", errBuf.String())
+	}
+}

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // assertSingleOK checks that out is exactly one line, an `ok ` receipt whose
@@ -46,6 +48,37 @@ func TestQuietEnvSet(t *testing.T) {
 		if got := quietEnvSet(); got != want {
 			t.Errorf("quietEnvSet(%q) = %v; want %v", v, got, want)
 		}
+	}
+}
+
+// TestQuietEnabled_ExplicitFlagBeatsEnv pins the precedence contract: an
+// explicit --quiet / --quiet=false on the command line wins over the
+// LOGMIND_QUIET env var; the env var only decides when the flag is absent.
+func TestQuietEnabled_ExplicitFlagBeatsEnv(t *testing.T) {
+	mk := func(args ...string) *cobra.Command {
+		c := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+		c.Flags().Bool(quietFlagName, false, "")
+		c.SetArgs(args)
+		if err := c.Execute(); err != nil {
+			t.Fatalf("parse %v: %v", args, err)
+		}
+		return c
+	}
+
+	t.Setenv(quietEnvVar, "1") // env says quiet ON
+	if quietEnabled(mk("--quiet=false")) {
+		t.Error("--quiet=false must override LOGMIND_QUIET=1 (explicit flag wins)")
+	}
+	if !quietEnabled(mk()) {
+		t.Error("LOGMIND_QUIET=1 with no flag should enable quiet")
+	}
+
+	t.Setenv(quietEnvVar, "0") // env says quiet OFF
+	if !quietEnabled(mk("--quiet")) {
+		t.Error("--quiet should enable quiet even with LOGMIND_QUIET=0")
+	}
+	if quietEnabled(mk()) {
+		t.Error("no flag + env off should be the default (non-quiet)")
 	}
 }
 
@@ -160,6 +193,36 @@ func TestQuiet_Headline_SetSingleOK(t *testing.T) {
 	assertSingleOK(t, out.String(), "headline", "state=set", "docs/decisions-branches/feat__x.md")
 	if strings.Contains(out.String(), "✓") {
 		t.Errorf("quiet leaked the ✓ chatter: %q", out.String())
+	}
+}
+
+// TestQuiet_Headline_SetDefaultReceipt closes the default-mode coverage gap:
+// on the headline SET path, default (non-quiet) stdout must carry the legacy
+// ✓ receipt + the `ok headline: <rel>` trailer, and NOT the quiet k=v form.
+func TestQuiet_Headline_SetDefaultReceipt(t *testing.T) {
+	cwd := t.TempDir()
+	branchDir := filepath.Join(cwd, "docs", "decisions-branches")
+	if err := os.MkdirAll(branchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(branchDir, "feat__x.md")
+	if err := os.WriteFile(target, []byte("## 2026-07-01 10:00 - First\n\n---\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	q := newQout(false, &out, &errBuf) // DEFAULT (non-quiet)
+	if err := setHeadlineInFile(cwd, target, "Whole-branch summary", q); err != nil {
+		t.Fatalf("setHeadlineInFile default: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "✓ Branch summary set: Whole-branch summary") {
+		t.Errorf("default mode dropped the ✓ receipt: %q", s)
+	}
+	if !strings.Contains(s, "ok headline: docs/decisions-branches/feat__x.md") {
+		t.Errorf("default mode dropped the legacy `ok headline:` trailer: %q", s)
+	}
+	if strings.Contains(s, "state=set") {
+		t.Errorf("default mode leaked the quiet k=v form: %q", s)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,14 @@ func NewRootCmd() *cobra.Command {
 		SilenceErrors: true,
 	}
 
+	// Persistent --quiet flag (token-killer Phase 1b). Inherited by every
+	// subcommand; wired verbs (log, timeline, file-structure, doctor,
+	// headline) then suppress progress chatter and emit a single chainable
+	// `ok <k=v>` line. Opt-in twin of the LOGMIND_QUIET env var — the default
+	// (unset) path stays byte-identical. See quiet.go.
+	root.PersistentFlags().Bool(quietFlagName, false,
+		"Terse machine output: suppress progress chatter, emit one chainable `ok <k=v>` line per verb (env: LOGMIND_QUIET=1). Errors still go to stderr.")
+
 	root.AddCommand(newVersionCmd())
 	// B2: git integration + hooks subcommands.
 	root.AddCommand(newInstallHookCmd())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,8 +53,11 @@ func NewRootCmd() *cobra.Command {
 	// headline) then suppress progress chatter and emit a single chainable
 	// `ok <k=v>` line. Opt-in twin of the LOGMIND_QUIET env var — the default
 	// (unset) path stays byte-identical. See quiet.go.
+	// NB: no back-quotes in this usage string — pflag's UnquoteUsage treats a
+	// back-quoted span as the flag's value placeholder, which would make this
+	// boolean flag render misleadingly as `--quiet ok <k=v>` in --help.
 	root.PersistentFlags().Bool(quietFlagName, false,
-		"Terse machine output: suppress progress chatter, emit one chainable `ok <k=v>` line per verb (env: LOGMIND_QUIET=1). Errors still go to stderr.")
+		"Terse machine output: suppress progress chatter, emit one chainable 'ok <k=v>' line per verb (env: LOGMIND_QUIET=1). Errors still go to stderr.")
 
 	root.AddCommand(newVersionCmd())
 	// B2: git integration + hooks subcommands.

--- a/internal/cli/timeline.go
+++ b/internal/cli/timeline.go
@@ -48,7 +48,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			return runTimeline(cwd, writePath, check, full, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runTimeline(cwd, writePath, check, full, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().StringVar(&writePath, "write", "",
@@ -64,12 +64,14 @@ Examples:
 	return cmd
 }
 
-func runTimeline(cwd, writePath string, check, full bool, stdout, stderr io.Writer) error {
+func runTimeline(cwd, writePath string, check, full, quiet bool, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
 	docsPath := filepath.Join(cwd, "docs")
 	if !pathExists(docsPath) {
 		// Python: click.secho fg=red + sys.exit(1). secho defaults to
-		// stdout — we match. Then ErrSilent triggers exit 1.
-		fmt.Fprintln(stdout, "Error: docs/ directory not found. Run 'logmind init' first.")
+		// stdout — we match (quiet routes it to stderr). Then ErrSilent
+		// triggers exit 1.
+		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
 		return ErrSilent
 	}
 	brief := !full
@@ -89,8 +91,8 @@ func runTimeline(cwd, writePath string, check, full bool, stdout, stderr io.Writ
 		if writePath == "" {
 			// Python sys.exit(2); we exit 1 via ErrSilent. Stdout
 			// message is byte-identical so consumers see the same
-			// diagnostic.
-			fmt.Fprintln(stdout, "Error: --check requires --write PATH to compare against.")
+			// diagnostic (quiet routes it to stderr).
+			q.fail("Error: --check requires --write PATH to compare against.\n")
 			return ErrSilent
 		}
 		rendered, err := timeline.GenerateFor(docsPath, brief, canonical, stderr)
@@ -99,11 +101,15 @@ func runTimeline(cwd, writePath string, check, full bool, stdout, stderr io.Writ
 		}
 		existing, _ := os.ReadFile(writePath)
 		if string(existing) != rendered {
-			fmt.Fprintf(stdout, "✗ %s is stale — re-run `logmind timeline --write %s` and commit.\n", writePath, writePath)
+			q.fail("✗ %s is stale — re-run `logmind timeline --write %s` and commit.\n", writePath, writePath)
 			return ErrSilent
 		}
-		fmt.Fprintf(stdout, "✓ %s is up to date\n", writePath)
-		fmt.Fprintf(stdout, "ok timeline: %s up to date\n", writePath)
+		q.chat("✓ %s is up to date\n", writePath)
+		if quiet {
+			q.ok("timeline path=%s mode=%s state=up-to-date", writePath, mode)
+		} else {
+			fmt.Fprintf(stdout, "ok timeline: %s up to date\n", writePath)
+		}
 		return nil
 	}
 
@@ -112,15 +118,22 @@ func runTimeline(cwd, writePath string, check, full bool, stdout, stderr io.Writ
 		if err != nil {
 			return err
 		}
-		// Python: _orig_click_echo(rendered, nl=False) — no trailing
-		// newline added beyond what render produces. Render already
-		// ends with `\n`, so the next-line ok still starts on its own
-		// line.
-		fmt.Fprint(stdout, rendered)
-		// utf-8 byte count. Python uses len(rendered.encode('utf-8'))
-		// for the same reason — em-dashes/non-ASCII would otherwise
-		// undercount. Go strings ARE UTF-8 bytes, so len() works.
-		fmt.Fprintf(stdout, "ok timeline: %d bytes (stdout, %s)\n", len(rendered), mode)
+		// Default mode prints the rendered timeline itself (the payload the
+		// agent asked for) then the trailer. Quiet mode suppresses the body
+		// — an agent that opted into quiet wants only the receipt.
+		if !quiet {
+			// Python: _orig_click_echo(rendered, nl=False) — no trailing
+			// newline added beyond what render produces. Render already
+			// ends with `\n`, so the next-line ok still starts on its own
+			// line.
+			fmt.Fprint(stdout, rendered)
+			// utf-8 byte count. Python uses len(rendered.encode('utf-8'))
+			// for the same reason — em-dashes/non-ASCII would otherwise
+			// undercount. Go strings ARE UTF-8 bytes, so len() works.
+			fmt.Fprintf(stdout, "ok timeline: %d bytes (stdout, %s)\n", len(rendered), mode)
+		} else {
+			q.ok("timeline bytes=%d mode=%s sink=stdout", len(rendered), mode)
+		}
 		return nil
 	}
 
@@ -134,15 +147,19 @@ func runTimeline(cwd, writePath string, check, full bool, stdout, stderr io.Writ
 		if err := writeAtomic(writePath, rendered); err != nil {
 			return err
 		}
-		fmt.Fprintf(stdout, "✓ Regenerated %s\n", writePath)
+		q.chat("✓ Regenerated %s\n", writePath)
 	} else {
-		fmt.Fprintf(stdout, "  %s already up to date\n", writePath)
+		q.chat("  %s already up to date\n", writePath)
 	}
 	st, err := os.Stat(writePath)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "ok timeline: %s (%d bytes, %s)\n", writePath, st.Size(), mode)
+	if quiet {
+		q.ok("timeline path=%s bytes=%d mode=%s changed=%t", writePath, st.Size(), mode, changed)
+	} else {
+		fmt.Fprintf(stdout, "ok timeline: %s (%d bytes, %s)\n", writePath, st.Size(), mode)
+	}
 	return nil
 }
 

--- a/internal/cli/timeline_test.go
+++ b/internal/cli/timeline_test.go
@@ -41,7 +41,7 @@ func makeDocs(t *testing.T, decisionsBody, archiveBody string, branchFiles map[s
 func TestTimelineNoDocs(t *testing.T) {
 	cwd := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	err := runTimeline(cwd, "", false, false, &stdout, &stderr)
+	err := runTimeline(cwd, "", false, false, false, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Fatalf("err = %v; want ErrSilent", err)
 	}
@@ -61,7 +61,7 @@ func TestTimelineStdoutBrief(t *testing.T) {
 		"", nil,
 	)
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, "", false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, "", false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	compareCLI(t, "timeline_stdout_brief.golden", stdout.String())
@@ -77,7 +77,7 @@ func TestTimelineStdoutFull(t *testing.T) {
 		"", nil,
 	)
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, "", false, true, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, "", false, true, false, &stdout, &stderr); err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	compareCLI(t, "timeline_stdout_full.golden", stdout.String())
@@ -92,7 +92,7 @@ func TestTimelineWriteFresh(t *testing.T) {
 	)
 	target := filepath.Join(cwd, "docs", "timeline.md")
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, target, false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("err = %v", err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("✓ Regenerated")) {
@@ -108,12 +108,12 @@ func TestTimelineWriteIdempotent(t *testing.T) {
 	cwd := makeDocs(t, "## 2026-06-01 10:00 - One\n", "", nil)
 	target := filepath.Join(cwd, "docs", "timeline.md")
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, target, false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("first run: %v", err)
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if err := runTimeline(cwd, target, false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("second run: %v", err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("already up to date")) {
@@ -127,12 +127,12 @@ func TestTimelineCheckClean(t *testing.T) {
 	target := filepath.Join(cwd, "docs", "timeline.md")
 	// Seed the file by writing it first.
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, target, false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("seed write: %v", err)
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if err := runTimeline(cwd, target, true, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, true, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("check err = %v", err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("is up to date")) {
@@ -149,7 +149,7 @@ func TestTimelineCheckStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	err := runTimeline(cwd, target, true, false, &stdout, &stderr)
+	err := runTimeline(cwd, target, true, false, false, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Errorf("stale check err = %v; want ErrSilent", err)
 	}
@@ -162,7 +162,7 @@ func TestTimelineCheckStale(t *testing.T) {
 func TestTimelineCheckRequiresWrite(t *testing.T) {
 	cwd := makeDocs(t, "## 2026-06-01 10:00 - One\n", "", nil)
 	var stdout, stderr bytes.Buffer
-	err := runTimeline(cwd, "", true, false, &stdout, &stderr)
+	err := runTimeline(cwd, "", true, false, false, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Errorf("err = %v; want ErrSilent", err)
 	}
@@ -190,7 +190,7 @@ func TestTimelineMainCanonicalDispatch(t *testing.T) {
 	target := filepath.Join(cwd, "docs", "timeline.md")
 
 	var stdout, stderr bytes.Buffer
-	if err := runTimeline(cwd, target, false, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, false, false, false, &stdout, &stderr); err != nil {
 		t.Fatalf("write: %v (%s)", err, stderr.String())
 	}
 	got, _ := os.ReadFile(target)
@@ -200,7 +200,7 @@ func TestTimelineMainCanonicalDispatch(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	if err := runTimeline(cwd, target, true, false, &stdout, &stderr); err != nil {
+	if err := runTimeline(cwd, target, true, false, false, &stdout, &stderr); err != nil {
 		t.Errorf("--check after a main-canonical write reported stale: %v\n%s", err, stdout.String())
 	}
 }

--- a/internal/templates/AGENTS.md.template
+++ b/internal/templates/AGENTS.md.template
@@ -103,6 +103,9 @@ logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
 ```
 
+Working as an agent? Set `LOGMIND_QUIET=1` for terse, chainable machine output:
+each verb suppresses progress chatter and prints a single `ok <key=value>` line.
+
 Reading prior decisions first prevents you from re-litigating something
 the team already decided.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -66,6 +66,9 @@ logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
 ```
 
+As an agent, set `LOGMIND_QUIET=1` for terse, chainable machine output: each
+verb suppresses progress chatter and prints a single `ok <key=value>` line.
+
 ## Setup (one-time, per project)
 
 If the project doesn't yet have logmind:


### PR DESCRIPTION
## token-killer Phase 1b — the `LOGMIND_QUIET` output discipline

Borrows clud-bug's proven output-side token-saver (`CLUD_BUG_QUIET`). Under
`LOGMIND_QUIET=1` (env) **OR** the new persistent `--quiet` root flag, each
wired verb suppresses its progress/`✓`-chatter and emits **exactly one**
chainable `ok <key=value>` line to stdout. Errors + recovery hints always go
to **stderr** and are never suppressed (clud-bug's own regression lesson).

### Wired verbs (highest-traffic agent surface)

| verb | quiet receipt |
|------|----------------|
| `log` | `ok logged path=<rel> committed=<bool>` |
| `timeline` | `ok timeline path=… bytes=… mode=… changed=…` (and stdout/`--check` variants) |
| `file-structure` | `ok file-structure path=… bytes=… depth=N changed=…` |
| `doctor` | `ok doctor overall=<OK\|DRIFT> drift=N` |
| `headline` | `ok headline path=… state=<set\|unchanged\|skipped> …` |

### How it works

- New `internal/cli/quiet.go`: a QUIET detector (`quietEnabled` = flag OR env)
  plus a small `qout` writer bundle with `chat()` (suppressed under quiet),
  `ok()` (the single chainable line), and `fail()` (errors — stdout in default
  mode for byte-parity, stderr under quiet).
- Persistent `--quiet` flag registered on the root command.
- `doctor --fix` was already quiet-shaped (one `ok doctor-fix …` line + stderr
  notes) so its trailer is reused as-is.

### Byte-parity guardrail

QUIET is strictly **opt-in**. The default (no flag, no env) path is unchanged —
`chat`/`fail`/legacy `ok` trailers all still write to stdout exactly as before.
The `internal/timeline`, `internal/tree`, and `internal/cli` goldens pass
**unchanged**; `go build ./... && go test ./... && gofmt -l && go vet ./...`
are all clean.

### Tests

`internal/cli/quiet_test.go` — per wired verb: quiet emits exactly one
`ok <k=v>` line + suppresses chatter, errors still land on stderr, and a
default-mode contrast guard. Plus an env-var-enables case and the
`quietEnvSet` truth table.

### Docs

One-line hint seeded into `internal/templates/AGENTS.md.template` and
`skill/SKILL.md` (ungoverned-marker files — no block marker bumped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG
