### PR TITLE
feat(context): fold the repomap into logmind context behind context.repomap (R2)

### DIFF
--- a/docs/decisions-branches/feat__context-repomap.md
+++ b/docs/decisions-branches/feat__context-repomap.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-04 00:30 - context.repomap: fold the Go signature skeleton into logmind context (default off)
+
+**Reasoning:** Makes the repomap AUTOMATIC — an agent's cold-start context carries the repo's API surface with zero extra action (the built-in-token-saving thesis). Folded stable-first (file-structure -> repomap -> timeline) so the cache prefix stays byte-identical longest. Additive config key context.repomap via the file_structure.root_label recipe: default false -> payload byte-identical, OMITTED from DefaultMap (config-list byte-parity); the v1.0 flip turns it on.
+
+**Alternatives considered:** Write a committed docs/repomap.md derived doc + read it like the other two — rejected: adds another branch-divergent-churn source + hook/CI/doctor regen wiring. Chosen: generate in-memory in contextPayload (deterministic, cheap, no new committed file). contextDoc gains optional gen/enabled fields so contextDocs stays the single ordering authority.
+
+**Implications:**
+- New top-level 'context' config section (ContextConfig.Repomap); contextDoc gen/enabled fields + shared writeDoc helper; --stats gains a repomap term (density claimed only when genuinely denser, so toy repos don't print '0.6x'). Paired protocol 0.10.0 SPEC PR retro-specs logmind context + specs the repomap + the context.repomap key + §14.3 cross-link.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (17 decisions)
+## 2026-07 (18 decisions)
 
-- **2026-07-04** — repomap review fixes: valid inline-composite rendering + walk robustness *(feat/repomap-go-signatures)* — [decisions-branches/feat__repomap-go-signatures.md](decisions-branches/feat__repomap-go-signatures.md)
-- *... 15 more decisions ...*
+- **2026-07-04** — context.repomap: fold the Go signature skeleton into logmind context (default off) *(feat/context-repomap)* — [decisions-branches/feat__context-repomap.md](decisions-branches/feat__context-repomap.md)
+- *... 16 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/repomap"
 	"github.com/thrillmade/logmind/internal/tokens"
 )
 
@@ -59,6 +61,11 @@ so treat it as a cacheable PREFIX —
   - use the 1-hour TTL for multi-step / multi-agent sessions, and pre-warm it,
   - read it ONCE per task; byte-identical re-reads hit the cache at ~0.1x input.
 
+Set 'context.repomap: true' in .logmind/config.yml to also fold in the Go
+signature skeleton (see 'logmind repomap') as a third, stable document — the
+repo's API surface, placed between the file map and the timeline. Default off
+keeps the payload byte-identical.
+
 --stats prints a deterministic token receipt (est. ~4 chars/token) instead of
 the payload.`,
 		Args: cobra.NoArgs,
@@ -80,17 +87,38 @@ the payload.`,
 
 // contextDoc is one document in the cold-start payload.
 type contextDoc struct {
-	rel   string // repo-relative path to the derived doc
+	rel   string // repo-relative path to the derived doc (file-backed docs)
 	typ   string // <document type=…> — machine label
 	regen string // command to regenerate it when missing
+	// gen, when non-nil, produces the document body IN-MEMORY instead of
+	// reading `rel` off disk (e.g. the repomap skeleton). It returns the body
+	// and a source label; an empty body omits the document entirely.
+	gen func(cwd string, cfg config.Config) (body, source string)
+	// enabled, when non-nil, gates whether this doc participates. Used for
+	// opt-in additive docs so the default payload stays byte-stable. nil =
+	// always included.
+	enabled func(cfg config.Config) bool
 }
 
-// contextDocs is the ordered payload: the stable "what" (file-structure)
-// before the volatile "why" (newest-first timeline), so the cacheable prefix
-// stays byte-identical for as long as possible.
+// contextDocs is the ordered payload, most-stable first so the cacheable
+// prefix stays byte-identical for as long as possible: the file map (what) →
+// the repomap API surface (also stable; opt-in) → the volatile newest-first
+// timeline (why).
 var contextDocs = []contextDoc{
-	{"docs/file-structure.md", "file-structure", "logmind file-structure --write docs/file-structure.md"},
-	{"docs/timeline.md", "decision-timeline", "logmind timeline --write docs/timeline.md"},
+	{rel: "docs/file-structure.md", typ: "file-structure", regen: "logmind file-structure --write docs/file-structure.md"},
+	{typ: "repomap", gen: repomapDoc, enabled: func(c config.Config) bool { return c.Context.Repomap }},
+	{rel: "docs/timeline.md", typ: "decision-timeline", regen: "logmind timeline --write docs/timeline.md"},
+}
+
+// repomapDoc renders the Go signature skeleton for the context payload. An
+// empty result (no Go symbols, or an extraction error) omits the document — the
+// repomap is a convenience, never a gate.
+func repomapDoc(cwd string, cfg config.Config) (body, source string) {
+	text, files, err := repomap.Generate(cwd, cfg.FileStructure.IgnorePatterns)
+	if err != nil || len(files) == 0 {
+		return "", ""
+	}
+	return text, "logmind repomap"
 }
 
 const contextPreface = "Pre-baked repo cold-start context: the file map (what) + the decision " +
@@ -102,10 +130,22 @@ const contextPreface = "Pre-baked repo cold-start context: the file map (what) +
 // Deterministic by construction (fixed strings + on-disk doc bytes, stable
 // order) — the property prompt caching depends on.
 func contextPayload(cwd string) string {
+	cfg, _ := config.Load(cwd)
 	var b strings.Builder
 	b.WriteString(contextPreface)
 	b.WriteString("\n<repo_context>\n")
 	for _, d := range contextDocs {
+		if d.enabled != nil && !d.enabled(cfg) {
+			continue // opt-in additive doc, disabled → omit (default byte-stable)
+		}
+		if d.gen != nil {
+			body, source := d.gen(cwd, cfg)
+			if body == "" {
+				continue // nothing to contribute — omit cleanly
+			}
+			writeDoc(&b, d.typ, source, []byte(body))
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(cwd, d.rel))
 		if err != nil {
 			// A missing doc becomes a self-closing element carrying the
@@ -115,15 +155,22 @@ func contextPayload(cwd string) string {
 			fmt.Fprintf(&b, "<document type=%q source=%q status=\"absent\" regenerate=%q/>\n", d.typ, d.rel, d.regen)
 			continue
 		}
-		fmt.Fprintf(&b, "<document type=%q>\n<source>%s</source>\n<document_content>\n", d.typ, d.rel)
-		b.Write(data)
-		if n := len(data); n == 0 || data[n-1] != '\n' {
-			b.WriteByte('\n')
-		}
-		b.WriteString("</document_content>\n</document>\n")
+		writeDoc(&b, d.typ, d.rel, data)
 	}
 	b.WriteString("</repo_context>\n")
 	return b.String()
+}
+
+// writeDoc emits one <document> envelope with a trailing-newline guarantee on
+// the body. Shared by the file-backed and generated doc paths so both render
+// byte-identically.
+func writeDoc(b *strings.Builder, typ, source string, data []byte) {
+	fmt.Fprintf(b, "<document type=%q>\n<source>%s</source>\n<document_content>\n", typ, source)
+	b.Write(data)
+	if n := len(data); n == 0 || data[n-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	b.WriteString("</document_content>\n</document>\n")
 }
 
 func runContext(cwd string, stdout io.Writer) error {
@@ -134,14 +181,39 @@ func runContext(cwd string, stdout io.Writer) error {
 // runContextStats prints a deterministic token receipt: the payload size and
 // how much denser the timeline is than the raw decision logs it distills.
 func runContextStats(cwd string, stdout io.Writer) error {
+	cfg, _ := config.Load(cwd)
 	payload := contextPayload(cwd)
 	fsTok := tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, "docs", "file-structure.md")))
 	tlTok := tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, "docs", "timeline.md")))
 	rawWhy := rawDecisionTokens(cwd)
 
 	fmt.Fprint(stdout, "logmind context — token receipt (est. ~4 chars/token, deterministic)\n\n")
-	fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + timeline %d + framing)\n",
-		tokens.Estimate(payload), fsTok, tlTok)
+
+	// The repomap term appears only when it is enabled AND has symbols to
+	// contribute (matching what contextPayload actually emits).
+	mapTok, rawGo := 0, 0
+	if cfg.Context.Repomap {
+		if mapText, files, err := repomap.Generate(cwd, cfg.FileStructure.IgnorePatterns); err == nil && len(files) > 0 {
+			mapTok = tokens.Estimate(mapText)
+			for _, f := range files {
+				rawGo += tokens.Estimate(ctxReadOrEmpty(filepath.Join(cwd, filepath.FromSlash(f.Path))))
+			}
+		}
+	}
+	if mapTok > 0 {
+		fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + repomap %d + timeline %d + framing)\n",
+			tokens.Estimate(payload), fsTok, mapTok, tlTok)
+	} else {
+		fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + timeline %d + framing)\n",
+			tokens.Estimate(payload), fsTok, tlTok)
+	}
+	// Only claim density when the skeleton is genuinely smaller than the source
+	// it summarizes — on a trivial repo the `# Repomap` framing can exceed a
+	// one-file source, and "0.6x denser" reads worse than saying nothing.
+	if mapTok > 0 && rawGo > mapTok {
+		fmt.Fprintf(stdout, "  the repomap distills %d tok of Go source -> %.1fx denser.\n",
+			rawGo, float64(rawGo)/float64(mapTok))
+	}
 	if rawWhy > 0 && tlTok > 0 {
 		fmt.Fprintf(stdout, "  the timeline distills %d tok of raw decision logs -> %.1fx denser.\n",
 			rawWhy, float64(rawWhy)/float64(tlTok))

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -88,3 +88,70 @@ func TestContext_Stats(t *testing.T) {
 		}
 	})
 }
+
+// TestContext_Repomap_DisabledByDefault: without the context.repomap opt-in,
+// the payload carries no repomap document (default stays byte-stable).
+func TestContext_Repomap_DisabledByDefault(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "FS\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		mustWriteUnder(t, d, "svc.go", "package p\nfunc Serve() error { return nil }\n")
+		s := runContextCapture(t)
+		if strings.Contains(s, `type="repomap"`) {
+			t.Errorf("repomap doc present without opt-in (breaks byte-parity):\n%s", s)
+		}
+	})
+}
+
+// TestContext_Repomap_Enabled_StableFirst: context.repomap:true folds the
+// signature skeleton in as a <document type="repomap"> placed stable-first
+// (after file-structure, before the volatile timeline).
+func TestContext_Repomap_Enabled_StableFirst(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "FS\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		mustWriteUnder(t, d, "svc.go", "package p\nfunc Serve() error { return nil }\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  repomap: true\n")
+		s := runContextCapture(t)
+		if !strings.Contains(s, `<document type="repomap">`) {
+			t.Fatalf("repomap doc missing when enabled:\n%s", s)
+		}
+		if !strings.Contains(s, "func Serve() error") {
+			t.Errorf("repomap body missing the signature:\n%s", s)
+		}
+		iFS := strings.Index(s, `type="file-structure"`)
+		iRM := strings.Index(s, `type="repomap"`)
+		iTL := strings.Index(s, `type="decision-timeline"`)
+		if !(iFS < iRM && iRM < iTL) {
+			t.Errorf("repomap not stable-first (fs=%d repomap=%d tl=%d):\n%s", iFS, iRM, iTL, s)
+		}
+	})
+}
+
+// TestContext_Repomap_EnabledNoGo_Omitted: enabled but no Go symbols → the
+// repomap document is omitted cleanly (never an empty envelope).
+func TestContext_Repomap_EnabledNoGo_Omitted(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "FS\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  repomap: true\n")
+		s := runContextCapture(t) // no .go files
+		if strings.Contains(s, `type="repomap"`) {
+			t.Errorf("empty repomap should be omitted, not an empty envelope:\n%s", s)
+		}
+	})
+}
+
+// TestContext_Repomap_Stats: --stats breaks out the repomap term when enabled.
+func TestContext_Repomap_Stats(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "docs/file-structure.md", "FS\n")
+		mustWriteUnder(t, d, "docs/timeline.md", "TL\n")
+		mustWriteUnder(t, d, "svc.go", "package p\nfunc Serve() error { return nil }\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  repomap: true\n")
+		s := runContextCapture(t, "--stats")
+		if !strings.Contains(s, "+ repomap ") {
+			t.Errorf("--stats missing the repomap term:\n%s", s)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,8 +39,11 @@ type Config struct {
 	FileStructure FileStructureConfig `yaml:"file_structure"`
 	// Timeline gates the §1.6.4 main-canonical timeline (Slice 2, 0.8.0).
 	// Additive: the default reproduces today's output byte-for-byte.
-	Timeline TimelineConfig  `yaml:"timeline"`
-	Agents   map[string]bool `yaml:"agents"`
+	Timeline TimelineConfig `yaml:"timeline"`
+	// Context gates what `logmind context` folds into the cold-start payload
+	// (token-killer). Additive: the default reproduces today's payload.
+	Context ContextConfig   `yaml:"context"`
+	Agents  map[string]bool `yaml:"agents"`
 	// CatalogTarget is the default `<owner>/<repo>` slug `logmind skill
 	// push` opens PRs against. Overrideable on the CLI via --catalog.
 	// Per plan §"Skill suggestion cycle §4" + §"Skill catalog
@@ -125,6 +128,16 @@ type TimelineConfig struct {
 	Canonical string `yaml:"canonical"`
 }
 
+// ContextConfig mirrors the `context:` section — knobs for the `logmind
+// context` cold-start payload (token-killer Phase 2).
+type ContextConfig struct {
+	// Repomap folds the Go signature skeleton (see internal/repomap) into the
+	// context payload as a third <document>, inserted stable-first (after the
+	// file tree, before the volatile timeline). Default false preserves the
+	// current two-doc payload byte-for-byte; the v1.0 flip turns it on.
+	Repomap bool `yaml:"repomap"`
+}
+
 // IsMainCanonical reports whether main-canonical timeline assembly is
 // enabled. Fail-safe: ONLY the exact string "main-canonical" qualifies, so
 // a typo, empty value, or future/unknown value can never silently flip the
@@ -172,6 +185,12 @@ func DefaultConfig() Config {
 		// would change `logmind config list` bytes and break Python parity.
 		Timeline: TimelineConfig{
 			Canonical: "branch-divergent",
+		},
+		// Context.Repomap default false → `logmind context` emits today's
+		// two-doc payload byte-for-byte. NOT added to DefaultMap (below); the
+		// v1.0 flip turns it on and surfaces it in `config list`.
+		Context: ContextConfig{
+			Repomap: false,
 		},
 		Agents: map[string]bool{
 			"claude":   true,

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -84,6 +84,9 @@ func TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity(t *testing.T) {
 	if _, ok := m.Get("timeline"); ok {
 		t.Errorf("DefaultMap contains `timeline` — breaks `config list` byte-parity")
 	}
+	if _, ok := m.Get("context"); ok {
+		t.Errorf("DefaultMap contains `context` — breaks `config list` byte-parity")
+	}
 	fs, ok := m.Get("file_structure")
 	if !ok {
 		t.Fatal("file_structure missing from DefaultMap")


### PR DESCRIPTION
## R2 — make the repomap AUTOMATIC (token-killer)

Folds the Go signature skeleton into `logmind context` so an agent's cold-start payload carries the repo's **API surface** with zero extra action — the "built-in, just happens" token-saving thesis.

### Behavior
- New additive config key **`context.repomap`** (bool, **default false**). Off → `context` emits today's two-doc payload **byte-for-byte** (no golden/test change). On → a third `<document type="repomap">` is inserted **stable-first**: after `file-structure` (stable), before the volatile newest-first `timeline`, so the cache prefix stays byte-identical longest.
- Generated **in-memory** (via `repomap.Generate`) — no new committed `docs/repomap.md`, so it adds no branch-divergent-churn source and needs no hook/CI/doctor wiring.
- `context --stats` gains a repomap term in the breakdown; the "Nx denser" line prints **only when genuinely denser** (a trivial one-file repo won't print "0.6x").
- Empty (no Go symbols) or extraction error → the document is omitted cleanly.

### Byte-parity (the invariant)
`context.repomap` follows the `file_structure.root_label` recipe: typed field, default off in `DefaultConfig()`, **omitted from `DefaultMap()`** (keeps `logmind config list` byte-stable), with an absence-assertion added to `TestDefaultMap_OmitsNewKeys...`. The v1.0 flip turns it on + surfaces it in `config list`.

### Files
`internal/config/config.go` (new `context` section + `ContextConfig.Repomap`), `internal/config/timeline_test.go` (absence assertion), `internal/cli/context.go` (`contextDoc` gains optional `gen`/`enabled`; `repomapDoc`; shared `writeDoc`; `--stats` term), `internal/cli/context_test.go` (4 new tests: disabled-by-default, enabled-stable-first, empty-omitted, stats).

### Paired SPEC PR
protocol → **0.10.0** (additive §8.3): retro-spec the never-spec'd `logmind context`, spec the repomap artifact + `logmind repomap`, add the `context.repomap` key to §1.2.1, cross-link §14.3.

Full suite green; default context tests unchanged.
