### PR TITLE
feat(v1): flip default timeline to main-canonical (R5a — HELD for coordinated v1.0)

### DIFF
--- a/docs/decisions-branches/feat__v1-flip-main-canonical.md
+++ b/docs/decisions-branches/feat__v1-flip-main-canonical.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-04-flip-the-default-timeline-to-main-canonical-pin-branch-diver -->
+- **2026-07-04** — flip the default timeline to main-canonical; pin branch-divergent in opt-out tests (v1.0 flip, R5a)
+<!-- logmind-entry-end -->
+
+## 2026-07-04 02:57 - flip the default timeline to main-canonical; pin branch-divergent in opt-out tests (v1.0 flip, R5a)
+
+**Reasoning:** The v1.0 milestone flip: DefaultConfig now sets timeline.canonical main-canonical (the conflict-free source-derived union). branch-divergent (the v0.1.x byte floor) remains a SUPPORTED but DEPRECATED opt-out. Version-gated: repos on pre-flip logmind are undisturbed until they upgrade. The 10 tests that verified branch-divergent opt-out/no-op behavior now pin branch-divergent explicitly (still-supported mode; coverage kept); the default-mode assertion flips to main-canonical; a new lock test proves a DEFAULT-config log writes a §1.6.3 marker and renders the entry-block format. The branch-divergent byte-floor goldens are UNCHANGED (verified).
+
+**Alternatives considered:** Regen the cli timeline goldens to main-canonical (rejected — keep the branch-divergent byte floor under test; pin the mode instead). Delete the opt-out tests (rejected — branch-divergent still exists and must stay covered).
+
+**Implications:**
+- main-canonical is the default; branch-divergent is opt-out + deprecated. NO version bump here — the release version (1.3.0 vs 2.0.0) is a CEO call at the release cut (current is 1.2.0-dev). The SPEC section 8.7 deprecation, AGENTS v6 to v7, and agent-skills land coordinated; DefaultMap surfacing is a follow-up. HELD for CEO coordination + the release gate.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -12,21 +12,576 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ---
 
+## 2026-07
 
-## 2026-07 (23 decisions)
+<!-- logmind-entry-start: 2026-07-04-repomap-ranking-map-tokens-budget-packing-token-killer-r3 -->
+- **2026-07-04** — repomap ranking + --map-tokens budget packing (token-killer R3) → [detail](decisions-branches/feat__repomap-rank-budget.md)
+<!-- logmind-entry-end -->
 
-- **2026-07-04** — R4 review fixes: direct-arrow const detection + extends word-boundary + language-agnostic text *(feat/repomap-multilang)* — [decisions-branches/feat__repomap-multilang.md](decisions-branches/feat__repomap-multilang.md)
-- *... 21 more decisions ...*
-- **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) *(fix/check-doc-links-advisory-no-strand)* — [decisions-branches/fix__check-doc-links-advisory-no-strand.md](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
+<!-- logmind-entry-start: 2026-07-04-repomap-generalize-extraction-into-a-language-dispatch-regis -->
+- **2026-07-04** — repomap: generalize extraction into a language-dispatch registry (R4 framework) → [detail](decisions-branches/feat__repomap-multilang.md)
+<!-- logmind-entry-end -->
 
-## 2026-06 (102 decisions)
+<!-- logmind-entry-start: 2026-07-04-flip-the-default-timeline-to-main-canonical-pin-branch-diver -->
+- **2026-07-04** — flip the default timeline to main-canonical; pin branch-divergent in opt-out tests (v1.0 flip, R5a) → [detail](decisions-branches/feat__v1-flip-main-canonical.md)
+<!-- logmind-entry-end -->
 
-- **2026-06-29** — Slice 2 PR10: doctor branch-summary health (advisory + --fix backfill) + logmind headline --file *(feat/doctor-branch-summary)* — [decisions-branches/feat__doctor-branch-summary.md](decisions-branches/feat__doctor-branch-summary.md)
-- *... 100 more decisions ...*
-- **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) *(chore/clud-bug-v0.6.30)* — [decisions-branches/chore__clud-bug-v0.6.30.md](decisions-branches/chore__clud-bug-v0.6.30.md)
+<!-- logmind-entry-start: 2026-07-04-context-repomap-fold-the-go-signature-skeleton-into-logmind- -->
+- **2026-07-04** — context.repomap: fold the Go signature skeleton into logmind context (default off) → [detail](decisions-branches/feat__context-repomap.md)
+<!-- logmind-entry-end -->
 
-## 2026-05 (87 decisions)
+<!-- logmind-entry-start: 2026-07-03-token-killer-phase-1b-logmind-quiet-output-discipline-across -->
+- **2026-07-03** — token-killer Phase 1b: LOGMIND_QUIET output discipline across log/timeline/file-structure/doctor/headline → [detail](decisions-branches/feat__token-killer-1b-quiet.md)
+<!-- logmind-entry-end -->
 
-- **2026-05-31** — chore: propagate clud-bug v0.6.29 to logmind (skill-usage workflow integration) *(chore/clud-bug-v0.6.29)* — [decisions-branches/chore__clud-bug-v0.6.29.md](decisions-branches/chore__clud-bug-v0.6.29.md)
-- *... 85 more decisions ...*
-- **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 *(virtual-kurzweil)* — [decisions-branches/virtual-kurzweil.md](decisions-branches/virtual-kurzweil.md)
+<!-- logmind-entry-start: 2026-07-03-templates-drop-the-last-dead-python-api-block-from-agents-md -->
+- **2026-07-03** — templates: drop the last dead Python-API block from AGENTS.md.template (completes the off-Python template purge) → [detail](decisions-branches/fix__agents-template-drop-python-api.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-templates-drop-dead-python-api-blocks-fix-wrong-org-urls-dea -->
+- **2026-07-03** — templates: drop dead Python-API blocks, fix wrong-org URLs + dead required-reading → [detail](decisions-branches/fix__templates-dead-python-api-and-links.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-skill-drop-the-dead-python-api-section-from-the-logmind-skil -->
+- **2026-07-03** — skill: drop the dead Python-API section from the logmind skill (off-Python completeness) → [detail](decisions-branches/fix__skill-drop-python-api.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-route-the-main-canonical-non-tty-headline-nudge-to-stderr-3- -->
+- **2026-07-03** — Route the main-canonical non-TTY headline nudge to stderr (§3.1.1 conformance) → [detail](decisions-branches/fix__nudge-stderr-conformance.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-hygiene-gofmt-sweep-gofmt-vet-ci-gate-surface-doctor-fix-bac -->
+- **2026-07-03** — hygiene: gofmt sweep + gofmt/vet CI gate + surface doctor --fix backfill write errors → [detail](decisions-branches/fix__gofmt-sweep-and-ci-gate.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-feat-logmind-context-one-read-agent-cold-start-payload-timel -->
+- **2026-07-03** — feat: logmind context — one-read agent cold-start payload (timeline + file-structure) → [detail](decisions-branches/feat__context-command.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-feat-context-cache-optimal-cold-start-payload-stats-token-re -->
+- **2026-07-03** — feat(context): cache-optimal cold-start payload + --stats token receipt (token-killer Phase 1a/1c) → [detail](decisions-branches/feat__token-killer-phase1-context.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-document-homebrew-6-0-0-tap-trust-cleanup-for-the-stale-thri -->
+- **2026-07-03** — Document Homebrew 6.0.0 tap-trust cleanup for the stale thrillmot/logmind personal tap → [detail](decisions-branches/fix__homebrew-tap-trust.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-docs-repo-version-consistency-specversion-0-1-1-0-8-0-readme -->
+- **2026-07-03** — docs: repo version consistency — SpecVersion 0.1.1→0.8.0, README badges/version, AGENTS.md Python-era dedup → [detail](decisions-branches/fix__repo-docs-version-consistency.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-check-doc-links-workflow-template-advisory-no-github-token-p -->
+- **2026-07-03** — check-doc-links workflow template: advisory + no GITHUB_TOKEN push (v6) → [detail](decisions-branches/fix__check-doc-links-advisory-no-strand.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-07-03-add-repomap-deterministic-go-signature-skeleton-token-killer -->
+- **2026-07-03** — Add repomap: deterministic Go signature skeleton (token-killer Phase 2, first slice) → [detail](decisions-branches/feat__repomap-go-signatures.md)
+<!-- logmind-entry-end -->
+
+## 2026-06
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr8-add-clud-bug-reviewcontext-byte-parity-marker-in -->
+- **2026-06-29** — Slice 2 PR8: add clud-bug reviewContext (byte-parity / marker-injection / GITHUB_TOKEN / determinism); defer branch-summary convention wiring → [detail](decisions-branches/feat__branch-summary-convention.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr7-agent-authored-branch-summary-logmind-headline-l -->
+- **2026-06-29** — Slice 2 PR7: agent-authored branch summary — logmind headline + log -H + per-log nudge → [detail](decisions-branches/feat__branch-summary-headline.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr6-confirm-guard-the-main-canonical-roll-up-no-new- -->
+- **2026-06-29** — Slice 2 PR6: confirm + guard the main-canonical roll-up (no new mechanism, no push-to-default) → [detail](decisions-branches/feat__timeline-rollup-confirm.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr5-deterministic-file-structure-root-label-renderwi -->
+- **2026-06-29** — Slice 2 PR5: deterministic file-structure root label (RenderWithLabel + file_structure.root_label) → [detail](decisions-branches/feat__tree-root-label.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr4-logmind-log-writes-the-1-6-3-timeline-marker-uni -->
+- **2026-06-29** — Slice 2 PR4: logmind log writes the §1.6.3 timeline marker; union computes the detail link → [detail](decisions-branches/feat__timeline-log-marker.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr3-main-canonical-timeline-read-path-generatemainca -->
+- **2026-06-29** — Slice 2 PR3: main-canonical timeline read path (GenerateMainCanonical) + single-point config dispatch → [detail](decisions-branches/feat__timeline-main-canonical-readpath.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr2-timeline-canonical-file-structure-root-label-con -->
+- **2026-06-29** — Slice 2 PR2: timeline.canonical + file_structure.root_label config keys (typed-only) → [detail](decisions-branches/feat__timeline-config-keys.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr10-doctor-branch-summary-health-advisory-fix-backf -->
+- **2026-06-29** — Slice 2 PR10: doctor branch-summary health (advisory + --fix backfill) + logmind headline --file → [detail](decisions-branches/feat__doctor-branch-summary.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-slice-2-pr1-timeline-entry-block-primitives-slugify-extract- -->
+- **2026-06-29** — Slice 2 PR1: timeline entry-block primitives (Slugify, extract, detect) — zero wiring → [detail](decisions-branches/feat__timeline-canonical-primitives.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-make-the-derived-doc-ci-gate-advisory-slice-1-de-friction-ne -->
+- **2026-06-29** — Make the derived-doc CI gate advisory (Slice 1 de-friction): never block, never GITHUB_TOKEN-push → [detail](decisions-branches/fix__derived-docs-advisory-gate.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-drop-vestigial-pip-pypi-machinery-from-doctor-init-slice-4-c -->
+- **2026-06-29** — Drop vestigial pip/PyPI machinery from doctor + init (Slice 4 cleanup) → [detail](decisions-branches/chore__doctor-drop-vestigial-pypi.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-29-add-logmind-doctor-fix-one-command-idempotent-repo-refresh-s -->
+- **2026-06-29** — Add `logmind doctor --fix`: one-command idempotent repo refresh (Slice 1) → [detail](decisions-branches/fix__doctor-fix.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-07-v1-2-0-port-logmind-log-to-go-and-add-3-layer-markdown-self- -->
+- **2026-06-07** — v1.2.0: Port logmind log to Go and add 3-layer markdown self-healing → [detail](decisions-branches/feat__v1.2.0-log-go-port-self-heal.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-05-ship-v1-1-0-install-sh-fetch-latest-setup-logmind-scaffold -->
+- **2026-06-05** — Ship v1.1.0: install.sh fetch-latest + setup-logmind scaffold → [detail](decisions-branches/feat__v1.1.0-install-and-scaffold.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-05-remove-clud-bug-review-yml-workflow-g3-b-extension-app-cover -->
+- **2026-06-05** — Remove clud-bug-review.yml workflow (G3.b extension — App covers logmind now) → [detail](decisions-branches/chore__migrate-to-clud-bug-app-tooling-repos.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-05-migrate-logmind-templates-to-setup-logmind-v1-0-1-dependabot -->
+- **2026-06-05** — Migrate logmind templates to setup-logmind@v1.0.1 + dependabot group → [detail](decisions-branches/chore__migrate-to-setup-logmind.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-05-feat-skill-push-privacy-gate-layers-3-4-content-scanner-repo -->
+- **2026-06-05** — feat(skill push): privacy gate layers 3+4 — content scanner + repo-visibility (§8.2 wave-2) → [detail](decisions-branches/feat__skill-push-privacy-gate-layers-3-4.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-05-check-links-exclude-docs-reviews-pr-md-spec-6-2-review-write -->
+- **2026-06-05** — check-links: exclude docs/reviews/PR-*.md (SPEC §6.2 review-writeback path) → [detail](decisions-branches/feat__check-links-exclude-review-writebacks.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-wire-thrillmade-orchestrator-bot-app-for-cask-bump-g1-e-2 -->
+- **2026-06-03** — Wire thrillmade-orchestrator[bot] App for cask-bump (G1.e.2) → [detail](decisions-branches/v1-go-rewrite.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-site-lead-install-with-brew-curl-go-binary-mark-pip-wheel-de -->
+- **2026-06-03** — Site: lead install with brew/curl Go binary; mark pip wheel deprecated (frozen v0.6.16) → [detail](decisions-branches/chore__v1-install-rewrite.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-remove-python-source-tree-post-cutover-g3-a-consumers-migrat -->
+- **2026-06-03** — Remove Python source tree post-cutover (G3.a consumers migrated) → [detail](decisions-branches/chore__post-cutover-python-cleanup.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-port-logmind-sync-to-go-provenance-md-writeback-driven-by-do -->
+- **2026-06-03** — Port logmind sync to Go: PROVENANCE.md writeback driven by docs/reviews/PR-*.md → [detail](decisions-branches/feat__sync-go-port.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-lead-readme-install-with-go-binary-mark-python-wheel-frozen- -->
+- **2026-06-03** — Lead README install with Go binary; mark Python wheel frozen at v0.6.16 → [detail](decisions-branches/chore__v1-deprecation-readme.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-03-feat-skill-push-privacy-gate-layers-1-2-frontmatter-dir-conv -->
+- **2026-06-03** — feat(skill push): privacy gate layers 1+2 (frontmatter + dir convention) (§8.2 first slice) → [detail](decisions-branches/feat__skill-push-privacy-gate-layers-1-2.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-test-b6-follow-up-port-commit-msg-hook-tests-from-main-to-v1 -->
+- **2026-06-02** — test(B6 follow-up): port commit-msg hook tests from main to v1-go-rewrite → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-lock-specversion-to-0-1-0-drop-draft-suffix -->
+- **2026-06-02** — Lock SpecVersion to 0.1.0 (drop -draft suffix) → [detail](decisions-branches/chore__v1-pre-final-polish.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-strip-origin-prefix-from-symbolic-ref-short-output-in-po -->
+- **2026-06-02** — fix: strip 'origin/' prefix from symbolic-ref --short output in post-merge hook → [detail](decisions-branches/fix__symbolic-ref-default-branch-strip.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-b7-wire-homebrew-tap-pat-now-that-it-s-provisioned -->
+- **2026-06-02** — fix(B7): wire HOMEBREW_TAP_PAT now that it's provisioned → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-b7-tag-trigger-glob-pattern-v-1-9-v-1-9 -->
+- **2026-06-02** — fix(B7): tag-trigger glob pattern (v[1-9]+ → v[1-9]*) → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-b7-replace-missing-homebrew-tap-pat-secret-with-github-t -->
+- **2026-06-02** — fix(B7): replace missing HOMEBREW_TAP_PAT secret with GITHUB_TOKEN → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-b7-remove-empty-env-block-from-goreleaser-snapshot-step -->
+- **2026-06-02** — fix(B7): remove empty env: block from GoReleaser snapshot step → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-fix-b7-bisect-release-yml-minimal-version-to-identify-startu -->
+- **2026-06-02** — fix(B7): bisect release.yml — minimal version to identify startup_failure cause → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-feat-go-b4-port-agents-list-add-remove-update-migrate-insert -->
+- **2026-06-02** — feat(go-b4): port agents (list/add/remove/update/migrate) + inserter package + embed AGENTS.md templates → [detail](decisions-branches/feat__go-b4-agents.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-feat-go-b3-port-timeline-file-structure-tree-rebase-internal -->
+- **2026-06-02** — feat(go-b3): port timeline, file-structure, tree, rebase + internal config/decisions/timeline/tree packages with byte-identical Python v0.6.14 output → [detail](decisions-branches/feat__go-b3-derived-docs.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-feat-go-b2-port-install-hook-check-decisions-check-links-git -->
+- **2026-06-02** — feat(go-b2): port install-hook, check-decisions, check-links + git/hook helpers → [detail](decisions-branches/feat__go-b2-git-hooks.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-feat-go-b1-scaffold-go-module-cobra-version-snapshot-infra -->
+- **2026-06-02** — feat(go-b1): scaffold Go module + cobra + version + snapshot infra → [detail](decisions-branches/feat__go-b1-scaffold.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-chore-bump-version-0-6-14-0-6-16-on-v1-go-rewrite -->
+- **2026-06-02** — chore: bump __version__ 0.6.14 → 0.6.16 on v1-go-rewrite → [detail](decisions-branches/chore__v1-go-pytest-pin-bump.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-bisect-b7-add-workflow-dispatch-inputs-packages-write-back -->
+- **2026-06-02** — bisect(B7): add workflow_dispatch inputs + packages:write back → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-bisect-b7-1-add-codesign-import-step-on-top-of-minimal-relea -->
+- **2026-06-02** — bisect(B7-1): add codesign import step on top of minimal release.yml → [detail](decisions-branches/fix__release-workflow-startup-failure.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-b7-choose-goreleaser-for-cross-platform-go-binary-distributi -->
+- **2026-06-02** — B7: choose GoReleaser for cross-platform Go binary distribution → [detail](decisions-branches/feat__go-b7-distribution.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-b6-config-doctor-init-self-update-go-rewrite -->
+- **2026-06-02** — B6: config + doctor + init + self-update (Go rewrite) → [detail](decisions-branches/feat__go-b6-config-doctor.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-b5-wave-1-5-skill-core-package-scaffold-validate-bench-audit -->
+- **2026-06-02** — B5 wave 1/5: skill core package — scaffold, validate, bench, audit, suggest (heuristic) → [detail](decisions-branches/feat__go-b5-skills.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-02-b2-carry-forward-go-post-merge-hook-body-absorbs-v0-6-16-hea -->
+- **2026-06-02** — B2 carry-forward: Go post-merge hook body absorbs v0.6.16 HEAD-vs-origin skip → [detail](decisions-branches/feat__go-v0.6.16-carry-forward.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-8-logmind-init-with-skdd-flag-unified-install-python-en -->
+- **2026-06-01** — v0.6.8: logmind init --with-skdd flag (unified install, Python entry) → [detail](decisions-branches/feat__v0.6.8-with-skdd-flag.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-7-post-merge-hook-leaves-derived-docs-unstaged-downstre -->
+- **2026-06-01** — v0.6.7: post-merge hook leaves derived docs unstaged (downstream bug fix) → [detail](decisions-branches/fix__v0.6.7-post-merge-no-stage.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-6-doctor-surfaces-clud-bug-skill-usage-upload-drift-pos -->
+- **2026-06-01** — v0.6.6: doctor surfaces clud-bug skill-usage upload drift (post-v0.6.31 hardening) → [detail](decisions-branches/feat__v0.6.6-doctor-skill-usage-check.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-5-skill-suggest-human-gated-pattern-detection-closes-st -->
+- **2026-06-01** — v0.6.5: skill suggest — human-gated pattern detection (closes Stream 6 follow-ons) → [detail](decisions-branches/feat__v0.6.5-skill-suggest.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-4-skill-audit-author-s-side-staleness-read-stream-6-fol -->
+- **2026-06-01** — v0.6.4: skill audit — author's-side staleness read (Stream 6 follow-on) → [detail](decisions-branches/feat__v0.6.4-skill-audit.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-v0-6-3-skill-bench-per-call-token-cost-measurement-stream-6- -->
+- **2026-06-01** — v0.6.3: skill bench — per-call token-cost measurement (Stream 6 follow-on) → [detail](decisions-branches/feat__v0.6.3-skill-bench.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-fix-readme-use-full-skill-path-in-skills-sh-badge-url -->
+- **2026-06-01** — fix(README): use full skill path in skills.sh badge URL → [detail](decisions-branches/fix__skills-sh-badge-url.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-v0-6-14-propagation-pipeline-polish-doctor-content-diff -->
+- **2026-06-01** — feat(v0.6.14): propagation-pipeline polish — doctor content-diff + [skip-logmind] auto-title + PyPI CDN retry → [detail](decisions-branches/feat__v0.6.14-doctor-content-diff-and-skip-logmind-title.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-v0-6-13-4-consumer-product-ux-fixes-issues-112-113-prop -->
+- **2026-06-01** — feat(v0.6.13): 4 consumer-product UX fixes (issues #112 + #113 + propagation friction) → [detail](decisions-branches/feat__v0.6.13-orphan-hook-skip-log-no-self-update.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-v0-6-12-doctor-surfaces-logmind-auto-regen-pat-status-p -->
+- **2026-06-01** — feat(v0.6.12): doctor surfaces LOGMIND_AUTO_REGEN_PAT status proactively → [detail](decisions-branches/feat__v0.6.12-doctor-pat-check.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-v0-6-11-single-quoted-pin-regex-self-update-template-us -->
+- **2026-06-01** — feat(v0.6.11): single-quoted pin regex + self-update template uses PAT for workflow refreshes → [detail](decisions-branches/feat__v0.6.11-pin-regex-and-self-update-pat.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-v0-6-10-hook-version-drift-detection-tokenomics-2026-06 -->
+- **2026-06-01** — feat(v0.6.10): hook-version drift detection (tokenomics 2026-06-01 bug report) → [detail](decisions-branches/feat__v0.6.10-hook-drift-detection.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-feat-logmind-file-structure-check-v0-6-9-symmetric-ci-gate-w -->
+- **2026-06-01** — feat: `logmind file-structure --check` (v0.6.9 — symmetric CI gate with timeline) → [detail](decisions-branches/feat__file-structure-check.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-chore-propagate-clud-bug-v0-6-32 -->
+- **2026-06-01** — chore: propagate clud-bug v0.6.32 → [detail](decisions-branches/chore__clud-bug-v0.6.32.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-chore-propagate-clud-bug-v0-6-31-hotfix -->
+- **2026-06-01** — chore: propagate clud-bug v0.6.31 (hotfix) → [detail](decisions-branches/chore__clud-bug-v0.6.31.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-06-01-chore-propagate-clud-bug-v0-6-30-cross-review-aggregation-re -->
+- **2026-06-01** — chore: propagate clud-bug v0.6.30 (cross-review aggregation reads workflow artifacts) → [detail](decisions-branches/chore__clud-bug-v0.6.30.md)
+<!-- logmind-entry-end -->
+
+## 2026-05
+
+<!-- logmind-entry-start: 2026-05-31-v0-6-2-notify-agent-skills-skips-pr-creation-when-skill-md-d -->
+- **2026-05-31** — v0.6.2: notify-agent-skills skips PR creation when SKILL.md diff is no-op → [detail](decisions-branches/feat__v0.6.2-notify-skip-noop.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-31-feat-stream-1-path-a-historical-clud-bug-review-scrape-layer -->
+- **2026-05-31** — feat: Stream 1 Path A — historical clud-bug-review scrape + Layer 1 formula in Python → [detail](decisions-branches/feat__stream1-path-a-historical-scrape.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-31-chore-propagate-clud-bug-v0-6-29-to-logmind-skill-usage-work -->
+- **2026-05-31** — chore: propagate clud-bug v0.6.29 to logmind (skill-usage workflow integration) → [detail](decisions-branches/chore__clud-bug-v0.6.29.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-site-4th-principle-always-in-sync-measured-section-v0-5-12-p -->
+- **2026-05-30** — site: 4th principle 'always in sync' + measured. section + v0.5.12 pin → [detail](decisions-branches/site__docs-stay-in-sync-and-measured-saver.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-6-1-deterministic-auto-rebase-on-timeline-md-gap-opt -->
+- **2026-05-30** — feat(v0.6.1): deterministic auto-rebase on timeline.md gap (opt-in) → [detail](decisions-branches/feat__v0.5.14-auto-rebase.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-6-0-logmind-skill-new-test-cli-first-step-of-the-skd -->
+- **2026-05-30** — feat(v0.6.0): logmind skill new/test CLI — first step of the SkDD auto-dev loop → [detail](decisions-branches/feat__v0.6.0-skill-cli.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-5-13-5-item-quality-batch-4b-2-workflow-pin-auto-upd -->
+- **2026-05-30** — feat(v0.5.13): 5-item quality batch — §4b.2 + workflow pin auto-update + doctor non-zero + doctor stale-derived-docs warning + logmind rebase → [detail](decisions-branches/feat__v0.5.13-quality-batch.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-5-12-logmind-log-auto-installs-merge-driver-hooks-on -->
+- **2026-05-30** — feat(v0.5.12): `logmind log` auto-installs merge driver + hooks on every invocation (fresh-clone auto-resolve) → [detail](decisions-branches/fix__v0.5.12-auto-install-merge-driver-on-log.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-5-11-post-rewrite-hook-so-multi-commit-rebases-don-t -->
+- **2026-05-30** — feat(v0.5.11): post-rewrite hook so multi-commit rebases don't leave timeline.md stale (#58) → [detail](decisions-branches/fix__v0.5.11-post-rewrite-hook-issue-58.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-feat-v0-5-10-warn-loudly-when-stage-scoped-leaves-tracked-mo -->
+- **2026-05-30** — feat(v0.5.10): warn loudly when --stage scoped leaves tracked modifications unstaged (#59) → [detail](decisions-branches/fix__v0.5.10-stage-scoped-warn-issue-59.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-chore-propagate-clud-bug-v0-6-22-v0-6-27-to-logmind-smart-bu -->
+- **2026-05-30** — chore: propagate clud-bug v0.6.22 → v0.6.27 to logmind (Smart Budget self-upgrade) → [detail](decisions-branches/chore__clud-bug-v0.6.27-self-upgrade.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-30-bench-stream-1-path-c-calibration-aggregate-py -->
+- **2026-05-30** — bench: Stream 1 Path C — calibration_aggregate.py → [detail](decisions-branches/feat__calibration-aggregate-path-c.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-upgrade-logmind-to-clud-bug-v0-6-22-picks-up-phase-0-5-effic -->
+- **2026-05-29** — Upgrade logmind to clud-bug v0.6.22 — picks up Phase 0.5 efficiency + quality improvements → [detail](decisions-branches/chore__clud-bug-v0.6.22-upgrade.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-release-logmind-v0-5-5-rtk-inspired-fail-safe-0-0-t-logmind- -->
+- **2026-05-29** — Release logmind v0.5.5 — RTK-inspired fail-safe (0.0.T logmind side) → [detail](decisions-branches/release__v0.5.5.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-implement-bench-per-session-py-q7-logmind-s-4th-angle-now-re -->
+- **2026-05-29** — Implement bench/per_session.py — Q7-logmind's 4th angle now real, surfaces 0.B.5/0.B.6 decision data → [detail](decisions-branches/feat__bench-per-session.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-implement-bench-org-cumulative-real-impl-phase-0-5-2-v0-5-7 -->
+- **2026-05-29** — Implement bench/org_cumulative real impl (Phase 0.5 §2, v0.5.7) → [detail](decisions-branches/feat__0.5-S2-org-cumulative-bench.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-feat-v0-5-9-fix-60-strip-code-regions-before-scanning-for-li -->
+- **2026-05-29** — feat(v0.5.9): fix #60 — strip code regions before scanning for links → [detail](decisions-branches/feat__v0.5.9-check-links-strip-code.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-feat-v0-5-8-quality-batch-issue-57-dry-run-output-issue-66-f -->
+- **2026-05-29** — feat(v0.5.8): quality batch — issue #57 dry-run output + issue #66 file-structure on feature branches → [detail](decisions-branches/feat__v0.5.8-quality-batch.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-defer-0-b-5-docs-decisions-md-per-entry-compact-to-phase-3-s -->
+- **2026-05-29** — Defer 0.B.5 (docs/decisions.md per-entry compact) to Phase 3+ — structural overhead too small to be worth a release → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-chore-agents-md-import-in-claude-md-q4-refinement-0-0-i -->
+- **2026-05-29** — chore: @AGENTS.md import in CLAUDE.md (Q4 refinement / 0.0.I) → [detail](decisions-branches/chore__agents-md-import.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-0-b-6-trim-agents-md-logmind-block-v5-slim-v6-pointer-69-red -->
+- **2026-05-29** — 0.B.6: trim AGENTS.md logmind-block v5-slim → v6-pointer (~69% reduction, data-justified by PR #78 per_session) → [detail](decisions-branches/feat__0.B.6-agents-block-trim.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-29-0-0-t-logmind-side-rtk-inspired-fail-safe-warn-not-silent-on -->
+- **2026-05-29** — 0.0.T (logmind side): RTK-inspired fail-safe → warn-not-silent on parser; orphan-cleanup on atomic_write → [detail](decisions-branches/feat__0.0.T-rtk-inspired-fail-safe.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-v0-5-4-docs-timeline-md-ships-brief-format-on-disk-phase-0-b -->
+- **2026-05-28** — v0.5.4: docs/timeline.md ships brief format on disk (Phase 0.B.4) → [detail](decisions-branches/feat__0.B.4-timeline-brief-format.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-v0-5-3-patch-click-secho-for-logmind-quiet-1-progress-vs-err -->
+- **2026-05-28** — v0.5.3: patch click.secho for LOGMIND_QUIET=1 (progress vs error fg) → [detail](decisions-branches/feat__0.B.3.1-secho-quiet-fix.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-chore-clud-bug-v0-6-7-v0-6-12-sonnet-pin-incremental-diff-ma -->
+- **2026-05-28** — chore: clud-bug v0.6.7 → v0.6.12 (Sonnet pin, incremental-diff, --max-turns, secho lessons, self-update YAML fix) → [detail](decisions-branches/chore__clud-bug-update-v0.6.12.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-b-2-show-brief-limit-json-v0-5-2 -->
+- **2026-05-28** — B.2: show --brief / --limit / --json (v0.5.2) → [detail](decisions-branches/feat__0.B.2-show-brief-limit-json.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-0-a-9-audit-all-7-consuming-repos-pass-q4-200-line-claude-md -->
+- **2026-05-28** — 0.A.9 audit: all 7 consuming repos pass Q4 + <200-line CLAUDE.md; zero Q5 path-scope candidates found → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-28-0-0-m-2-logmind-bench-internal-q7-enforcement-4-angle-net-sa -->
+- **2026-05-28** — 0.0.M.2: logmind-bench internal Q7 enforcement (4-angle net-saver measurement) → [detail](decisions-branches/feat__0.0.M.2-logmind-bench.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-v0-3-2-homebrew-bump-auto-merge-nothing-to-commit-guard-site -->
+- **2026-05-27** — v0.3.2: homebrew-bump auto-merge + nothing-to-commit guard + site/app/page.tsx URL fix → [detail](decisions-branches/chore__v0.3.2-homebrew-automerge.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-phase-a-b-propagation-clud-bug-v0-5-6-v0-6-7-in-logmind -->
+- **2026-05-27** — Phase A → B propagation: clud-bug v0.5.6 → v0.6.7 in logmind → [detail](decisions-branches/chore__clud-bug-v0.5.6-to-v0.6.7.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-fix-vercel-json-guard-ignorecommand-against-bad-vercel-git-p -->
+- **2026-05-27** — fix(vercel.json): guard ignoreCommand against bad VERCEL_GIT_PREVIOUS_SHA → [detail](decisions-branches/fix__vercel-ignore-bad-sha.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-fix-v0-3-3-drop-wall-clock-timestamp-from-docs-file-structur -->
+- **2026-05-27** — fix(v0.3.3): drop wall-clock timestamp from docs/file-structure.md → [detail](decisions-branches/fix__v0.3.3-file-structure-determinism.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-feat-v0-4-0-notify-agent-skills-yml-opens-a-claude-proposed- -->
+- **2026-05-27** — feat(v0.4.0): notify-agent-skills.yml opens a Claude-proposed SKILL.md PR (not an issue) → [detail](decisions-branches/feat__v0.4.0-notify-pr-shape.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-feat-v0-3-4-check-derived-docs-auto-fixes-when-logmind-auto- -->
+- **2026-05-27** — feat(v0.3.4): check-derived-docs auto-fixes when LOGMIND_AUTO_REGEN_PAT configured → [detail](decisions-branches/feat__v0.3.4-auto-regen-derived-docs.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-chore-regen-docs-file-structure-md-drop-legacy-last-updated- -->
+- **2026-05-27** — chore: regen docs/file-structure.md (drop legacy Last updated line) → [detail](decisions-branches/chore__regen-derived-docs.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-chore-add-test-aggregator-job-reports-under-literal-test-con -->
+- **2026-05-27** — chore: add test aggregator job (reports under literal 'test' context) → [detail](decisions-branches/chore__add-test-aggregator-job.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-b-3-logmind-quiet-logmind-quiet-1-with-ok-output-v0-5-1 -->
+- **2026-05-27** — B.3: logmind --quiet / LOGMIND_QUIET=1 with ok output (v0.5.1) → [detail](decisions-branches/feat__0.B.3-quiet-ok-output.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-27-b-1-file-structure-md-default-depth-2-logmind-v0-5-0 -->
+- **2026-05-27** — B.1: file-structure.md default depth=2 (logmind v0.5.0) → [detail](decisions-branches/feat__0.B.1-file-structure-max-depth.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-v0-3-1-pre-transfer-url-update-thrillmot-thrillmade -->
+- **2026-05-26** — v0.3.1: pre-transfer URL update — thrillmot → thrillmade → [detail](decisions-branches/chore__migrate-to-thrillmade.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-fix-v0-2-8-replace-pyyaml-python-pinversion-detection-with-g -->
+- **2026-05-26** — fix: v0.2.8 — replace PyYAML+Python pinVersion detection with grep → [detail](decisions-branches/fix__v0.2.8-pinversion-grep.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-fix-v0-2-5-refresh-mode-also-updates-stale-version-pins -->
+- **2026-05-26** — fix: v0.2.5 — refresh-mode also updates stale version pins → [detail](decisions-branches/fix__v0.2.5-pin-refresh.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-3-0-custom-git-merge-driver-for-derived-files-post-m -->
+- **2026-05-26** — feat: v0.3.0 — custom git merge driver for derived files + post-merge hook → [detail](decisions-branches/feat__v0.3.0-merge-driver.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-2-7-stage-all-becomes-the-default-logmind-log-is-the -->
+- **2026-05-26** — feat: v0.2.7 — --stage all becomes the default; logmind log is the commit primitive → [detail](decisions-branches/feat__v0.2.7-stage-all-default.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-2-6-notify-agent-skills-workflow-closes-the-release- -->
+- **2026-05-26** — feat: v0.2.6 — notify-agent-skills workflow closes the release→skill update gap → [detail](decisions-branches/feat__v0.2.6-notify-agent-skills.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-2-4-new-logmind-doctor-stack-status-command -->
+- **2026-05-26** — feat: v0.2.4 — new logmind doctor stack-status command → [detail](decisions-branches/feat__v0.2.4-doctor.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-2-3-logmind-log-auto-regenerates-docs-timeline-md -->
+- **2026-05-26** — feat: v0.2.3 — logmind log auto-regenerates docs/timeline.md → [detail](decisions-branches/feat__v0.2.3-auto-regen-timeline.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-feat-v0-2-10-changelog-on-upgrade-escape-backticks-in-self-u -->
+- **2026-05-26** — feat: v0.2.10 changelog-on-upgrade + escape backticks in self-update notice → [detail](decisions-branches/feat__v0.2.10-changelog-on-upgrade.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-26-chore-v0-2-9-bump-actions-to-v6-across-templates-dogfood-add -->
+- **2026-05-26** — chore: v0.2.9 — bump actions to v6 across templates + dogfood; add vercel.json skip-on-non-site → [detail](decisions-branches/chore__v0.2.9-action-bumps-and-vercel-skip.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-18-v0-2-2-fix-paths-filter-bug-in-check-doc-links-yml-template -->
+- **2026-05-18** — v0.2.2: fix paths-filter bug in check-doc-links.yml.template → [detail](decisions-branches/fix__check-doc-links-paths-filter-v0.2.2.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-18-v0-2-1-audit-driven-fixes-version-pinning-idempotent-init-at -->
+- **2026-05-18** — v0.2.1: audit-driven fixes — version pinning, idempotent init, atomic writes, hardened git helpers → [detail](decisions-branches/feat__v0.2.1-audit-fixes.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-18-feat-ship-logmind-self-update-yml-workflow-template -->
+- **2026-05-18** — feat: ship logmind-self-update.yml workflow template → [detail](decisions-branches/feat__logmind-self-update.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-18-docs-fix-stale-skills-sh-badge-url-in-readme -->
+- **2026-05-18** — docs: fix stale skills.sh badge URL in README → [detail](decisions-branches/docs__fix-skills-badge-url.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-18-docs-correct-readme-required-repo-settings-for-v0-2-add-repo -->
+- **2026-05-18** — docs: correct README required-repo-settings for v0.2 + add reporulez one-command → [detail](decisions-branches/docs__readme-v0.2-corrections.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-v0-2-0-derived-file-architecture-replaces-per-merge-aggregat -->
+- **2026-05-15** — v0.2.0: derived-file architecture replaces per-merge aggregator → [detail](decisions-branches/feat__v0.2-derived-decisions-md.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-v0-1-4-optional-logmind-bot-pat-lets-aggregator-prs-satisfy- -->
+- **2026-05-15** — v0.1.4: optional LOGMIND_BOT_PAT lets aggregator PRs satisfy required checks → [detail](decisions-branches/feat__v0.1.4-bot-pat-fallback.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-v0-1-3-kill-file-structure-conflicts-fix-agents-md-drift-aft -->
+- **2026-05-15** — v0.1.3: kill file-structure conflicts + fix AGENTS.md drift after logmind log → [detail](decisions-branches/feat__v0.1.3-structural-fix.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-v0-1-2-upstream-bug-fixes-from-clud-bug-pr-21-skill-repo-res -->
+- **2026-05-15** — v0.1.2: upstream bug fixes from clud-bug PR #21 + skill repo restructure to thrillmade/agent-skills collection → [detail](decisions-branches/feat__v0.1.2-upstream-fixes.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-site-tighten-copy-drop-pseudo-numbering-remove-ornament-side -->
+- **2026-05-15** — site: tighten copy, drop pseudo-numbering, remove ornament side-rules → [detail](decisions-branches/site-copy-cleanup.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-site-responsive-fixes-mobile-375-desktop-wide-screen -->
+- **2026-05-15** — Site: responsive fixes (mobile 375 + desktop wide-screen) → [detail](decisions-branches/site-responsive.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-site-footer-polish-version-skill-url-breathing-room-single-l -->
+- **2026-05-15** — site: footer polish — version, skill URL, breathing room, single-line nav → [detail](decisions-branches/footer-polish.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-release-v0-1-1-phase-13-polish -->
+- **2026-05-15** — Release v0.1.1 (Phase 13 polish) → [detail](decisions-branches/release-0.1.1.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-refresh-repo-s-own-workflows-to-v0-1-2-fix-windows-utf-8-enc -->
+- **2026-05-15** — refresh repo's own workflows to v0.1.2 + fix Windows utf-8 encoding bug → [detail](decisions-branches/feat__repo-workflows-v0.1.2.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-merged-footer-polish-32 -->
+- **2026-05-15** — Merged: footer-polish (#32) → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-merged-dogfood-workflows-15 -->
+- **2026-05-15** — Merged: dogfood-workflows (#15) → [detail](decisions.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-install-logmind-workflows-in-own-repo-for-dogfood -->
+- **2026-05-15** — Install logmind workflows in own repo for dogfood → [detail](decisions-branches/dogfood-workflows.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-15-dogfood-check-decisions-workflow-fix-branch-aware-bug-always -->
+- **2026-05-15** — Dogfood check-decisions workflow + fix branch-aware bug + always-run check-doc-links → [detail](decisions-branches/agents-update-cli.md)
+<!-- logmind-entry-end -->
+
+<!-- logmind-entry-start: 2026-05-14-branch-aware-logging-agents-md-consolidation-link-integrity- -->
+- **2026-05-14** — Branch-aware logging, AGENTS.md consolidation, link-integrity CI, logmind agent skill, OSS readiness for v0.1 → [detail](decisions-branches/virtual-kurzweil.md)
+<!-- logmind-entry-end -->

--- a/internal/cli/doctor_summary_test.go
+++ b/internal/cli/doctor_summary_test.go
@@ -70,18 +70,20 @@ func TestBackfillBranchSummaries(t *testing.T) {
 	}
 }
 
-// TestBackfillBranchSummaries_DefaultModeNoop: branch-divergent mode never
-// backfills (the feature is main-canonical-only → default repos byte-stable).
-func TestBackfillBranchSummaries_DefaultModeNoop(t *testing.T) {
+// TestBackfillBranchSummaries_BranchDivergentNoop: the branch-divergent
+// opt-out never backfills (the feature is main-canonical-only → opted-out
+// repos stay byte-stable). Post-v1.0 flip this must pin branch-divergent
+// explicitly, since main-canonical (which DOES backfill) is now the default.
+func TestBackfillBranchSummaries_BranchDivergentNoop(t *testing.T) {
 	dir := withTempCwd(t, func(d string) {
-		mustWriteUnder(t, d, ".logmind/config.yml", "git:\n  auto_commit: true\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "timeline:\n  canonical: branch-divergent\n")
 		mustWriteUnder(t, d, "docs/decisions-branches/feat__old.md",
 			"← back\n\n## 2026-06-10 09:00 - Old\n\n---\n")
 		if n := backfillBranchSummaries(d, io.Discard); n != 0 {
-			t.Errorf("default-mode backfill = %d; want 0", n)
+			t.Errorf("branch-divergent backfill = %d; want 0", n)
 		}
 	})
 	if strings.Contains(readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__old.md")), "logmind-entry-start") {
-		t.Errorf("default mode wrote a marker; want none")
+		t.Errorf("branch-divergent mode wrote a marker; want none")
 	}
 }

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -103,7 +103,8 @@ func TestHeadline_NewlineSummaryDoesNotInjectMarker(t *testing.T) {
 func TestHeadline_NoopWhenNotMainCanonical(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
-		scaffoldDocs(t) // default config → branch-divergent
+		scaffoldDocs(t)
+		pinBranchDivergent(t, d) // explicit opt-out: headline is main-canonical-only
 		checkoutBranch(t, d, "feat/x")
 		withFakeTTY(t, false, func() { logOnce(t, "decision") })
 		out := runHeadlineCmd(t, "some summary")

--- a/internal/cli/log_marker_test.go
+++ b/internal/cli/log_marker_test.go
@@ -8,14 +8,37 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/timeline"
 )
 
 // optIntoMainCanonical overwrites the scaffolded config to enable the
 // main-canonical timeline. Call after scaffoldDocs, before the first log.
+//
+// NOTE post-v1.0-flip: main-canonical is now the DEFAULT, so this call is
+// belt-and-suspenders on a scaffolded repo — it makes the mode explicit and
+// keeps these tests decoupled from any future default change.
 func optIntoMainCanonical(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, ".logmind", "config.yml"),
 		[]byte("timeline:\n  canonical: main-canonical\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// pinBranchDivergent writes the DEPRECATED-but-supported branch-divergent
+// opt-out into dir's config. Symmetric to optIntoMainCanonical. Post-v1.0
+// flip, branch-divergent-specific behavior (no entry-block marker, doctor
+// no-ops, the v0.1.x byte floor) must EXPLICITLY opt out of the new default.
+// Creates .logmind/ if absent so it works on a bare TempDir or after
+// scaffoldDocs (overriding the scaffolded default).
+func pinBranchDivergent(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".logmind"), 0o755); err != nil {
+		t.Fatalf("mkdir .logmind: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".logmind", "config.yml"),
+		[]byte("timeline:\n  canonical: branch-divergent\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 }
@@ -76,12 +99,16 @@ func TestLog_MainCanonical_WritesAndPreservesMarker(t *testing.T) {
 	}
 }
 
-// TestLog_DefaultMode_NoMarker: with no opt-in, branch files are byte-stable
-// — NO entry-block marker is written (the parity guard at the log layer).
-func TestLog_DefaultMode_NoMarker(t *testing.T) {
+// TestLog_BranchDivergent_NoMarker: in the branch-divergent opt-out, branch
+// files are byte-stable — NO entry-block marker is written (the v0.1.x parity
+// guard at the log layer). Post-v1.0 flip this must explicitly pin
+// branch-divergent, since main-canonical (which DOES write a marker) is now
+// the default; see TestLog_DefaultIsMainCanonical_WritesMarker.
+func TestLog_BranchDivergent_NoMarker(t *testing.T) {
 	dir := withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
-		scaffoldDocs(t) // default config — branch-divergent
+		scaffoldDocs(t)
+		pinBranchDivergent(t, d) // explicit opt-out of the new default
 		cmd := exec.Command("git", "checkout", "-b", "feat/plain")
 		cmd.Dir = d
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -91,7 +118,45 @@ func TestLog_DefaultMode_NoMarker(t *testing.T) {
 	})
 	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__plain.md"))
 	if strings.Contains(s, "logmind-entry-start") {
-		t.Errorf("default mode wrote a marker; want none\n%s", s)
+		t.Errorf("branch-divergent mode wrote a marker; want none\n%s", s)
+	}
+}
+
+// TestLog_DefaultIsMainCanonical_WritesMarker is the v1.0-flip lock: with a
+// DEFAULT scaffolded config (config.yml.template has NO `timeline` key, so the
+// main-canonical default governs), the first log on a feature branch WRITES a
+// §1.6.3 entry-block marker and `logmind timeline` renders the main-canonical
+// (entry-block) format. Proves the flip is real end-to-end — no explicit opt-in.
+func TestLog_DefaultIsMainCanonical_WritesMarker(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t) // default config — main-canonical (the v1.0 default)
+		cmd := exec.Command("git", "checkout", "-b", "feat/default")
+		cmd.Dir = d
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("checkout: %v\n%s", err, out)
+		}
+		withFakeTTY(t, false, func() { logOnce(t, "Default-mode decision") })
+	})
+	s := readFileStr(t, filepath.Join(dir, "docs", "decisions-branches", "feat__default.md"))
+	if n := strings.Count(s, "<!-- logmind-entry-start: "); n != 1 {
+		t.Fatalf("default (main-canonical) mode marker count = %d; want 1\n%s", n, s)
+	}
+
+	// The default config must resolve to main-canonical timeline mode, and a
+	// --write render must emit the entry-block format (the same generator the
+	// --check path uses — no false-stale wedge).
+	if !canonicalEnabled(dir) {
+		t.Errorf("default config did not resolve to main-canonical timeline mode")
+	}
+	target := filepath.Join(dir, "docs", "timeline.md")
+	var stdout, stderr bytes.Buffer
+	if err := runTimeline(dir, target, false, false, false, &stdout, &stderr); err != nil {
+		t.Fatalf("runTimeline: %v (%s)", err, stderr.String())
+	}
+	got := readFileStr(t, target)
+	if !timeline.HasEntryBlocks(got) {
+		t.Errorf("default (main-canonical) timeline did not render entry-block format:\n%s", got)
 	}
 }
 

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -152,7 +152,8 @@ func TestQuiet_FileStructure_DefaultUnchanged(t *testing.T) {
 }
 
 func TestQuiet_Headline_SkippedSingleOK(t *testing.T) {
-	cwd := t.TempDir() // no main-canonical config
+	cwd := t.TempDir()
+	pinBranchDivergent(t, cwd) // opt out of the main-canonical default → headline skips
 	var out, errBuf bytes.Buffer
 	if err := runHeadline(cwd, "A summary", "", true, &out, &errBuf); err != nil {
 		t.Fatalf("runHeadline quiet: %v", err)
@@ -162,6 +163,7 @@ func TestQuiet_Headline_SkippedSingleOK(t *testing.T) {
 
 func TestQuiet_Headline_DefaultUnchanged(t *testing.T) {
 	cwd := t.TempDir()
+	pinBranchDivergent(t, cwd) // opt out of the main-canonical default → guidance line
 	var out, errBuf bytes.Buffer
 	if err := runHeadline(cwd, "A summary", "", false, &out, &errBuf); err != nil {
 		t.Fatalf("runHeadline default: %v", err)

--- a/internal/cli/timeline_test.go
+++ b/internal/cli/timeline_test.go
@@ -12,9 +12,16 @@ import (
 
 // makeDocs lays out a minimal docs/ tree with a few decision entries.
 // Returns the cwd path the runTimeline subroutine should use.
+//
+// The default timeline mode flipped to main-canonical in v1.0, but these
+// fixtures assert the branch-divergent byte floor (the timeline_stdout_*
+// goldens) — so makeDocs pins the branch-divergent opt-out. Tests that want
+// main-canonical (e.g. TestTimelineMainCanonicalDispatch) overwrite this
+// config after calling makeDocs.
 func makeDocs(t *testing.T, decisionsBody, archiveBody string, branchFiles map[string]string) string {
 	t.Helper()
 	cwd := t.TempDir()
+	pinBranchDivergent(t, cwd)
 	docs := filepath.Join(cwd, "docs")
 	if err := os.MkdirAll(filepath.Join(docs, "decisions-branches"), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,12 +179,13 @@ func DefaultConfig() Config {
 			},
 			RootLabel: "",
 		},
-		// Timeline: default "branch-divergent" reproduces today's output
-		// byte-for-byte; the main-canonical opt-in + the eventual default
-		// flip ride later releases. NOT added to DefaultMap (below) — that
-		// would change `logmind config list` bytes and break Python parity.
+		// Timeline: default "main-canonical" (the v1.0 flip). The conflict-free
+		// source-derived union (§1.6.4) is now the default assembly model;
+		// "branch-divergent" (the v0.1.x byte floor) remains a supported opt-out
+		// but is DEPRECATED. Version-gated: repos on pre-1.0 logmind are
+		// undisturbed until they upgrade.
 		Timeline: TimelineConfig{
-			Canonical: "branch-divergent",
+			Canonical: "main-canonical",
 		},
 		// Context.Repomap default false → `logmind context` emits today's
 		// two-doc payload byte-for-byte. NOT added to DefaultMap (below); the

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -16,10 +16,30 @@ func writeTimelineCfg(t *testing.T, content string) string {
 	return path
 }
 
-func TestTimelineCanonical_DefaultIsBranchDivergent(t *testing.T) {
-	// An absent `timeline` key must yield the DefaultConfig default, with
-	// main-canonical OFF.
+func TestTimelineCanonical_DefaultIsMainCanonical(t *testing.T) {
+	// The v1.0 flip: an absent `timeline` key must yield the DefaultConfig
+	// default, with main-canonical ON. branch-divergent is now a supported
+	// but DEPRECATED opt-out (see TestTimelineCanonical_OptOutBranchDivergent).
 	cfg, err := LoadPath(writeTimelineCfg(t, "git:\n  auto_commit: true\n"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if cfg.Timeline.Canonical != "main-canonical" {
+		t.Errorf("Canonical = %q; want main-canonical", cfg.Timeline.Canonical)
+	}
+	if !cfg.Timeline.IsMainCanonical() {
+		t.Errorf("IsMainCanonical() = false; want true on the default")
+	}
+	// A wholly missing file degrades to the same default.
+	cfg2, _ := LoadPath(filepath.Join(t.TempDir(), "does-not-exist.yml"))
+	if !cfg2.Timeline.IsMainCanonical() {
+		t.Errorf("missing-file default must be main-canonical (the v1.0 default)")
+	}
+}
+
+func TestTimelineCanonical_OptOutBranchDivergent(t *testing.T) {
+	// branch-divergent survives the flip as an explicit, supported opt-out.
+	cfg, err := LoadPath(writeTimelineCfg(t, "timeline:\n  canonical: branch-divergent\n"))
 	if err != nil {
 		t.Fatalf("LoadPath: %v", err)
 	}
@@ -27,12 +47,7 @@ func TestTimelineCanonical_DefaultIsBranchDivergent(t *testing.T) {
 		t.Errorf("Canonical = %q; want branch-divergent", cfg.Timeline.Canonical)
 	}
 	if cfg.Timeline.IsMainCanonical() {
-		t.Errorf("IsMainCanonical() = true; want false on the default")
-	}
-	// A wholly missing file degrades to the same default.
-	cfg2, _ := LoadPath(filepath.Join(t.TempDir(), "does-not-exist.yml"))
-	if cfg2.Timeline.IsMainCanonical() {
-		t.Errorf("missing-file default must be branch-divergent (main-canonical OFF)")
+		t.Errorf("IsMainCanonical() = true; want false when opted out to branch-divergent")
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -349,11 +349,13 @@ func TestCollectStatus_SummariesNeeded(t *testing.T) {
 	}
 }
 
-// TestCollectStatus_SummariesNeeded_DefaultModeEmpty: in the default
-// branch-divergent mode the check is OFF entirely (doctor output unchanged).
-func TestCollectStatus_SummariesNeeded_DefaultModeEmpty(t *testing.T) {
+// TestCollectStatus_SummariesNeeded_BranchDivergentEmpty: in the
+// branch-divergent opt-out the check is OFF entirely (doctor output
+// unchanged). Post-v1.0 flip this must pin branch-divergent explicitly,
+// since main-canonical (which runs the check) is now the default.
+func TestCollectStatus_SummariesNeeded_BranchDivergentEmpty(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "git:\n  auto_commit: true\n")
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "timeline:\n  canonical: branch-divergent\n")
 	mustWrite(t, filepath.Join(dir, "docs", "decisions-branches", "feat__x.md"),
 		"← back\n\n## 2026-06-10 09:00 - X\n\n---\n")
 	if r := CollectStatus(dir, true); len(r.SummariesNeeded) != 0 {


### PR DESCRIPTION
## R5a — the v1.0 default flip: main-canonical becomes the default

> **⚠️ HELD — do not merge without CEO coordination.** This is the outward-facing v1.0 flip. It needs (1) a **version-number decision** (see below), (2) the coordinated **SPEC §8.7 deprecation** (protocol), and (3) **AGENTS v6→v7 + agent-skills** propagation — all landing together.

### What this changes
`DefaultConfig()` now sets `timeline.canonical: "main-canonical"` (was `"branch-divergent"`). The conflict-free, source-derived union (§1.6.4) is now the DEFAULT timeline assembly model. **`branch-divergent` (the v0.1.x byte floor) remains a supported but DEPRECATED opt-out.** Version-gated: repos on pre-flip logmind are undisturbed until they upgrade.

### Test strategy (the 10-test blast radius, all green)
- Tests that verified **branch-divergent** (opt-out / no-op) behavior now **explicitly pin** `timeline.canonical: branch-divergent` (via a new `pinBranchDivergent` helper) — that mode still exists and stays covered; several renamed `…DefaultMode…` → `…BranchDivergent…`.
- The config default assertion flips: `TestTimelineCanonical_DefaultIsMainCanonical` (+ a retained opt-out test).
- **New lock test** `TestLog_DefaultIsMainCanonical_WritesMarker`: a DEFAULT-config log on a feature branch writes a §1.6.3 entry-block marker and renders the entry-block format — proving the flip end-to-end.
- **Byte-floor goldens UNCHANGED** (`timeline_stdout_*.golden`, `internal/timeline/testdata/*`, `internal/tree/testdata/*`) — pinned, not regenerated.

### Deliberately NOT here (the coordinated remainder)
- **No version bump.** Current is `1.2.0-dev` (latest tag v1.2.0). The "v1.0 flip" is a *milestone name* — the actual release version (**1.3.0** feature-flip vs **2.0.0** if the default-format change is deemed breaking) is a **CEO call at the release cut**.
- **No SpecVersion bump** — it's stale at 0.8.0; reconcile to the post-deprecation spec (0.12.0) at release.
- **`DefaultMap()` untouched** — config-list surfacing of `timeline`/`context` is a follow-up.
- **SPEC §8.7 deprecation, AGENTS v6→v7, agent-skills** — separate coordinated changes.

Full suite green (16 packages).
