### PR TITLE
fix(ci): auto-regen bot identity → canonical github-actions[bot] (P0, salvaged from #154)

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -77,8 +77,8 @@ jobs:
 
           if [ -n "${PAT:-}" ] && [ "$is_fork" = "false" ]; then
             echo "::notice title=Auto-fixing derived docs::Regenerating and pushing to ${HEAD_REF}."
-            git config user.name "logmind-auto-regen"
-            git config user.email "logmind-auto-regen@users.noreply.github.com"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add docs/timeline.md docs/file-structure.md
             git commit -m "[skip-logmind] chore: regen derived docs"
             if ! git push "https://x-access-token:${PAT}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"; then

--- a/docs/decisions-branches/fix__regen-bot-identity.md
+++ b/docs/decisions-branches/fix__regen-bot-identity.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-11-fix-auto-regen-bot-identity-to-canonical-github-actions-bot -->
+- **2026-07-11** — Fix the auto-regen bot commit identity to the canonical github-actions[bot], and bump the two workflow templates so consumer repos pick it up via doctor --fix
+<!-- logmind-entry-end -->
+
+## 2026-07-11 14:12 - Fix auto-regen bot identity to canonical github-actions bot
+
+**Reasoning:** The fake logmind-auto-regen email on auto-regen commits is rejected by Vercel and clud-bug; the canonical github-actions bot identity is accepted, unblocking derived-doc self-heal on PRs
+
+**Alternatives considered:** Keep the fake identity and disable the auto-regen push path, which would lose the self-heal automation
+
+**Implications:**
+- Live regen-timeline.yml fixed immediately; both workflow templates bumped (regen-timeline v5 to v6, check-doc-links v6 to v7) so consumer repos refresh via doctor --fix; templates_test updated
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-11-fix-auto-regen-bot-identity-to-canonical-github-actions-bot -->
+- **2026-07-11** — Fix the auto-regen bot commit identity to the canonical github-actions[bot], and bump the two workflow templates so consumer repos pick it up via doctor --fix → [detail](decisions-branches/fix__regen-bot-identity.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-04-v2-0-0-breaking-remove-branch-divergent-entirely-main-canoni -->
 - **2026-07-04** — v2.0.0 BREAKING: remove branch-divergent entirely — main-canonical is the sole timeline model → [detail](decisions-branches/feat__v2-remove-branch-divergent.md)
 <!-- logmind-entry-end -->

--- a/internal/templates/github/check-doc-links.yml.template
+++ b/internal/templates/github/check-doc-links.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v6
+# logmind-template-version: v7
 name: logmind / check-links
 
 # Flag broken or orphaned markdown links so agents stay in context when
@@ -206,8 +206,8 @@ jobs:
           fi
 
           # Commit + push if there's a diff.
-          git config user.name "logmind-auto-regen"
-          git config user.email "logmind-auto-regen@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet || ! git diff --cached --quiet; then
             git add -A
             git commit -m "fix(docs): self-heal markdown links

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v5
+# logmind-template-version: v6
 name: logmind / check-derived-docs
 
 # Self-healing derived-doc gate (v5 — advisory model).
@@ -96,8 +96,8 @@ jobs:
           # PAT push re-triggers downstream required checks.
           if [ -n "${PAT:-}" ] && [ "$is_fork" = "false" ]; then
             echo "::notice title=Auto-fixing derived docs::Regenerating and pushing to ${HEAD_REF}."
-            git config user.name "logmind-auto-regen"
-            git config user.email "logmind-auto-regen@users.noreply.github.com"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add docs/timeline.md docs/file-structure.md
             git commit -m "[skip-logmind] chore: regen derived docs"
             if ! git push "https://x-access-token:${PAT}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"; then

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -166,159 +166,159 @@ func TestWorkflowTemplates_UseSetupLogmindAction(t *testing.T) {
 	}
 }
 
-// TestRegenTimelineTemplate_V5_Advisory pins the Slice-1 de-friction
+// TestRegenTimelineTemplate_V6_Advisory pins the Slice-1 de-friction
 // contract: the derived-doc gate must NEVER hard-block a PR and must NEVER
 // push with the default GITHUB_TOKEN (a GITHUB_TOKEN push moves the PR head
 // SHA without re-triggering checks, stranding every required check). On
 // stale docs it either pushes via LOGMIND_AUTO_REGEN_PAT (which re-triggers
 // checks) or emits an advisory ::warning:: and exits 0.
-func TestRegenTimelineTemplate_V5_Advisory(t *testing.T) {
+func TestRegenTimelineTemplate_V6_Advisory(t *testing.T) {
 	body := Workflow("regen-timeline.yml.template")
 
 	// Marker bump v4 → v5.
-	if !strings.Contains(body, "# logmind-template-version: v5") {
-		t.Errorf("regen-timeline template missing v5 marker")
+	if !strings.Contains(body, "# logmind-template-version: v6") {
+		t.Errorf("regen-timeline template missing v6 marker")
 	}
 	// Advisory, never fail-fast: no literal `exit 1`. Staleness must not
 	// red-light the PR (a real tool crash still fails the job via `set -e`).
 	if strings.Contains(body, "exit 1") {
-		t.Errorf("regen-timeline v5 must not `exit 1` — the gate is advisory and must never block a PR")
+		t.Errorf("regen-timeline v6 must not `exit 1` — the gate is advisory and must never block a PR")
 	}
 	// The no-PAT / fork path must warn and pass.
 	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
-		t.Errorf("regen-timeline v5 missing the advisory warn + exit 0 path")
+		t.Errorf("regen-timeline v6 missing the advisory warn + exit 0 path")
 	}
 	// The PAT auto-push path is retained (the only path that pushes).
 	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
-		t.Errorf("regen-timeline v5 missing the LOGMIND_AUTO_REGEN_PAT auto-push path")
+		t.Errorf("regen-timeline v6 missing the LOGMIND_AUTO_REGEN_PAT auto-push path")
 	}
 	// Regen commits carry the [skip-logmind] convention (SPEC §5.1/§5.2).
 	if !strings.Contains(body, "[skip-logmind]") {
-		t.Errorf("regen-timeline v5 PAT-push commit missing the [skip-logmind] prefix")
+		t.Errorf("regen-timeline v6 PAT-push commit missing the [skip-logmind] prefix")
 	}
 	// The job must NOT filter itself out by actor: a filtered required check
 	// strands as "Expected — Waiting…". Bots/forks take the advisory path.
 	if strings.Contains(body, "github.actor != ") {
-		t.Errorf("regen-timeline v5 must not filter the job by actor (a filtered required check hangs forever)")
+		t.Errorf("regen-timeline v6 must not filter the job by actor (a filtered required check hangs forever)")
 	}
 	// Fork PRs must reach the advisory path, not die at checkout: the
 	// checkout MUST set `repository:` to the PR head repo (a fork's head_ref
 	// does not exist on the base repo, so checkout would otherwise fail red).
 	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
-		t.Errorf("regen-timeline v5 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
+		t.Errorf("regen-timeline v6 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
 	}
 	// The advisory diff display MUST be SIGPIPE/pipefail-guarded: a large
 	// stale diff piped into `head` exits 141 under `set -euo pipefail` and
 	// would abort the job before `exit 0` — re-blocking on big diffs.
 	if !strings.Contains(body, "| head -80 || true") {
-		t.Errorf("regen-timeline v5 advisory diff must be `|| true`-guarded against SIGPIPE/pipefail")
+		t.Errorf("regen-timeline v6 advisory diff must be `|| true`-guarded against SIGPIPE/pipefail")
 	}
 	// GITHUB_TOKEN must never push: the workflow token stays read-only and
 	// the push (if any) uses the explicit PAT-credentialed URL.
 	if !strings.Contains(body, "contents: read") {
-		t.Errorf("regen-timeline v5 must keep the workflow token read-only (contents: read)")
+		t.Errorf("regen-timeline v6 must keep the workflow token read-only (contents: read)")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("regen-timeline v5 PAT push must use the explicit PAT URL, not a persisted/GITHUB_TOKEN credential")
+		t.Errorf("regen-timeline v6 PAT push must use the explicit PAT URL, not a persisted/GITHUB_TOKEN credential")
 	}
 	// The PAT/token must not be persisted into .git during regeneration/build.
 	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("regen-timeline v5 checkout must set persist-credentials: false")
+		t.Errorf("regen-timeline v6 checkout must set persist-credentials: false")
 	}
 }
 
-// TestCheckDocLinksTemplate_V6_AdvisoryNoStrand pins the v1.2.0 advisory
+// TestCheckDocLinksTemplate_V7_AdvisoryNoStrand pins the v1.2.0 advisory
 // contract for the doc-link gate: like regen-timeline, it must NEVER
 // hard-block a PR and must NEVER push with the default GITHUB_TOKEN (a
 // GITHUB_TOKEN push moves the PR head SHA without re-triggering checks,
 // stranding every required check). check-links is advisory (warn +
 // exit 0); the dual-mode self-heal either PAT-pushes a Claude fix
 // (mode A) or posts a deterministic PR comment (mode B).
-func TestCheckDocLinksTemplate_V6_AdvisoryNoStrand(t *testing.T) {
+func TestCheckDocLinksTemplate_V7_AdvisoryNoStrand(t *testing.T) {
 	body := Workflow("check-doc-links.yml.template")
 
 	// Marker bump v5 → v6.
-	if !strings.Contains(body, "# logmind-template-version: v6") {
-		t.Errorf("check-doc-links template missing v6 marker")
+	if !strings.Contains(body, "# logmind-template-version: v7") {
+		t.Errorf("check-doc-links template missing v7 marker")
 	}
 
 	// Advisory: the old `exit $rc` (re-raise the linkcheck exit) red-lit
 	// the PR — it must be gone, replaced by an advisory warning + exit 0.
 	if strings.Contains(body, "exit $rc") {
-		t.Errorf("check-doc-links v6 must not `exit $rc` — check-links is advisory and must never block a PR")
+		t.Errorf("check-doc-links v7 must not `exit $rc` — check-links is advisory and must never block a PR")
 	}
 	if !strings.Contains(body, "::warning") {
-		t.Errorf("check-doc-links v6 missing the advisory ::warning:: on broken links")
+		t.Errorf("check-doc-links v7 missing the advisory ::warning:: on broken links")
 	}
 
 	// No GITHUB_TOKEN push: the old `git push origin HEAD:<head-ref>`
 	// (authenticated by GITHUB_TOKEN) stranded the PR. Any push must go
 	// through the explicit PAT-credentialed URL.
 	if strings.Contains(body, "git push origin") {
-		t.Errorf("check-doc-links v6 must not `git push origin` (a GITHUB_TOKEN push strands the PR's required checks)")
+		t.Errorf("check-doc-links v7 must not `git push origin` (a GITHUB_TOKEN push strands the PR's required checks)")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("check-doc-links v6 mode-A push must use the explicit PAT URL, not a GITHUB_TOKEN credential")
+		t.Errorf("check-doc-links v7 mode-A push must use the explicit PAT URL, not a GITHUB_TOKEN credential")
 	}
 
 	// Mode A is PAT-gated: without LOGMIND_AUTO_REGEN_PAT there is no safe
 	// push, so mode A must require it (and fall through to mode B otherwise).
 	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
-		t.Errorf("check-doc-links v6 missing the LOGMIND_AUTO_REGEN_PAT push gate")
+		t.Errorf("check-doc-links v7 missing the LOGMIND_AUTO_REGEN_PAT push gate")
 	}
 	if !strings.Contains(body, "env.PAT != ''") {
-		t.Errorf("check-doc-links v6 mode-A must be gated on a configured PAT (env.PAT != '')")
+		t.Errorf("check-doc-links v7 mode-A must be gated on a configured PAT (env.PAT != '')")
 	}
 
 	// Workflow token stays read-only; the PAT does any push.
 	if !strings.Contains(body, "contents: read") {
-		t.Errorf("check-doc-links v6 must keep the workflow token read-only (contents: read)")
+		t.Errorf("check-doc-links v7 must keep the workflow token read-only (contents: read)")
 	}
 	if strings.Contains(body, "contents: write") {
-		t.Errorf("check-doc-links v6 must not grant contents: write (the PAT, not GITHUB_TOKEN, pushes)")
+		t.Errorf("check-doc-links v7 must not grant contents: write (the PAT, not GITHUB_TOKEN, pushes)")
 	}
 
 	// No actor filter: a filtered required check strands as "Expected —
 	// Waiting…". Bots/forks take the advisory / mode-B path.
 	if strings.Contains(body, "github.actor != ") {
-		t.Errorf("check-doc-links v6 must not filter a job by actor (a filtered required check hangs forever)")
+		t.Errorf("check-doc-links v7 must not filter a job by actor (a filtered required check hangs forever)")
 	}
 
 	// Fork PRs must reach the advisory path, not die at checkout.
 	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
-		t.Errorf("check-doc-links v6 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
+		t.Errorf("check-doc-links v7 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
 	}
 	// No token persisted into .git; the PAT is injected only at push time.
 	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("check-doc-links v6 checkout must set persist-credentials: false")
+		t.Errorf("check-doc-links v7 checkout must set persist-credentials: false")
 	}
 
 	// Dual-mode self-heal preserved: mode A (Claude auto-fix) + mode B
 	// (deterministic PR comment), both keyed off the check-links report.
 	if !strings.Contains(body, "Mode A") || !strings.Contains(body, "Mode B") {
-		t.Errorf("check-doc-links v6 missing a self-heal mode (both mode A and mode B required)")
+		t.Errorf("check-doc-links v7 missing a self-heal mode (both mode A and mode B required)")
 	}
 	if !strings.Contains(body, "secrets.ANTHROPIC_API_KEY") || !strings.Contains(body, "ANTHROPIC_API_KEY != ''") {
-		t.Errorf("check-doc-links v6 missing the mode-A ANTHROPIC_API_KEY gate")
+		t.Errorf("check-doc-links v7 missing the mode-A ANTHROPIC_API_KEY gate")
 	}
 	if !strings.Contains(body, "gh pr comment") {
-		t.Errorf("check-doc-links v6 missing `gh pr comment` (mode B deterministic path)")
+		t.Errorf("check-doc-links v7 missing `gh pr comment` (mode B deterministic path)")
 	}
 	if !strings.Contains(body, "logmind check-links --json") {
-		t.Errorf("check-doc-links v6 missing `logmind check-links --json` invocation")
+		t.Errorf("check-doc-links v7 missing `logmind check-links --json` invocation")
 	}
 
 	// Self-heal fires on pull_request when check-links reported issues
 	// (keyed off the `failed` output, since check-links now always exits 0).
 	if !strings.Contains(body, "github.event_name == 'pull_request'") {
-		t.Errorf("check-doc-links v6 self-heal must be gated on pull_request events")
+		t.Errorf("check-doc-links v7 self-heal must be gated on pull_request events")
 	}
 	if !strings.Contains(body, "needs.check-links.outputs.failed != '0'") {
-		t.Errorf("check-doc-links v6 self-heal must key off the check-links `failed` output")
+		t.Errorf("check-doc-links v7 self-heal must key off the check-links `failed` output")
 	}
 	// pull-requests:write is still needed for the mode-B comment.
 	if !strings.Contains(body, "pull-requests: write") {
-		t.Errorf("check-doc-links v6 missing pull-requests:write permission (mode B comment)")
+		t.Errorf("check-doc-links v7 missing pull-requests:write permission (mode B comment)")
 	}
 
 	// Both self-heal modes are best-effort advisory: a transient auto-fix
@@ -326,10 +326,10 @@ func TestCheckDocLinksTemplate_V6_AdvisoryNoStrand(t *testing.T) {
 	// to a ::warning:: and never red-light the helper job. Guarding these is
 	// what keeps the header's "forks take the mode-B path" promise honest.
 	if !strings.Contains(body, "if ! python3") {
-		t.Errorf("check-doc-links v6 mode A must guard the Claude auto-fix (a transient failure must not red the self-heal job)")
+		t.Errorf("check-doc-links v7 mode A must guard the Claude auto-fix (a transient failure must not red the self-heal job)")
 	}
 	if !strings.Contains(body, "if ! gh pr comment") {
-		t.Errorf("check-doc-links v6 mode B must guard `gh pr comment` (a fork 403 must not red the self-heal job)")
+		t.Errorf("check-doc-links v7 mode B must guard `gh pr comment` (a fork 403 must not red the self-heal job)")
 	}
 }
 


### PR DESCRIPTION
Salvages the **P0 bot-author-email fix** from the retired #154 bundle.

## Problem
Auto-regen commits use a fake git identity `logmind-auto-regen <logmind-auto-regen@users.noreply.github.com>` that **Vercel and clud-bug reject**, red-lighting derived-doc self-heal on PRs.

## Fix
Swap it for the canonical `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` (matches the already-correct `logmind-self-update.yml.template`):
- **Live:** `.github/workflows/regen-timeline.yml` — stops the bug on this repo now.
- **Templates:** `regen-timeline.yml.template` + `check-doc-links.yml.template`, with marker bumps (**v5→v6**, **v6→v7**) so existing consumer repos refresh via `doctor --fix`/`installWorkflowTemplates(refresh=true)`.
- `templates_test.go` marker/label assertions updated.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)