### PR TITLE
feat(agents): AGENTS block v6→v7 — branch-summary (headline) convention

### DIFF
--- a/docs/decisions-branches/feat__agents-v7-headline-convention.md
+++ b/docs/decisions-branches/feat__agents-v7-headline-convention.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-04-bumps-the-full-agents-md-template-to-v7-carrying-the-branch- -->
+- **2026-07-04** — Bumps the full AGENTS.md template to v7 carrying the branch-summary (headline) convention, and makes doctor --fix / init-refresh flavour-preserving so legacy full-block repos refresh to full v7 instead of flipping to slim.
+<!-- logmind-entry-end -->
+
+## 2026-07-04 15:18 - Bump AGENTS.md full block v6 to v7 with the branch-summary (headline) convention
+
+**Reasoning:** The full AGENTS.md template is the tool-owned block installed into consumer repos; bumping its marker v6 to v7 with new content makes every full-block repo show drift so doctor --fix and agents update refresh them to v7. That is the delivery mechanism that carries the Slice-2 branch-summary convention into existing repos.
+
+**Alternatives considered:** Ship the convention only via the logmind skill plus slim template, leaving full-block repos without it -- rejected because legacy full installs render the procedure inline and never load the skill body., Leave EnsureAgentsMD refreshing against the slim default -- rejected because it silently downgrades a legacy full v6 repo to slim on doctor --fix, contradicting the documented full-slim guard and the task goal of refreshing to full v7.
+
+**Implications:**
+- matchingTemplate now maps v5, v6 and v7 all to the full flavour so older full blocks refresh forward to v7.
+- EnsureAgentsMD (the doctor --fix and init-refresh path) now selects the refresh template by the installed flavour via matchingTemplate, so a full v6 repo refreshes to full v7 rather than flipping to slim; verified idempotent.
+- Fresh logmind init still writes the slim v8-pointer default; the v7 full body is only what legacy full-block repos refresh to.
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -30,6 +30,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-04** — context.repomap: fold the Go signature skeleton into logmind context (default off) → [detail](decisions-branches/feat__context-repomap.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-04-bumps-the-full-agents-md-template-to-v7-carrying-the-branch- -->
+- **2026-07-04** — Bumps the full AGENTS.md template to v7 carrying the branch-summary (headline) convention, and makes doctor --fix / init-refresh flavour-preserving so legacy full-block repos refresh to full v7 instead of flipping to slim. → [detail](decisions-branches/feat__agents-v7-headline-convention.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-03-token-killer-phase-1b-logmind-quiet-output-discipline-across -->
 - **2026-07-03** — token-killer Phase 1b: LOGMIND_QUIET output discipline across log/timeline/file-structure/doctor/headline → [detail](decisions-branches/feat__token-killer-1b-quiet.md)
 <!-- logmind-entry-end -->

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -19,9 +19,11 @@
 //     quotes — matches the Python v0.6.11+ widened pattern.
 //
 //   - Template version markers gate "is the installed block stale".
-//     `<!-- logmind-block-version: v6 -->` for the full template,
-//     `<!-- logmind-block-version: v8-pointer -->` for slim (v0.6.16
-//     bumped both from v5 / v7-pointer respectively). Drift is
+//     `<!-- logmind-block-version: v7 -->` for the full template,
+//     `<!-- logmind-block-version: v8-pointer -->` for slim (the
+//     Slice-2 branch-summary wave bumped the full template v6→v7;
+//     v0.6.16 bumped it v5→v6 and the slim variant v7-pointer→v8-pointer).
+//     Drift is
 //     detected by comparing the marker bodies stripped (the Python
 //     code uses .strip() to be whitespace-tolerant; we mirror that).
 //     The matchingTemplate helper accepts both old and new markers
@@ -333,9 +335,12 @@ func jsonAgentBody() string {
 // current canonical logmind block. Behaviour mirror of
 // ensure_agents_md(root_path):
 //
-//   - Missing → write the canonical template.
+//   - Missing → write the canonical (slim) template.
 //   - Exists without markers → insert the logmind block in-place.
-//   - Exists with markers but stale body → silently refresh the body.
+//   - Exists with markers but stale body → refresh the body IN PLACE,
+//     preserving the installed flavour (a repo that shipped the full
+//     block refreshes into the current full body, a slim repo into the
+//     current slim body — never a silent full↔slim flip).
 //   - Exists with markers and matching body → no-op (return "").
 //
 // Returns a status string when a write happened, or "" for no-op.
@@ -363,9 +368,23 @@ func EnsureAgentsMD(repoRoot string) (string, error) {
 		return "Added logmind section to existing AGENTS.md", nil
 	}
 
-	templateBlock, tok := ExtractMarkerBlock(template)
 	installedBlock, iok := ExtractMarkerBlock(content)
-	if tok && iok && strings.TrimSpace(installedBlock) != strings.TrimSpace(templateBlock) {
+	if !iok {
+		return "", nil
+	}
+	// Refresh AGAINST THE INSTALLED FLAVOUR, not an unconditional slim
+	// default: a repo that shipped the full block must refresh into the
+	// current full body, never silently flip full↔slim (that migration is
+	// an explicit init/migrate decision). This mirrors the version-guard
+	// in matchingTemplate / FindOutdatedMarkerBlocks and honours invariant
+	// #3 documented on agentsMDTemplate. When the installed marker is
+	// unrecognized, fall back to the slim default (pre-existing behaviour).
+	refreshTemplate := template
+	if mt := matchingTemplate(installedBlock); mt != "" {
+		refreshTemplate = mt
+	}
+	templateBlock, tok := ExtractMarkerBlock(refreshTemplate)
+	if tok && strings.TrimSpace(installedBlock) != strings.TrimSpace(templateBlock) {
 		refreshed := ReplaceMarkerBlock(content, templateBlock)
 		if err := os.WriteFile(agentsPath, []byte(refreshed), 0o644); err != nil {
 			return "", err
@@ -384,12 +403,12 @@ func EnsureAgentsMD(repoRoot string) (string, error) {
 //  1. SPEC §1.1 makes slim the default for new repos since v0.6.8+.
 //  2. Detecting `skills.sh` from inside the binary would require
 //     spawning npx — defer that to a later wave if needed.
-//  3. Repos that already shipped the full template stay on full
-//     (a v5 / v6 full-template marker won't match v7-pointer /
-//     v8-pointer slim, so the stale-block detection will read
-//     DIFFERENT but the byte-for-byte compare in ExtractMarkerBlock
-//     will reject the refresh because we never auto-migrate
-//     full → slim). See OutdatedMarkerBlocks for the explicit guard.
+//  3. Repos that already shipped the full template stay on full: the
+//     refresh paths (EnsureAgentsMD and FindOutdatedMarkerBlocks) both
+//     select the template flavour matching the installed block-version
+//     marker via matchingTemplate, so a v5 / v6 / v7 full block refreshes
+//     into the current full body rather than silently flipping to slim.
+//     See matchingTemplate for the explicit flavour guard.
 //
 // Callers that need the full variant (e.g., during `init --no-slim`)
 // can call templates.AgentsTemplate() directly.
@@ -470,13 +489,20 @@ func FindOutdatedMarkerBlocks(repoRoot string) ([]OutdatedMarkerEntry, error) {
 // FLAVOUR (full vs slim) so existing repos with the older marker
 // get refreshed to the new body, while the explicit guard against
 // silent full↔slim flips (the substring of "-pointer") is preserved.
+//
+// The Slice-2 branch-summary wave bumped the full template v6→v7,
+// carrying the branch-summary (headline) convention into the inline
+// procedure. v5 / v6 / v7 all map to the full flavour, so a repo that
+// shipped an older full block refreshes forward into the v7 body while
+// the full↔slim guard still holds.
 func matchingTemplate(installedBody string) string {
 	if strings.Contains(installedBody, "logmind-block-version: v7-pointer") ||
 		strings.Contains(installedBody, "logmind-block-version: v8-pointer") {
 		return templates.AgentsSlimTemplate()
 	}
 	if strings.Contains(installedBody, "logmind-block-version: v5") ||
-		strings.Contains(installedBody, "logmind-block-version: v6") {
+		strings.Contains(installedBody, "logmind-block-version: v6") ||
+		strings.Contains(installedBody, "logmind-block-version: v7") {
 		return templates.AgentsTemplate()
 	}
 	return ""

--- a/internal/inserter/inserter_test.go
+++ b/internal/inserter/inserter_test.go
@@ -282,6 +282,54 @@ func TestEnsureAgentsMD_NoMarkersInserts(t *testing.T) {
 	}
 }
 
+// TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim pins the flavour-
+// preserving refresh contract for the `doctor --fix` / `init`-refresh
+// path (both go through EnsureAgentsMD). A repo that shipped a FULL block
+// (here a stale v6 full body) must refresh IN PLACE to the current full
+// v7 body — NOT get silently flipped to the slim v8-pointer default.
+// Second run is a no-op (idempotent). Mirrors invariant #3 documented on
+// agentsMDTemplate and the version-guard in matchingTemplate.
+func TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	// A stale v6 full block: correct FULL marker flavour, differing bytes.
+	staleFull := ReplaceMarkerBlock(templates.AgentsTemplate(),
+		"\n<!-- logmind-block-version: v6 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nstale full body\n")
+	if err := os.WriteFile(agentsPath, []byte(staleFull), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	msg, err := EnsureAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMD: %v", err)
+	}
+	if msg == "" {
+		t.Fatalf("stale full block should have been refreshed; got no-op")
+	}
+	got, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "logmind-block-version: v7") {
+		t.Errorf("full block must refresh to the v7 full body; marker missing")
+	}
+	if strings.Contains(string(got), "v8-pointer") {
+		t.Errorf("full block must NOT be flipped to the slim v8-pointer body")
+	}
+	if !strings.Contains(string(got), "Branch summary (headline)") {
+		t.Errorf("refreshed full body must carry the branch-summary convention")
+	}
+
+	// Idempotent: a second pass over the now-current full body is a no-op.
+	msg2, err := EnsureAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("second EnsureAgentsMD: %v", err)
+	}
+	if msg2 != "" {
+		t.Errorf("second EnsureAgentsMD over current v7 body must be a no-op; got %q", msg2)
+	}
+}
+
 // TestGetAgentStatus_AllAbsent — no files anywhere → every entry has
 // exists=false, configured=false.
 func TestGetAgentStatus_AllAbsent(t *testing.T) {
@@ -558,16 +606,17 @@ func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	}
 }
 
-// TestFindOutdatedMarkerBlocks_NeverFlipsFlavour — installed v6 full
+// TestFindOutdatedMarkerBlocks_NeverFlipsFlavour — installed v7 full
 // + Go binary defaults to slim → DO NOT report as outdated. Matches
-// the version-guard documented in matchingTemplate.
+// the version-guard documented in matchingTemplate. Also serves as the
+// "a repo already on the current full body is up-to-date" no-drift case.
 //
-// v0.6.16 bumped the full template v5→v6; the explicit guard against
-// silent full↔slim flips still fires because v6 maps to the full
-// template flavour, not slim.
+// The Slice-2 branch-summary wave bumped the full template v6→v7; the
+// explicit guard against silent full↔slim flips still fires because v7
+// maps to the full template flavour, not slim.
 func TestFindOutdatedMarkerBlocks_NeverFlipsFlavour(t *testing.T) {
 	dir := t.TempDir()
-	// Install the FULL v6 template. We don't want the slim default to
+	// Install the FULL v7 template. We don't want the slim default to
 	// silently rewrite this into v8-pointer.
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"),
 		[]byte(templates.AgentsTemplate()), 0o644); err != nil {
@@ -578,19 +627,19 @@ func TestFindOutdatedMarkerBlocks_NeverFlipsFlavour(t *testing.T) {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
 	if len(out) != 0 {
-		t.Errorf("installed v6 vs default-slim must NOT be reported as outdated; got %v", out)
+		t.Errorf("installed v7 vs default-slim must NOT be reported as outdated; got %v", out)
 	}
 }
 
-// TestFindOutdatedMarkerBlocks_OldFullRefreshesToV6 — installed v5
-// full template (pre-v0.6.16) MUST be reported as outdated so the
-// `agents update --apply` workflow refreshes it to the v6 body
-// (REQUIRED-framing heading + DO-NOT blockquote). Without this,
-// existing v5 installs never see the v0.6.16 prose changes.
-func TestFindOutdatedMarkerBlocks_OldFullRefreshesToV6(t *testing.T) {
+// TestFindOutdatedMarkerBlocks_OldFullRefreshesToV7 — installed v5
+// full template MUST be reported as outdated so the `agents update
+// --apply` workflow refreshes it forward to the current v7 body
+// (branch-summary convention). Without this, existing full installs
+// never see the prose changes.
+func TestFindOutdatedMarkerBlocks_OldFullRefreshesToV7(t *testing.T) {
 	dir := t.TempDir()
 	// Synthesize a v5-shaped block body. The byte content differs from
-	// v6 (no DO-NOT blockquote), so the drift compare must fire.
+	// v7, so the drift compare must fire.
 	v5Body := "\n<!-- logmind-block-version: v5 -->\n## Decision Logging (logmind)\nold v5 body\n"
 	wrecked := ReplaceMarkerBlock(templates.AgentsTemplate(), v5Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
@@ -601,10 +650,44 @@ func TestFindOutdatedMarkerBlocks_OldFullRefreshesToV6(t *testing.T) {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
 	if len(out) != 1 {
-		t.Fatalf("v5 block vs v6 template must be reported as outdated; got %d entries", len(out))
+		t.Fatalf("v5 block vs v7 template must be reported as outdated; got %d entries", len(out))
 	}
-	if !strings.Contains(out[0].NewBody, "logmind-block-version: v6") {
-		t.Errorf("refresh target NewBody must carry v6 marker; got %q", out[0].NewBody)
+	if !strings.Contains(out[0].NewBody, "logmind-block-version: v7") {
+		t.Errorf("refresh target NewBody must carry v7 marker; got %q", out[0].NewBody)
+	}
+}
+
+// TestFindOutdatedMarkerBlocks_V6RefreshesToV7 — the load-bearing case
+// for the Slice-2 branch-summary wave: a repo carrying a v6 full block
+// (the immediately-prior full flavour, shipped to consumer repos before
+// this bump) MUST be reported as outdated and its refresh target MUST be
+// the v7 full body (carrying the branch-summary convention), NOT the slim
+// v8-pointer body. This is what lets consumer repos pick up v7 via
+// `agents update` / `doctor --fix` drift detection.
+func TestFindOutdatedMarkerBlocks_V6RefreshesToV7(t *testing.T) {
+	dir := t.TempDir()
+	// Synthesize a v6-shaped full block body (older marker, differing bytes).
+	v6Body := "\n<!-- logmind-block-version: v6 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nold v6 body without the branch-summary convention\n"
+	wrecked := ReplaceMarkerBlock(templates.AgentsTemplate(), v6Body)
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := FindOutdatedMarkerBlocks(dir)
+	if err != nil {
+		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("v6 block vs v7 template must be reported as outdated; got %d entries", len(out))
+	}
+	// Refresh target must be the FULL v7 body — not a full↔slim flip.
+	if !strings.Contains(out[0].NewBody, "logmind-block-version: v7") {
+		t.Errorf("refresh target NewBody must carry v7 marker; got %q", out[0].NewBody)
+	}
+	if strings.Contains(out[0].NewBody, "v8-pointer") {
+		t.Errorf("v6 full block must NOT refresh to the slim v8-pointer body")
+	}
+	if !strings.Contains(out[0].NewBody, "Branch summary (headline)") {
+		t.Errorf("v7 refresh target must carry the branch-summary (headline) convention")
 	}
 }
 

--- a/internal/templates/AGENTS.md.template
+++ b/internal/templates/AGENTS.md.template
@@ -7,7 +7,7 @@ files like `CLAUDE.md` or `.cursorrules` are stubs that point here so the
 guidance lives in one place.
 
 <!-- logmind-start -->
-<!-- logmind-block-version: v6 -->
+<!-- logmind-block-version: v7 -->
 ## Decision Logging (logmind) — REQUIRED for substantive commits
 
 > **DO NOT run `git add` / `git commit` / `git push` for substantive code changes.**
@@ -87,6 +87,16 @@ On a feature branch, the entry lands in
 it lands in `docs/decisions.md`. On PR merge, a workflow appends a
 one-line summary to `docs/decisions.md` linking the PR and the
 per-branch file. You don't manage this — `logmind log` does.
+
+### Branch summary (headline)
+
+On a feature branch, set a one-sentence, plain-English summary of what
+the WHOLE branch does — `logmind headline "<one sentence>"`, or bundle it
+into a decision with `logmind log "..." -H "<one sentence>"`. It's stored
+at the top of the branch's decision file and copied verbatim into
+`docs/timeline.md`, so it's the FIRST thing the next agent reads. Refine
+it as the branch grows (the entry key stays stable). It's a no-op on the
+default branch, which logs to `docs/decisions.md` directly.
 
 ### Required reading at task start
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -41,18 +41,20 @@ import (
 //go:embed github/*.yml.template
 var embedFS embed.FS
 
-// AgentsTemplate returns the full v6 AGENTS.md template (the inline
+// AgentsTemplate returns the full v7 AGENTS.md template (the inline
 // procedure variant) — used when the host doesn't have skills.sh
 // available, or when the caller explicitly requests the full body.
 //
 // The block between `<!-- logmind-start -->` and `<!-- logmind-end -->`
-// carries the version marker `<!-- logmind-block-version: v6 -->`. The
+// carries the version marker `<!-- logmind-block-version: v7 -->`. The
 // inserter package uses that marker to decide whether an installed block
 // is stale.
 //
-// v0.6.16 bumped v5→v6: heading reframed as "REQUIRED for substantive
-// commits", added an explicit DO-NOT-git-commit blockquote that pairs
-// with the commit-msg hook installed by `logmind init`.
+// The Slice-2 branch-summary wave bumped v6→v7: added the branch-summary
+// (headline) convention to the inline procedure. v0.6.16 bumped v5→v6:
+// heading reframed as "REQUIRED for substantive commits", added an
+// explicit DO-NOT-git-commit blockquote that pairs with the commit-msg
+// hook installed by `logmind init`.
 func AgentsTemplate() string {
 	return readEmbed("AGENTS.md.template")
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -46,29 +46,43 @@ func TestTemplates_ByteIdenticalToPython(t *testing.T) {
 	}
 }
 
-// TestAgentsTemplate_HasV6Marker pins the protocol-version marker. The
+// TestAgentsTemplate_HasV7Marker pins the protocol-version marker. The
 // `agents update --apply` workflow keys on this marker to decide
 // whether an installed block is stale.
 //
-// v0.6.16 bumped v5→v6: heading reframed as "REQUIRED for substantive
-// commits" with an explicit DO-NOT-git-commit blockquote that pairs
-// with the commit-msg hook installed by `logmind init`.
-func TestAgentsTemplate_HasV6Marker(t *testing.T) {
+// The Slice-2 branch-summary wave bumped v6→v7: the full inline procedure
+// now carries the branch-summary (headline) convention. The v0.6.16
+// REQUIRED framing + DO-NOT-git-commit blockquote are retained.
+func TestAgentsTemplate_HasV7Marker(t *testing.T) {
 	body := AgentsTemplate()
-	if !strings.Contains(body, "<!-- logmind-block-version: v6 -->") {
-		t.Fatalf("full template missing v6 marker")
+	if !strings.Contains(body, "<!-- logmind-block-version: v7 -->") {
+		t.Fatalf("full template missing v7 marker")
 	}
 	if !strings.Contains(body, "<!-- logmind-start -->") || !strings.Contains(body, "<!-- logmind-end -->") {
 		t.Fatalf("full template missing start/end markers")
 	}
-	// v0.6.16: the REQUIRED framing + DO-NOT blockquote are the
-	// user-visible delta over v5. Pin both so a future inadvertent
-	// revert to the v5 prose trips this test.
+	// The REQUIRED framing + DO-NOT blockquote are retained from v6. Pin
+	// both so a future inadvertent revert to the v5 prose trips this test.
 	if !strings.Contains(body, "REQUIRED for substantive commits") {
-		t.Fatalf("v6 template missing REQUIRED framing in heading")
+		t.Fatalf("v7 template missing REQUIRED framing in heading")
 	}
 	if !strings.Contains(body, "DO NOT run `git add` / `git commit` / `git push`") {
-		t.Fatalf("v6 template missing DO-NOT-git-commit blockquote")
+		t.Fatalf("v7 template missing DO-NOT-git-commit blockquote")
+	}
+	// v7 delta: the branch-summary (headline) convention. Pin the heading,
+	// both authoring forms, and the verbatim-into-timeline promise so a
+	// future revert that drops the convention trips this test.
+	if !strings.Contains(body, "Branch summary (headline)") {
+		t.Fatalf("v7 template missing the branch-summary (headline) subsection")
+	}
+	if !strings.Contains(body, `logmind headline "<one sentence>"`) {
+		t.Fatalf("v7 template missing the `logmind headline` authoring form")
+	}
+	if !strings.Contains(body, `logmind log "..." -H "<one sentence>"`) {
+		t.Fatalf("v7 template missing the bundled `logmind log -H` authoring form")
+	}
+	if !strings.Contains(body, "copied verbatim into") {
+		t.Fatalf("v7 template missing the verbatim-into-timeline promise")
 	}
 }
 


### PR DESCRIPTION
## What

Bumps the tool-owned **full** `AGENTS.md` block from `v6` → `v7`, adding the **branch-summary (headline) convention** to the inline procedure. Because the full block's marker gates drift detection, every consumer repo still carrying a full block now shows drift and refreshes forward to `v7`, picking up the convention.

## Changes

- **`internal/templates/AGENTS.md.template`** — marker `v6` → `v7`; new concise `### Branch summary (headline)` subsection near the branch-routing guidance. It documents `logmind headline "<one sentence>"` / the bundled `logmind log "..." -H "<one sentence>"` form, that the summary is stored atop the branch decision file and copied verbatim into `docs/timeline.md` (first thing the next agent reads), that it is refined as the branch grows (entry key stays stable), and that it is a no-op on the default branch. No stale `branch-divergent` / `timeline.canonical` / timeline-mode references (verified).
- **`internal/inserter/inserter.go`**
  - `matchingTemplate`: full-flavour recognition now accepts `v5` || `v6` || `v7` (was `v5` || `v6`), so an installed v7 body maps to the full template and older full blocks refresh forward.
  - `EnsureAgentsMD` (the `doctor --fix` / `init`-refresh path) now selects the refresh template **by the installed flavour** via `matchingTemplate`, instead of always comparing against the slim default. This fixes a latent bug: a legacy full `v6` block was being silently **flipped to slim** on `doctor --fix`, contradicting both this task's goal ("refresh to v7") and invariant #3 already documented on `agentsMDTemplate` ("repos that already shipped the full template stay on full … never auto-migrate full → slim"). Now a full block refreshes to full `v7`; a slim block stays slim; an unrecognized marker falls back to the slim default (unchanged).
  - Doc comments updated (package header, `EnsureAgentsMD`, `agentsMDTemplate` #3, `matchingTemplate`) to reflect the v6→v7 bump and the enforced flavour guard.
- **Tests** — `TestAgentsTemplate_HasV6Marker` → `HasV7Marker` (asserts v7 marker + the new headline prose); `TestFindOutdatedMarkerBlocks_OldFullRefreshesToV6` → `…ToV7`; added `TestFindOutdatedMarkerBlocks_V6RefreshesToV7` and `TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim` (full v6 → full v7, not slim; idempotent).

No golden files required regeneration — the full template is never written to disk by `init`/`agents` (those default to slim), so no golden embeds its body.

## Verification

- `go build ./...` · `gofmt -l .` (clean) · `go vet ./...` (clean) · `go test ./...` (all packages ok)
- By hand with the built binary:
  - fresh `logmind init` → slim `v8-pointer` (unchanged default)
  - repo with a `v6` full block → `logmind doctor` reports `STALE` → `logmind doctor --fix` rewrites to full `v7` (branch-summary subsection present) → second `doctor --fix` is a no-op (`agents-md=current`)
  - slim `v8-pointer` repo → `doctor --fix` leaves it slim/current (no full↔slim flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG
