### PR TITLE
feat(repomap): importance ranking + --map-tokens budget packing (R3)

### DIFF
--- a/docs/decisions-branches/feat__repomap-rank-budget.md
+++ b/docs/decisions-branches/feat__repomap-rank-budget.md
@@ -11,3 +11,14 @@
 
 ---
 
+## 2026-07-04 01:06 - R3 review fixes: §14.5 never-worse passthrough + ranking-signal robustness
+
+**Reasoning:** Dual review (adversarial + clud-bug-lens) found a BLOCKER: the ~47-byte truncation marker can exceed a few small omitted blocks, making the packed render LARGER than the full one (worse AND lossy) — a §14.5 violation. Fixed via passthrough in GenerateBudget (emit the full map when packing fails to shrink it). Plus 2 ranking MINORs: decision-link used strings.Contains so 'a.go' matched inside 'data.go' (false boost); go.mod 'module x // comment' glued the comment onto the module path, zeroing all fan-in.
+
+**Alternatives considered:** Account for the marker size inside Pack (rejected — passthrough IS the §14.5 'on doubt, passthrough' rule, cleaner). Require decision-link paths to contain '/' (rejected — misses root-level files; the boundary-aware match is correct). 
+
+**Implications:**
+- Budgeting never enlarges the output (verified empirically: tiny repo passes through at every sub-full budget). Ranking is robust to substring false-positives (new mentionsPath boundary check) and vanity-import go.mod (strings.Fields). Regression tests for all three; the never-worse guarantee doc moved from Pack to GenerateBudget.
+
+---
+

--- a/docs/decisions-branches/feat__repomap-rank-budget.md
+++ b/docs/decisions-branches/feat__repomap-rank-budget.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-04 00:53 - repomap ranking + --map-tokens budget packing (token-killer R3)
+
+**Reasoning:** With a token budget the map can't carry every file, so it must carry the MOST IMPORTANT first. Deterministic ranking (the caching invariant): decision-linked files (logmind-native — the file's path is named in a decision doc/timeline) rank above unlinked; then intra-repo import fan-in (centrality — the repomap's core signal, Aider's insight); then path. --map-tokens N greedily keeps whole files within an est. ceil(len/4) budget, appends a §14.4 truncation marker for the rest, and honors §14.5 never-worse (packed is a subset). Default (no budget) stays byte-stable (0 = Generate).
+
+**Alternatives considered:** Iterated PageRank (deferred — first-order in-degree fan-in is a cheap, deterministic proxy; iteration is a later refinement). Symbol-granularity packing (deferred — file-granularity is cleaner for v1). A git-recency signal (rejected — non-deterministic across shallow clones, would break the caching invariant).
+
+**Implications:**
+- FileSymbols gains Imports (captured during the existing parse); new rank.go (Rank/Pack/importFanIn/decisionLinkedPaths/moduleImportPath); GenerateBudget + RenderWithOmitted + a shared fileBlock; --map-tokens flag; the repomap receipt gains an omitted count. The §3.26 SPEC --map-tokens note bundles with the R4 multi-language bump. Context (R2) still folds the FULL map; a context budget cap is a later refinement.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (18 decisions)
+## 2026-07 (19 decisions)
 
-- **2026-07-04** — context.repomap: fold the Go signature skeleton into logmind context (default off) *(feat/context-repomap)* — [decisions-branches/feat__context-repomap.md](decisions-branches/feat__context-repomap.md)
-- *... 16 more decisions ...*
+- **2026-07-04** — repomap ranking + --map-tokens budget packing (token-killer R3) *(feat/repomap-rank-budget)* — [decisions-branches/feat__repomap-rank-budget.md](decisions-branches/feat__repomap-rank-budget.md)
+- *... 17 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -13,10 +13,10 @@ PR's CI run, so this file is always coherent with current `main`.
 ---
 
 
-## 2026-07 (19 decisions)
+## 2026-07 (20 decisions)
 
-- **2026-07-04** — repomap ranking + --map-tokens budget packing (token-killer R3) *(feat/repomap-rank-budget)* — [decisions-branches/feat__repomap-rank-budget.md](decisions-branches/feat__repomap-rank-budget.md)
-- *... 17 more decisions ...*
+- **2026-07-04** — R3 review fixes: §14.5 never-worse passthrough + ranking-signal robustness *(feat/repomap-rank-budget)* — [decisions-branches/feat__repomap-rank-budget.md](decisions-branches/feat__repomap-rank-budget.md)
+- *... 18 more decisions ...*
 - **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
 
 ## 2026-06 (102 decisions)

--- a/internal/cli/repomap.go
+++ b/internal/cli/repomap.go
@@ -24,6 +24,7 @@ import (
 )
 
 func newRepomapCmd() *cobra.Command {
+	var mapTokens int
 	cmd := &cobra.Command{
 		Use:   "repomap",
 		Short: "Print a deterministic Go signature skeleton of the repo (experimental; token-killer Phase 2)",
@@ -39,34 +40,40 @@ Deterministic (files sorted, stdlib pretty-printing, no timestamps / absolute
 paths / filesystem order) so it caches as a stable prefix, exactly like
 ` + "`logmind context`" + `.
 
+--map-tokens N ranks files by importance (files the team logged decisions
+about, then intra-repo import fan-in, then path) and keeps as many whole files
+as fit an estimated N-token budget, marking the rest omitted. Without it, every
+file is emitted in path order (unchanged, byte-stable).
+
 Experimental: currently Go-only (uses the go/parser standard library — zero
-external dependency). Other languages, importance ranking, and a token budget
-land in later slices; the default derived docs are unchanged.`,
+external dependency). Other languages land in a later slice.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
 			}
-			return runRepomap(cwd, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runRepomap(cwd, mapTokens, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
+	cmd.Flags().IntVar(&mapTokens, "map-tokens", 0,
+		"Rank by importance and pack the skeleton to an estimated N-token budget (est. ~4 chars/token), omitting the least-important files. 0 = no budget (all files, path order).")
 	return cmd
 }
 
-func runRepomap(cwd string, quiet bool, stdout, stderr io.Writer) error {
+func runRepomap(cwd string, mapTokens int, quiet bool, stdout, stderr io.Writer) error {
 	q := newQout(quiet, stdout, stderr)
 	cfg, _ := config.Load(cwd)
-	text, files, err := repomap.Generate(cwd, cfg.FileStructure.IgnorePatterns)
+	text, kept, omitted, err := repomap.GenerateBudget(cwd, cfg.FileStructure.IgnorePatterns, mapTokens)
 	if err != nil {
 		return err
 	}
-	nSyms := repomap.CountSymbols(files)
+	nSyms := repomap.CountSymbols(kept)
 	if quiet {
-		q.ok("repomap files=%d symbols=%d bytes=%d sink=stdout", len(files), nSyms, len(text))
+		q.ok("repomap files=%d symbols=%d omitted=%d bytes=%d sink=stdout", len(kept), nSyms, omitted, len(text))
 		return nil
 	}
 	fmt.Fprint(stdout, text)
-	fmt.Fprintf(stdout, "ok repomap: %d files, %d symbols, %d bytes (stdout)\n", len(files), nSyms, len(text))
+	fmt.Fprintf(stdout, "ok repomap: %d files, %d symbols, %d omitted, %d bytes (stdout)\n", len(kept), nSyms, omitted, len(text))
 	return nil
 }

--- a/internal/cli/repomap_test.go
+++ b/internal/cli/repomap_test.go
@@ -63,18 +63,22 @@ func TestRepomap_Quiet(t *testing.T) {
 }
 
 // TestRepomap_MapTokensBudget: --map-tokens packs to a budget and marks the
-// omitted files; the receipt reports the omitted count.
+// omitted files; the receipt reports the omitted count. Uses several
+// substantial files so omitting some genuinely shrinks the output (past the
+// never-worse passthrough).
 func TestRepomap_MapTokensBudget(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		mustWriteUnder(t, d, "go.mod", "module x\n")
-		mustWriteUnder(t, d, "a.go", "package p\nfunc A() {}\n")
-		mustWriteUnder(t, d, "b.go", "package p\nfunc B() {}\n")
-		s := runRepomapCapture(t, "--map-tokens", "30")
+		for _, name := range []string{"a", "b", "c", "d", "e"} {
+			mustWriteUnder(t, d, name+".go",
+				"package p\nfunc "+name+"1(x int) error { return nil }\nfunc "+name+"2(y string) bool { return false }\nfunc "+name+"3() {}\n")
+		}
+		s := runRepomapCapture(t, "--map-tokens", "60")
 		if !strings.Contains(s, "omitted to fit the token budget") {
 			t.Errorf("budget marker missing:\n%s", s)
 		}
-		if !strings.Contains(s, " omitted, ") {
-			t.Errorf("receipt missing omitted count:\n%s", s)
+		if strings.Contains(s, "0 omitted,") {
+			t.Errorf("expected some files omitted at a tight budget:\n%s", s)
 		}
 	})
 }

--- a/internal/cli/repomap_test.go
+++ b/internal/cli/repomap_test.go
@@ -62,6 +62,39 @@ func TestRepomap_Quiet(t *testing.T) {
 	})
 }
 
+// TestRepomap_MapTokensBudget: --map-tokens packs to a budget and marks the
+// omitted files; the receipt reports the omitted count.
+func TestRepomap_MapTokensBudget(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "go.mod", "module x\n")
+		mustWriteUnder(t, d, "a.go", "package p\nfunc A() {}\n")
+		mustWriteUnder(t, d, "b.go", "package p\nfunc B() {}\n")
+		s := runRepomapCapture(t, "--map-tokens", "30")
+		if !strings.Contains(s, "omitted to fit the token budget") {
+			t.Errorf("budget marker missing:\n%s", s)
+		}
+		if !strings.Contains(s, " omitted, ") {
+			t.Errorf("receipt missing omitted count:\n%s", s)
+		}
+	})
+}
+
+// TestRepomap_NoBudgetNoOmittedMarker: without --map-tokens, all files emit and
+// no truncation marker appears (the byte-stable default).
+func TestRepomap_NoBudgetNoOmittedMarker(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, "go.mod", "module x\n")
+		mustWriteUnder(t, d, "a.go", "package p\nfunc A() {}\n")
+		s := runRepomapCapture(t)
+		if strings.Contains(s, "omitted to fit") {
+			t.Errorf("no-budget run must not emit a truncation marker:\n%s", s)
+		}
+		if !strings.Contains(s, "0 omitted") {
+			t.Errorf("receipt should report 0 omitted:\n%s", s)
+		}
+	})
+}
+
 // TestRepomap_Deterministic: byte-identical across runs (caching invariant).
 func TestRepomap_Deterministic(t *testing.T) {
 	withTempCwd(t, func(d string) {

--- a/internal/repomap/rank.go
+++ b/internal/repomap/rank.go
@@ -1,0 +1,147 @@
+// rank.go — importance ranking + token-budget packing for the repomap
+// (token-killer Phase 2, R3). When a budget is set, the map can't carry every
+// file, so it must carry the MOST IMPORTANT ones first. Ranking is deterministic
+// (the caching invariant) and native (no external dep, no network).
+package repomap
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/thrillmade/logmind/internal/tokens"
+)
+
+// Rank orders files by importance, most-important first, deterministically:
+//
+//  1. decision-linked files first — the file's path appears in the repo's
+//     decision docs / timeline (a logmind-native signal: the team logged a
+//     decision that names this file, so it is load-bearing);
+//  2. then higher intra-repo fan-in — imported by more of the repo's own files
+//     (the centrality signal at the heart of a repomap);
+//  3. path ascending as the final, always-decisive tiebreak.
+//
+// The input slice is not mutated. (This is first-order in-degree centrality,
+// not iterated PageRank — a strong, cheap, deterministic proxy; iteration is a
+// later refinement.)
+func Rank(repoRoot string, files []FileSymbols) []FileSymbols {
+	linked := decisionLinkedPaths(repoRoot, files)
+	fanIn := importFanIn(repoRoot, files)
+	out := make([]FileSymbols, len(files))
+	copy(out, files)
+	sort.SliceStable(out, func(i, j int) bool {
+		if li, lj := linked[out[i].Path], linked[out[j].Path]; li != lj {
+			return li // decision-linked ranks above unlinked
+		}
+		if fi, fj := fanIn[out[i].Path], fanIn[out[j].Path]; fi != fj {
+			return fi > fj // higher fan-in first
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+// Pack greedily keeps whole files from the (already Rank-ordered) slice while
+// the rendered skeleton stays within maxTokens (the §14.2 ceil(len/4) estimate),
+// and reports how many trailing files were dropped. maxTokens <= 0 means "no
+// budget" — keep everything. Never-worse (§14.5): the packed render is a subset
+// of the full render, never larger.
+func Pack(ranked []FileSymbols, maxTokens int) (kept []FileSymbols, omitted int) {
+	if maxTokens <= 0 {
+		return ranked, 0
+	}
+	// Reserve headroom so the "... (N files omitted)" marker itself fits.
+	const markerReserve = 20
+	budget := maxTokens - markerReserve
+	used := tokens.Estimate(repomapHeader)
+	kept = make([]FileSymbols, 0, len(ranked))
+	for i, f := range ranked {
+		cost := tokens.Estimate(fileBlock(f))
+		if used+cost > budget {
+			return kept, len(ranked) - i
+		}
+		used += cost
+		kept = append(kept, f)
+	}
+	return kept, 0
+}
+
+// decisionLinkedPaths returns the set of file paths (from files) that are named
+// in the repo's decision docs or timeline — a logmind-native importance signal.
+// Deterministic: reads committed docs in a fixed order.
+func decisionLinkedPaths(repoRoot string, files []FileSymbols) map[string]bool {
+	var corpus strings.Builder
+	for _, p := range []string{"decisions.md", "decisions-archive.md", "timeline.md"} {
+		if data, err := os.ReadFile(filepath.Join(repoRoot, "docs", p)); err == nil {
+			corpus.Write(data)
+			corpus.WriteByte('\n')
+		}
+	}
+	branches, _ := filepath.Glob(filepath.Join(repoRoot, "docs", "decisions-branches", "*.md"))
+	sort.Strings(branches)
+	for _, p := range branches {
+		if data, err := os.ReadFile(p); err == nil {
+			corpus.Write(data)
+			corpus.WriteByte('\n')
+		}
+	}
+	text := corpus.String()
+	linked := make(map[string]bool)
+	for _, f := range files {
+		if strings.Contains(text, f.Path) {
+			linked[f.Path] = true
+		}
+	}
+	return linked
+}
+
+// importFanIn counts, per file, how many OTHER files in the repo import that
+// file's package — an intra-repo centrality (fan-in) score. All-zero when the
+// module path can't be resolved (no go.mod). Deterministic.
+func importFanIn(repoRoot string, files []FileSymbols) map[string]int {
+	fanIn := make(map[string]int, len(files))
+	mod := moduleImportPath(repoRoot)
+	if mod == "" {
+		return fanIn
+	}
+	// Each file's own package import path, derived from its directory.
+	pkgOf := make(map[string]string, len(files))
+	for _, f := range files {
+		if dir := filepath.ToSlash(filepath.Dir(f.Path)); dir == "." {
+			pkgOf[f.Path] = mod
+		} else {
+			pkgOf[f.Path] = mod + "/" + dir
+		}
+	}
+	// Count importers per package path (deduped within a file), intra-repo only.
+	importers := make(map[string]int)
+	for _, f := range files {
+		seen := make(map[string]bool)
+		for _, imp := range f.Imports {
+			if (imp == mod || strings.HasPrefix(imp, mod+"/")) && !seen[imp] {
+				importers[imp]++
+				seen[imp] = true
+			}
+		}
+	}
+	for _, f := range files {
+		fanIn[f.Path] = importers[pkgOf[f.Path]]
+	}
+	return fanIn
+}
+
+// moduleImportPath reads the module path from go.mod (the `module X` line), or
+// "" when there is no go.mod / no module directive.
+func moduleImportPath(repoRoot string) string {
+	data, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+	return ""
+}

--- a/internal/repomap/rank.go
+++ b/internal/repomap/rank.go
@@ -45,8 +45,9 @@ func Rank(repoRoot string, files []FileSymbols) []FileSymbols {
 // Pack greedily keeps whole files from the (already Rank-ordered) slice while
 // the rendered skeleton stays within maxTokens (the §14.2 ceil(len/4) estimate),
 // and reports how many trailing files were dropped. maxTokens <= 0 means "no
-// budget" — keep everything. Never-worse (§14.5): the packed render is a subset
-// of the full render, never larger.
+// budget" — keep everything. (The §14.5 never-worse guarantee is enforced by
+// GenerateBudget, which passes through the full map when the truncation
+// marker's overhead would make the packed output larger than the full one.)
 func Pack(ranked []FileSymbols, maxTokens int) (kept []FileSymbols, omitted int) {
 	if maxTokens <= 0 {
 		return ranked, 0
@@ -89,11 +90,46 @@ func decisionLinkedPaths(repoRoot string, files []FileSymbols) map[string]bool {
 	text := corpus.String()
 	linked := make(map[string]bool)
 	for _, f := range files {
-		if strings.Contains(text, f.Path) {
+		if mentionsPath(text, f.Path) {
 			linked[f.Path] = true
 		}
 	}
 	return linked
+}
+
+// mentionsPath reports whether path appears in text as a whole path token, not
+// as the tail/head of a longer word — so a short root path like `a.go` is NOT
+// matched inside `data.go`. A match is valid when the char before it is not a
+// path-continuation char and the char after it is not alphanumeric.
+func mentionsPath(text, path string) bool {
+	for from := 0; ; {
+		i := strings.Index(text[from:], path)
+		if i < 0 {
+			return false
+		}
+		i += from
+		var before, after byte = ' ', ' '
+		if i > 0 {
+			before = text[i-1]
+		}
+		if end := i + len(path); end < len(text) {
+			after = text[end]
+		}
+		if !isPathContByte(before) && !isAlnumByte(after) {
+			return true
+		}
+		from = i + 1
+	}
+}
+
+func isAlnumByte(b byte) bool {
+	return b >= 'A' && b <= 'Z' || b >= 'a' && b <= 'z' || b >= '0' && b <= '9'
+}
+
+// isPathContByte reports whether b could be part of a filename/path token, so a
+// preceding one means the match is only the TAIL of a longer path/word.
+func isPathContByte(b byte) bool {
+	return isAlnumByte(b) || b == '.' || b == '_' || b == '-' || b == '/'
 }
 
 // importFanIn counts, per file, how many OTHER files in the repo import that
@@ -140,7 +176,13 @@ func moduleImportPath(repoRoot string) string {
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		if line = strings.TrimSpace(line); strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			// Fields drops surrounding whitespace AND any trailing `// comment`
+			// (e.g. `module example.com/m // vanity import`), whose bytes would
+			// otherwise be glued onto the module path and break every prefix
+			// match, silently zeroing all fan-in.
+			if f := strings.Fields(strings.TrimPrefix(line, "module ")); len(f) > 0 {
+				return f[0]
+			}
 		}
 	}
 	return ""

--- a/internal/repomap/rank_test.go
+++ b/internal/repomap/rank_test.go
@@ -1,0 +1,152 @@
+package repomap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/tree"
+)
+
+// setupRankRepo builds a tiny module: `hub` is imported by `a` and `b`
+// (fan-in 2); `lonely` has no fan-in but is named in a decision doc.
+func setupRankRepo(t *testing.T) (dir string, files []FileSymbols) {
+	t.Helper()
+	dir = t.TempDir()
+	write := func(rel, src string) {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module example.com/m\n\ngo 1.22\n")
+	write("hub/hub.go", "package hub\nfunc H() {}\n")
+	write("a/a.go", "package a\nimport \"example.com/m/hub\"\nfunc A() { hub.H() }\n")
+	write("b/b.go", "package b\nimport \"example.com/m/hub\"\nfunc B() { hub.H() }\n")
+	write("lonely/lonely.go", "package lonely\nfunc L() {}\n")
+	write("docs/decisions.md", "## X\n\nWe refactored lonely/lonely.go for good reasons.\n")
+
+	rules, err := tree.ResolveRules(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err = ExtractGo(dir, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, files
+}
+
+func paths(fs []FileSymbols) string {
+	var p []string
+	for _, f := range fs {
+		p = append(p, f.Path)
+	}
+	return strings.Join(p, ",")
+}
+
+func TestRank_DecisionLinkedThenFanInThenPath(t *testing.T) {
+	dir, files := setupRankRepo(t)
+	got := paths(Rank(dir, files))
+	// lonely: decision-linked (beats fan-in). hub: fan-in 2. a,b: fan-in 0 → path order.
+	want := "lonely/lonely.go,hub/hub.go,a/a.go,b/b.go"
+	if got != want {
+		t.Errorf("rank order = %q; want %q", got, want)
+	}
+	if paths(Rank(dir, files)) != got {
+		t.Error("Rank not deterministic across runs")
+	}
+	// Rank must not mutate the input order (ExtractGo returns path-sorted).
+	if paths(files) != "a/a.go,b/b.go,hub/hub.go,lonely/lonely.go" {
+		t.Errorf("Rank mutated the input slice: %q", paths(files))
+	}
+}
+
+func TestImportFanIn_Counts(t *testing.T) {
+	dir, files := setupRankRepo(t)
+	fi := importFanIn(dir, files)
+	if fi["hub/hub.go"] != 2 {
+		t.Errorf("hub fan-in = %d; want 2", fi["hub/hub.go"])
+	}
+	if fi["a/a.go"] != 0 || fi["lonely/lonely.go"] != 0 {
+		t.Errorf("leaf files should have fan-in 0: %+v", fi)
+	}
+}
+
+func TestImportFanIn_NoModuleIsZero(t *testing.T) {
+	dir := t.TempDir()
+	// no go.mod
+	files := []FileSymbols{{Path: "a.go", Imports: []string{"fmt"}}}
+	if fi := importFanIn(dir, files); fi["a.go"] != 0 {
+		t.Errorf("no go.mod should yield zero fan-in, got %+v", fi)
+	}
+}
+
+func TestPack_NoBudgetKeepsAll(t *testing.T) {
+	_, files := setupRankRepo(t)
+	kept, omitted := Pack(files, 0)
+	if len(kept) != len(files) || omitted != 0 {
+		t.Fatalf("no-budget should keep all: kept=%d omitted=%d (of %d)", len(kept), omitted, len(files))
+	}
+}
+
+func TestPack_HugeBudgetKeepsAll(t *testing.T) {
+	dir, files := setupRankRepo(t)
+	kept, omitted := Pack(Rank(dir, files), 1_000_000)
+	if len(kept) != len(files) || omitted != 0 {
+		t.Fatalf("huge budget should keep all: kept=%d omitted=%d", len(kept), omitted)
+	}
+}
+
+func TestPack_TrimsAndAccountsExactly(t *testing.T) {
+	dir, files := setupRankRepo(t)
+	ranked := Rank(dir, files)
+	kept, omitted := Pack(ranked, 40) // tiny — nothing fits past the header
+	if len(kept)+omitted != len(ranked) {
+		t.Fatalf("kept(%d)+omitted(%d) != total(%d)", len(kept), omitted, len(ranked))
+	}
+	if omitted == 0 {
+		t.Fatal("tiny budget should omit at least one file")
+	}
+	// never-worse (§14.5): the packed render is never larger than the full render.
+	if packed, full := RenderWithOmitted(kept, omitted), Render(files); len(packed) > len(full) {
+		t.Errorf("packed (%d B) larger than full (%d B) — never-worse violated", len(packed), len(full))
+	}
+}
+
+func TestGenerateBudget_ZeroEqualsGenerate(t *testing.T) {
+	dir, _ := setupRankRepo(t)
+	a, _, err := Generate(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, _, err := GenerateBudget(dir, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Errorf("GenerateBudget(…, 0) must byte-equal Generate:\n--a--\n%s\n--b--\n%s", a, b)
+	}
+}
+
+func TestGenerateBudget_MarkerAndDeterminism(t *testing.T) {
+	dir, _ := setupRankRepo(t)
+	text, kept, omitted, err := GenerateBudget(dir, nil, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if omitted > 0 && !strings.Contains(text, "omitted to fit the token budget") {
+		t.Errorf("omitted=%d but no truncation marker:\n%s", omitted, text)
+	}
+	if len(kept)+omitted != 4 {
+		t.Errorf("kept+omitted = %d; want 4", len(kept)+omitted)
+	}
+	b, _, _, _ := GenerateBudget(dir, nil, 60)
+	if text != b {
+		t.Error("GenerateBudget not byte-deterministic")
+	}
+}

--- a/internal/repomap/rank_test.go
+++ b/internal/repomap/rank_test.go
@@ -133,6 +133,78 @@ func TestGenerateBudget_ZeroEqualsGenerate(t *testing.T) {
 	}
 }
 
+func idxOf(fs []FileSymbols, p string) int {
+	for i, f := range fs {
+		if f.Path == p {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestGenerateBudget_NeverWorseThanFull: across budgets that would omit only a
+// few small files (where the marker overhead exceeds the dropped blocks),
+// GenerateBudget must never emit more than the full render — it passes through
+// the full map instead (§14.5). Regression for the never-worse BLOCKER.
+func TestGenerateBudget_NeverWorseThanFull(t *testing.T) {
+	dir := t.TempDir()
+	writeGo(t, dir, "go.mod", "module x\n")
+	writeGo(t, dir, "a.go", "package p\nfunc A() {}\n")
+	writeGo(t, dir, "b.go", "package p\nfunc B() {}\n")
+	full, _, _, err := GenerateBudget(dir, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, budget := range []int{1, 20, 40, 48, 55, 80} {
+		text, _, omitted, err := GenerateBudget(dir, nil, budget)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(text) > len(full) {
+			t.Errorf("budget %d: packed %dB > full %dB — never-worse violated:\n%s", budget, len(text), len(full), text)
+		}
+		// At full size, passthrough must have kicked in (omitted 0, == full).
+		if len(text) == len(full) && (omitted != 0 || text != full) {
+			t.Errorf("budget %d: full-size output but omitted=%d / not the full map", budget, omitted)
+		}
+	}
+}
+
+// TestRank_DecisionLinkSubstringNotMatched: a short path must not be falsely
+// decision-linked because it is a substring of an unrelated word in the docs.
+func TestRank_DecisionLinkSubstringNotMatched(t *testing.T) {
+	dir := t.TempDir()
+	writeGo(t, dir, "go.mod", "module example.com/m\n")
+	writeGo(t, dir, "a.go", "package p\nfunc A() {}\n") // fan-in 0, NOT referenced
+	writeGo(t, dir, "hub/hub.go", "package hub\nfunc H() {}\n")
+	writeGo(t, dir, "u/u.go", "package u\nimport \"example.com/m/hub\"\nfunc U() { hub.H() }\n")
+	// The doc mentions only "data.go" — which CONTAINS "a.go" as a substring.
+	writeGo(t, dir, "docs/decisions.md", "## X\n\nWe touched data.go for reasons.\n")
+
+	rules, _ := tree.ResolveRules(dir, nil)
+	files, err := ExtractGo(dir, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ranked := Rank(dir, files)
+	// hub (fan-in 1) must outrank a.go — i.e. a.go was NOT falsely boosted.
+	if idxOf(ranked, "hub/hub.go") > idxOf(ranked, "a.go") {
+		t.Errorf("a.go falsely decision-linked via `data.go` substring; order: %s", paths(ranked))
+	}
+	// Sanity: a legitimately-named path IS matched.
+	if !mentionsPath("see internal/x/a.go here", "internal/x/a.go") {
+		t.Error("a real whole-path mention should match")
+	}
+}
+
+func TestModuleImportPath_TrailingComment(t *testing.T) {
+	dir := t.TempDir()
+	writeGo(t, dir, "go.mod", "module example.com/m // vanity import path\n\ngo 1.22\n")
+	if got := moduleImportPath(dir); got != "example.com/m" {
+		t.Errorf("module path = %q; want example.com/m (trailing comment must be stripped)", got)
+	}
+}
+
 func TestGenerateBudget_MarkerAndDeterminism(t *testing.T) {
 	dir, _ := setupRankRepo(t)
 	text, kept, omitted, err := GenerateBudget(dir, nil, 60)

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/thrillmade/logmind/internal/tree"
@@ -54,6 +55,9 @@ type Symbol struct {
 type FileSymbols struct {
 	Path    string // repo-relative, forward-slashed (stable across platforms)
 	Symbols []Symbol
+	// Imports is the file's imported package paths (unquoted). Used by Rank to
+	// compute intra-repo fan-in centrality; ignored by the default Render.
+	Imports []string
 }
 
 // ExtractGo walks repoRoot for tracked, non-test .go files (honoring the same
@@ -114,22 +118,23 @@ func ExtractGo(repoRoot string, rules tree.IgnoreRules) ([]FileSymbols, error) {
 
 	out := make([]FileSymbols, 0, len(goFiles))
 	for _, rel := range goFiles {
-		syms := extractGoFile(filepath.Join(repoRoot, filepath.FromSlash(rel)))
+		syms, imports := extractGoFile(filepath.Join(repoRoot, filepath.FromSlash(rel)))
 		if len(syms) == 0 {
 			continue
 		}
-		out = append(out, FileSymbols{Path: rel, Symbols: syms})
+		out = append(out, FileSymbols{Path: rel, Symbols: syms, Imports: imports})
 	}
 	return out, nil
 }
 
 // extractGoFile parses a single Go file and returns its top-level signatures in
-// source order. Returns nil on a parse error (skip, don't fail the whole map).
-func extractGoFile(absPath string) []Symbol {
+// source order plus its imported package paths (unquoted). Returns nil, nil on
+// a parse error (skip, don't fail the whole map).
+func extractGoFile(absPath string) ([]Symbol, []string) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, absPath, nil, parser.SkipObjectResolution)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var syms []Symbol
 	for _, decl := range file.Decls {
@@ -146,7 +151,15 @@ func extractGoFile(absPath string) []Symbol {
 			}
 		}
 	}
-	return syms
+	// file.Imports is populated by the full parse — the file's imported package
+	// paths, used by Rank for intra-repo fan-in.
+	var imports []string
+	for _, imp := range file.Imports {
+		if p, err := strconv.Unquote(imp.Path.Value); err == nil {
+			imports = append(imports, p)
+		}
+	}
+	return syms, imports
 }
 
 // funcSignature renders a FuncDecl with its body (and doc) dropped — the exact
@@ -249,6 +262,25 @@ func flattenOneLine(s string) string {
 	return b.String()
 }
 
+const repomapHeader = "# Repomap\n\nSignature skeleton (bodies dropped) — the repo's API surface for agents.\n"
+
+// fileBlock renders one file's portion of the skeleton: a leading blank line,
+// the path, then each signature indented two spaces. Shared by Render and the
+// budget renderer so their output stays byte-identical, and used by Pack to
+// cost each file.
+func fileBlock(f FileSymbols) string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(f.Path)
+	b.WriteString("\n")
+	for _, s := range f.Symbols {
+		b.WriteString("  ")
+		b.WriteString(s.Signature)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
 // Render assembles the deterministic skeleton text: each file's path as a
 // header, its signatures indented beneath. Byte-stable by construction.
 func Render(files []FileSymbols) string {
@@ -256,18 +288,26 @@ func Render(files []FileSymbols) string {
 		return "# Repomap\n\nNo Go symbols found.\n"
 	}
 	var b strings.Builder
-	b.WriteString("# Repomap\n\n")
-	b.WriteString("Signature skeleton (bodies dropped) — the repo's API surface for agents.\n")
+	b.WriteString(repomapHeader)
 	for _, f := range files {
-		b.WriteString("\n")
-		b.WriteString(f.Path)
-		b.WriteString("\n")
-		for _, s := range f.Symbols {
-			b.WriteString("  ")
-			b.WriteString(s.Signature)
-			b.WriteString("\n")
-		}
+		b.WriteString(fileBlock(f))
 	}
+	return b.String()
+}
+
+// RenderWithOmitted renders kept files plus, when omitted > 0, a canonical
+// truncation marker (§14.4) naming how many files were dropped to fit the
+// budget. omitted == 0 renders identically to Render(kept).
+func RenderWithOmitted(kept []FileSymbols, omitted int) string {
+	if omitted <= 0 {
+		return Render(kept)
+	}
+	var b strings.Builder
+	b.WriteString(repomapHeader)
+	for _, f := range kept {
+		b.WriteString(fileBlock(f))
+	}
+	fmt.Fprintf(&b, "\n... (%d files omitted to fit the token budget)\n", omitted)
 	return b.String()
 }
 
@@ -285,6 +325,28 @@ func Generate(repoRoot string, defaults []string) (string, []FileSymbols, error)
 		return "", nil, err
 	}
 	return Render(files), files, nil
+}
+
+// GenerateBudget is Generate + importance ranking + token-budget packing: it
+// ranks files (see Rank) and keeps as many whole files as fit maxTokens,
+// appending a truncation marker for the rest. maxTokens <= 0 behaves exactly
+// like Generate — no ranking, no budget, the byte-stable path-sorted default.
+// Returns the rendered text, the KEPT files, and the omitted count.
+func GenerateBudget(repoRoot string, defaults []string, maxTokens int) (text string, kept []FileSymbols, omitted int, err error) {
+	rules, err := tree.ResolveRules(repoRoot, defaults)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("resolve ignore rules: %w", err)
+	}
+	files, err := ExtractGo(repoRoot, rules)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	if maxTokens <= 0 {
+		return Render(files), files, 0, nil
+	}
+	ranked := Rank(repoRoot, files)
+	kept, omitted = Pack(ranked, maxTokens)
+	return RenderWithOmitted(kept, omitted), kept, omitted, nil
 }
 
 // CountSymbols totals the symbols across all files — the denominator for the

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -344,9 +344,18 @@ func GenerateBudget(repoRoot string, defaults []string, maxTokens int) (text str
 	if maxTokens <= 0 {
 		return Render(files), files, 0, nil
 	}
+	full := Render(files)
 	ranked := Rank(repoRoot, files)
 	kept, omitted = Pack(ranked, maxTokens)
-	return RenderWithOmitted(kept, omitted), kept, omitted, nil
+	packed := RenderWithOmitted(kept, omitted)
+	// Never-worse (§14.5): the truncation marker's fixed overhead can exceed a
+	// few small omitted blocks, making the packed render LARGER than the full
+	// one — worse AND lossy. When budgeting fails to actually shrink the output,
+	// passthrough the full map; a budget must never make the output bigger.
+	if len(packed) >= len(full) {
+		return full, files, 0, nil
+	}
+	return packed, kept, omitted, nil
 }
 
 // CountSymbols totals the symbols across all files — the denominator for the


### PR DESCRIPTION
## R3 — repomap importance ranking + `--map-tokens` budget packing

With a token budget the map can't carry every file, so it must carry the **most important** first.

### Ranking (deterministic — the caching invariant)
`Rank` orders files lexicographically by:
1. **decision-linked** — the file's path is named in a decision doc / timeline (a **logmind-native** signal: the team logged a decision about it);
2. **intra-repo import fan-in** — imported by more of the repo's own files (centrality; the repomap's core signal — Aider's insight). Computed from `go.mod`'s module path + each file's imports;
3. **path** ascending (always-decisive tiebreak).

First-order in-degree, not iterated PageRank (a cheap, deterministic proxy; iteration is a later refinement). No git-recency signal — it's non-deterministic across shallow clones and would break caching.

### Budget
`logmind repomap --map-tokens N` greedily keeps whole files within an estimated `ceil(len/4)` budget, appends a canonical **§14.4** truncation marker (`... (N files omitted to fit the token budget)`), and honors **§14.5 never-worse** (the packed render is a subset — never larger than the full render). **Default (no `--map-tokens`) is byte-stable** (`0` ⇒ the existing path-sorted `Generate`).

Dogfood: `--map-tokens 400` on logmind ranks `internal/gitcli/gitcli.go` first (highest fan-in) and packs to ~290 tok < 400.

### Files
`internal/repomap/repomap.go` (`FileSymbols.Imports`; `fileBlock`/`RenderWithOmitted`/`GenerateBudget`), new `internal/repomap/rank.go` (`Rank`/`Pack`/`importFanIn`/`decisionLinkedPaths`/`moduleImportPath`), `internal/cli/repomap.go` (`--map-tokens` flag; receipt gains an omitted count), + rank/CLI tests.

### SPEC
The `--map-tokens` note on §3.26 bundles with the **R4** (multi-language) SPEC bump to avoid back-to-back single-flag minor bumps. Context (R2) still folds the full map; a context budget cap is a later refinement.

Full suite green; the default repomap skeleton is byte-unchanged.
