### PR TITLE
feat(cli): logmind show + search — implement the documented decision-read commands (salvaged from #154)

### DIFF
--- a/docs/decisions-branches/feat__cli-show-search.md
+++ b/docs/decisions-branches/feat__cli-show-search.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-11-implement-logmind-show-and-search-the-documented-decision-re -->
+- **2026-07-11** — Implement logmind show and search — the documented decision-read commands salvaged from retired PR #154
+<!-- logmind-entry-end -->
+
+## 2026-07-11 14:18 - Implement logmind show and search — the documented decision-read commands salvaged from retired PR #154
+
+**Reasoning:** SKILL.md, AGENTS.md, and internal/templates/logmind-section.md all document show and search but the v1.0 Go rewrite dropped both, so the documented interface silently 404s. PR #154 built these against the pre-branch-aware v1 shape; main has since moved to branch-aware decision routing via resolveDecisionsPath, so a straight cherry-pick would regress current-branch semantics and the v2 quiet contract.
+
+**Alternatives considered:** Cherry-pick PR #154 verbatim, Leave the commands undocumented instead of implementing them
+
+**Implications:**
+- show and search now resolve the SAME file logmind log/headline just wrote via resolveDecisionsPath, so current-branch scoping is correct out of the box; matches the documented current-branch contract more precisely than PR 154 did.
+- Both commands follow the repomap.go quiet precedent: --quiet suppresses the payload entirely and emits one ok k=v receipt, since the verbatim/search output is the deliverable, not chatter.
+- search's flag surface is intentionally narrower than PR 154 (only --case-sensitive and --no-archive, the documented flags); context lines are a fixed default of 2, not a flag.
+
+---
+

--- a/docs/decisions-branches/feat__cli-show-search.md
+++ b/docs/decisions-branches/feat__cli-show-search.md
@@ -17,3 +17,16 @@
 
 ---
 
+## 2026-07-11 14:32 - Address PR #191 review: literal substring search + branch-spanning scope
+
+**Reasoning:** Regex matching gave silent false negatives (a valid-but-non-matching pattern like cost dollar-paren drops the hit) and over-matches (dot, pipe as metachars); a keyword search must be literal. And a feature-branch agent needs to find main's decisions, so search must span decisions.md, not just the current-branch file like show does.
+
+**Alternatives considered:** Keep regex with a literal fallback only on compile error (rejected: still wrong for valid-but-non-matching patterns), Add a --regex flag (rejected: undocumented, widens the promised surface)
+
+**Implications:**
+- search now matches via strings.Contains with case folding; highlightLiteral wraps the actual matched substring by index, so regex-special queries highlight correctly with no pattern compiled
+- search source order is decisions.md, then the branch file if different, then archive unless --no-archive, deduped by path; show stays current-branch-only per the docs
+- empty query now errors via q.fail; quiet ok line gained a sources=N field
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-11-implement-logmind-show-and-search-the-documented-decision-re -->
+- **2026-07-11** — Implement logmind show and search — the documented decision-read commands salvaged from retired PR #154 → [detail](decisions-branches/feat__cli-show-search.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-11-fix-auto-regen-bot-identity-to-canonical-github-actions-bot -->
 - **2026-07-11** — Fix the auto-regen bot commit identity to the canonical github-actions[bot], and bump the two workflow templates so consumer repos pick it up via doctor --fix → [detail](decisions-branches/fix__regen-bot-identity.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -293,3 +293,31 @@ func TestQuiet_Log_ErrorToStderr(t *testing.T) {
 		t.Errorf("error not routed to stderr under quiet: %q", errBuf.String())
 	}
 }
+
+func TestQuiet_Show_ErrorToStderr(t *testing.T) {
+	cwd := t.TempDir() // no docs/ → error path
+	var out, errBuf bytes.Buffer
+	if err := runShow(cwd, false, true, &out, &errBuf); err == nil {
+		t.Fatal("expected ErrSilent when docs/ missing")
+	}
+	if out.Len() != 0 {
+		t.Errorf("quiet show error path wrote to stdout: %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "Error: docs/ directory not found") {
+		t.Errorf("error not routed to stderr under quiet: %q", errBuf.String())
+	}
+}
+
+func TestQuiet_Search_ErrorToStderr(t *testing.T) {
+	cwd := t.TempDir() // no docs/ → error path
+	var out, errBuf bytes.Buffer
+	if err := runSearch(cwd, "term", &searchFlags{}, true, &out, &errBuf); err == nil {
+		t.Fatal("expected ErrSilent when docs/ missing")
+	}
+	if out.Len() != 0 {
+		t.Errorf("quiet search error path wrote to stdout: %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "Error: docs/ directory not found") {
+		t.Errorf("error not routed to stderr under quiet: %q", errBuf.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,6 +91,12 @@ func NewRootCmd() *cobra.Command {
 	// Slice 2: set the branch's one-sentence timeline headline (the
 	// main-canonical summary line). Companion to `logmind log --headline`.
 	root.AddCommand(newHeadlineCmd())
+	// `show` / `search` are documented (skill/SKILL.md, AGENTS.md,
+	// internal/templates/logmind-section.md) but were dropped in the v1.0
+	// Go rewrite. Restored here as v2 re-implementations — branch-aware via
+	// resolveDecisionsPath, not the old hardcoded docs/decisions.md.
+	root.AddCommand(newShowCmd())
+	root.AddCommand(newSearchCmd())
 
 	// Top-level --version flag mirrors `logmind version` so both
 	// `logmind --version` and `logmind version` produce the same line.

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -2,22 +2,32 @@
 //
 // SKILL.md / AGENTS.md / internal/templates/logmind-section.md document
 // `logmind search "keyword"` as "full-text search across recent + archive"
-// with `--case-sensitive` and `--no-archive`, but the v2 Go binary never
-// shipped it. This is the v2 re-implementation, searching the SAME "recent"
-// source `logmind show` prints — resolveDecisionsPath's branch-aware target —
-// plus docs/decisions-archive.md unless --no-archive is passed.
+// with `--case-sensitive` and `--no-archive`. This is the v2 implementation.
 //
-// The query is compiled as a regular expression; on compile failure it falls
-// back to a literal substring match (regexp.QuoteMeta), so a query containing
-// unbalanced regex metacharacters still searches instead of erroring. Matches
-// are case-insensitive by default; --case-sensitive requires an exact-case
-// match.
+// MATCHING IS LITERAL SUBSTRING, not regex. "Full-text search" means the
+// query is matched verbatim: `search "cost($)"` finds a line containing the
+// literal text `cost($)`, `search "v1.0"` does NOT match `v1x0`, and
+// `search "a|b"` matches only the literal `a|b`. Treating the query as a regex
+// would silently drop hits (a valid-but-non-matching pattern) or over-match
+// (metacharacters), both surprising for a keyword search. Case-insensitive by
+// default; --case-sensitive requires an exact-case match.
 //
-// There is no existing decisions-package helper for full-text grep-with-
-// context — decisions.Iter only extracts header metadata (date/title), not
-// line-level content — so the line scan here is new, but file SELECTION
-// reuses resolveDecisionsPath (the same helper `logmind log`/`headline`/
-// `show` use) rather than hardcoding docs/decisions.md.
+// SCOPE (deterministic source order, existence-checked, deduped by path):
+//
+//  1. docs/decisions.md            — main's recent decisions (always)
+//  2. the current feature-branch file from resolveDecisionsPath, IF it
+//     differs from decisions.md (i.e. only when on a feature branch)
+//  3. docs/decisions-archive.md    — unless --no-archive
+//
+// So a feature-branch agent searching finds main's decisions AND its own
+// branch's in-flight decisions AND the archive — the union the docs promise
+// ("across recent + archive"). On the default branch, (1) and (2) collapse to
+// a single decisions.md entry.
+//
+// File SELECTION reuses resolveDecisionsPath (the same helper `logmind log`/
+// `headline`/`show` use). There is no existing decisions-package helper for
+// full-text grep-with-context — decisions.Iter only extracts header metadata
+// (date/title), not line-level content — so the line scan here is new.
 package cli
 
 import (
@@ -25,7 +35,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -62,16 +71,17 @@ func newSearchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Full-text search across recent decisions and the archive",
-		Long: `Full-text search across the decision log for a term or pattern.
+		Long: `Full-text search across the decision log for a keyword or phrase.
 
-Searches the current branch's decision file — the same file "logmind show"
-prints (docs/decisions.md on the default branch, docs/decisions-branches/
-<branch>.md on a feature branch) — plus docs/decisions-archive.md, unless
---no-archive is passed.
+Searches, in order: docs/decisions.md (main's recent decisions), the current
+feature branch's decision file (docs/decisions-branches/<branch>.md, when on a
+feature branch), and docs/decisions-archive.md — so a feature-branch agent
+finds main's decisions, its own branch's in-flight decisions, and the archive.
+Pass --no-archive to skip the archive.
 
-The query is treated as a regular expression; if it fails to compile, it
-falls back to a literal substring search. Matching is case-insensitive by
-default — pass --case-sensitive to require an exact-case match.
+The query is matched as a LITERAL substring (not a regex): "cost($)" finds the
+literal text "cost($)". Matching is case-insensitive by default — pass
+--case-sensitive to require an exact-case match.
 
 Examples:
     logmind search "postgres"
@@ -89,38 +99,30 @@ Examples:
 	cmd.Flags().BoolVar(&f.caseSensitive, "case-sensitive", false,
 		"Require an exact-case match (default: case-insensitive).")
 	cmd.Flags().BoolVar(&f.noArchive, "no-archive", false,
-		"Search only the current branch's recent decisions; skip docs/decisions-archive.md.")
+		"Skip docs/decisions-archive.md (search only decisions.md + the current branch file).")
 	return cmd
 }
 
 // runSearch implements `logmind search`.
 func runSearch(cwd, query string, f *searchFlags, quiet bool, stdout, stderr io.Writer) error {
 	q := newQout(quiet, stdout, stderr)
+
+	if strings.TrimSpace(query) == "" {
+		q.fail("Error: empty search query.\n")
+		return ErrSilent
+	}
+
 	docsPath := filepath.Join(cwd, "docs")
 	if !pathExists(docsPath) {
 		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
 		return ErrSilent
 	}
 
-	cfg, _ := config.Load(cwd)
-	recentPath, _ := resolveDecisionsPath(cwd, docsPath, cfg)
-	files := []string{recentPath}
-	includeArchive := !f.noArchive
-	if includeArchive {
-		archivePath := filepath.Join(docsPath, "decisions-archive.md")
-		if pathExists(archivePath) {
-			files = append(files, archivePath)
-		}
-	}
-
-	pattern := compileSearchPattern(query, f.caseSensitive)
+	files := searchSources(cwd, docsPath, !f.noArchive)
 
 	var results []searchResult
 	for _, file := range files {
-		if !pathExists(file) {
-			continue
-		}
-		hits, err := searchFile(cwd, file, pattern)
+		hits, err := searchFile(cwd, file, query, f.caseSensitive)
 		if err != nil {
 			return fmt.Errorf("search %s: %w", file, err)
 		}
@@ -128,7 +130,7 @@ func runSearch(cwd, query string, f *searchFlags, quiet bool, stdout, stderr io.
 	}
 
 	if quiet {
-		q.ok("search matches=%d archive=%t case_sensitive=%t", len(results), includeArchive, f.caseSensitive)
+		q.ok("search matches=%d sources=%d archive=%t case_sensitive=%t", len(results), len(files), !f.noArchive, f.caseSensitive)
 		return nil
 	}
 
@@ -143,29 +145,62 @@ func runSearch(cwd, query string, f *searchFlags, quiet bool, stdout, stderr io.
 		matchWord = "match"
 	}
 	fmt.Fprintf(stdout, "Found %d %s for: %s\n\n", len(results), matchWord, query)
-	fmt.Fprintln(stdout, formatSearchResults(results, query))
+	fmt.Fprintln(stdout, formatSearchResults(results, query, f.caseSensitive))
 	fmt.Fprintf(stdout, "ok search: %d %s for %q\n", len(results), matchWord, query)
 	return nil
 }
 
-// compileSearchPattern builds the match regex. A query that fails to compile
-// as a regex (e.g. an unbalanced group) falls back to a literal substring
-// match via regexp.QuoteMeta, which cannot itself fail to compile.
-func compileSearchPattern(query string, caseSensitive bool) *regexp.Regexp {
-	prefix := "(?i)"
-	if caseSensitive {
-		prefix = ""
+// searchSources returns the deterministic, existence-checked, path-deduped
+// list of decision files `search` scans:
+//
+//  1. docs/decisions.md (main's recent decisions)
+//  2. the current feature-branch file (resolveDecisionsPath), if != #1
+//  3. docs/decisions-archive.md, when includeArchive
+//
+// On the default branch #1 and #2 resolve to the same path and collapse to a
+// single entry. Missing files are dropped silently — a repo without an archive
+// (or a brand-new branch with no decisions file yet) still searches whatever
+// exists.
+func searchSources(cwd, docsPath string, includeArchive bool) []string {
+	cfg, _ := config.Load(cwd)
+	branchPath, _ := resolveDecisionsPath(cwd, docsPath, cfg)
+
+	candidates := []string{
+		filepath.Join(docsPath, "decisions.md"),
+		branchPath, // == decisions.md on the default branch (deduped below)
 	}
-	if pattern, err := regexp.Compile(prefix + query); err == nil {
-		return pattern
+	if includeArchive {
+		candidates = append(candidates, filepath.Join(docsPath, "decisions-archive.md"))
 	}
-	return regexp.MustCompile(prefix + regexp.QuoteMeta(query))
+
+	seen := make(map[string]bool, len(candidates))
+	var files []string
+	for _, p := range candidates {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		if pathExists(p) {
+			files = append(files, p)
+		}
+	}
+	return files
 }
 
-// searchFile scans path line-by-line for pattern, returning one searchResult
-// per matching line with ±searchContextLines of surrounding context and the
-// nearest preceding "## ..." decision header as the title label.
-func searchFile(cwd, path string, pattern *regexp.Regexp) ([]searchResult, error) {
+// lineMatches reports whether query occurs as a literal substring of line,
+// honoring case sensitivity. This is the single source of truth for match
+// semantics — the highlighter uses the same case folding.
+func lineMatches(line, query string, caseSensitive bool) bool {
+	if caseSensitive {
+		return strings.Contains(line, query)
+	}
+	return strings.Contains(strings.ToLower(line), strings.ToLower(query))
+}
+
+// searchFile scans path line-by-line for the literal query, returning one
+// searchResult per matching line with ±searchContextLines of surrounding
+// context and the nearest preceding "## ..." decision header as the title.
+func searchFile(cwd, path, query string, caseSensitive bool) ([]searchResult, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -184,7 +219,7 @@ func searchFile(cwd, path string, pattern *regexp.Regexp) ([]searchResult, error
 		if strings.HasPrefix(line, "## ") {
 			currentTitle = strings.TrimSpace(strings.TrimPrefix(line, "##"))
 		}
-		if !pattern.MatchString(line) {
+		if !lineMatches(line, query, caseSensitive) {
 			continue
 		}
 		title := currentTitle
@@ -210,20 +245,15 @@ func searchFile(cwd, path string, pattern *regexp.Regexp) ([]searchResult, error
 //	<file> - <decision-title> (line N)
 //	------------------------------------
 //	  <context line>
-//	> <matched line, with >>> term <<< markers>
+//	> <matched line, with >>> query <<< markers>
 //	  <context line>
 //
-// Results are separated by a blank line. highlightTerm is wrapped in
-// >>> <<< markers wherever it (case-insensitively) appears in the matched
-// line, regardless of whether the search itself was case-sensitive — the
-// marker is a display aid, not a re-assertion of the match semantics.
-func formatSearchResults(results []searchResult, highlightTerm string) string {
+// Results are separated by a blank line. Highlighting wraps the actual matched
+// literal substring in >>> <<< markers using the SAME case folding as the
+// match test — so a query with regex-special characters (e.g. "cost($)")
+// highlights correctly because nothing is ever compiled as a pattern.
+func formatSearchResults(results []searchResult, query string, caseSensitive bool) string {
 	var out []string
-	var highlight *regexp.Regexp
-	if highlightTerm != "" {
-		highlight = regexp.MustCompile("(?i)(" + regexp.QuoteMeta(highlightTerm) + ")")
-	}
-
 	for i, r := range results {
 		if i > 0 {
 			out = append(out, "")
@@ -234,14 +264,42 @@ func formatSearchResults(results []searchResult, highlightTerm string) string {
 		for _, ctx := range r.ContextBefore {
 			out = append(out, "  "+ctx)
 		}
-		matched := r.MatchedLine
-		if highlight != nil {
-			matched = highlight.ReplaceAllString(matched, ">>> $1 <<<")
-		}
-		out = append(out, "> "+matched)
+		out = append(out, "> "+highlightLiteral(r.MatchedLine, query, caseSensitive))
 		for _, ctx := range r.ContextAfter {
 			out = append(out, "  "+ctx)
 		}
 	}
 	return strings.Join(out, "\n")
+}
+
+// highlightLiteral wraps every literal occurrence of query in line with
+// ">>> " ... " <<<" markers, preserving the ORIGINAL casing of the matched
+// text (not the query's). Case folding matches lineMatches so what gets
+// highlighted is exactly what matched. Purely string-index based — no regex —
+// so regex-special characters in query are treated literally.
+func highlightLiteral(line, query string, caseSensitive bool) string {
+	if query == "" {
+		return line
+	}
+	hayIdx := line
+	needle := query
+	if !caseSensitive {
+		hayIdx = strings.ToLower(line)
+		needle = strings.ToLower(query)
+	}
+	var b strings.Builder
+	for {
+		off := strings.Index(hayIdx, needle)
+		if off < 0 {
+			b.WriteString(line)
+			break
+		}
+		b.WriteString(line[:off])
+		b.WriteString(">>> ")
+		b.WriteString(line[off : off+len(needle)]) // original casing from line
+		b.WriteString(" <<<")
+		line = line[off+len(needle):]
+		hayIdx = hayIdx[off+len(needle):]
+	}
+	return b.String()
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -287,6 +287,15 @@ func highlightLiteral(line, query string, caseSensitive bool) string {
 		hayIdx = strings.ToLower(line)
 		needle = strings.ToLower(query)
 	}
+	// Offsets are computed in hayIdx but sliced out of the original `line`.
+	// strings.ToLower can CHANGE byte length for some Unicode (e.g. İ U+0130
+	// lowercases to i̇, ẞ → ß), which would desync those offsets and slice
+	// `line` at the wrong bytes — misaligned markers or an out-of-range panic.
+	// Highlighting is purely cosmetic (match DETECTION via lineMatches is
+	// unaffected), so bail out unhighlighted on the rare length-changing fold.
+	if len(hayIdx) != len(line) {
+		return line
+	}
 	var b strings.Builder
 	for {
 		off := strings.Index(hayIdx, needle)

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1,0 +1,247 @@
+// search.go — `logmind search <query>` subcommand.
+//
+// SKILL.md / AGENTS.md / internal/templates/logmind-section.md document
+// `logmind search "keyword"` as "full-text search across recent + archive"
+// with `--case-sensitive` and `--no-archive`, but the v2 Go binary never
+// shipped it. This is the v2 re-implementation, searching the SAME "recent"
+// source `logmind show` prints — resolveDecisionsPath's branch-aware target —
+// plus docs/decisions-archive.md unless --no-archive is passed.
+//
+// The query is compiled as a regular expression; on compile failure it falls
+// back to a literal substring match (regexp.QuoteMeta), so a query containing
+// unbalanced regex metacharacters still searches instead of erroring. Matches
+// are case-insensitive by default; --case-sensitive requires an exact-case
+// match.
+//
+// There is no existing decisions-package helper for full-text grep-with-
+// context — decisions.Iter only extracts header metadata (date/title), not
+// line-level content — so the line scan here is new, but file SELECTION
+// reuses resolveDecisionsPath (the same helper `logmind log`/`headline`/
+// `show` use) rather than hardcoding docs/decisions.md.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/config"
+)
+
+// searchContextLines is the fixed number of lines of surrounding context
+// shown above/below each match. Not exposed as a flag — the documented
+// interface (SKILL.md / AGENTS.md) only promises --case-sensitive and
+// --no-archive; a fixed, generous default keeps results readable without
+// growing the flag surface beyond what's documented.
+const searchContextLines = 2
+
+// searchResult is one line-level hit within a decisions file.
+type searchResult struct {
+	File          string // repo-relative path the hit came from
+	DecisionTitle string // nearest preceding "## ..." header, or a placeholder
+	LineNumber    int    // 1-indexed
+	MatchedLine   string
+	ContextBefore []string
+	ContextAfter  []string
+}
+
+// searchFlags carries the parsed flags for `logmind search`.
+type searchFlags struct {
+	caseSensitive bool
+	noArchive     bool
+}
+
+// newSearchCmd wires the `logmind search <query>` subcommand.
+func newSearchCmd() *cobra.Command {
+	f := &searchFlags{}
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Full-text search across recent decisions and the archive",
+		Long: `Full-text search across the decision log for a term or pattern.
+
+Searches the current branch's decision file — the same file "logmind show"
+prints (docs/decisions.md on the default branch, docs/decisions-branches/
+<branch>.md on a feature branch) — plus docs/decisions-archive.md, unless
+--no-archive is passed.
+
+The query is treated as a regular expression; if it fails to compile, it
+falls back to a literal substring search. Matching is case-insensitive by
+default — pass --case-sensitive to require an exact-case match.
+
+Examples:
+    logmind search "postgres"
+    logmind search "API" --case-sensitive
+    logmind search "database" --no-archive`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runSearch(cwd, args[0], f, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	cmd.Flags().BoolVar(&f.caseSensitive, "case-sensitive", false,
+		"Require an exact-case match (default: case-insensitive).")
+	cmd.Flags().BoolVar(&f.noArchive, "no-archive", false,
+		"Search only the current branch's recent decisions; skip docs/decisions-archive.md.")
+	return cmd
+}
+
+// runSearch implements `logmind search`.
+func runSearch(cwd, query string, f *searchFlags, quiet bool, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
+	docsPath := filepath.Join(cwd, "docs")
+	if !pathExists(docsPath) {
+		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
+		return ErrSilent
+	}
+
+	cfg, _ := config.Load(cwd)
+	recentPath, _ := resolveDecisionsPath(cwd, docsPath, cfg)
+	files := []string{recentPath}
+	includeArchive := !f.noArchive
+	if includeArchive {
+		archivePath := filepath.Join(docsPath, "decisions-archive.md")
+		if pathExists(archivePath) {
+			files = append(files, archivePath)
+		}
+	}
+
+	pattern := compileSearchPattern(query, f.caseSensitive)
+
+	var results []searchResult
+	for _, file := range files {
+		if !pathExists(file) {
+			continue
+		}
+		hits, err := searchFile(cwd, file, pattern)
+		if err != nil {
+			return fmt.Errorf("search %s: %w", file, err)
+		}
+		results = append(results, hits...)
+	}
+
+	if quiet {
+		q.ok("search matches=%d archive=%t case_sensitive=%t", len(results), includeArchive, f.caseSensitive)
+		return nil
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintf(stdout, "No matches found for: %s\n", query)
+		fmt.Fprintf(stdout, "ok search: 0 matches for %q\n", query)
+		return nil
+	}
+
+	matchWord := "matches"
+	if len(results) == 1 {
+		matchWord = "match"
+	}
+	fmt.Fprintf(stdout, "Found %d %s for: %s\n\n", len(results), matchWord, query)
+	fmt.Fprintln(stdout, formatSearchResults(results, query))
+	fmt.Fprintf(stdout, "ok search: %d %s for %q\n", len(results), matchWord, query)
+	return nil
+}
+
+// compileSearchPattern builds the match regex. A query that fails to compile
+// as a regex (e.g. an unbalanced group) falls back to a literal substring
+// match via regexp.QuoteMeta, which cannot itself fail to compile.
+func compileSearchPattern(query string, caseSensitive bool) *regexp.Regexp {
+	prefix := "(?i)"
+	if caseSensitive {
+		prefix = ""
+	}
+	if pattern, err := regexp.Compile(prefix + query); err == nil {
+		return pattern
+	}
+	return regexp.MustCompile(prefix + regexp.QuoteMeta(query))
+}
+
+// searchFile scans path line-by-line for pattern, returning one searchResult
+// per matching line with ±searchContextLines of surrounding context and the
+// nearest preceding "## ..." decision header as the title label.
+func searchFile(cwd, path string, pattern *regexp.Regexp) ([]searchResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// Split on "\n"; drop the trailing empty element a trailing newline
+	// produces so line numbers match what a text editor would show.
+	lines := strings.Split(string(data), "\n")
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+
+	rel := relForOk(cwd, path)
+	currentTitle := ""
+	var results []searchResult
+	for i, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			currentTitle = strings.TrimSpace(strings.TrimPrefix(line, "##"))
+		}
+		if !pattern.MatchString(line) {
+			continue
+		}
+		title := currentTitle
+		if title == "" {
+			title = "(no decision header yet)"
+		}
+		start := max(0, i-searchContextLines)
+		end := min(len(lines), i+searchContextLines+1)
+		results = append(results, searchResult{
+			File:          rel,
+			DecisionTitle: title,
+			LineNumber:    i + 1, // 1-indexed
+			MatchedLine:   line,
+			ContextBefore: append([]string{}, lines[start:i]...),
+			ContextAfter:  append([]string{}, lines[i+1:end]...),
+		})
+	}
+	return results, nil
+}
+
+// formatSearchResults renders the multi-line per-result block:
+//
+//	<file> - <decision-title> (line N)
+//	------------------------------------
+//	  <context line>
+//	> <matched line, with >>> term <<< markers>
+//	  <context line>
+//
+// Results are separated by a blank line. highlightTerm is wrapped in
+// >>> <<< markers wherever it (case-insensitively) appears in the matched
+// line, regardless of whether the search itself was case-sensitive — the
+// marker is a display aid, not a re-assertion of the match semantics.
+func formatSearchResults(results []searchResult, highlightTerm string) string {
+	var out []string
+	var highlight *regexp.Regexp
+	if highlightTerm != "" {
+		highlight = regexp.MustCompile("(?i)(" + regexp.QuoteMeta(highlightTerm) + ")")
+	}
+
+	for i, r := range results {
+		if i > 0 {
+			out = append(out, "")
+		}
+		header := fmt.Sprintf("%s - %s (line %d)", r.File, r.DecisionTitle, r.LineNumber)
+		out = append(out, header, strings.Repeat("-", len(header)))
+
+		for _, ctx := range r.ContextBefore {
+			out = append(out, "  "+ctx)
+		}
+		matched := r.MatchedLine
+		if highlight != nil {
+			matched = highlight.ReplaceAllString(matched, ">>> $1 <<<")
+		}
+		out = append(out, "> "+matched)
+		for _, ctx := range r.ContextAfter {
+			out = append(out, "  "+ctx)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -1,0 +1,186 @@
+// search_test.go — exercises `logmind search` against tmpdir fixtures.
+//
+// Coverage:
+//   - substring match returns a hit with context lines + >>> highlight <<<
+//   - "current branch" scoping: a feature branch's search does NOT see
+//     docs/decisions.md content, only its own branch file + the archive
+//   - --case-sensitive / --no-archive flag matrix (table-driven)
+//   - regex query supported; an invalid regex falls back to a literal match
+//   - no matches → friendly message, exit 0
+//   - --quiet collapses stdout to exactly one `ok k=v` line
+//   - docs/ missing → friendly error + ErrSilent
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runSearchCmd runs `logmind search <query> [extraArgs...]` and returns
+// combined output.
+func runSearchCmd(t *testing.T, query string, extraArgs ...string) string {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(append([]string{"search", query}, extraArgs...))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("search %q %v: %v\n%s", query, extraArgs, err, out.String())
+	}
+	return out.String()
+}
+
+// TestSearch_SubstringMatch_ContextAndHighlight: a basic hit prints the
+// found-count header, the file/decision-title/line-number header, context
+// lines, and >>> highlight <<< markers around the match.
+func TestSearch_SubstringMatch_ContextAndHighlight(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Use PostgreSQL\n"+
+				"Body line 1\n"+
+				"This mentions PostgreSQL again\n"+
+				"Body line 3\n"+
+				"Body line 4\n")
+
+		body := runSearchCmd(t, "PostgreSQL")
+		mustContain(t, body, "Found 2 matches for: PostgreSQL")
+		mustContain(t, body, "docs/decisions.md - 2026-06-01 10:00 - Use PostgreSQL")
+		mustContain(t, body, ">>> PostgreSQL <<<")
+		mustContain(t, body, `ok search: 2 matches for "PostgreSQL"`)
+	})
+}
+
+// TestSearch_CurrentBranchOnly: search is scoped to the SAME "recent" file
+// `show` prints (resolveDecisionsPath's branch-aware target). A term that
+// only lives in docs/decisions.md (the default branch's file) must NOT be
+// found while on a feature branch that has its own, unrelated decisions
+// file — matching the documented "current branch" contract.
+func TestSearch_CurrentBranchOnly(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		withFakeTTY(t, false, func() { logOnce(t, "Use PostgreSQL for storage") })
+
+		checkoutBranch(t, d, "feat/unrelated")
+		withFakeTTY(t, false, func() { logOnce(t, "Add rate limiting") })
+
+		body := runSearchCmd(t, "PostgreSQL")
+		mustContain(t, body, "No matches found for: PostgreSQL")
+
+		// Sanity: the branch's own decision IS found. It appears twice on
+		// disk — once in the §1.6.3 branch-summary marker line `logmind log`
+		// writes automatically, once in the "## ..." decision header itself.
+		body = runSearchCmd(t, "rate limiting")
+		mustContain(t, body, "Found 2 matches for: rate limiting")
+		mustContain(t, body, "docs/decisions-branches/feat__unrelated.md")
+	})
+}
+
+// TestSearch_FlagMatrix: --case-sensitive and --no-archive, table-driven
+// across the combinations that matter.
+func TestSearch_FlagMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		extraArgs []string
+		wantHit   bool
+	}{
+		{name: "case-insensitive default matches mixed case", query: "postgresql", wantHit: true},
+		{name: "case-sensitive rejects mismatched case", query: "postgresql", extraArgs: []string{"--case-sensitive"}, wantHit: false},
+		{name: "case-sensitive accepts exact case", query: "PostgreSQL", extraArgs: []string{"--case-sensitive"}, wantHit: true},
+		{name: "archive included by default", query: "archived-term", wantHit: true},
+		{name: "no-archive excludes the archive", query: "archived-term", extraArgs: []string{"--no-archive"}, wantHit: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempCwd(t, func(d string) {
+				mustMkdir(t, filepath.Join(d, "docs"))
+				mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+					"## 2026-06-01 10:00 - PostgreSQL choice\n")
+				mustWrite(t, filepath.Join(d, "docs", "decisions-archive.md"),
+					"## 2025-01-01 09:00 - Old decision mentioning archived-term\n")
+				_ = d
+
+				body := runSearchCmd(t, tc.query, tc.extraArgs...)
+				gotHit := strings.Contains(body, "Found ")
+				if gotHit != tc.wantHit {
+					t.Errorf("query %q args %v: hit=%t, want %t; body:\n%s", tc.query, tc.extraArgs, gotHit, tc.wantHit, body)
+				}
+			})
+		})
+	}
+}
+
+// TestSearch_RegexQuery: regex patterns work; an invalid regex falls back
+// to a literal substring match instead of erroring.
+func TestSearch_RegexQuery(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - DB foo\n"+
+				"## 2026-06-02 10:00 - DB bar\n")
+
+		// Valid regex: matches both "DB foo" and "DB bar" headers.
+		body := runSearchCmd(t, "DB .{3}")
+		mustContain(t, body, "Found 2 matches")
+
+		// Invalid regex (unbalanced group) falls back to a literal search
+		// for the string "DB (" — no such literal text exists, so 0 hits,
+		// and critically: no error/panic.
+		body = runSearchCmd(t, "DB (")
+		mustContain(t, body, "No matches found for: DB (")
+	})
+}
+
+// TestSearch_NoMatches: returns 0 + "No matches found for: <q>", exit 0.
+func TestSearch_NoMatches(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - About cats\n")
+
+		body := runSearchCmd(t, "dragons")
+		mustContain(t, body, "No matches found for: dragons")
+		mustContain(t, body, `ok search: 0 matches for "dragons"`)
+	})
+}
+
+// TestSearch_Quiet_EmitsOneOkLine: --quiet collapses stdout to exactly one
+// `ok k=v` line — no result bodies, no "Found N matches" chatter.
+func TestSearch_Quiet_EmitsOneOkLine(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Use PostgreSQL\n")
+
+		body := runSearchCmd(t, "PostgreSQL", "--quiet")
+		lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+		if len(lines) != 1 {
+			t.Fatalf("quiet search: want exactly 1 line, got %d:\n%s", len(lines), body)
+		}
+		if !strings.HasPrefix(lines[0], "ok search ") {
+			t.Errorf("quiet search line = %q; want prefix %q", lines[0], "ok search ")
+		}
+		mustContain(t, body, "matches=1")
+	})
+}
+
+// TestSearch_DocsMissingErrors: no docs/ → ErrSilent.
+func TestSearch_DocsMissingErrors(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"search", "term"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		err := root.Execute()
+		if err == nil {
+			t.Fatalf("expected ErrSilent when docs/ missing")
+		}
+		mustContain(t, out.String(), "docs/ directory not found")
+	})
+}

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -2,10 +2,13 @@
 //
 // Coverage:
 //   - substring match returns a hit with context lines + >>> highlight <<<
-//   - "current branch" scoping: a feature branch's search does NOT see
-//     docs/decisions.md content, only its own branch file + the archive
+//   - LITERAL (not regex) semantics: "cost($)" finds the literal "cost($)";
+//     "v1.0" does NOT match "v1x0"; "a|b" matches only the literal "a|b"
+//   - highlighting works for a query containing regex-special characters
+//   - scope: a term living ONLY in docs/decisions.md IS found while on an
+//     unrelated feature branch; a branch-file-only term is also found there
 //   - --case-sensitive / --no-archive flag matrix (table-driven)
-//   - regex query supported; an invalid regex falls back to a literal match
+//   - empty query → error
 //   - no matches → friendly message, exit 0
 //   - --quiet collapses stdout to exactly one `ok k=v` line
 //   - docs/ missing → friendly error + ErrSilent
@@ -54,26 +57,76 @@ func TestSearch_SubstringMatch_ContextAndHighlight(t *testing.T) {
 	})
 }
 
-// TestSearch_CurrentBranchOnly: search is scoped to the SAME "recent" file
-// `show` prints (resolveDecisionsPath's branch-aware target). A term that
-// only lives in docs/decisions.md (the default branch's file) must NOT be
-// found while on a feature branch that has its own, unrelated decisions
-// file — matching the documented "current branch" contract.
-func TestSearch_CurrentBranchOnly(t *testing.T) {
+// TestSearch_LiteralSemantics: the query is matched as a LITERAL substring,
+// never compiled as a regex. Each sub-case pins one way a regex engine would
+// give the wrong answer.
+func TestSearch_LiteralSemantics(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string // the sole body line in the fixture
+		query   string
+		wantHit bool
+	}{
+		// A valid regex that as a regex would match ZERO of a plain-text line:
+		// `cost($)` compiles fine (an empty group anchored at end) but a regex
+		// search of the literal text "cost($)" yields nothing. Literal search
+		// must FIND it.
+		{name: "regex-special query finds literal", line: "estimated cost($) is high", query: "cost($)", wantHit: true},
+		// `.` is the regex any-char wildcard: "v1.0" as a regex matches "v1x0".
+		// As a literal it must NOT.
+		{name: "dot is literal not wildcard", line: "shipped v1x0 today", query: "v1.0", wantHit: false},
+		// Same query DOES match the literal "v1.0".
+		{name: "dot matches literal dot", line: "shipped v1.0 today", query: "v1.0", wantHit: true},
+		// `|` is regex alternation: "a|b" as a regex matches a line with just
+		// "a". As a literal it must match ONLY the literal "a|b".
+		{name: "pipe is literal not alternation", line: "just an a here", query: "a|b", wantHit: false},
+		{name: "pipe matches literal pipe", line: "the a|b toggle", query: "a|b", wantHit: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempCwd(t, func(d string) {
+				mustMkdir(t, filepath.Join(d, "docs"))
+				mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+					"## 2026-06-01 10:00 - Decision\n"+tc.line+"\n")
+
+				body := runSearchCmd(t, tc.query)
+				gotHit := strings.Contains(body, "Found ")
+				if gotHit != tc.wantHit {
+					t.Errorf("query %q over line %q: hit=%t, want %t; body:\n%s", tc.query, tc.line, gotHit, tc.wantHit, body)
+				}
+				// When we expect a hit, the regex-special query must also
+				// highlight correctly (no regex compiled anywhere).
+				if tc.wantHit {
+					mustContain(t, body, ">>> "+tc.query+" <<<")
+				}
+			})
+		})
+	}
+}
+
+// TestSearch_Scope_SpansMainAndBranch: search must span docs/decisions.md
+// (main's decisions) AND the current branch file even when checked out on an
+// unrelated feature branch — a term living ONLY in decisions.md is found, and
+// a term living ONLY in the branch file is found.
+func TestSearch_Scope_SpansMainAndBranch(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		// A decision on main → docs/decisions.md.
 		withFakeTTY(t, false, func() { logOnce(t, "Use PostgreSQL for storage") })
 
+		// Move to an unrelated feature branch and log there.
 		checkoutBranch(t, d, "feat/unrelated")
 		withFakeTTY(t, false, func() { logOnce(t, "Add rate limiting") })
 
+		// Main's decision IS found from the feature branch.
 		body := runSearchCmd(t, "PostgreSQL")
-		mustContain(t, body, "No matches found for: PostgreSQL")
+		mustContain(t, body, "Found 1 match for: PostgreSQL")
+		mustContain(t, body, "docs/decisions.md")
 
-		// Sanity: the branch's own decision IS found. It appears twice on
-		// disk — once in the §1.6.3 branch-summary marker line `logmind log`
-		// writes automatically, once in the "## ..." decision header itself.
+		// The branch's own decision is ALSO found. It appears twice on disk —
+		// once in the §1.6.3 branch-summary marker line, once in the "## ..."
+		// header — so 2 matches.
 		body = runSearchCmd(t, "rate limiting")
 		mustContain(t, body, "Found 2 matches for: rate limiting")
 		mustContain(t, body, "docs/decisions-branches/feat__unrelated.md")
@@ -103,7 +156,6 @@ func TestSearch_FlagMatrix(t *testing.T) {
 					"## 2026-06-01 10:00 - PostgreSQL choice\n")
 				mustWrite(t, filepath.Join(d, "docs", "decisions-archive.md"),
 					"## 2025-01-01 09:00 - Old decision mentioning archived-term\n")
-				_ = d
 
 				body := runSearchCmd(t, tc.query, tc.extraArgs...)
 				gotHit := strings.Contains(body, "Found ")
@@ -115,24 +167,35 @@ func TestSearch_FlagMatrix(t *testing.T) {
 	}
 }
 
-// TestSearch_RegexQuery: regex patterns work; an invalid regex falls back
-// to a literal substring match instead of erroring.
-func TestSearch_RegexQuery(t *testing.T) {
+// TestSearch_CaseInsensitiveHighlightPreservesOriginalCasing: a lowercase
+// query highlights the mixed-case text that actually matched, not the query.
+func TestSearch_CaseInsensitiveHighlightPreservesOriginalCasing(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		mustMkdir(t, filepath.Join(d, "docs"))
 		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
-			"## 2026-06-01 10:00 - DB foo\n"+
-				"## 2026-06-02 10:00 - DB bar\n")
+			"## 2026-06-01 10:00 - Use PostgreSQL here\n")
 
-		// Valid regex: matches both "DB foo" and "DB bar" headers.
-		body := runSearchCmd(t, "DB .{3}")
-		mustContain(t, body, "Found 2 matches")
+		body := runSearchCmd(t, "postgresql")
+		mustContain(t, body, ">>> PostgreSQL <<<")
+	})
+}
 
-		// Invalid regex (unbalanced group) falls back to a literal search
-		// for the string "DB (" — no such literal text exists, so 0 hits,
-		// and critically: no error/panic.
-		body = runSearchCmd(t, "DB (")
-		mustContain(t, body, "No matches found for: DB (")
+// TestSearch_EmptyQueryErrors: an empty query must error, not match every line.
+func TestSearch_EmptyQueryErrors(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Something\n")
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"search", ""})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err == nil {
+			t.Fatalf("expected an error for an empty query; output:\n%s", out.String())
+		}
+		mustContain(t, out.String(), "empty search query")
 	})
 }
 

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -180,6 +180,26 @@ func TestSearch_CaseInsensitiveHighlightPreservesOriginalCasing(t *testing.T) {
 	})
 }
 
+// TestSearch_CaseInsensitiveHighlightLengthChangingFold: a line containing a
+// Unicode char whose ToLower changes byte length (İ U+0130 → i̇) must not
+// panic or corrupt output on a case-insensitive match. Highlighting bails out
+// gracefully (line returned intact); DETECTION still works.
+func TestSearch_CaseInsensitiveHighlightLengthChangingFold(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		line := "İ uses postgres here"
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Decision\n"+line+"\n")
+
+		// Must not panic; must still find the match.
+		body := runSearchCmd(t, "postgres")
+		mustContain(t, body, "Found 1 match for: postgres")
+		// The length-changing fold makes highlighting bail out, so the matched
+		// line is emitted intact (no >>> <<< markers), byte-for-byte.
+		mustContain(t, body, "> "+line)
+	})
+}
+
 // TestSearch_EmptyQueryErrors: an empty query must error, not match every line.
 func TestSearch_EmptyQueryErrors(t *testing.T) {
 	withTempCwd(t, func(d string) {

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,0 +1,136 @@
+// show.go — `logmind show` subcommand.
+//
+// SKILL.md / AGENTS.md / internal/templates/logmind-section.md all document
+// `logmind show` as "recent decisions on the current branch" with `--all` to
+// include the archive, but the v2 Go binary never shipped it (a v1.0
+// rewrite gap; a retired PR #154 built a version against the pre-branch-aware
+// v1 shape). This is the v2 re-implementation: it reads the SAME file `logmind
+// log` would write to right now — resolveDecisionsPath's branch-aware target,
+// not a hardcoded docs/decisions.md — so `show` always reflects "this branch's
+// recent decisions", matching the documented contract.
+//
+// Output shape:
+//
+//   - default: streams the resolved decision file verbatim.
+//   - --all: appends docs/decisions-archive.md under an ARCHIVED DECISIONS
+//     banner, when the archive exists.
+//
+// Quiet discipline (quiet.go): under --quiet/LOGMIND_QUIET the verbatim body
+// is suppressed — the deliverable a human wants (the markdown) isn't
+// "chatter", but an agent that opted into quiet mode wants a receipt, not the
+// payload, matching `logmind repomap`'s stdout-sink precedent. The single `ok`
+// line always carries the byte count so a script can tell empty from missing.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/config"
+)
+
+// newShowCmd wires the `logmind show` subcommand.
+func newShowCmd() *cobra.Command {
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show recent decisions on the current branch",
+		Long: `Show recent decisions on the current branch.
+
+Streams the decision file "logmind log" would write to right now:
+docs/decisions.md on the default branch, or
+docs/decisions-branches/<branch>.md on a feature branch (when
+decisions.branch_aware is on and this branch has entries).
+
+Pass --all to also print docs/decisions-archive.md, appended under an
+ARCHIVED DECISIONS banner.
+
+Examples:
+    logmind show
+    logmind show --all`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runShow(cwd, all, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false,
+		"Also print docs/decisions-archive.md, appended under an ARCHIVED DECISIONS banner.")
+	return cmd
+}
+
+// runShow implements `logmind show`.
+func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
+	q := newQout(quiet, stdout, stderr)
+	docsPath := filepath.Join(cwd, "docs")
+	if !pathExists(docsPath) {
+		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
+		return ErrSilent
+	}
+
+	cfg, _ := config.Load(cwd)
+	target, _ := resolveDecisionsPath(cwd, docsPath, cfg)
+	rel := relForOk(cwd, target)
+
+	var body string
+	if pathExists(target) {
+		data, err := os.ReadFile(target)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", target, err)
+		}
+		body = string(data)
+	}
+
+	var archiveBody string
+	archiveShown := false
+	if all {
+		archivePath := filepath.Join(docsPath, "decisions-archive.md")
+		if pathExists(archivePath) {
+			data, err := os.ReadFile(archivePath)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", archivePath, err)
+			}
+			archiveBody = string(data)
+			archiveShown = true
+		}
+	}
+
+	if quiet {
+		q.ok("show path=%s bytes=%d all=%t archive=%t", rel, len(body), all, archiveShown)
+		return nil
+	}
+
+	if body == "" {
+		fmt.Fprintln(stdout, "No decisions logged yet on this branch.")
+	} else {
+		fmt.Fprint(stdout, body)
+	}
+
+	if archiveShown {
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, strings.Repeat("=", 80))
+		fmt.Fprintln(stdout, "ARCHIVED DECISIONS")
+		fmt.Fprintln(stdout, strings.Repeat("=", 80))
+		fmt.Fprintln(stdout)
+		fmt.Fprint(stdout, archiveBody)
+	}
+
+	suffix := ""
+	if all {
+		if archiveShown {
+			suffix = " + archive"
+		} else {
+			suffix = " (no archive)"
+		}
+	}
+	fmt.Fprintf(stdout, "ok show: %s (%d bytes%s)\n", rel, len(body), suffix)
+	return nil
+}

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -1,0 +1,182 @@
+// show_test.go — exercises `logmind show` against tmpdir fixtures.
+//
+// Coverage:
+//   - default branch streams docs/decisions.md
+//   - feature branch streams docs/decisions-branches/<branch>.md, NOT
+//     docs/decisions.md (the "current branch" contract SKILL.md/AGENTS.md
+//     document)
+//   - no decisions logged yet on the current branch → friendly message
+//   - --all appends the archive under an ARCHIVED DECISIONS banner when the
+//     archive file exists, and a "(no archive)" ok-suffix when it doesn't
+//   - --quiet collapses stdout to exactly one `ok k=v` line
+//   - docs/ missing → friendly error + ErrSilent
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mustMkdir + mustWrite are tiny fixture helpers shared by show_test.go and
+// search_test.go — both build docs/ trees directly (without going through
+// `logmind init`/`logmind log`) so tests can pin exact file contents.
+func mustMkdir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// runShowCmd runs `logmind show [extraArgs...]` and returns combined output.
+func runShowCmd(t *testing.T, extraArgs ...string) string {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(append([]string{"show"}, extraArgs...))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("show %v: %v\n%s", extraArgs, err, out.String())
+	}
+	return out.String()
+}
+
+// TestShow_DefaultBranch_StreamsDecisionsMd: on the default branch, `show`
+// streams docs/decisions.md verbatim and prints the ok-trailer.
+func TestShow_DefaultBranch_StreamsDecisionsMd(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		withFakeTTY(t, false, func() { logOnce(t, "Use PostgreSQL") })
+
+		body := runShowCmd(t)
+		mustContain(t, body, "## ")
+		mustContain(t, body, "Use PostgreSQL")
+		mustContain(t, body, "ok show: docs/decisions.md")
+		mustContain(t, body, "bytes")
+	})
+}
+
+// TestShow_FeatureBranch_StreamsBranchFile: on a feature branch, `show`
+// streams docs/decisions-branches/<branch>.md — the SAME file `logmind log`
+// just wrote to — not docs/decisions.md. This is the "current branch"
+// contract the docs promise.
+func TestShow_FeatureBranch_StreamsBranchFile(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		checkoutBranch(t, d, "feat/login")
+		withFakeTTY(t, false, func() { logOnce(t, "Add JWT auth") })
+
+		body := runShowCmd(t)
+		mustContain(t, body, "Add JWT auth")
+		mustContain(t, body, "ok show: docs/decisions-branches/feat__login.md")
+		// The default-branch decisions.md content must NOT leak in.
+		if strings.Contains(body, "Initialize logmind decision tracking") {
+			t.Errorf("feature-branch show leaked docs/decisions.md content:\n%s", body)
+		}
+	})
+}
+
+// TestShow_NoDecisionsYetOnBranch: a fresh feature branch with no `logmind
+// log` yet has no decisions-branches file on disk — `show` reports the
+// friendly empty message rather than erroring.
+func TestShow_NoDecisionsYetOnBranch(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		checkoutBranch(t, d, "feat/empty")
+
+		body := runShowCmd(t)
+		mustContain(t, body, "No decisions logged yet on this branch.")
+		mustContain(t, body, "ok show:")
+	})
+}
+
+// TestShow_All_ArchiveVariants: --all appends the archive under a banner
+// when it exists, and degrades gracefully (no banner, "(no archive)"
+// ok-suffix) when it doesn't.
+func TestShow_All_ArchiveVariants(t *testing.T) {
+	cases := []struct {
+		name         string
+		writeArchive bool
+		wantBanner   bool
+		wantOkSuffix string
+	}{
+		{name: "archive present", writeArchive: true, wantBanner: true, wantOkSuffix: "+ archive"},
+		{name: "archive absent", writeArchive: false, wantBanner: false, wantOkSuffix: "(no archive)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempCwd(t, func(d string) {
+				mustMkdir(t, filepath.Join(d, "docs"))
+				mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+					"## 2026-06-01 10:00 - Main decision\n")
+				if tc.writeArchive {
+					mustWrite(t, filepath.Join(d, "docs", "decisions-archive.md"),
+						"## 2025-01-01 09:00 - Archived decision\n")
+				}
+
+				body := runShowCmd(t, "--all")
+				mustContain(t, body, "Main decision")
+				if tc.wantBanner {
+					mustContain(t, body, "ARCHIVED DECISIONS")
+					mustContain(t, body, "Archived decision")
+				} else if strings.Contains(body, "ARCHIVED DECISIONS") {
+					t.Errorf("did not expect ARCHIVED DECISIONS banner:\n%s", body)
+				}
+				mustContain(t, body, tc.wantOkSuffix)
+			})
+		})
+	}
+}
+
+// TestShow_Quiet_EmitsOneOkLine: --quiet suppresses the verbatim body —
+// matching `logmind repomap`'s stdout-sink precedent — leaving exactly one
+// `ok k=v` line.
+func TestShow_Quiet_EmitsOneOkLine(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Quiet decision\n")
+
+		body := runShowCmd(t, "--quiet")
+		lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+		if len(lines) != 1 {
+			t.Fatalf("quiet show: want exactly 1 line, got %d:\n%s", len(lines), body)
+		}
+		if !strings.HasPrefix(lines[0], "ok show ") {
+			t.Errorf("quiet show line = %q; want prefix %q", lines[0], "ok show ")
+		}
+		if strings.Contains(body, "Quiet decision") {
+			t.Errorf("quiet show leaked the decision body:\n%s", body)
+		}
+		mustContain(t, body, "path=docs/decisions.md")
+	})
+}
+
+// TestShow_DocsMissingErrors: no docs/ → friendly error on the error
+// channel + ErrSilent.
+func TestShow_DocsMissingErrors(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"show"})
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		if err := root.Execute(); err == nil {
+			t.Fatalf("expected ErrSilent when docs/ missing")
+		}
+		mustContain(t, out.String(), "docs/ directory not found")
+	})
+}


### PR DESCRIPTION
## Summary

- `logmind show` and `logmind search` are documented (`skill/SKILL.md:64-66`, `internal/templates/logmind-section.md:33-41`, `AGENTS.md:35-36`) but the binary has never shipped them since the v1.0 Go rewrite — running either errors `unknown command`. This PR implements both, closing the documented-but-missing gap.
- A retired PR #154 (`gh pr diff 154`) built these against the pre-branch-aware v1 shape (hardcoded `docs/decisions.md`). Main has since moved to branch-aware decision routing (`resolveDecisionsPath`, the v2 quiet/`qout` discipline in `internal/cli/quiet.go`), so this is a clean v2 re-implementation informed by #154's intent rather than a cherry-pick.
- `show` and `search` now resolve the **same file `logmind log`/`headline` just wrote** via `resolveDecisionsPath` — matching the documented "recent decisions on the current branch" contract more precisely than #154 did (#154 always read `docs/decisions.md`, which isn't "current branch" once branch-aware routing is in play).
- Quiet mode (`--quiet` / `LOGMIND_QUIET`) follows the `logmind repomap` precedent: the verbatim/search output is the deliverable, not progress chatter, so `--quiet` suppresses the payload entirely and emits exactly one `ok <k=v>` receipt line — not the payload plus a receipt.

## Command surface

```
logmind show [--all]
logmind search <query> [--case-sensitive] [--no-archive]
```

- `show` streams `docs/decisions.md` (default branch) or `docs/decisions-branches/<branch>.md` (feature branch); `--all` appends `docs/decisions-archive.md` under an `ARCHIVED DECISIONS` banner when it exists.
- `search` scans the same "current branch" file plus the archive (unless `--no-archive`); the query compiles as a regex, falling back to a literal substring match on compile failure. Case-insensitive by default; `--case-sensitive` requires exact case. Results show ±2 lines of context and `>>> term <<<` highlight markers.

## Files added/changed

- `internal/cli/show.go` (new) — `newShowCmd` / `runShow`
- `internal/cli/search.go` (new) — `newSearchCmd` / `runSearch`
- `internal/cli/root.go` — registers both commands
- `internal/cli/show_test.go`, `internal/cli/search_test.go` (new) — table-driven coverage: default/feature-branch routing, current-branch scoping (a term only in `decisions.md` is NOT found while on an unrelated feature branch), `--all`/archive-present/absent, `--case-sensitive`, `--no-archive`, regex + literal-fallback, no-match, `--quiet` (exactly one `ok` line), docs-missing → `ErrSilent`.

## Behavior inferred (docs were silent on this)

- "Current branch" scoping for both commands, rather than always reading `docs/decisions.md` — inferred from the branch-aware routing `logmind log`/`headline` already use, since the docs just say "recent decisions on the current branch" without spec'ing the resolution.
- `search`'s context window is fixed at 2 lines (not a flag) — the documented interface only promises `--case-sensitive`/`--no-archive`, so the flag surface stays exactly as documented rather than growing to match #154's undocumented `--no-context`/`--context-lines`.
- Quiet-mode semantics (suppress payload, one receipt line) — inferred from the `logmind repomap` stdout-sink precedent, since `show`/`search` have no prior v2 example to follow directly.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages green, including the new `internal/cli` table-driven tests)
- [x] Manual smoke test of `show`/`search`/`--all`/`--quiet`/case-sensitivity/`--no-archive`/docs-missing against a scratch repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG