### PR TITLE
feat(log): reconcile logmind log stdout to SPEC §3.1 + --no-push (salvaged from #154)

### DIFF
--- a/docs/decisions-branches/feat__log-spec-3-1-no-push.md
+++ b/docs/decisions-branches/feat__log-spec-3-1-no-push.md
@@ -1,0 +1,20 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-11-reconcile-logmind-log-stdout-to-spec-3-1-three-line-contract -->
+- **2026-07-11** — Reconcile logmind log stdout to SPEC §3.1 three-line contract + add --no-push and a real gitcli.Push (salvaged from retired PR #154)
+<!-- logmind-entry-end -->
+
+## 2026-07-11 14:27 - Reconcile logmind log stdout to SPEC §3.1 three-line contract + add --no-push and a real gitcli.Push (salvaged from retired PR #154)
+
+**Reasoning:** SPEC §3.1 mandates byte-exact stdout: an info stage-notice, then Logged decision with the quoted summary, then a Committed[-and-pushed] line; config.yml already documented git.auto_push default true but log.go never implemented push at all. PR #154 sketched this but used raw fmt.Fprintln instead of the v2 quiet-aware q.chat API and its line-3 wording (Committed changes (push disabled)) doesn't match the SPEC's literal Committed changes text, so it was reconciled to the SPEC verbatim rather than ported as-is.
+
+**Alternatives considered:** Port PR #154 unchanged onto q.chat -- rejected, its line-3 suffix and no --stage-scoped notice drift from the current SPEC text, Leave push out of scope again -- rejected, config.yml already promises git.auto_push and nothing implemented it, a real gap
+
+**Implications:**
+- New gitcli.Push wraps git push, gated by shouldPush = shouldCommit && cfg.Git.AutoPush && not noPush; push failure (e.g. no upstream) is non-fatal and falls back to the Committed changes line
+- Stage-notice wording for --stage scoped has no SPEC example, so it is this port's own text (Staging decision file only) -- flagged for review
+- Known pre-existing gap left unfixed: in the TTY-interactive branch-file path, nudgeBranchSummary still prints between required lines 2 and 3, violating SPEC 3.1.1's line-3-must-be-third rule; fixing it would break the nudge's real-time prompt UX or decouple the edit from landing in the same commit, so it needs a separate product call
+- internal/timeline/merge_driver_test.go already pre-patched auto_push: false in its test fixture anticipating this wiring; go test ./... and the integration-tagged merge-driver suite both pass unchanged
+
+---
+

--- a/docs/decisions-branches/feat__log-spec-3-1-no-push.md
+++ b/docs/decisions-branches/feat__log-spec-3-1-no-push.md
@@ -18,3 +18,17 @@
 
 ---
 
+## 2026-07-11 14:47 - Harden gitcli.Push against credential-prompt hangs and fill the push test gap (PR #192 review fixes)
+
+**Reasoning:** Push is the first network git op in gitcli and runs on the logmind log hot path since auto_push defaults true; git credential and ssh passphrase prompts read from the controlling TTY not cmd.Stdin, so an auth-needed https/ssh remote could block indefinitely on a box with a controlling terminal, defeating the push-is-non-fatal guarantee. Reviewer also flagged the push surface as essentially untested and two minors.
+
+**Alternatives considered:** Leave Push interactive and rely on callers to timeout -- rejected, no caller sets a deadline and a blocked push freezes the whole log command, Skip the bare-remote success test as too heavy -- rejected, a local git init --bare remote needs no network and proves the pushed=true and Committed and pushed changes path end to end
+
+**Implications:**
+- Push now sets GIT_TERMINAL_PROMPT=0 and GIT_SSH_COMMAND=ssh -oBatchMode=yes so auth-needed always fails fast and the log falls back to Committed changes
+- New gitcli_push_test.go: success to local bare remote, no-remote fast error, bad-remote fast error (each bounded well under a 20s non-block ceiling)
+- New cli tests: log --no-push proves no push attempted (no auto-push warning on stderr) plus quiet pushed=false; log to a bare remote proves Committed and pushed changes, quiet pushed=true, and the commit actually lands on the remote
+- Minor: line-1 stage notice now gated on gitcli.IsRepo so it no longer prints in a non-git dir where nothing is staged; minor: added a comment at the line-2 percent-q site explaining Go-quoting is the safe escape superset
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-11-reconcile-logmind-log-stdout-to-spec-3-1-three-line-contract -->
+- **2026-07-11** — Reconcile logmind log stdout to SPEC §3.1 three-line contract + add --no-push and a real gitcli.Push (salvaged from retired PR #154) → [detail](decisions-branches/feat__log-spec-3-1-no-push.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-11-implement-logmind-show-and-search-the-documented-decision-re -->
 - **2026-07-11** — Implement logmind show and search — the documented decision-read commands salvaged from retired PR #154 → [detail](decisions-branches/feat__cli-show-search.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -249,9 +249,11 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	// required stdout contract. The --stage all wording is the SPEC's
 	// own §3.1 example, verbatim; --stage scoped has no SPEC example so
 	// this is this port's extrapolation (flagged in the PR description).
-	// Only emitted when a commit is actually about to be attempted —
-	// --no-commit stages nothing, so there is nothing to announce.
-	if shouldCommit {
+	// Gated on BOTH a pending commit AND actually being in a git repo:
+	// --no-commit stages nothing, and outside a git repo the commit is
+	// skipped too (see the AddAll block below), so in neither case does
+	// any staging occur — the notice would be a lie.
+	if shouldCommit && gitcli.IsRepo(cwd) {
 		if f.stage == "all" {
 			q.chat("ℹ Staging all changes (use --stage scoped to limit)\n")
 		} else {
@@ -338,6 +340,13 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	// %q quotes + escapes the summary the same way Go would for any
 	// embedded control characters; a plain-text summary renders as a
 	// simple double-quoted string, matching the SPEC example exactly.
+	//
+	// The Go-quoted rendering is a DELIBERATE, unambiguous escape choice:
+	// SPEC §3.1 shows plain surrounding quotes, but a summary that itself
+	// contains a `"` or `\` would make the naive `"%s"` form ambiguous
+	// (unparseable back to the original). %q is the safe superset —
+	// identical to the plain form for ordinary summaries — and no §6.6
+	// fixture pins the naive spelling, so this stays conformant.
 	q.chat("✓ Logged decision: %q\n", summary)
 
 	// Branch-summary nudge — steer the author toward a clean one-sentence

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -37,6 +37,25 @@
 //     found AND not interactive → print advisory and exit 0 (CI's
 //     check-doc-links workflow Layer 3 will catch it).
 //
+// SPEC §3.1 stdout contract (reconciled, salvaged from retired #154):
+//
+// On success stdout's first three lines are, byte-exact:
+//
+//	ℹ Staging all changes (use --stage scoped to limit)
+//	✓ Logged decision: "<summary>"
+//	✓ Committed and pushed changes
+//
+// (line 3 reads "✓ Committed changes" when push was suppressed via
+// --no-push / git.auto_push: false, or when the push itself failed —
+// e.g. no upstream configured.) TTY-interactive invocations MAY print
+// additional advisory lines AFTER these three (SPEC §3.1.1); non-TTY
+// and --no-interactive invocations emit exactly the three lines. See
+// runSelfHealLayer1 and nudgeBranchSummary for the TTY-gated extras.
+//
+// --no-push (this port, closing the gap the file docstring used to
+// carry as "out of scope"): suppresses the auto-push step. gitcli.Push
+// wraps the underlying `git push`.
+//
 // Out of scope for v1.2.0 (carried by the Python shim until v1.3.x or
 // folded into a follow-up):
 //
@@ -46,8 +65,6 @@
 //     self-heal feature.
 //   - `--template` flag for pre-filled reasoning/alternatives/impl
 //     (low-traffic; users craft their own entries with -r/-a/-i).
-//   - `--no-push` (push is a follow-up; v1.2.0 commits but does not
-//     push, matching the safer default for the new Go path).
 package cli
 
 import (
@@ -114,6 +131,7 @@ type logFlags struct {
 	alternatives  []string
 	implications  []string
 	noCommit      bool
+	noPush        bool
 	noInteractive bool
 	stage         string
 	// headline, when set, becomes the branch's one-sentence timeline summary
@@ -141,10 +159,11 @@ branch_aware=true). When creating a branch decision file for the first
 time, prepends a backlink header pointing at docs/timeline.md so the
 two files cross-link bidirectionally.
 
-After committing (unless --no-commit), runs linkcheck.Check() against the
-repo. If issues are found, prints an advisory + (when stdin is a TTY)
-enters an interactive retry loop giving you up to 3 attempts to fix and
-re-check. Non-interactive contexts (CI, piped stdin, --no-interactive)
+After committing (unless --no-commit), pushes (unless --no-push or
+git.auto_push: false in .logmind/config.yml), then runs linkcheck.Check()
+against the repo. If issues are found, prints an advisory + (when stdin is
+a TTY) enters an interactive retry loop giving you up to 3 attempts to fix
+and re-check. Non-interactive contexts (CI, piped stdin, --no-interactive)
 print the advisory and exit 0 — the check-doc-links workflow's Layer 3
 self-heal will catch any leftover issues at PR time.
 
@@ -170,6 +189,8 @@ Example:
 		"Implication of this decision (repeatable).")
 	cmd.Flags().BoolVar(&f.noCommit, "no-commit", false,
 		"Don't auto-commit the decision (write the file only).")
+	cmd.Flags().BoolVar(&f.noPush, "no-push", false,
+		"Don't auto-push after committing. Honored alongside .logmind/config.yml's git.auto_push (either suppresses the push).")
 	cmd.Flags().BoolVar(&f.noInteractive, "no-interactive", false,
 		"Skip the Layer 1 interactive retry prompt; print advisory + exit 0 when linkcheck has issues.")
 	cmd.Flags().StringVar(&f.stage, "stage", "all",
@@ -216,6 +237,27 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	}
 
 	cfg, _ := config.Load(cwd)
+
+	// Commit/push gating. Commit keeps its existing --no-commit-only gate
+	// (cfg.Git.AutoCommit is a pre-existing, still-unwired config knob —
+	// out of scope here). Push is the new surface: CLI flag OR config can
+	// suppress it, matching git.auto_push's documented semantics.
+	shouldCommit := !f.noCommit
+	shouldPush := shouldCommit && cfg.Git.AutoPush && !f.noPush
+
+	// SPEC §3.1 line 1 of 3 — stage notice, the first line of the
+	// required stdout contract. The --stage all wording is the SPEC's
+	// own §3.1 example, verbatim; --stage scoped has no SPEC example so
+	// this is this port's extrapolation (flagged in the PR description).
+	// Only emitted when a commit is actually about to be attempted —
+	// --no-commit stages nothing, so there is nothing to announce.
+	if shouldCommit {
+		if f.stage == "all" {
+			q.chat("ℹ Staging all changes (use --stage scoped to limit)\n")
+		} else {
+			q.chat("ℹ Staging decision file only (--stage scoped)\n")
+		}
+	}
 
 	// Resolve target file based on git state + config.branch_aware.
 	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
@@ -291,7 +333,12 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 		relTarget = target
 	}
 	relTarget = filepath.ToSlash(relTarget)
-	q.chat("✓ Logged decision to %s\n", relTarget)
+
+	// SPEC §3.1 line 2 of 3 — byte-exact `✓ Logged decision: "<summary>"`.
+	// %q quotes + escapes the summary the same way Go would for any
+	// embedded control characters; a plain-text summary renders as a
+	// simple double-quoted string, matching the SPEC example exactly.
+	q.chat("✓ Logged decision: %q\n", summary)
 
 	// Branch-summary nudge — steer the author toward a clean one-sentence
 	// summary of the WHOLE branch (the timeline headline the next agent reads).
@@ -299,13 +346,31 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	// commit so a TTY edit lands in the same commit. Gated to a branch file.
 	// Best-effort: never fails the log. Suppressed under QUIET — an agent that
 	// opted into terse output doesn't want the multi-line nudge.
+	//
+	// KNOWN SPEC §3.1.1 GAP (pre-existing, not introduced by this change,
+	// left as-is — flagged for the lead): in the TTY-interactive path this
+	// prints prompts to stdout BETWEEN required line 2 and required line 3,
+	// which strictly reads as "additional lines" appearing before the third
+	// required line rather than after it. Deferring the nudge until after
+	// line 3 would break its real-time TTY UX (the prompt has to appear
+	// before the user types a reply) and would also decouple the edit from
+	// landing in the same commit. The non-TTY / --no-interactive path is
+	// unaffected — the nudge there goes to stderr only (§3.1.1's carve-out)
+	// so the 3-line stdout contract holds exactly for the fixture-relevant
+	// case. Needs a product call: either accept this narrow TTY exemption
+	// explicitly in the SPEC, or redesign the nudge to run after commit.
 	if isBranchFile && f.headline == "" && !quiet {
 		nudgeBranchSummary(target, f.noInteractive, stdin, stdout, stderr)
 	}
 
-	// Commit (unless --no-commit OR not in a git repo).
+	// Commit + push (unless --no-commit OR not in a git repo). SPEC §3.1
+	// line 3 of 3 — byte-exact "✓ Committed and pushed changes" when the
+	// push actually lands, else byte-exact "✓ Committed changes" (push
+	// suppressed via --no-push / git.auto_push: false, OR the push
+	// itself failed — e.g. no upstream on a fresh local repo).
 	committed := false
-	if !f.noCommit && gitcli.IsRepo(cwd) {
+	pushed := false
+	if shouldCommit && gitcli.IsRepo(cwd) {
 		if err := commitDecision(cwd, target, relTarget, f.stage, summary, cfg); err != nil {
 			// Commit failure isn't fatal to the decision-logging
 			// surface: the file is on disk; the user can commit
@@ -314,9 +379,24 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 			fmt.Fprintf(stderr, "Warning: auto-commit failed: %v\n", err)
 		} else {
 			committed = true
-			q.chat("✓ Committed decision\n")
+			if shouldPush {
+				if err := gitcli.Push(cwd); err != nil {
+					// Push failure is non-fatal — the commit already
+					// landed locally. Surface to stderr so the user
+					// knows to retry the push manually; stdout still
+					// reports the (accurate) "Committed changes" line.
+					fmt.Fprintf(stderr, "Warning: auto-push failed: %v\n", err)
+				} else {
+					pushed = true
+				}
+			}
+			if pushed {
+				q.chat("✓ Committed and pushed changes\n")
+			} else {
+				q.chat("✓ Committed changes\n")
+			}
 		}
-	} else if !f.noCommit {
+	} else if shouldCommit {
 		fmt.Fprintln(stderr, "Warning: not inside a git repo; skipping auto-commit.")
 	}
 
@@ -336,7 +416,7 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	// its historical multi-line ✓ output (no `ok` trailer) for byte parity;
 	// this line is the quiet MODE's sole stdout output.
 	if quiet {
-		q.ok("logged path=%s committed=%t", relTarget, committed)
+		q.ok("logged path=%s committed=%t pushed=%t", relTarget, committed, pushed)
 	}
 	return nil
 }

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -521,7 +521,7 @@ func TestLog_PushesToBareRemote(t *testing.T) {
 			t.Fatalf("remote %s = %q; want local HEAD %q (push did not land)", branch, remoteHead, localHead)
 		}
 		// And the decision commit is the one that landed.
-		if msg := runGitOut(t, remote, "log", "--oneline", "-1"); !strings.Contains(msg, "pushed decision") {
+		if msg := runGitOut(t, remote, "log", "--oneline", "-1", branch); !strings.Contains(msg, "pushed decision") {
 			t.Fatalf("remote tip commit missing decision summary; got: %s", msg)
 		}
 

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -83,7 +83,7 @@ func TestLog_DefaultBranch_WritesToDecisionsMd(t *testing.T) {
 			if err := root.Execute(); err != nil {
 				t.Fatalf("log: %v\n%s", err, out.String())
 			}
-			mustContain(t, out.String(), "Logged decision to docs/decisions.md")
+			mustContain(t, out.String(), `✓ Logged decision: "Test decision"`)
 		})
 	})
 	body, err := os.ReadFile(filepath.Join(dir, "docs", "decisions.md"))
@@ -128,7 +128,7 @@ func TestLog_FeatureBranch_WritesToBranchFile(t *testing.T) {
 			if err := root.Execute(); err != nil {
 				t.Fatalf("log: %v\n%s", err, out.String())
 			}
-			mustContain(t, out.String(), "docs/decisions-branches/feat__test.md")
+			mustContain(t, out.String(), `✓ Logged decision: "Branch decision"`)
 		})
 	})
 	body, err := os.ReadFile(filepath.Join(dir, "docs", "decisions-branches", "feat__test.md"))
@@ -409,7 +409,10 @@ func TestLog_AutoCommit_OnGitRepo(t *testing.T) {
 			if err := root.Execute(); err != nil {
 				t.Fatalf("log: %v\n%s", err, out.String())
 			}
-			mustContain(t, out.String(), "✓ Committed decision")
+			// No remote configured in this test repo, so the push step
+			// fails (no upstream) and line 3 falls back to the SPEC's
+			// "push suppressed/failed" wording.
+			mustContain(t, out.String(), "✓ Committed changes")
 		})
 	})
 	cmd := exec.Command("git", "log", "--oneline", "-1")

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -426,6 +426,151 @@ func TestLog_AutoCommit_OnGitRepo(t *testing.T) {
 	}
 }
 
+// TestLog_NoPush_SkipsPush: --no-push must NOT attempt a push. Proof:
+//   - line 3 is the SPEC's "✓ Committed changes" (never "and pushed").
+//   - stderr carries NO "auto-push failed" warning — that warning only
+//     appears when a push is ATTEMPTED and fails, so its absence in a
+//     no-remote repo proves no attempt was made.
+//   - the quiet trailer reports pushed=false.
+func TestLog_NoPush_SkipsPush(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		// Baseline commit so `git add -A` has a parent (init --no-git
+		// skips the initial commit).
+		commitAll(t, d, "initial")
+
+		// Default (verbose) mode: line 3 + no push-warning on stderr.
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "no-push decision", "-r", "test", "--no-push", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log --no-push: %v\n%s", err, errBuf.String())
+			}
+			mustContain(t, out.String(), "✓ Committed changes")
+			if strings.Contains(out.String(), "and pushed") {
+				t.Fatalf("--no-push emitted the pushed line:\n%s", out.String())
+			}
+			if strings.Contains(errBuf.String(), "auto-push failed") {
+				t.Fatalf("--no-push attempted a push (saw auto-push warning):\n%s", errBuf.String())
+			}
+		})
+
+		// Quiet mode: trailer must report pushed=false.
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "no-push quiet", "-r", "test", "--no-push", "--no-interactive", "--quiet"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log --no-push --quiet: %v\n%s", err, errBuf.String())
+			}
+			assertSingleOK(t, out.String(), "logged", "committed=true", "pushed=false")
+		})
+	})
+}
+
+// TestLog_PushesToBareRemote: with an upstream to a local bare repo,
+// `logmind log` pushes for real. Line 3 is "✓ Committed and pushed
+// changes", the quiet trailer reports pushed=true, and the decision
+// commit actually lands on the bare remote.
+func TestLog_PushesToBareRemote(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		commitAll(t, d, "initial")
+
+		// Local bare remote (no network) + upstream tracking so a bare
+		// `git push` inside `logmind log` has a destination.
+		remote := filepath.Join(t.TempDir(), "bare.git")
+		branch := strings.TrimSpace(runGitOut(t, d, "rev-parse", "--abbrev-ref", "HEAD"))
+		for _, args := range [][]string{
+			{"init", "--bare", "-q", remote},
+		} {
+			cmd := exec.Command("git", args...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+		runGitIn(t, d, "remote", "add", "origin", remote)
+		runGitIn(t, d, "push", "-u", "-q", "origin", branch)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "pushed decision", "-r", "test", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log (push): %v\n%s", err, errBuf.String())
+			}
+			mustContain(t, out.String(), "✓ Committed and pushed changes")
+			if strings.Contains(errBuf.String(), "auto-push failed") {
+				t.Fatalf("push unexpectedly failed:\n%s", errBuf.String())
+			}
+		})
+
+		// The remote's branch tip now equals local HEAD (push landed).
+		localHead := strings.TrimSpace(runGitOut(t, d, "rev-parse", "HEAD"))
+		remoteHead := strings.TrimSpace(runGitOut(t, remote, "rev-parse", branch))
+		if localHead != remoteHead {
+			t.Fatalf("remote %s = %q; want local HEAD %q (push did not land)", branch, remoteHead, localHead)
+		}
+		// And the decision commit is the one that landed.
+		if msg := runGitOut(t, remote, "log", "--oneline", "-1"); !strings.Contains(msg, "pushed decision") {
+			t.Fatalf("remote tip commit missing decision summary; got: %s", msg)
+		}
+
+		// Quiet run: trailer reports pushed=true (a second decision, still
+		// a fast-forward, still pushes cleanly).
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "second pushed", "-r", "test", "--no-interactive", "--quiet"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log (push) --quiet: %v\n%s", err, errBuf.String())
+			}
+			assertSingleOK(t, out.String(), "logged", "committed=true", "pushed=true")
+		})
+	})
+}
+
+// commitAll stages everything and commits with the given message. Used
+// to seed a parent commit before the log tests run `git add -A`.
+func commitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	runGitIn(t, dir, "add", "-A")
+	runGitIn(t, dir, "commit", "-q", "-m", msg)
+}
+
+// runGitIn runs `git <args>` in dir and fails the test on error.
+func runGitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// runGitOut runs `git <args>` in dir and returns combined output.
+func runGitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
 // TestLog_EmptySummaryRejected: defends against argparse misuse.
 // `logmind log ""` → ErrSilent + clear error message.
 func TestLog_EmptySummaryRejected(t *testing.T) {

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -32,6 +32,7 @@ package gitcli
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -437,10 +438,28 @@ func Commit(repoRoot, message string) error {
 // Args are appended verbatim (e.g., Push(cwd, "origin", "main") runs
 // `git push origin main`). Zero args runs plain `git push` and relies
 // on the branch's upstream tracking.
+//
+// Fail-fast on auth. Push is the FIRST network git op in this package,
+// and `logmind log` runs it on the hot path (auto_push defaults true).
+// git's credential/passphrase prompts read from the controlling TTY,
+// NOT from cmd.Stdin — so on a box that HAS a controlling terminal and
+// no credential helper, an https/ssh remote needing auth would BLOCK
+// indefinitely, defeating the "push is non-fatal, never blocks the log"
+// guarantee. We force non-interactive auth so any auth-needed case
+// errors out immediately and the caller falls back to the
+// "✓ Committed changes" line:
+//   - GIT_TERMINAL_PROMPT=0 disables git's own username/password and
+//     "authenticity of host" prompts (https + git's ssh prompts).
+//   - GIT_SSH_COMMAND=ssh -oBatchMode=yes tells OpenSSH never to prompt
+//     for a passphrase / password (ssh remotes).
 func Push(repoRoot string, args ...string) error {
 	gitArgs := append([]string{"push"}, args...)
 	cmd := exec.Command("git", gitArgs...)
 	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_SSH_COMMAND=ssh -oBatchMode=yes",
+	)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -421,6 +421,38 @@ func Commit(repoRoot, message string) error {
 	return nil
 }
 
+// Push runs `git push` against repoRoot. Returns a GitError carrying
+// git's stderr on failure (e.g., no upstream configured, network error,
+// rejected non-fast-forward). Used by `logmind log` per SPEC §3.1: on
+// success the third stdout line reads "✓ Committed and pushed changes";
+// when push is suppressed OR fails (including the common "no upstream"
+// case for a fresh local repo), the caller falls back to
+// "✓ Committed changes".
+//
+// No --force / --force-with-lease here — `logmind log` is an append-only
+// primitive and pushing a regular fast-forward is the right shape. The
+// `logmind rebase` wrapper carries the force-with-lease surface for the
+// rare case a rebase is involved.
+//
+// Args are appended verbatim (e.g., Push(cwd, "origin", "main") runs
+// `git push origin main`). Zero args runs plain `git push` and relies
+// on the branch's upstream tracking.
+func Push(repoRoot string, args ...string) error {
+	gitArgs := append([]string{"push"}, args...)
+	cmd := exec.Command("git", gitArgs...)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return ErrGitNotFound
+		}
+		return &GitError{Op: "push", Err: err, Stderr: stderr.String()}
+	}
+	return nil
+}
+
 // GitError wraps a git subprocess failure with the captured stderr
 // so callers can present meaningful diagnostics. The Python helpers
 // raise GitError(f"...{e.stderr}") in the same style.

--- a/internal/gitcli/gitcli_push_test.go
+++ b/internal/gitcli/gitcli_push_test.go
@@ -1,0 +1,129 @@
+package gitcli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// bareRemote creates a `git init --bare` repo under t.TempDir() and
+// returns its path. No network — a bare repo on the local filesystem is
+// a valid git remote, so Push can exercise a real fast-forward push
+// without touching GitHub.
+func bareRemote(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping push integration test")
+	}
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "--bare", "-q", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+	return dir
+}
+
+// TestPush_SucceedsToLocalBareRemote: a real fast-forward push to a
+// local bare remote lands on the remote (verified by reading the
+// remote's branch tip back).
+func TestPush_SucceedsToLocalBareRemote(t *testing.T) {
+	repo := initRepo(t) // one commit on the default branch, HEAD born
+	remote := bareRemote(t)
+
+	branch := CurrentBranch(repo)
+	runGit(t, repo, "remote", "add", "origin", remote)
+	// Set upstream so a bare `git push` (zero args) has a destination —
+	// this mirrors how `logmind log` calls Push(cwd) with no args.
+	runGit(t, repo, "push", "-u", "origin", branch)
+
+	// Add a second commit locally, then Push() it via the wrapper.
+	writeAndCommit(t, repo, "second.txt", "second\n", "second")
+	if err := Push(repo); err != nil {
+		t.Fatalf("Push to local bare remote: %v", err)
+	}
+
+	// The remote's branch tip must now equal the local HEAD.
+	localHead := revParse(t, repo, "HEAD")
+	remoteHead := revParse(t, remote, branch)
+	if localHead != remoteHead {
+		t.Fatalf("remote %s = %q; want local HEAD %q (push did not land)", branch, remoteHead, localHead)
+	}
+}
+
+// TestPush_NoRemoteReturnsErrorFast: a repo with NO remote configured
+// makes `git push` fail fast (no configured destination). The wrapper
+// must return a non-nil error quickly — never block.
+func TestPush_NoRemoteReturnsErrorFast(t *testing.T) {
+	repo := initRepo(t) // no `git remote add`
+
+	start := time.Now()
+	err := Push(repo)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Push with no remote returned nil; want non-nil error")
+	}
+	// "Fast" is a generous ceiling — the real point is it returns at all
+	// (no hang). A local `git push` with no destination fails in well
+	// under a second; 20s catches a genuine block without flaking on a
+	// loaded CI box.
+	if elapsed > 20*time.Second {
+		t.Fatalf("Push took %v; expected a fast non-blocking failure", elapsed)
+	}
+}
+
+// TestPush_BadRemoteReturnsErrorFast: an origin pointing at a
+// nonexistent local path fails fast too. GIT_TERMINAL_PROMPT=0 +
+// ssh BatchMode (set inside Push) guarantee no interactive prompt can
+// stall this even for an auth-shaped URL; a bogus local path needs no
+// auth and simply errors immediately.
+func TestPush_BadRemoteReturnsErrorFast(t *testing.T) {
+	repo := initRepo(t)
+	branch := CurrentBranch(repo)
+	// Point origin at a path that does not exist.
+	runGit(t, repo, "remote", "add", "origin", filepath.Join(t.TempDir(), "does-not-exist.git"))
+
+	start := time.Now()
+	err := Push(repo, "origin", branch)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Push to a nonexistent remote returned nil; want non-nil error")
+	}
+	if elapsed > 20*time.Second {
+		t.Fatalf("Push took %v; expected a fast non-blocking failure", elapsed)
+	}
+}
+
+// --- small local helpers (kept here so the push tests are self-contained) ---
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeAndCommit(t *testing.T, dir, name, content, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runGit(t, dir, "add", name)
+	runGit(t, dir, "commit", "-q", "-m", msg)
+}
+
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse %s in %s: %v\n%s", ref, dir, err, out)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

Salvages the remaining `logmind log` scope from retired PR #154: byte-exact SPEC §3.1 stdout + a real push step, ported onto the v2 `q.chat`/`qout` quiet-aware API (PR #154 predates that API and used raw `fmt.Fprintln`).

## What changed

**`internal/cli/log.go`**
- Line 1 of 3: `ℹ Staging all changes (use --stage scoped to limit)` — SPEC's own §3.1 example, verbatim. A `--stage scoped` counterpart (`ℹ Staging decision file only (--stage scoped)`) is this port's extrapolation — SPEC gives no scoped example (flagged below).
- Line 2 of 3: `✓ Logged decision: "<summary>"` (was `✓ Logged decision to <path>`).
- Line 3 of 3: `✓ Committed and pushed changes` / `✓ Committed changes` (was `✓ Committed decision`; no non-SPEC suffix).
- New `--no-push` flag. Push is gated by `shouldPush := shouldCommit && cfg.Git.AutoPush && !f.noPush` — wiring up `git.auto_push`, which `.logmind/config.yml` has documented as default-`true` since the config schema landed, but nothing implemented until now.
- Quiet-mode `ok` trailer gains `pushed=%t`.

**`internal/gitcli/gitcli.go`**
- New `Push(repoRoot string, args ...string) error` — thin `git push` wrapper matching the existing `Commit`/`AddAll` shape (buried stderr on success, `GitError` with captured stderr on failure).

**`internal/cli/log_test.go`**
- Updated the 3 assertions pinned to old wording (`TestLog_DefaultBranch_WritesToDecisionsMd`, `TestLog_FeatureBranch_WritesToBranchFile`, `TestLog_AutoCommit_OnGitRepo`).

## SPEC §3.1 lines targeted (quoted verbatim)

> 1. `ℹ <stage-notice>` — short notice describing what was staged (e.g. `ℹ Staging all changes (use --stage scoped to limit)`).
> 2. `✓ Logged decision: "<summary>"`.
> 3. `✓ Committed and pushed changes` (or `✓ Committed changes` if push was suppressed/no upstream).

## Reconciliation decisions (flagging per task brief)

1. **Line 1 wording** — used the SPEC's own example text verbatim for `--stage all`. PR #154 instead used a longer non-SPEC sentence; I did not port that, since the SPEC text is the more defensible byte-exact target.
2. **`--stage scoped` notice** — SPEC gives no example for this case. I added `ℹ Staging decision file only (--stage scoped)` as a reasonable parallel; this is a judgment call, not a literal SPEC quote.
3. **Line 3 "no push" wording** — SPEC says exactly `✓ Committed changes`. PR #154 appended `(push disabled)`. I did not port that suffix — went with the byte-exact SPEC text instead.
4. **Push gating** — `cfg.Git.AutoPush` (already present in config, already documented in SPEC §1.2.1, previously unused anywhere) now gates the push alongside `--no-push`. Commit gating is unchanged (`--no-commit` only) — `cfg.Git.AutoCommit` is a separate, still-unwired knob that's out of scope here.
5. **Known pre-existing gap, left unfixed** — in the TTY-interactive + branch-file + no-`--headline` path, `nudgeBranchSummary` still prints prompts to stdout *between* required lines 2 and 3, which reads as a SPEC §3.1.1 violation (extra lines must come *after* line 3, not between). Fixing it properly means either deferring the nudge's real-time prompts (breaks interactive UX — the user needs to see the prompt before typing) or moving the nudge after commit (decouples the edit from landing in the same commit, an existing intentional design choice). Flagged in a code comment at the call site; needs a separate product call. The non-TTY / `--no-interactive` path (the one §6.6 fixtures actually exercise) is unaffected — that nudge already goes to stderr only.

## Verification

- `go build ./... && go vet ./... && gofmt -l . && go test ./...` — all clean.
- `go test ./internal/cli/... ./internal/gitcli/... -race` — clean.
- `go test -tags=integration ./internal/timeline/... -run TestMergeDriver` — passes unchanged (that suite's `setupLogmindRepo` helper already pre-patches `auto_push: false` in its fixture, anticipating this exact wiring).
- No golden files under `internal/cli/testdata/` reference `log` output — `make snapshot` confirmed zero diffs across the SNAPSHOT_PKGS that build (the pre-existing, unrelated `internal/timeline -update` flag gap reproduces identically on `main`, so it isn't a regression from this change).
- Manual end-to-end runs (default / `--quiet` / `--no-push` / `--stage scoped` / real push) — see PR description samples below.

### Sample output — default (non-TTY, `--no-interactive`, no remote)
```
$ logmind log "Sample decision" -r "why" --no-interactive
ℹ Staging all changes (use --stage scoped to limit)
✓ Logged decision: "Sample decision"
✓ Committed changes
```
(stderr, separately: `Warning: auto-push failed: git push: fatal: No configured push destination. ...`)

### Sample output — `--quiet`
```
$ logmind log "Quiet decision" -r "why" --quiet --no-interactive
ok logged path=docs/decisions.md committed=true pushed=false
```

### Sample output — `--no-push` (no push attempted, no stderr noise)
```
$ logmind log "No-push decision" -r "why" --no-push --no-interactive
ℹ Staging all changes (use --stage scoped to limit)
✓ Logged decision: "No-push decision"
✓ Committed changes
```

### Sample output — real push (bare remote configured)
```
$ logmind log "Pushed decision" -r "why" --no-interactive
ℹ Staging all changes (use --stage scoped to limit)
✓ Logged decision: "Pushed decision"
✓ Committed and pushed changes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)