### PR TITLE
feat(enforce): logmind guard-commit decision engine (enforcement PR1/3)

### DIFF
--- a/docs/decisions-branches/feat__guard-commit-decision-engine.md
+++ b/docs/decisions-branches/feat__guard-commit-decision-engine.md
@@ -1,0 +1,18 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-11-add-guard-commit-decision-engine-internal-guardcommit-logmin -->
+- **2026-07-11** — Add guard-commit decision engine (internal/guardcommit) + logmind guard-commit cobra command, PR1/3 of force-logmind-usage enforcement
+<!-- logmind-entry-end -->
+
+## 2026-07-11 15:46 - Add guard-commit decision engine (internal/guardcommit) + logmind guard-commit cobra command, PR1/3 of force-logmind-usage enforcement
+
+**Reasoning:** Enforcement needs one shared decision engine two future hook layers (git commit-msg, Claude Code harness PreToolUse) can both call; splitting the LOC-counting/decision-file logic out of check_decisions.go into internal/guardcommit avoids the two enforcement surfaces drifting on what counts as substantive. WorkingTreeUnion diff mode exists because the harness fires before a compound git add -A && git commit stages anything, so StagedOnly alone would silently bypass enforcement in that shape.
+
+**Alternatives considered:** Have the harness hook call git diff --cached only (StagedOnly everywhere) - rejected, this is the exact bug WorkingTreeUnion prevents: a staged-only check run before staging happens always sees zero lines and allows., Return ErrSilent from guard-commit's harness layer like every other command - rejected, main.go maps ErrSilent to exit 1, but Claude Code's PreToolUse protocol only blocks on exit 2, so ErrSilent would make the harness layer a silent no-op.
+
+**Implications:**
+- guard-commit is Hidden:true and not wired into any hook yet - it is manually invocable only until PR2 installs the git commit-msg hook and the harness PreToolUse hook.
+- Added git.enforce_commits (default true) and git.commit_line_threshold (default 20) to GitConfig as the repo-level off-ramp and threshold override; not yet exposed via logmind config list/get/set (DefaultMap untouched) to keep this PR's diff scoped to the decision engine.
+
+---
+

--- a/docs/decisions-branches/feat__guard-commit-decision-engine.md
+++ b/docs/decisions-branches/feat__guard-commit-decision-engine.md
@@ -16,3 +16,15 @@
 
 ---
 
+## 2026-07-11 16:11 - Close five guard-commit silent-bypass holes found in PR #194 review: env-assignment prefix, subdir cwd for config+diffs, unicode untracked filenames, and second -m skip-marker
+
+**Reasoning:** Rigorous review found a compliant agent could bypass the commit gate three ways. (1) An inline env-var prefix (FOO=1 git commit, GIT_AUTHOR_DATE=x git commit, HUSKY=0 git commit, env git commit) tokenized so words[0] != git and InvokesGitCommit returned false. (2) The harness evaluated Evaluate and loaded config from the payload cwd, which can be a subdirectory of the repo; git status/diff root-relative paths did not resolve from a subdir so untracked files were miscounted to zero, and enforce_commits/threshold were read from the wrong or missing config. (3) git status --porcelain octal-escapes non-ASCII paths so git diff --no-index could not open them, dropping unicode-named untracked files from the count. Plus extractSubjectHint only read the first -m, over-blocking a commit whose skip-marker was in a second -m.
+
+**Alternatives considered:** Leave InvokesGitCommit as-is and rely only on the git-hook layer - rejected, the harness layer is the pre-stage gate and must catch env-prefixed and compound git add -A && git commit shapes before staging., Pass the raw payload cwd to Evaluate - rejected, that is the exact subdir bug; resolving the git toplevel once via gitcli.TopLevel and using it for BOTH config load AND every git op is the single correct fix., Strip quotes from git status --porcelain output for unicode paths - rejected, core.quotepath octal-escapes bytes not just quoting; -z NUL-terminated output is the only robust fix.
+
+**Implications:**
+- Added gitcli.TopLevel(cwd) (string, bool) returning the toplevel from an arbitrary cwd; guard-commit now resolves it once and passes it everywhere. UntrackedFiles switched to git status --porcelain -z. InvokesGitCommit stripWrapperPrefix now skips env assignments and the env command. extractSubjectHint collects all -m/--message values.
+- The same-line staged+unstaged double-count in WorkingTreeUnion is left intentional (over-counts toward Block, the safe direction) with a code comment. Added regression tests for every hole: env-prefix table cases, untracked-only-from-subdir Block, unicode-untracked-from-subdir Block, enforce_commits:false-from-subdir Allow, and skip-marker-in-second-m Allow.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -41,6 +41,7 @@ logmind
 │   ├── doctor
 │   ├── gitattr
 │   ├── gitcli
+│   ├── guardcommit
 │   ├── hooks
 │   ├── inserter
 │   ├── linkcheck

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -30,6 +30,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-11** — Fix the auto-regen bot commit identity to the canonical github-actions[bot], and bump the two workflow templates so consumer repos pick it up via doctor --fix → [detail](decisions-branches/fix__regen-bot-identity.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-11-add-guard-commit-decision-engine-internal-guardcommit-logmin -->
+- **2026-07-11** — Add guard-commit decision engine (internal/guardcommit) + logmind guard-commit cobra command, PR1/3 of force-logmind-usage enforcement → [detail](decisions-branches/feat__guard-commit-decision-engine.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-04-v2-0-0-breaking-remove-branch-divergent-entirely-main-canoni -->
 - **2026-07-04** — v2.0.0 BREAKING: remove branch-divergent entirely — main-canonical is the sole timeline model → [detail](decisions-branches/feat__v2-remove-branch-divergent.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/gitcli"
+	"github.com/thrillmade/logmind/internal/guardcommit"
 )
 
 // newCheckDecisionsCmd wires `logmind check-decisions [--threshold N] [--no-fail]`.
@@ -76,31 +75,18 @@ func runCheckDecisions(cwd string, threshold int, noFail bool, stdout io.Writer)
 
 	staged := gitcli.DiffCachedNames(cwd)
 	for _, f := range staged {
-		if isDecisionFile(f) {
+		if guardcommit.IsDecisionFile(f) {
 			fmt.Fprintln(stdout, "✓ A decision log file is staged — changes are documented.")
 			return nil
 		}
 	}
 
-	total := 0
-	for _, row := range gitcli.DiffCachedNumstat(cwd) {
-		// Mirror the Python skip rules verbatim (cli.py:2498-2504):
-		//   * filepath.startswith("docs/")  → skipped
-		//   * added == "-"                  → binary, skipped
-		//   * any int parse failure         → swallowed (pass)
-		if strings.HasPrefix(row.Path, "docs/") {
-			continue
-		}
-		if row.Added == "-" {
-			continue
-		}
-		added, errA := strconv.Atoi(row.Added)
-		removed, errR := strconv.Atoi(row.Removed)
-		if errA != nil || errR != nil {
-			continue
-		}
-		total += added + removed
-	}
+	// LOC counting + the docs/-prefix and binary skip rules live in
+	// guardcommit.SubstantiveLines now — shared with `logmind
+	// guard-commit` (internal/guardcommit) so the two enforcement
+	// surfaces can never drift on what counts as "substantive." Mirrors
+	// the Python skip rules verbatim (cli.py:2498-2504).
+	total := guardcommit.SubstantiveLines(gitcli.DiffCachedNumstat(cwd))
 
 	if total >= threshold {
 		// Multi-line warning identical to Python click.secho block.
@@ -118,21 +104,4 @@ func runCheckDecisions(cwd string, threshold int, noFail bool, stdout io.Writer)
 
 	fmt.Fprintf(stdout, "✓ %d lines changed (below %d-line threshold).\n", total, threshold)
 	return nil
-}
-
-// isDecisionFile mirrors the inline _is_decision_file predicate from
-// cli.py:2469-2474. Branch-aware mode routes feature-branch logs
-// to docs/decisions-branches/<branch>.md; both layouts must satisfy
-// "documented".
-func isDecisionFile(path string) bool {
-	if path == "docs/decisions.md" {
-		return true
-	}
-	if strings.HasSuffix(path, "/decisions.md") {
-		return true
-	}
-	if strings.HasPrefix(path, "docs/decisions-branches/") {
-		return true
-	}
-	return false
 }

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
 )
 
@@ -106,9 +107,10 @@ manually, e.g. for testing:
 	return cmd
 }
 
-// runGuardCommit is the testable core shared by both layers. It resolves
-// config (git.enforce_commits, git.commit_line_threshold) once against
-// repoRootFlag-or-cwd, then dispatches to the layer-specific evaluation.
+// runGuardCommit is the testable core shared by both layers. It dispatches
+// to the layer-specific evaluation, which is where the git toplevel is
+// resolved from the EVALUATED cwd (see resolveRepoAndConfig) and used for
+// BOTH config loading AND the guardcommit.Evaluate call.
 //
 // Return shape: (exitCode, err). exitCode != 0 tells the RunE wrapper to
 // call os.Exit(exitCode) directly (see the LOUD COMMENT above) — used ONLY
@@ -127,41 +129,68 @@ func runGuardCommit(
 	quiet bool,
 	stdin io.Reader, stdout, stderr io.Writer,
 ) (exitCode int, err error) {
-	repoRootForConfig := repoRootFlag
-	if repoRootForConfig == "" {
-		cwd, wdErr := os.Getwd()
-		if wdErr != nil {
-			return 0, wdErr
-		}
-		repoRootForConfig = cwd
-	}
-
-	// config.Load degrades to defaults on a missing/unparseable
-	// .logmind/config.yml (see internal/config's documented "broken
-	// config is user-fixing-it-later" stance) — guard-commit inherits
-	// that same best-effort posture rather than treating a config
-	// problem as a reason to block commits.
-	cfg, _ := config.Load(repoRootForConfig)
-	threshold := resolveThreshold(cfg, thresholdFlag, thresholdExplicit)
-
 	switch layer {
 	case "harness":
-		if !cfg.Git.EnforceCommits {
-			// The repo off-ramp: exit 0, no output, for both layers.
-			return 0, nil
-		}
-		return guardCommitHarness(stdin, stderr, repoRootFlag, threshold), nil
+		return guardCommitHarness(stdin, stderr, repoRootFlag, thresholdFlag, thresholdExplicit), nil
 	case "git-hook":
-		if !cfg.Git.EnforceCommits {
-			return 0, nil
-		}
 		if msgFile == "" {
+			// Pure CLI-usage error, independent of any repo/config state.
 			return 0, fmt.Errorf("--msg-file is required for --layer git-hook")
 		}
-		return 0, guardCommitGitHook(repoRootForConfig, msgFile, threshold, quiet, stdout, stderr)
+		return 0, guardCommitGitHook(repoRootFlag, msgFile, thresholdFlag, thresholdExplicit, quiet, stdout, stderr)
 	default:
 		return 0, fmt.Errorf("--layer must be %q or %q (got %q)", "harness", "git-hook", layer)
 	}
+}
+
+// resolveRepoAndConfig is the single choke point that fixes the
+// "evaluate/config against the wrong directory" family of silent bypasses.
+// Given the EVALUATED cwd (which, for the harness layer, may be a
+// SUBDIRECTORY of the repo — PreToolUse payloads carry the tool call's
+// cwd), it resolves the git toplevel ONCE and returns:
+//
+//   - repoRoot: the directory to hand guardcommit.Evaluate. When evalCwd
+//     is inside a repo this is the TOPLEVEL, so every git diff/status op
+//     Evaluate runs (whose --porcelain paths are root-relative) resolves
+//     correctly AND config is read from the repo root's
+//     .logmind/config.yml. When evalCwd isn't in a repo, we hand back
+//     evalCwd unchanged so Evaluate's own IsRepo(evalCwd) check fails and
+//     it takes its not-a-repo Allow path (handing back "" instead would
+//     make IsRepo inspect the PROCESS cwd, which could wrongly BE a repo).
+//   - enforce: git.enforce_commits from the toplevel's config (default
+//     true). The full repo off-ramp.
+//   - threshold: the effective substantive-line threshold.
+//
+// config.Load degrades to defaults on a missing/unparseable
+// .logmind/config.yml (internal/config's documented "broken config is
+// user-fixing-it-later" stance), so a config problem never becomes a
+// reason to block — or to wrongly allow — a commit.
+func resolveRepoAndConfig(evalCwd string, thresholdFlag int, thresholdExplicit bool) (repoRoot string, enforce bool, threshold int) {
+	toplevel, ok := gitcli.TopLevel(evalCwd)
+	if !ok {
+		// Not in a repo: config falls back to defaults, and we hand
+		// Evaluate the original evalCwd so its IsRepo check fails cleanly.
+		cfg := config.DefaultConfig()
+		return evalCwd, cfg.Git.EnforceCommits, resolveThreshold(cfg, thresholdFlag, thresholdExplicit)
+	}
+	cfg, _ := config.Load(toplevel)
+	return toplevel, cfg.Git.EnforceCommits, resolveThreshold(cfg, thresholdFlag, thresholdExplicit)
+}
+
+// evalCwdOr returns the first of preferred / repoRootFlag / the process
+// working directory that is non-empty. Used to pick the directory the
+// git toplevel is resolved from.
+func evalCwdOr(preferred, repoRootFlag string) string {
+	if preferred != "" {
+		return preferred
+	}
+	if repoRootFlag != "" {
+		return repoRootFlag
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return ""
 }
 
 // resolveThreshold implements the documented precedence: an explicit
@@ -192,9 +221,15 @@ type harnessPayload struct {
 // guardCommitHarness implements the --layer harness evaluation. Returns
 // the process exit code the caller should use: 0 to allow (INCLUDING every
 // fail-open case — bad/foreign JSON, a non-Bash tool call, a Bash command
-// that isn't a git-commit invocation), or 2 to block (with the reason
-// already written to stderr).
-func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, threshold int) int {
+// that isn't a git-commit invocation, and the enforce_commits:false
+// off-ramp), or 2 to block (with the reason already written to stderr).
+//
+// The evaluated cwd is the payload's own cwd when present (a PreToolUse
+// payload carries the Bash tool call's working directory, which may be a
+// SUBDIRECTORY of the repo), falling back to --repo-root then the process
+// cwd. resolveRepoAndConfig then resolves that to the git toplevel so both
+// config AND every git op use the correct base directory.
+func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, thresholdFlag int, thresholdExplicit bool) int {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return 0 // fail open: couldn't even read the payload
@@ -211,14 +246,10 @@ func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, 
 		return 0 // not a git-commit shape at all — nothing to evaluate
 	}
 
-	repoRoot := payload.Cwd
-	if repoRoot == "" {
-		repoRoot = repoRootFlag
-	}
-	if repoRoot == "" {
-		if cwd, err := os.Getwd(); err == nil {
-			repoRoot = cwd
-		}
+	evalCwd := evalCwdOr(payload.Cwd, repoRootFlag)
+	repoRoot, enforce, threshold := resolveRepoAndConfig(evalCwd, thresholdFlag, thresholdExplicit)
+	if !enforce {
+		return 0 // the repo off-ramp: git.enforce_commits: false
 	}
 
 	subject := extractSubjectHint(payload.ToolInput.Command)
@@ -230,11 +261,18 @@ func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, 
 	return 2
 }
 
-// guardCommitGitHook implements the --layer git-hook evaluation: read the
-// commit subject from msgFile's first line, evaluate under StagedOnly (the
-// index is final by the time a commit-msg hook runs), and translate the
-// result into the standard nil / ErrSilent convention.
-func guardCommitGitHook(repoRoot, msgFile string, threshold int, quiet bool, stdout, stderr io.Writer) error {
+// guardCommitGitHook implements the --layer git-hook evaluation: resolve
+// the git toplevel from --repo-root (or the process cwd), read config +
+// the commit subject, evaluate under StagedOnly (the index is final by the
+// time a commit-msg hook runs), and translate the result into the standard
+// nil / ErrSilent convention.
+func guardCommitGitHook(repoRootFlag, msgFile string, thresholdFlag int, thresholdExplicit bool, quiet bool, stdout, stderr io.Writer) error {
+	evalCwd := evalCwdOr("", repoRootFlag)
+	repoRoot, enforce, threshold := resolveRepoAndConfig(evalCwd, thresholdFlag, thresholdExplicit)
+	if !enforce {
+		return nil // the repo off-ramp: git.enforce_commits: false
+	}
+
 	subject, err := firstLineOfFile(msgFile)
 	if err != nil {
 		return err
@@ -269,32 +307,45 @@ func firstLineOfFile(path string) (string, error) {
 	return line, nil
 }
 
-// extractSubjectHint does a best-effort, quote-aware scan for a
-// `-m <value>` / `-m<value>` / `--message <value>` / `--message=<value>`
-// flag in a raw shell command string. It exists solely so the harness
-// layer's [skip-logmind] carve-out can see the intended commit message
-// BEFORE git has recorded anything (the harness runs at PreToolUse, ahead
-// of the actual `git commit` invocation). This is not a shell parser: a
-// message that comes from $EDITOR, a template, or is buried inside a
-// substitution simply yields "" here, which just means the
-// [skip-logmind] carve-out won't apply — every other carve-out (env var,
-// decision-file-staged, under-threshold) still works normally.
+// extractSubjectHint does a best-effort, quote-aware scan for git's commit
+// message flags — `-m <value>` / `-m<value>` / `--message <value>` /
+// `--message=<value>` — in a raw shell command string, and joins EVERY
+// occurrence (newline-separated) into one hint string. It exists solely so
+// the harness layer's [skip-logmind] carve-out can see the intended commit
+// message BEFORE git has recorded anything (the harness runs at PreToolUse,
+// ahead of the actual `git commit` invocation).
+//
+// ALL -m/--message values are collected, not just the first: git
+// concatenates multiple -m arguments into the message body, so a
+// `[skip-logmind]` marker placed in a SECOND -m (e.g.
+// `git commit -m "subject" -m "[skip-logmind]"`) must still be seen —
+// reading only the first -m would ignore the marker and OVER-block a
+// commit the agent explicitly opted out of.
+//
+// This is not a shell parser: a message that comes from $EDITOR, a
+// template, or is buried inside a substitution simply contributes nothing
+// here, which just means the [skip-logmind] carve-out won't apply — every
+// other carve-out (env var, decision-file-staged, under-threshold) still
+// works normally.
 func extractSubjectHint(command string) string {
 	words := splitCommandWords(command)
-	for i, w := range words {
+	var messages []string
+	for i := 0; i < len(words); i++ {
+		w := words[i]
 		switch {
 		case w == "-m" || w == "--message":
 			if i+1 < len(words) {
-				return words[i+1]
+				messages = append(messages, words[i+1])
+				i++ // skip the consumed value
 			}
 		case strings.HasPrefix(w, "--message="):
-			return strings.TrimPrefix(w, "--message=")
+			messages = append(messages, strings.TrimPrefix(w, "--message="))
 		case strings.HasPrefix(w, "-m") && w != "-m":
 			// git's short-flag-with-attached-value form, e.g. `-mSubject`.
-			return strings.TrimPrefix(w, "-m")
+			messages = append(messages, strings.TrimPrefix(w, "-m"))
 		}
 	}
-	return ""
+	return strings.Join(messages, "\n")
 }
 
 // splitCommandWords is a small, self-contained quote-aware whitespace

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -1,0 +1,355 @@
+// guard_commit.go — `logmind guard-commit`, the cobra surface over the
+// internal/guardcommit decision engine.
+//
+// This is PR1/3 of the "force-logmind-usage enforcement" feature (plan.md
+// §v2.0.0). guard-commit is deliberately Hidden (plumbing, not a
+// user-facing verb) and does NOT install itself anywhere — no hook
+// registration, no .git/hooks writes, no harness settings.json edits. It
+// exists purely so the two hook layers built in a follow-up PR have a
+// single binary entry point to shell out to:
+//
+//   - `logmind guard-commit --layer git-hook --msg-file <path>` from a git
+//     commit-msg hook.
+//   - `logmind guard-commit --layer harness` (JSON payload on stdin) from
+//     the Claude Code harness's PreToolUse hook.
+//
+// Both layers are manually invocable today (this PR); wiring either one up
+// automatically is out of scope here.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/guardcommit"
+)
+
+func newGuardCommitCmd() *cobra.Command {
+	var layer string
+	var threshold int
+	var msgFile string
+	var repoRootFlag string
+	cmd := &cobra.Command{
+		Use:    "guard-commit --layer {harness|git-hook}",
+		Short:  "Decision engine behind logmind's commit-enforcement hooks (plumbing)",
+		Hidden: true,
+		Long: `guard-commit is the shared decision engine two hook layers call to decide
+whether a git commit must be steered through 'logmind log' before it's
+allowed to proceed.
+
+  --layer harness    the Claude Code harness's PreToolUse hook. Reads a
+                      PreToolUse JSON payload ({"tool_name","tool_input":
+                      {"command"},"cwd"}) from stdin. Blocks by exiting 2 —
+                      PreToolUse only treats exit 2 as "block this tool
+                      call." Fails open (exit 0) on anything that isn't a
+                      recognizable Bash git-commit invocation.
+
+  --layer git-hook    the git commit-msg hook. Reads --msg-file (first
+                      line = the commit subject). Blocks via the standard
+                      nonzero-exit convention (git only needs a nonzero
+                      status to abort the commit).
+
+This command does not install anything. The hooks that call it
+automatically are wired up in a separate PR — today it is invoked
+manually, e.g. for testing:
+
+    echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"},"cwd":"."}' \
+      | logmind guard-commit --layer harness`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			exitCode, err := runGuardCommit(
+				repoRootFlag, layer, msgFile, threshold, cmd.Flags().Changed("threshold"),
+				quietEnabled(cmd), cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+			)
+			if exitCode != 0 {
+				// LOUD COMMENT — read this before touching this branch.
+				//
+				// cmd/logmind/main.go maps EVERY non-nil Execute() error to
+				// exit 1 (including cli.ErrSilent — that's the whole point
+				// of the ErrSilent convention: "exit non-zero, message
+				// already printed"). That convention is correct for every
+				// other command in this CLI, but it is WRONG here: the
+				// Claude Code harness's PreToolUse hook protocol only
+				// treats exit code 2 as "BLOCK this tool call" — exit 1 is
+				// non-blocking (the tool call proceeds as if nothing
+				// happened). If this branch returned an error instead of
+				// calling os.Exit directly, guard-commit's harness layer
+				// would silently degrade into a no-op the moment it tried
+				// to block anything, while still LOOKING like it worked
+				// (main.go would print "Error: ..." and exit 1, easy to
+				// miss in hook output). So: this is the one place in this
+				// command — and, as of this PR, the only place in the
+				// whole CLI — that deliberately bypasses the
+				// ErrSilent/exit-1 convention and calls os.Exit directly
+				// from inside RunE. Do not "fix" this to `return
+				// ErrSilent`; that would reintroduce the silent-bypass bug
+				// this comment exists to prevent. runGuardCommit itself
+				// never calls os.Exit — only this RunE wrapper does, which
+				// is what keeps the harness layer unit-testable (see
+				// guard_commit_test.go) without killing the test binary.
+				os.Exit(exitCode)
+			}
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&layer, "layer", "", "Which hook layer is calling: 'harness' or 'git-hook' (required)")
+	cmd.Flags().IntVar(&threshold, "threshold", 20,
+		"Substantive-line threshold. Explicit use of this flag wins over config git.commit_line_threshold, which wins over the built-in default of 20.")
+	cmd.Flags().StringVar(&msgFile, "msg-file", "", "Path to the commit message file (required for --layer git-hook; its first line is the subject)")
+	cmd.Flags().StringVar(&repoRootFlag, "repo-root", "", "Repo root to evaluate against. --layer harness prefers the PreToolUse payload's cwd when present; both layers fall back to this flag, then the process's working directory.")
+	return cmd
+}
+
+// runGuardCommit is the testable core shared by both layers. It resolves
+// config (git.enforce_commits, git.commit_line_threshold) once against
+// repoRootFlag-or-cwd, then dispatches to the layer-specific evaluation.
+//
+// Return shape: (exitCode, err). exitCode != 0 tells the RunE wrapper to
+// call os.Exit(exitCode) directly (see the LOUD COMMENT above) — used ONLY
+// by the harness layer's block path (exit 2). Every other path returns
+// exitCode 0 and lets `err` carry the result through the normal
+// nil / ErrSilent / plain-error convention: nil on allow, ErrSilent on a
+// git-hook block (git just needs nonzero to abort the commit — no special
+// exit code required there), or a plain error for genuine misuse (bad
+// --layer, missing --msg-file).
+//
+// This function never calls os.Exit itself, which is what makes it safe to
+// call directly from unit tests.
+func runGuardCommit(
+	repoRootFlag, layer, msgFile string,
+	thresholdFlag int, thresholdExplicit bool,
+	quiet bool,
+	stdin io.Reader, stdout, stderr io.Writer,
+) (exitCode int, err error) {
+	repoRootForConfig := repoRootFlag
+	if repoRootForConfig == "" {
+		cwd, wdErr := os.Getwd()
+		if wdErr != nil {
+			return 0, wdErr
+		}
+		repoRootForConfig = cwd
+	}
+
+	// config.Load degrades to defaults on a missing/unparseable
+	// .logmind/config.yml (see internal/config's documented "broken
+	// config is user-fixing-it-later" stance) — guard-commit inherits
+	// that same best-effort posture rather than treating a config
+	// problem as a reason to block commits.
+	cfg, _ := config.Load(repoRootForConfig)
+	threshold := resolveThreshold(cfg, thresholdFlag, thresholdExplicit)
+
+	switch layer {
+	case "harness":
+		if !cfg.Git.EnforceCommits {
+			// The repo off-ramp: exit 0, no output, for both layers.
+			return 0, nil
+		}
+		return guardCommitHarness(stdin, stderr, repoRootFlag, threshold), nil
+	case "git-hook":
+		if !cfg.Git.EnforceCommits {
+			return 0, nil
+		}
+		if msgFile == "" {
+			return 0, fmt.Errorf("--msg-file is required for --layer git-hook")
+		}
+		return 0, guardCommitGitHook(repoRootForConfig, msgFile, threshold, quiet, stdout, stderr)
+	default:
+		return 0, fmt.Errorf("--layer must be %q or %q (got %q)", "harness", "git-hook", layer)
+	}
+}
+
+// resolveThreshold implements the documented precedence: an explicit
+// --threshold flag wins; otherwise a positive git.commit_line_threshold
+// from config wins; otherwise the hardcoded fallback of 20.
+func resolveThreshold(cfg config.Config, flagValue int, flagExplicit bool) int {
+	if flagExplicit {
+		return flagValue
+	}
+	if cfg.Git.CommitLineThreshold > 0 {
+		return cfg.Git.CommitLineThreshold
+	}
+	return 20
+}
+
+// harnessPayload is the subset of Claude Code's PreToolUse hook JSON
+// guard-commit needs. Unknown fields are ignored by encoding/json by
+// default, so this stays forward-compatible with payload fields we don't
+// care about.
+type harnessPayload struct {
+	ToolName  string `json:"tool_name"`
+	ToolInput struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+	Cwd string `json:"cwd"`
+}
+
+// guardCommitHarness implements the --layer harness evaluation. Returns
+// the process exit code the caller should use: 0 to allow (INCLUDING every
+// fail-open case — bad/foreign JSON, a non-Bash tool call, a Bash command
+// that isn't a git-commit invocation), or 2 to block (with the reason
+// already written to stderr).
+func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, threshold int) int {
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return 0 // fail open: couldn't even read the payload
+	}
+
+	var payload harnessPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return 0 // fail open: unparseable payload
+	}
+	if payload.ToolName != "Bash" {
+		return 0 // fail open: not a shell invocation we can inspect
+	}
+	if !guardcommit.InvokesGitCommit(payload.ToolInput.Command) {
+		return 0 // not a git-commit shape at all — nothing to evaluate
+	}
+
+	repoRoot := payload.Cwd
+	if repoRoot == "" {
+		repoRoot = repoRootFlag
+	}
+	if repoRoot == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			repoRoot = cwd
+		}
+	}
+
+	subject := extractSubjectHint(payload.ToolInput.Command)
+	d := guardcommit.Evaluate(repoRoot, subject, threshold, guardcommit.WorkingTreeUnion)
+	if d.Allow {
+		return 0
+	}
+	fmt.Fprintln(stderr, d.Reason)
+	return 2
+}
+
+// guardCommitGitHook implements the --layer git-hook evaluation: read the
+// commit subject from msgFile's first line, evaluate under StagedOnly (the
+// index is final by the time a commit-msg hook runs), and translate the
+// result into the standard nil / ErrSilent convention.
+func guardCommitGitHook(repoRoot, msgFile string, threshold int, quiet bool, stdout, stderr io.Writer) error {
+	subject, err := firstLineOfFile(msgFile)
+	if err != nil {
+		return err
+	}
+
+	d := guardcommit.Evaluate(repoRoot, subject, threshold, guardcommit.StagedOnly)
+	q := newQout(quiet, stdout, stderr)
+	if d.Allow {
+		reason := string(d.CarveOut)
+		if reason == "" {
+			reason = "not a git repository"
+		}
+		q.chat("✓ guard-commit: allowed (%s)\n", reason)
+		return nil
+	}
+	fmt.Fprintln(stderr, d.Reason)
+	return ErrSilent
+}
+
+// firstLineOfFile reads path and returns its first line (without the
+// trailing newline). Used to pull the commit subject out of the file git
+// hands a commit-msg hook.
+func firstLineOfFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	line := string(data)
+	if idx := strings.IndexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	return line, nil
+}
+
+// extractSubjectHint does a best-effort, quote-aware scan for a
+// `-m <value>` / `-m<value>` / `--message <value>` / `--message=<value>`
+// flag in a raw shell command string. It exists solely so the harness
+// layer's [skip-logmind] carve-out can see the intended commit message
+// BEFORE git has recorded anything (the harness runs at PreToolUse, ahead
+// of the actual `git commit` invocation). This is not a shell parser: a
+// message that comes from $EDITOR, a template, or is buried inside a
+// substitution simply yields "" here, which just means the
+// [skip-logmind] carve-out won't apply — every other carve-out (env var,
+// decision-file-staged, under-threshold) still works normally.
+func extractSubjectHint(command string) string {
+	words := splitCommandWords(command)
+	for i, w := range words {
+		switch {
+		case w == "-m" || w == "--message":
+			if i+1 < len(words) {
+				return words[i+1]
+			}
+		case strings.HasPrefix(w, "--message="):
+			return strings.TrimPrefix(w, "--message=")
+		case strings.HasPrefix(w, "-m") && w != "-m":
+			// git's short-flag-with-attached-value form, e.g. `-mSubject`.
+			return strings.TrimPrefix(w, "-m")
+		}
+	}
+	return ""
+}
+
+// splitCommandWords is a small, self-contained quote-aware whitespace
+// tokenizer — deliberately NOT shared with internal/guardcommit's
+// tokenizeWords (that one is unexported package-internal plumbing for
+// InvokesGitCommit's very different quote/substitution/separator rules).
+// This one only needs to turn a command string into words with quotes
+// stripped, for the narrow purpose of finding a -m/--message value.
+func splitCommandWords(s string) []string {
+	var words []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	hasContent := false
+	n := len(s)
+	flush := func() {
+		if hasContent {
+			words = append(words, cur.String())
+			cur.Reset()
+			hasContent = false
+		}
+	}
+	for i := 0; i < n; {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteByte(c)
+			}
+			i++
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			} else {
+				cur.WriteByte(c)
+			}
+			i++
+		case c == '\'':
+			inSingle = true
+			hasContent = true
+			i++
+		case c == '"':
+			inDouble = true
+			hasContent = true
+			i++
+		case c == ' ' || c == '\t':
+			flush()
+			i++
+		default:
+			cur.WriteByte(c)
+			hasContent = true
+			i++
+		}
+	}
+	flush()
+	return words
+}

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -130,6 +130,46 @@ func TestRunGuardCommit_Harness_SkipLogmindMarkerAllows(t *testing.T) {
 	}
 }
 
+// TestRunGuardCommit_Harness_SkipLogmindInSecondMessageArg is the MINOR B
+// regression: git concatenates multiple -m args, so a [skip-logmind]
+// marker in a SECOND -m must be honored (reading only the first -m would
+// over-block a commit the agent explicitly opted out of).
+func TestRunGuardCommit_Harness_SkipLogmindInSecondMessageArg(t *testing.T) {
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(50)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git commit -m "subject line" -m "body [skip-logmind]"`, repo)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil ([skip-logmind] in the SECOND -m must be honored)", exitCode, err)
+	}
+}
+
+func TestExtractSubjectHint_CollectsAllMessageForms(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want string // the joined hint must contain this marker
+	}{
+		{`git commit -m "a" -m "b [skip-logmind]"`, "[skip-logmind]"},
+		{`git commit --message="[skip-logmind]"`, "[skip-logmind]"},
+		{`git commit --message "[skip-logmind]"`, "[skip-logmind]"},
+		{`git commit -m"[skip-logmind]"`, "[skip-logmind]"},
+	}
+	for _, c := range cases {
+		got := extractSubjectHint(c.cmd)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("extractSubjectHint(%q) = %q; want it to contain %q", c.cmd, got, c.want)
+		}
+	}
+	// No message flag → empty hint (the [skip-logmind] carve-out just
+	// won't apply; other carve-outs still work).
+	if got := extractSubjectHint(`git commit`); got != "" {
+		t.Errorf("extractSubjectHint(`git commit`) = %q; want empty", got)
+	}
+}
+
 func TestRunGuardCommit_Harness_UsesPayloadCwdOverRepoRootFlag(t *testing.T) {
 	repo := initRepo(t)
 	other := t.TempDir() // not a git repo at all
@@ -146,6 +186,86 @@ func TestRunGuardCommit_Harness_UsesPayloadCwdOverRepoRootFlag(t *testing.T) {
 	}
 	if exitCode != 2 {
 		t.Fatalf("exitCode = %d; want 2 (payload cwd should have been used, not the --repo-root fallback)", exitCode)
+	}
+}
+
+// TestRunGuardCommit_Harness_UntrackedFromSubdir_Blocks is the MAJOR 2
+// regression: an untracked-only ~40-line file, with the harness payload's
+// cwd pointing at a SUBDIRECTORY of the repo. Before the toplevel-resolve
+// fix, the git status/diff ops ran with cmd.Dir = the subdir, so the
+// root-relative untracked paths never resolved and the change was silently
+// allowed. Resolving payload.cwd → repo toplevel makes it Block.
+func TestRunGuardCommit_Harness_UntrackedFromSubdir_Blocks(t *testing.T) {
+	repo := initRepo(t)
+	sub := filepath.Join(repo, "pkg", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	// Untracked (never `git add`ed) ~40-line file at the repo root.
+	if err := os.WriteFile(filepath.Join(repo, "brand_new.go"), []byte(bigLines(40)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Payload cwd = the SUBDIR, not the repo root.
+	payload := harnessJSON(t, "Bash", `git add -A && git commit -m x`, sub)
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit("", "harness", "", 20, true, false,
+		strings.NewReader(payload), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d; want 2 (untracked file must be caught even when evaluated from a subdir)", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Fatalf("stderr = %q; want it to mention `logmind log`", stderr.String())
+	}
+}
+
+// TestRunGuardCommit_Harness_UnicodeUntrackedFromSubdir_Blocks combines
+// MINOR A (unicode untracked filename via -z) with MAJOR 2 (subdir cwd):
+// an untracked ~40-line file named "é.go" must still be counted and block.
+func TestRunGuardCommit_Harness_UnicodeUntrackedFromSubdir_Blocks(t *testing.T) {
+	repo := initRepo(t)
+	sub := filepath.Join(repo, "pkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "é.go"), []byte(bigLines(40)), 0o644); err != nil {
+		t.Fatalf("write é.go: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git add -A && git commit -m x`, sub)
+
+	exitCode, err := runGuardCommit("", "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d; want 2 (unicode-named untracked file must be counted)", exitCode)
+	}
+}
+
+// TestRunGuardCommit_Harness_EnforceFalseFromSubdir_Allows is the MAJOR 3
+// regression: git.enforce_commits:false in the repo's config must be
+// honored even when the payload cwd is a SUBDIR (config must load from the
+// resolved toplevel, not the subdir where no .logmind/config.yml exists).
+func TestRunGuardCommit_Harness_EnforceFalseFromSubdir_Allows(t *testing.T) {
+	repo := initRepo(t)
+	writeGuardCommitConfig(t, repo, "git:\n  enforce_commits: false\n")
+	sub := filepath.Join(repo, "pkg", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(100)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git add -A && git commit -m x`, sub)
+
+	exitCode, err := runGuardCommit("", "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (enforce_commits:false must load from the toplevel, not the subdir)", exitCode, err)
 	}
 }
 

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -1,0 +1,422 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// writeGuardCommitConfig writes a minimal .logmind/config.yml under repo
+// so tests can exercise git.enforce_commits / git.commit_line_threshold
+// without hand-rolling the full config shape.
+func writeGuardCommitConfig(t *testing.T, repo, body string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".logmind")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .logmind: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write config.yml: %v", err)
+	}
+}
+
+// bigLines returns n newline-terminated lines, enough to trip a small
+// threshold regardless of diff mode.
+func bigLines(n int) string {
+	var b bytes.Buffer
+	for i := 0; i < n; i++ {
+		b.WriteString("line\n")
+	}
+	return b.String()
+}
+
+// --- runGuardCommit: --layer harness ------------------------------------
+
+func TestRunGuardCommit_Harness_AllowsSmallChange(t *testing.T) {
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "small.go"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git commit -m x`, repo)
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q; want empty (harness allow prints nothing)", stdout.String())
+	}
+}
+
+func TestRunGuardCommit_Harness_BlocksOverThresholdUnstagedChange(t *testing.T) {
+	repo := initRepo(t)
+	// Unstaged (not `git add`ed) — this is the WorkingTreeUnion regression:
+	// a compound `git add -A && git commit` hasn't staged anything yet
+	// when the harness's PreToolUse hook fires.
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte(bigLines(30)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git add -A && git commit -m x`, repo)
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d; want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q; want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Fatalf("stderr = %q; want it to mention `logmind log`", stderr.String())
+	}
+}
+
+func TestRunGuardCommit_Harness_NonBashToolAllowsWithoutInspection(t *testing.T) {
+	repo := initRepo(t)
+	payload := harnessJSON(t, "Read", `git commit -m x`, repo)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (non-Bash tool_name fails open)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_Harness_MalformedJSONFailsOpen(t *testing.T) {
+	repo := initRepo(t)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader("not json"), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (unparseable payload fails open)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_Harness_NonCommitBashCommandAllows(t *testing.T) {
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(50)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `npm test`, repo)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (not a git-commit shape)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_Harness_SkipLogmindMarkerAllows(t *testing.T) {
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(50)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git commit -m "wip [skip-logmind]"`, repo)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil ([skip-logmind] extracted from -m)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_Harness_UsesPayloadCwdOverRepoRootFlag(t *testing.T) {
+	repo := initRepo(t)
+	other := t.TempDir() // not a git repo at all
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(50)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// payload.cwd points at the real repo; --repo-root points nowhere
+	// useful. The real repo's cwd must win, so the big change is caught.
+	payload := harnessJSON(t, "Bash", `git commit -m x`, repo)
+	exitCode, err := runGuardCommit(other, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 2 {
+		t.Fatalf("exitCode = %d; want 2 (payload cwd should have been used, not the --repo-root fallback)", exitCode)
+	}
+}
+
+// --- runGuardCommit: --layer git-hook ------------------------------------
+
+func TestRunGuardCommit_GitHook_AllowsSmallStagedChange(t *testing.T) {
+	repo := initRepo(t)
+	stageLines(t, repo, "small.go", 5)
+	msgFile := writeMsgFile(t, repo, "a small change")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0", exitCode)
+	}
+}
+
+func TestRunGuardCommit_GitHook_BlocksOverThresholdStagedChange(t *testing.T) {
+	repo := initRepo(t)
+	stageLines(t, repo, "big.go", 25)
+	msgFile := writeMsgFile(t, repo, "a big change")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0 (git-hook blocks via ErrSilent, not a special exit code)", exitCode)
+	}
+	if err == nil || err != ErrSilent {
+		t.Fatalf("err = %v; want ErrSilent", err)
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Fatalf("stderr = %q; want it to mention `logmind log`", stderr.String())
+	}
+}
+
+func TestRunGuardCommit_GitHook_UnstagedOnlyChangeAllows(t *testing.T) {
+	// The StagedOnly half of the key regression: a large change that
+	// hasn't been staged is invisible to the git-hook layer by design
+	// (correct — the index IS final by the time commit-msg runs; an
+	// unstaged change literally cannot end up in this commit).
+	repo := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte(bigLines(30)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	msgFile := writeMsgFile(t, repo, "subject")
+
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (unstaged change invisible under StagedOnly)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_GitHook_MissingMsgFileFlag_PlainError(t *testing.T) {
+	repo := initRepo(t)
+	exitCode, err := runGuardCommit(repo, "git-hook", "", 20, true, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0", exitCode)
+	}
+	if err == nil {
+		t.Fatalf("err = nil; want a plain error (missing --msg-file)")
+	}
+	if err == ErrSilent {
+		t.Fatalf("err = ErrSilent; want a plain (non-ErrSilent) error for this misuse case")
+	}
+	if !strings.Contains(err.Error(), "--msg-file") {
+		t.Fatalf("err = %v; want it to mention --msg-file", err)
+	}
+}
+
+func TestRunGuardCommit_GitHook_MissingMsgFileOnDisk_PropagatesRealError(t *testing.T) {
+	repo := initRepo(t)
+	exitCode, err := runGuardCommit(repo, "git-hook", filepath.Join(repo, "does-not-exist.txt"), 20, true, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0", exitCode)
+	}
+	if err == nil || err == ErrSilent {
+		t.Fatalf("err = %v; want a plain os.ReadFile error", err)
+	}
+}
+
+// --- shared: --layer validation, threshold resolution, enforce_commits ---
+
+func TestRunGuardCommit_InvalidLayer_PlainError(t *testing.T) {
+	repo := initRepo(t)
+	exitCode, err := runGuardCommit(repo, "bogus", "", 20, true, false,
+		strings.NewReader("{}"), &bytes.Buffer{}, &bytes.Buffer{})
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0", exitCode)
+	}
+	if err == nil || err == ErrSilent {
+		t.Fatalf("err = %v; want a plain error naming the bad --layer value", err)
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("err = %v; want it to echo the invalid value", err)
+	}
+}
+
+func TestRunGuardCommit_EnforceCommitsFalse_AllowsBothLayers(t *testing.T) {
+	repo := initRepo(t)
+	writeGuardCommitConfig(t, repo, "git:\n  enforce_commits: false\n")
+
+	// Harness layer: a huge unstaged change that would otherwise block.
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(100)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	payload := harnessJSON(t, "Bash", `git commit -m x`, repo)
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("harness: exitCode=%d err=%v; want 0,nil (enforce_commits:false is a full off-ramp)", exitCode, err)
+	}
+
+	// git-hook layer: stage the same huge change.
+	stageLines(t, repo, "staged-big.go", 100)
+	msgFile := writeMsgFile(t, repo, "subject")
+	exitCode, err = runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("git-hook: exitCode=%d err=%v; want 0,nil (enforce_commits:false is a full off-ramp)", exitCode, err)
+	}
+}
+
+func TestRunGuardCommit_ThresholdPrecedence(t *testing.T) {
+	repo := initRepo(t)
+	writeGuardCommitConfig(t, repo, "git:\n  commit_line_threshold: 5\n")
+	stageLines(t, repo, "code.go", 10)
+	msgFile := writeMsgFile(t, repo, "subject")
+
+	// Config threshold (5) is below 10 changed lines → block, with no
+	// --threshold flag override (flagExplicit=false, flagValue ignored).
+	_, err := runGuardCommit(repo, "git-hook", msgFile, 999, false, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != ErrSilent {
+		t.Fatalf("err = %v; want ErrSilent (config threshold of 5 should have applied)", err)
+	}
+
+	// Explicit --threshold flag (50) wins over the config's 5.
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 50, true, false,
+		nil, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (explicit --threshold=50 should have won over config's 5)", exitCode, err)
+	}
+}
+
+// --- black-box subprocess test: exit code 2, not 1 -----------------------
+
+// TestGuardCommitBinary_Harness_ExitCode2NotJust1 builds the real binary
+// and pipes a blocking harness JSON payload to
+// `guard-commit --layer harness`, asserting the process exits 2 — NOT the
+// generic exit-1 every other error path in this CLI uses. Exit code 2 is
+// load-bearing: the Claude Code harness's PreToolUse protocol only treats
+// exit 2 as "block this tool call"; exit 1 would silently let it through.
+func TestGuardCommitBinary_Harness_ExitCode2NotJust1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess test in -short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH; skipping subprocess test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping subprocess test")
+	}
+
+	binPath := buildGuardCommitBinary(t, goBin)
+
+	t.Run("blocks with exit code 2", func(t *testing.T) {
+		repo := initRepo(t) // fresh repo per subtest — no cross-subtest state bleed
+		if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(30)), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		payload := harnessJSON(t, "Bash", `git add -A && git commit -m x`, repo)
+
+		cmd := exec.Command(binPath, "guard-commit", "--layer", "harness")
+		cmd.Stdin = strings.NewReader(payload)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr := cmd.Run()
+
+		exitErr, ok := runErr.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("expected *exec.ExitError, got %T (%v); stdout=%q stderr=%q", runErr, runErr, stdout.String(), stderr.String())
+		}
+		if got := exitErr.ExitCode(); got != 2 {
+			t.Fatalf("ExitCode() = %d; want 2 (not the generic exit 1)", got)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("stdout = %q; want empty on block", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "logmind log") {
+			t.Fatalf("stderr = %q; want it to mention `logmind log`", stderr.String())
+		}
+	})
+
+	t.Run("allows with exit code 0 and empty stdout", func(t *testing.T) {
+		repo := initRepo(t) // fresh repo per subtest — no cross-subtest state bleed
+		if err := os.WriteFile(filepath.Join(repo, "tiny.go"), []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		payload := harnessJSON(t, "Bash", `git commit -m x`, repo)
+
+		cmd := exec.Command(binPath, "guard-commit", "--layer", "harness")
+		cmd.Stdin = strings.NewReader(payload)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("logmind guard-commit --layer harness (allow case) failed: %v\nstdout=%q stderr=%q", err, stdout.String(), stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("stdout = %q; want empty on allow", stdout.String())
+		}
+	})
+}
+
+// buildGuardCommitBinary compiles ./cmd/logmind once per test run into a
+// temp dir and returns the binary path.
+func buildGuardCommitBinary(t *testing.T, goBin string) string {
+	t.Helper()
+	repoRoot := repoRootFromCaller(t)
+	binDir := t.TempDir()
+	binName := "logmind"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(binDir, binName)
+
+	build := exec.Command(goBin, "build", "-o", binPath, "./cmd/logmind")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// --- shared payload/file helpers ------------------------------------------
+
+// harnessJSON builds a minimal PreToolUse-shaped JSON payload.
+func harnessJSON(t *testing.T, toolName, command, cwd string) string {
+	t.Helper()
+	payload := struct {
+		ToolName  string `json:"tool_name"`
+		ToolInput struct {
+			Command string `json:"command"`
+		} `json:"tool_input"`
+		Cwd string `json:"cwd"`
+	}{ToolName: toolName, Cwd: cwd}
+	payload.ToolInput.Command = command
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal harness payload: %v", err)
+	}
+	return string(data)
+}
+
+// writeMsgFile writes a commit-message file (subject on the first line)
+// and returns its path, mimicking what git hands a commit-msg hook.
+func writeMsgFile(t *testing.T, repo, subject string) string {
+	t.Helper()
+	path := filepath.Join(repo, "COMMIT_EDITMSG")
+	if err := os.WriteFile(path, []byte(subject+"\n\nbody text\n"), 0o644); err != nil {
+		t.Fatalf("write msg file: %v", err)
+	}
+	return path
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -64,6 +64,10 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newInstallHookCmd())
 	root.AddCommand(newCheckDecisionsCmd())
 	root.AddCommand(newCheckLinksCmd())
+	// v2.0.0 enforcement PR1/3: the guard-commit decision engine. Hidden —
+	// it's plumbing invoked BY hook layers (built in a follow-up PR), not a
+	// user-facing verb. See internal/cli/guard_commit.go.
+	root.AddCommand(newGuardCommitCmd())
 	// B3: derived doc generators + rebase wrapper.
 	root.AddCommand(newTimelineCmd())
 	root.AddCommand(newFileStructureCmd())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,19 @@ type GitConfig struct {
 	AutoPush              bool   `yaml:"auto_push"`
 	AutoRebase            bool   `yaml:"auto_rebase"`
 	CommitMessageTemplate string `yaml:"commit_message_template"`
+	// EnforceCommits gates the v2.0 guard-commit decision engine (see
+	// internal/guardcommit + `logmind guard-commit`). Default true:
+	// substantive commits are steered through `logmind log` unless a
+	// carve-out applies. Set to false as a full repo off-ramp — when
+	// false, guard-commit allows unconditionally (exit 0) regardless
+	// of layer or change size.
+	EnforceCommits bool `yaml:"enforce_commits"`
+	// CommitLineThreshold overrides guard-commit's substantive-change
+	// line threshold (how many changed lines trigger the "log this
+	// decision" gate). A `--threshold` flag passed explicitly to
+	// `logmind guard-commit` wins over this; this value wins over the
+	// hardcoded fallback of 20.
+	CommitLineThreshold int `yaml:"commit_line_threshold"`
 }
 
 // DecisionsConfig mirrors the `decisions:` section.
@@ -135,6 +148,8 @@ func DefaultConfig() Config {
 			AutoPush:              true,
 			AutoRebase:            false,
 			CommitMessageTemplate: "logmind: {decision}",
+			EnforceCommits:        true,
+			CommitLineThreshold:   20,
 		},
 		Decisions: DecisionsConfig{
 			MaxRecent:   20,

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -80,6 +80,40 @@ func RevParseTopLevel(repoRoot string) (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+// TopLevel resolves the absolute repository root that contains cwd via
+// `git -C cwd rev-parse --show-toplevel`. Returns (toplevel, true) when
+// cwd is inside a work tree, or ("", false) for every failure path (not a
+// repo, missing git binary, permission error) — the boolean is the single
+// "is this a repo?" signal callers switch on, so they never have to
+// discriminate error kinds.
+//
+// This is the RIGHT resolver for guard-commit: the harness may hand it a
+// SUBDIRECTORY of the repo as the evaluated cwd (PreToolUse payloads carry
+// the tool call's cwd, not the repo root). Resolving to the toplevel means
+// both config loading (`.logmind/config.yml` lives at the repo root) AND
+// every git diff/status op (whose --porcelain paths are root-relative) use
+// the same, correct base directory — otherwise an untracked file staged
+// from a subdir would be miscounted and silently bypass enforcement.
+//
+// RevParseTopLevel (above) is the older error-returning twin kept for
+// install-hook's diagnostics; TopLevel is the boolean-returning form the
+// guard-commit hot path wants.
+func TopLevel(cwd string) (string, bool) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = cwd
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	top := strings.TrimSpace(stdout.String())
+	if top == "" {
+		return "", false
+	}
+	return top, true
+}
+
 // CurrentBranch returns the current branch name (e.g. "v1-go-rewrite")
 // or an empty string when HEAD is detached, the repo is unborn without
 // a usable symbolic-ref answer, or any error path. Mirrors
@@ -236,14 +270,22 @@ func DiffNumstat(repoRoot string) []NumstatLine {
 }
 
 // UntrackedFiles returns the repo-relative paths of every untracked
-// file (`git status --porcelain --untracked-files=all`, "??" rows).
+// file (`git status --porcelain -z --untracked-files=all`, "??" rows).
 // `--untracked-files=all` expands untracked directories to their
 // individual files rather than reporting the directory as one row, so
 // every file gets its own numstat below. gitignored files are NOT
 // included (git's default; we don't pass --ignored). Nil on any
 // failure or when there are no untracked files.
+//
+// The `-z` flag is load-bearing, not a nicety: without it, git applies
+// core.quotepath and octal-ESCAPES any non-ASCII path (e.g. "é.go"
+// becomes "\303\251.go" wrapped in double quotes). That escaped string
+// then can't be opened by the downstream `git diff --no-index` call in
+// UntrackedNumstat, so a unicode-named untracked file would be silently
+// dropped from the LOC count — a real enforcement bypass. `-z` emits raw,
+// NUL-terminated, unquoted paths instead, and we split on NUL.
 func UntrackedFiles(repoRoot string) []string {
-	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=all")
+	cmd := exec.Command("git", "status", "--porcelain", "-z", "--untracked-files=all")
 	cmd.Dir = repoRoot
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -252,16 +294,14 @@ func UntrackedFiles(repoRoot string) []string {
 		return nil
 	}
 	var files []string
-	for _, line := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
-		if !strings.HasPrefix(line, "?? ") {
+	// -z records are NUL-terminated (not NUL-separated) "XY <path>"
+	// entries, no quoting. Untracked files never carry the rename form's
+	// second path, so each record is exactly one status+path pair.
+	for _, entry := range strings.Split(stdout.String(), "\x00") {
+		if !strings.HasPrefix(entry, "?? ") {
 			continue
 		}
-		path := strings.TrimPrefix(line, "?? ")
-		// git wraps paths containing unusual bytes in double quotes
-		// (core.quotepath); best-effort strip, matching the
-		// "encoding round-trip is invisible for prefix/suffix use"
-		// stance documented on DiffCachedNames above.
-		path = strings.Trim(path, "\"")
+		path := strings.TrimPrefix(entry, "?? ")
 		if path != "" {
 			files = append(files, path)
 		}

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -213,8 +213,105 @@ func DiffCachedNumstat(repoRoot string) []NumstatLine {
 	if err := cmd.Run(); err != nil {
 		return nil
 	}
-	var rows []NumstatLine
+	return parseNumstat(stdout.String())
+}
+
+// DiffNumstat parses `git diff --numstat` (unstaged changes to
+// TRACKED files — working tree vs. index, no --cached) into typed
+// rows. Same parsing rules as DiffCachedNumstat; returns nil on git
+// failure. Used by guardcommit's WorkingTreeUnion diff mode: the
+// harness PreToolUse hook fires BEFORE a compound `git add -A &&
+// git commit` stages anything, so `--cached` alone would undercount a
+// change that is still sitting unstaged at evaluation time.
+func DiffNumstat(repoRoot string) []NumstatLine {
+	cmd := exec.Command("git", "diff", "--numstat")
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	return parseNumstat(stdout.String())
+}
+
+// UntrackedFiles returns the repo-relative paths of every untracked
+// file (`git status --porcelain --untracked-files=all`, "??" rows).
+// `--untracked-files=all` expands untracked directories to their
+// individual files rather than reporting the directory as one row, so
+// every file gets its own numstat below. gitignored files are NOT
+// included (git's default; we don't pass --ignored). Nil on any
+// failure or when there are no untracked files.
+func UntrackedFiles(repoRoot string) []string {
+	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=all")
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	var files []string
 	for _, line := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if !strings.HasPrefix(line, "?? ") {
+			continue
+		}
+		path := strings.TrimPrefix(line, "?? ")
+		// git wraps paths containing unusual bytes in double quotes
+		// (core.quotepath); best-effort strip, matching the
+		// "encoding round-trip is invisible for prefix/suffix use"
+		// stance documented on DiffCachedNames above.
+		path = strings.Trim(path, "\"")
+		if path != "" {
+			files = append(files, path)
+		}
+	}
+	return files
+}
+
+// UntrackedNumstat synthesizes numstat-shaped rows for every untracked
+// file, treating each as entirely new content. Computed via
+// `git diff --no-index --numstat -- <devnull> <path>` per file so
+// binary detection and line-counting exactly match git's own numstat
+// semantics instead of reimplementing them by hand.
+//
+// `git diff --no-index` follows plain `diff(1)` exit-status
+// conventions: 0 = no difference, 1 = difference found (the expected
+// case for every untracked file here — /dev/null vs. a real file is
+// always "different"), 2+ = trouble. We accept 0 and 1; anything else
+// (including a missing git binary) silently skips that file, matching
+// the best-effort posture of every other wrapper in this file.
+//
+// The raw numstat output echoes the devnull path (e.g.
+// "3\t0\t/dev/null => new.txt"), so we discard its Path and
+// substitute the real untracked path ourselves.
+func UntrackedNumstat(repoRoot string) []NumstatLine {
+	var rows []NumstatLine
+	for _, path := range UntrackedFiles(repoRoot) {
+		cmd := exec.Command("git", "diff", "--no-index", "--numstat", "--", os.DevNull, path)
+		cmd.Dir = repoRoot
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() > 1 {
+				continue
+			}
+		}
+		for _, row := range parseNumstat(stdout.String()) {
+			rows = append(rows, NumstatLine{Added: row.Added, Removed: row.Removed, Path: path})
+		}
+	}
+	return rows
+}
+
+// parseNumstat is the shared tab-split parser behind DiffCachedNumstat
+// and DiffNumstat — kept as one routine so the "3 tab-separated
+// fields or skip the line" rule can't drift between the two callers.
+func parseNumstat(out string) []NumstatLine {
+	var rows []NumstatLine
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
@@ -225,6 +322,30 @@ func DiffCachedNumstat(repoRoot string) []NumstatLine {
 		rows = append(rows, NumstatLine{Added: parts[0], Removed: parts[1], Path: parts[2]})
 	}
 	return rows
+}
+
+// GitDir resolves the repository's actual git directory for repoRoot
+// (`git rev-parse --absolute-git-dir`). Callers that need to inspect
+// state files like MERGE_HEAD or rebase-merge/ MUST use this rather
+// than naively joining "<repoRoot>/.git" — inside a linked worktree,
+// ".git" at the worktree root is a FILE (not a directory) whose
+// contents point at "<main-repo>/.git/worktrees/<name>", and the
+// per-worktree state files live under THAT directory, not the main
+// repo's top-level .git/. Empty string + error on any failure (not a
+// repo, no git binary).
+func GitDir(repoRoot string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--absolute-git-dir")
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", ErrGitNotFound
+		}
+		return "", &GitError{Op: "rev-parse --absolute-git-dir", Err: err, Stderr: stderr.String()}
+	}
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 // ConfigGet returns the value of `git config --get <key>` for the

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -238,3 +238,66 @@ func TestUntrackedNumstat_BinaryFileMarkedWithDash(t *testing.T) {
 		t.Fatalf("row counts = (%q, %q); want (\"-\", \"-\") for a binary file", rows[0].Added, rows[0].Removed)
 	}
 }
+
+// TestUntrackedFiles_UnicodeName guards the -z / core.quotepath fix: a
+// non-ASCII untracked filename must be returned RAW (not octal-escaped),
+// so the downstream `git diff --no-index` in UntrackedNumstat can open it
+// and count its lines.
+func TestUntrackedFiles_UnicodeName(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "é.go"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write é.go: %v", err)
+	}
+	files := UntrackedFiles(dir)
+	if len(files) != 1 || files[0] != "é.go" {
+		t.Fatalf("UntrackedFiles = %v; want [é.go] (raw, not octal-escaped)", files)
+	}
+}
+
+func TestUntrackedNumstat_UnicodeNameCounted(t *testing.T) {
+	dir := initRepo(t)
+	var body bytes.Buffer
+	for i := 0; i < 12; i++ {
+		body.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "é.go"), body.Bytes(), 0o644); err != nil {
+		t.Fatalf("write é.go: %v", err)
+	}
+	rows := UntrackedNumstat(dir)
+	if len(rows) != 1 {
+		t.Fatalf("UntrackedNumstat = %+v; want 1 row for the unicode file", rows)
+	}
+	if rows[0].Path != "é.go" || rows[0].Added != "12" {
+		t.Fatalf("row = %+v; want path=é.go added=12", rows[0])
+	}
+}
+
+func TestTopLevel_ResolvesFromSubdir(t *testing.T) {
+	dir := initRepo(t)
+	sub := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	top, ok := TopLevel(sub)
+	if !ok {
+		t.Fatalf("TopLevel(%q) ok=false; want true", sub)
+	}
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("evalsymlinks(%q): %v", dir, err)
+	}
+	got, err := filepath.EvalSymlinks(top)
+	if err != nil {
+		t.Fatalf("evalsymlinks(%q): %v", top, err)
+	}
+	if got != want {
+		t.Fatalf("TopLevel(subdir) = %q; want repo root %q", got, want)
+	}
+}
+
+func TestTopLevel_FalseOutsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	if top, ok := TopLevel(dir); ok || top != "" {
+		t.Fatalf("TopLevel(%q) = (%q, %v); want (\"\", false)", dir, top, ok)
+	}
+}

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -145,3 +145,96 @@ func TestCurrentBranch_ReturnsBranchName(t *testing.T) {
 		t.Fatalf("CurrentBranch = %q; want main or master", branch)
 	}
 }
+
+func TestGitDir_ResolvesAbsolutePath(t *testing.T) {
+	dir := initRepo(t)
+	gitDir, err := GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if !filepath.IsAbs(gitDir) {
+		t.Fatalf("GitDir = %q; want an absolute path", gitDir)
+	}
+	if _, err := os.Stat(filepath.Join(gitDir, "HEAD")); err != nil {
+		t.Fatalf("GitDir %q doesn't look like a git dir (no HEAD): %v", gitDir, err)
+	}
+}
+
+func TestGitDir_ErrorsOutsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := GitDir(dir); err == nil {
+		t.Fatalf("GitDir(%q) = nil error; want an error (not a repo)", dir)
+	}
+}
+
+func TestDiffNumstat_ParsesUnstagedTrackedRows(t *testing.T) {
+	dir := initRepo(t)
+	// README.md is tracked (committed by initRepo); modify WITHOUT staging.
+	var body bytes.Buffer
+	for i := 0; i < 7; i++ {
+		body.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), body.Bytes(), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	rows := DiffNumstat(dir)
+	if len(rows) != 1 || rows[0].Path != "README.md" {
+		t.Fatalf("DiffNumstat = %+v; want one row for README.md", rows)
+	}
+	// DiffCachedNumstat must NOT see this unstaged change.
+	if cached := DiffCachedNumstat(dir); len(cached) != 0 {
+		t.Fatalf("DiffCachedNumstat = %+v; want empty (nothing staged)", cached)
+	}
+}
+
+func TestUntrackedFiles_ListsUntrackedOnly(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write new.txt: %v", err)
+	}
+	files := UntrackedFiles(dir)
+	if len(files) != 1 || files[0] != "new.txt" {
+		t.Fatalf("UntrackedFiles = %v; want [new.txt]", files)
+	}
+	// README.md is tracked+committed — must not show up as untracked.
+	for _, f := range files {
+		if f == "README.md" {
+			t.Fatalf("UntrackedFiles included tracked file README.md: %v", files)
+		}
+	}
+}
+
+func TestUntrackedNumstat_TreatsFileAsAllAdded(t *testing.T) {
+	dir := initRepo(t)
+	var body bytes.Buffer
+	for i := 0; i < 9; i++ {
+		body.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "brand_new.go"), body.Bytes(), 0o644); err != nil {
+		t.Fatalf("write brand_new.go: %v", err)
+	}
+	rows := UntrackedNumstat(dir)
+	if len(rows) != 1 {
+		t.Fatalf("UntrackedNumstat = %+v; want 1 row", rows)
+	}
+	if rows[0].Path != "brand_new.go" {
+		t.Fatalf("row.Path = %q; want brand_new.go (the /dev/null side must be discarded)", rows[0].Path)
+	}
+	if rows[0].Added != "9" || rows[0].Removed != "0" {
+		t.Fatalf("row counts = (%q, %q); want (9, 0)", rows[0].Added, rows[0].Removed)
+	}
+}
+
+func TestUntrackedNumstat_BinaryFileMarkedWithDash(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "bin.dat"), []byte{0, 1, 2, 0, 3}, 0o644); err != nil {
+		t.Fatalf("write bin.dat: %v", err)
+	}
+	rows := UntrackedNumstat(dir)
+	if len(rows) != 1 {
+		t.Fatalf("UntrackedNumstat = %+v; want 1 row", rows)
+	}
+	if rows[0].Added != "-" || rows[0].Removed != "-" {
+		t.Fatalf("row counts = (%q, %q); want (\"-\", \"-\") for a binary file", rows[0].Added, rows[0].Removed)
+	}
+}

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -212,6 +212,12 @@ func collectRows(repoRoot string, mode DiffMode) []gitcli.NumstatLine {
 		rows = append(rows, gitcli.DiffCachedNumstat(repoRoot)...)
 		rows = append(rows, gitcli.DiffNumstat(repoRoot)...)
 		rows = append(rows, gitcli.UntrackedNumstat(repoRoot)...)
+		// Note: a file with BOTH staged and unstaged hunks appears in
+		// both DiffCachedNumstat and DiffNumstat, so its changed lines are
+		// counted twice here. That's intentional and left as-is — the
+		// double-count only ever OVER-counts, biasing toward Block, which
+		// is the safe direction for an enforcement gate (it can't cause a
+		// silent bypass).
 		return rows
 	default: // StagedOnly
 		return gitcli.DiffCachedNumstat(repoRoot)

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -1,0 +1,294 @@
+// Package guardcommit is the shared decision engine behind
+// `logmind guard-commit` (internal/cli/guard_commit.go). It answers one
+// question — "should this git commit be allowed to proceed without going
+// through `logmind log`?" — and is deliberately kept free of cobra, stdin/
+// stdout, and process-exit concerns so it is fully unit-testable and can be
+// called from two different call sites with two different diff semantics:
+//
+//   - The git commit-msg hook (PR2, not built here) calls Evaluate with
+//     DiffMode = StagedOnly, because by the time a commit-msg hook runs the
+//     index is final — nothing more will be staged before the commit lands.
+//   - The Claude Code harness PreToolUse hook (also PR2) calls Evaluate with
+//     DiffMode = WorkingTreeUnion, because it fires BEFORE a Bash tool call
+//     runs — including a compound `git add -A && git commit` shape where,
+//     at evaluation time, the change under review is still sitting entirely
+//     unstaged. StagedOnly would see an empty index and silently allow a
+//     commit that is about to bypass enforcement; WorkingTreeUnion closes
+//     that gap by unioning staged + unstaged-tracked + untracked changes.
+//
+// This package is pure logic: no install wiring, no hook registration, and
+// no cobra command lives here. See internal/cli/guard_commit.go for the
+// (Hidden, manually-invokable-only) CLI surface this feeds; the hooks that
+// call it automatically are a follow-up PR.
+package guardcommit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+// CarveOut names the specific reason Evaluate allowed a commit through
+// without requiring a decision log. The empty string is used both for "no
+// specific carve-out applies" (e.g. outside a git repo entirely — there's
+// nothing to enforce) and as the Decision.CarveOut zero value on a Block.
+type CarveOut string
+
+const (
+	// CarveOutNone means "allowed, but not via one of the named carve-outs
+	// below" (currently: repoRoot isn't a git repo at all) — or, on a
+	// Block decision, simply "no carve-out applied."
+	CarveOutNone CarveOut = ""
+	// CarveOutEnvAllow: LOGMIND_ALLOW_GIT_COMMIT is set truthy.
+	CarveOutEnvAllow CarveOut = "env:LOGMIND_ALLOW_GIT_COMMIT"
+	// CarveOutSkipLogmind: the commit subject contains the literal marker
+	// "[skip-logmind]".
+	CarveOutSkipLogmind CarveOut = "skip-logmind"
+	// CarveOutRebaseInProgress: .git/rebase-apply or .git/rebase-merge
+	// exists — git itself is mid-rebase and generates commits internally
+	// (e.g. `rebase --continue`) that were never meant to go through
+	// `logmind log`.
+	CarveOutRebaseInProgress CarveOut = "rebase-in-progress"
+	// CarveOutMergeInProgress: .git/MERGE_HEAD exists (mid `git merge`).
+	CarveOutMergeInProgress CarveOut = "merge-in-progress"
+	// CarveOutCherryPickOrRevert: .git/CHERRY_PICK_HEAD or
+	// .git/REVERT_HEAD exists.
+	CarveOutCherryPickOrRevert CarveOut = "cherry-pick-or-revert-in-progress"
+	// CarveOutDecisionFileStaged: a decision-log file (docs/decisions.md,
+	// docs/decisions-branches/*.md, or any path ending in "/decisions.md")
+	// is already staged — the commit IS the documentation.
+	CarveOutDecisionFileStaged CarveOut = "decision-file-staged"
+	// CarveOutUnderThreshold: the computed substantive-line count is below
+	// the configured threshold — too small to be worth a decision log.
+	CarveOutUnderThreshold CarveOut = "under-threshold"
+)
+
+// DiffMode selects which git state Evaluate inspects to compute the
+// substantive-line count. See the package doc for why the two hook layers
+// need different modes.
+type DiffMode int
+
+const (
+	// StagedOnly inspects only `git diff --cached` — what's in the index
+	// right now. Correct for the git commit-msg hook layer.
+	StagedOnly DiffMode = iota
+	// WorkingTreeUnion inspects the union of staged, unstaged-tracked, and
+	// untracked changes. Correct for the harness PreToolUse layer, which
+	// runs before a compound `git add -A && git commit` has staged
+	// anything.
+	WorkingTreeUnion
+)
+
+// Decision is Evaluate's verdict.
+type Decision struct {
+	// Allow is true when the commit may proceed without a decision log.
+	Allow bool
+	// CarveOut names WHY (see the CarveOut constants). Empty on a Block,
+	// or on the "not a git repo" Allow path.
+	CarveOut CarveOut
+	// Lines is the substantive-line count SubstantiveLines computed. Only
+	// meaningful when the algorithm actually got as far as computing it
+	// (the CarveOutUnderThreshold Allow case and every Block); earlier
+	// carve-outs return before the diff is even read, so Lines is 0 there
+	// — that's "not computed," not "zero lines changed."
+	Lines int
+	// Reason is a human-readable explanation, populated only on Block.
+	Reason string
+}
+
+// allowedBy builds an Allow decision for the named carve-out. lines is 0
+// for every carve-out except CarveOutUnderThreshold, where the caller
+// passes the count it just computed.
+func allowedBy(carveOut CarveOut, lines int) Decision {
+	return Decision{Allow: true, CarveOut: carveOut, Lines: lines}
+}
+
+// Evaluate is the guard-commit decision engine. repoRoot is the working
+// directory to evaluate from (the git repo, or a subdirectory of one).
+// subject is the commit's (proposed or actual) subject line, used only to
+// look for the "[skip-logmind]" marker. threshold is the substantive-line
+// count at or above which a commit without a staged decision log is
+// blocked. mode selects the diff semantics (see DiffMode).
+//
+// The checks run in order and the FIRST MATCH WINS:
+//
+//  1. Not a git repo at all               → Allow (nothing to enforce)
+//  2. LOGMIND_ALLOW_GIT_COMMIT is truthy  → Allow (env carve-out)
+//  3. subject contains "[skip-logmind]"   → Allow (skip-logmind carve-out)
+//  4. git is mid-rebase/merge/cherry-pick/revert → Allow (the matching
+//     in-progress carve-out) — these are git-internal commits, not
+//     developer-authored ones.
+//  5. a decision-log file is already staged → Allow (decision-file-staged)
+//  6. substantive lines < threshold       → Allow (under-threshold)
+//  7. otherwise                           → Block, with a Reason
+func Evaluate(repoRoot, subject string, threshold int, mode DiffMode) Decision {
+	// 1. Outside a git repo there is nothing to enforce — never block a
+	// `git commit` (or a command that merely mentions one) run somewhere
+	// that isn't even under version control.
+	if !gitcli.IsRepo(repoRoot) {
+		return allowedBy(CarveOutNone, 0)
+	}
+
+	// 2. Explicit environment escape hatch. Checked before subject-parsing
+	// so a caller who can't control the commit message (e.g. an
+	// interactive `git commit` that opens $EDITOR) still has a way out.
+	if envTruthy("LOGMIND_ALLOW_GIT_COMMIT") {
+		return allowedBy(CarveOutEnvAllow, 0)
+	}
+
+	// 3. Explicit per-commit escape hatch via the subject line itself.
+	if strings.Contains(subject, "[skip-logmind]") {
+		return allowedBy(CarveOutSkipLogmind, 0)
+	}
+
+	// 4. git-internal operations in progress. These produce commits
+	// (rebase replays, merge commits, cherry-pick/revert commits) that
+	// are not "a developer made a substantive change out of nowhere" —
+	// the ORIGINAL commit being replayed/merged/picked already went
+	// through whatever enforcement applied when it was first authored.
+	gitDir, err := gitcli.GitDir(repoRoot)
+	if err != nil || gitDir == "" {
+		// Best-effort fallback matching install_hook.go's pattern: if
+		// git itself can't answer (shouldn't happen given IsRepo just
+		// succeeded, but stay defensive), fall back to the naive join.
+		// This only matters for the in-progress-state checks below —
+		// wrong in a worktree, but "wrong" here means "might fail to
+		// recognize an in-progress rebase," which degrades to falling
+		// through to the normal threshold check, not an unsafe allow.
+		gitDir = filepath.Join(repoRoot, ".git")
+	}
+	if exists(filepath.Join(gitDir, "rebase-apply")) || exists(filepath.Join(gitDir, "rebase-merge")) {
+		return allowedBy(CarveOutRebaseInProgress, 0)
+	}
+	if exists(filepath.Join(gitDir, "MERGE_HEAD")) {
+		return allowedBy(CarveOutMergeInProgress, 0)
+	}
+	if exists(filepath.Join(gitDir, "CHERRY_PICK_HEAD")) || exists(filepath.Join(gitDir, "REVERT_HEAD")) {
+		return allowedBy(CarveOutCherryPickOrRevert, 0)
+	}
+
+	// 5. The commit itself documents the decision.
+	for _, f := range gitcli.DiffCachedNames(repoRoot) {
+		if IsDecisionFile(f) {
+			return allowedBy(CarveOutDecisionFileStaged, 0)
+		}
+	}
+
+	// 6/7. Compute the substantive-line count per the requested diff mode
+	// and compare against threshold.
+	lines := SubstantiveLines(collectRows(repoRoot, mode))
+	if lines < threshold {
+		return allowedBy(CarveOutUnderThreshold, lines)
+	}
+	return Decision{
+		Allow: false,
+		Lines: lines,
+		Reason: fmt.Sprintf(
+			"%d lines changed without a decision log — record it with `logmind log` "+
+				"(or add [skip-logmind] to the subject / set LOGMIND_ALLOW_GIT_COMMIT=1 to bypass)",
+			lines,
+		),
+	}
+}
+
+// collectRows gathers the gitcli.NumstatLine rows relevant to mode.
+//
+//   - StagedOnly: just the index (`git diff --cached --numstat`) — correct
+//     for the git commit-msg hook, where the index is already final.
+//   - WorkingTreeUnion: the union of staged + unstaged-tracked +
+//     untracked. This is the critical correctness point for the harness
+//     layer: PreToolUse fires BEFORE a compound `git add -A && git commit`
+//     stages anything, so `--cached` alone would undercount (and silently
+//     bypass enforcement) whenever the change under review hasn't been
+//     staged yet.
+func collectRows(repoRoot string, mode DiffMode) []gitcli.NumstatLine {
+	switch mode {
+	case WorkingTreeUnion:
+		var rows []gitcli.NumstatLine
+		rows = append(rows, gitcli.DiffCachedNumstat(repoRoot)...)
+		rows = append(rows, gitcli.DiffNumstat(repoRoot)...)
+		rows = append(rows, gitcli.UntrackedNumstat(repoRoot)...)
+		return rows
+	default: // StagedOnly
+		return gitcli.DiffCachedNumstat(repoRoot)
+	}
+}
+
+// IsDecisionFile reports whether path is a decision-log file. Moved
+// verbatim from internal/cli/check_decisions.go's former isDecisionFile so
+// both check-decisions and guard-commit share one predicate:
+//
+//   - exact path "docs/decisions.md"
+//   - suffix "/decisions.md" (covers nested decisions.md)
+//   - prefix "docs/decisions-branches/" (per-branch decision files)
+func IsDecisionFile(path string) bool {
+	if path == "docs/decisions.md" {
+		return true
+	}
+	if strings.HasSuffix(path, "/decisions.md") {
+		return true
+	}
+	if strings.HasPrefix(path, "docs/decisions-branches/") {
+		return true
+	}
+	return false
+}
+
+// SubstantiveLines sums added+removed lines across rows, applying the same
+// skip rules check-decisions has always used (moved verbatim from
+// internal/cli/check_decisions.go's runCheckDecisions loop):
+//
+//   - a row whose Path starts with "docs/" is skipped (documentation
+//     changes aren't the kind of decision this gate is watching for)
+//   - a row with Added == "-" is a binary file (git's numstat marker) and
+//     is skipped
+//   - a row that fails to parse as integers is silently swallowed
+//
+// Taking a flat []gitcli.NumstatLine (rather than a repoRoot + diff mode)
+// is deliberate: it lets WorkingTreeUnion feed rows from three different
+// git commands (staged, unstaged-tracked, untracked) through the exact
+// same skip logic as StagedOnly's single source, with no risk of the two
+// modes' counting rules drifting apart.
+func SubstantiveLines(rows []gitcli.NumstatLine) int {
+	total := 0
+	for _, row := range rows {
+		if strings.HasPrefix(row.Path, "docs/") {
+			continue
+		}
+		if row.Added == "-" {
+			continue
+		}
+		added, errA := strconv.Atoi(row.Added)
+		removed, errR := strconv.Atoi(row.Removed)
+		if errA != nil || errR != nil {
+			continue
+		}
+		total += added + removed
+	}
+	return total
+}
+
+// envTruthy reports whether the named environment variable is set to a
+// truthy value: "1", "true", or "yes" (case-insensitive, surrounding
+// whitespace trimmed). Anything else — including unset — is falsey.
+func envTruthy(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// exists reports whether path exists (file OR directory — rebase-apply
+// and rebase-merge are directories; MERGE_HEAD/CHERRY_PICK_HEAD/
+// REVERT_HEAD are files). Any stat error (including "not found") reports
+// false — best-effort, matching the rest of this package's git wrappers.
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -1,0 +1,420 @@
+package guardcommit
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+// initRepo creates a fresh git repo at t.TempDir(), commits an initial
+// README so HEAD is born, and returns the path. Skips the test if `git`
+// isn't on PATH. Mirrors internal/gitcli's own initRepo test helper —
+// duplicated rather than exported so this package's tests don't reach
+// into gitcli's internals.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "test"},
+	} {
+		run(t, dir, args...)
+	}
+	writeFile(t, dir, "README.md", "hello\n")
+	run(t, dir, "add", "README.md")
+	run(t, dir, "commit", "-q", "-m", "init")
+	return dir
+}
+
+func run(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", relPath, err)
+	}
+}
+
+// linesOf returns a string with n newline-terminated lines — enough
+// "added" lines to trip a small threshold regardless of diff mode.
+func linesOf(n int) string {
+	var b bytes.Buffer
+	for i := 0; i < n; i++ {
+		b.WriteString("line\n")
+	}
+	return b.String()
+}
+
+// --- carve-out matrix -------------------------------------------------
+
+func TestEvaluate_NotARepo_Allows(t *testing.T) {
+	dir := t.TempDir() // no `git init`
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow {
+			t.Fatalf("mode=%v: Allow = false; want true (not a repo)", mode)
+		}
+		if d.CarveOut != CarveOutNone {
+			t.Fatalf("mode=%v: CarveOut = %q; want empty", mode, d.CarveOut)
+		}
+	}
+}
+
+func TestEvaluate_EnvAllow(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	t.Setenv("LOGMIND_ALLOW_GIT_COMMIT", "1")
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutEnvAllow {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutEnvAllow", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_EnvAllow_CaseInsensitiveTruthyValues(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	for _, val := range []string{"1", "true", "TRUE", "yes", "Yes"} {
+		t.Setenv("LOGMIND_ALLOW_GIT_COMMIT", val)
+		d := Evaluate(dir, "subject", 20, StagedOnly)
+		if !d.Allow || d.CarveOut != CarveOutEnvAllow {
+			t.Fatalf("val=%q: Decision = %+v; want Allow via CarveOutEnvAllow", val, d)
+		}
+	}
+	for _, val := range []string{"0", "false", "no", ""} {
+		t.Setenv("LOGMIND_ALLOW_GIT_COMMIT", val)
+		d := Evaluate(dir, "subject", 20, StagedOnly)
+		if d.CarveOut == CarveOutEnvAllow {
+			t.Fatalf("val=%q: CarveOut = env-allow; want NOT env-allow", val)
+		}
+	}
+}
+
+func TestEvaluate_SkipLogmindMarker(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "wip: quick fix [skip-logmind]", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutSkipLogmind {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutSkipLogmind", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_RebaseInProgress(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o755); err != nil {
+		t.Fatalf("mkdir rebase-merge: %v", err)
+	}
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutRebaseInProgress {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutRebaseInProgress", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_RebaseApplyInProgress(t *testing.T) {
+	dir := initRepo(t)
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(gitDir, "rebase-apply"), 0o755); err != nil {
+		t.Fatalf("mkdir rebase-apply: %v", err)
+	}
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutRebaseInProgress {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutRebaseInProgress", d)
+	}
+}
+
+func TestEvaluate_MergeInProgress(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "MERGE_HEAD"), []byte("abc123\n"), 0o644); err != nil {
+		t.Fatalf("write MERGE_HEAD: %v", err)
+	}
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutMergeInProgress {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutMergeInProgress", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_CherryPickInProgress(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	run(t, dir, "add", "big.go")
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "CHERRY_PICK_HEAD"), []byte("abc123\n"), 0o644); err != nil {
+		t.Fatalf("write CHERRY_PICK_HEAD: %v", err)
+	}
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutCherryPickOrRevert {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutCherryPickOrRevert", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_RevertInProgress(t *testing.T) {
+	dir := initRepo(t)
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "REVERT_HEAD"), []byte("abc123\n"), 0o644); err != nil {
+		t.Fatalf("write REVERT_HEAD: %v", err)
+	}
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutCherryPickOrRevert {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutCherryPickOrRevert", d)
+	}
+}
+
+func TestEvaluate_DecisionFileStaged(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	writeFile(t, dir, "docs/decisions.md", "## decision\n")
+	run(t, dir, "add", "big.go", "docs/decisions.md")
+	for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+		d := Evaluate(dir, "subject", 20, mode)
+		if !d.Allow || d.CarveOut != CarveOutDecisionFileStaged {
+			t.Fatalf("mode=%v: Decision = %+v; want Allow via CarveOutDecisionFileStaged", mode, d)
+		}
+	}
+}
+
+func TestEvaluate_BranchDecisionFileStaged(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(50))
+	writeFile(t, dir, "docs/decisions-branches/feature.md", "## decision\n")
+	run(t, dir, "add", "big.go", "docs/decisions-branches/feature.md")
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutDecisionFileStaged {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutDecisionFileStaged", d)
+	}
+}
+
+func TestEvaluate_UnderThreshold_Allows(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "small.go", linesOf(5))
+	run(t, dir, "add", "small.go")
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutUnderThreshold {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutUnderThreshold", d)
+	}
+	if d.Lines != 5 {
+		t.Fatalf("Lines = %d; want 5", d.Lines)
+	}
+}
+
+func TestEvaluate_OverThreshold_Blocks(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "big.go", linesOf(25))
+	run(t, dir, "add", "big.go")
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if d.Allow {
+		t.Fatalf("Decision = %+v; want Block", d)
+	}
+	if d.Lines != 25 {
+		t.Fatalf("Lines = %d; want 25", d.Lines)
+	}
+	if d.Reason == "" {
+		t.Fatalf("Reason is empty; want a block explanation")
+	}
+	if !strings.Contains(d.Reason, "logmind log") || !strings.Contains(d.Reason, "skip-logmind") || !strings.Contains(d.Reason, "LOGMIND_ALLOW_GIT_COMMIT") {
+		t.Fatalf("Reason = %q; want it to mention logmind log, skip-logmind, and LOGMIND_ALLOW_GIT_COMMIT", d.Reason)
+	}
+}
+
+func TestEvaluate_DocsOnlyChange_UnderThreshold(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "docs/random.md", linesOf(50))
+	run(t, dir, "add", "docs/random.md")
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutUnderThreshold || d.Lines != 0 {
+		t.Fatalf("Decision = %+v; want Allow/under-threshold with Lines=0 (docs/ is exempt)", d)
+	}
+}
+
+// --- the key StagedOnly vs. WorkingTreeUnion regression ----------------
+
+// TestEvaluate_UnstagedChange_BlockUnderUnion_AllowUnderStaged is THE
+// regression this package exists to prevent: a `git add -A && git commit`
+// shape where, at the moment the harness's PreToolUse hook fires, the
+// change under review is still sitting entirely UNSTAGED. StagedOnly
+// (correct for the git commit-msg hook, where the index is already final)
+// sees an empty index and allows; WorkingTreeUnion (correct for the
+// harness, which runs BEFORE `git add -A` stages anything) must still
+// catch it.
+func TestEvaluate_UnstagedChange_BlockUnderUnion_AllowUnderStaged(t *testing.T) {
+	dir := initRepo(t)
+	// Modify a TRACKED file (README.md starts as the 1-line "hello\n" from
+	// initRepo) without staging it: 30 added + 1 removed = 31 changed lines.
+	writeFile(t, dir, "README.md", linesOf(30))
+
+	staged := Evaluate(dir, "subject", 20, StagedOnly)
+	if !staged.Allow {
+		t.Fatalf("StagedOnly: Decision = %+v; want Allow (nothing staged yet)", staged)
+	}
+
+	union := Evaluate(dir, "subject", 20, WorkingTreeUnion)
+	if union.Allow {
+		t.Fatalf("WorkingTreeUnion: Decision = %+v; want Block (unstaged change must still be caught)", union)
+	}
+	if union.Lines != 31 {
+		t.Fatalf("WorkingTreeUnion: Lines = %d; want 31 (30 added + 1 removed)", union.Lines)
+	}
+}
+
+// TestEvaluate_UntrackedOnlyLargeFile_BlockUnderUnion covers the other
+// half of the harness's blind spot: a brand-new file that was never even
+// `git add`ed. StagedOnly sees nothing at all (correctly, for its use
+// case); WorkingTreeUnion must count it.
+func TestEvaluate_UntrackedOnlyLargeFile_BlockUnderUnion(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "brand_new.go", linesOf(40))
+
+	staged := Evaluate(dir, "subject", 20, StagedOnly)
+	if !staged.Allow {
+		t.Fatalf("StagedOnly: Decision = %+v; want Allow (untracked file is invisible to --cached)", staged)
+	}
+
+	union := Evaluate(dir, "subject", 20, WorkingTreeUnion)
+	if union.Allow {
+		t.Fatalf("WorkingTreeUnion: Decision = %+v; want Block (untracked-only large file must be caught)", union)
+	}
+	if union.Lines != 40 {
+		t.Fatalf("WorkingTreeUnion: Lines = %d; want 40", union.Lines)
+	}
+}
+
+// TestEvaluate_WorkingTreeUnion_SumsAllThreeSources sanity-checks that
+// WorkingTreeUnion really does UNION staged + unstaged-tracked +
+// untracked, rather than only catching one of the three.
+func TestEvaluate_WorkingTreeUnion_SumsAllThreeSources(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "staged.go", linesOf(3))
+	run(t, dir, "add", "staged.go")
+	// README.md starts as the 1-line "hello\n" from initRepo, so replacing
+	// it with 4 lines is 4 added + 1 removed = 5 changed lines.
+	writeFile(t, dir, "README.md", linesOf(4)) // tracked, unstaged
+	writeFile(t, dir, "untracked.go", linesOf(5))
+
+	d := Evaluate(dir, "subject", 1, WorkingTreeUnion)
+	if d.Allow {
+		t.Fatalf("Decision = %+v; want Block", d)
+	}
+	if d.Lines != 13 {
+		t.Fatalf("Lines = %d; want 13 (3 staged + 5 unstaged-tracked[4add+1rm] + 5 untracked)", d.Lines)
+	}
+}
+
+// --- carve-out precedence (first match wins) ----------------------------
+
+func TestEvaluate_CarveOutPrecedence_EnvBeatsSkipMarkerCheck(t *testing.T) {
+	// Not a meaningful ordering distinction on its own (both allow), but
+	// confirms env is checked ahead of subject parsing without requiring
+	// the subject to even be examined.
+	dir := initRepo(t)
+	t.Setenv("LOGMIND_ALLOW_GIT_COMMIT", "1")
+	d := Evaluate(dir, "", 20, StagedOnly)
+	if !d.Allow || d.CarveOut != CarveOutEnvAllow {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutEnvAllow even with empty subject", d)
+	}
+}
+
+func TestEvaluate_InProgressStateBeatsDecisionFileCheck(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "docs/decisions.md", "## decision\n")
+	run(t, dir, "add", "docs/decisions.md")
+	gitDir, err := gitcli.GitDir(dir)
+	if err != nil {
+		t.Fatalf("GitDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "MERGE_HEAD"), []byte("abc\n"), 0o644); err != nil {
+		t.Fatalf("write MERGE_HEAD: %v", err)
+	}
+	d := Evaluate(dir, "subject", 20, StagedOnly)
+	// Either carve-out would Allow; assert the DOCUMENTED order actually
+	// fires (merge-in-progress, checked before the staged-files loop).
+	if !d.Allow || d.CarveOut != CarveOutMergeInProgress {
+		t.Fatalf("Decision = %+v; want Allow via CarveOutMergeInProgress (checked before decision-file-staged)", d)
+	}
+}
+
+// --- IsDecisionFile / SubstantiveLines (moved verbatim from
+// check_decisions.go — behavior-preserving unit coverage lives here now) --
+
+func TestIsDecisionFile(t *testing.T) {
+	cases := map[string]bool{
+		"docs/decisions.md":                       true,
+		"nested/path/decisions.md":                true,
+		"docs/decisions-branches/feature.md":      true,
+		"docs/decisions-branches/nested/other.md": true,
+		"docs/decisions-archive.md":               false,
+		"README.md":                               false,
+		"src/decisions.txt":                       false,
+	}
+	for path, want := range cases {
+		if got := IsDecisionFile(path); got != want {
+			t.Errorf("IsDecisionFile(%q) = %v; want %v", path, got, want)
+		}
+	}
+}
+
+func TestSubstantiveLines_SkipsDocsAndBinaryAndUnparseable(t *testing.T) {
+	rows := []gitcli.NumstatLine{
+		{Added: "10", Removed: "2", Path: "main.go"},
+		{Added: "5", Removed: "0", Path: "docs/readme.md"}, // skipped: docs/
+		{Added: "-", Removed: "-", Path: "image.png"},      // skipped: binary
+		{Added: "x", Removed: "y", Path: "weird.go"},       // skipped: unparseable
+		{Added: "3", Removed: "1", Path: "other.go"},
+	}
+	got := SubstantiveLines(rows)
+	want := 10 + 2 + 3 + 1
+	if got != want {
+		t.Fatalf("SubstantiveLines = %d; want %d", got, want)
+	}
+}

--- a/internal/guardcommit/invokes_git_commit.go
+++ b/internal/guardcommit/invokes_git_commit.go
@@ -37,9 +37,11 @@ var wrapperCommands = map[string]bool{
 //     match even though the top-level statement starts with "echo".
 //  3. For each statement (from either source), tokenize it into
 //     whitespace-separated, quote-aware words; optionally strip a leading
-//     process-wrapper command (timeout/time/nice/nohup/stdbuf) and its own
-//     arguments; if the first remaining word isn't literally "git", the
-//     statement doesn't match.
+//     run of shell env-assignments (FOO=1, GIT_AUTHOR_DATE=...), the `env`
+//     command and its options, and process-wrapper commands
+//     (timeout/time/nice/nohup/stdbuf) with their own arguments; if the
+//     first remaining word isn't literally "git", the statement doesn't
+//     match.
 //  4. Walk git's global flags (-C x, -c x, --git-dir[=x], --work-tree[=x],
 //     any other -*) consuming their values as needed; the first non-flag
 //     word is git's subcommand. Match only if it is EXACTLY "commit" (a
@@ -80,27 +82,88 @@ func statementInvokesCommit(statement string) bool {
 	return ok && subcommand == "commit"
 }
 
-// stripWrapperPrefix removes a leading chain of process-wrapper commands
-// (and their own flags/positional args) so the wrapped command underneath
-// can be inspected. Repeats so `nohup timeout 30 git commit` (a wrapper
-// wrapping a wrapper) is also handled.
+// stripWrapperPrefix removes a leading chain of "cruft" tokens that a
+// shell would consume before the real command begins, so the wrapped
+// command underneath can be inspected. It loops so any combination — e.g.
+// `FOO=1 timeout 30 env GIT_AUTHOR_DATE=x git commit` — collapses down to
+// `git commit`. Three kinds of prefix are recognized:
 //
-// Only `timeout` has a REQUIRED bare positional (its duration) ahead of
-// the wrapped command; the others (`time`, `nice`, `nohup`, `stdbuf`) take
-// only flag-style options (if any) before the wrapped command begins, so
-// we special-case the single-positional skip to `timeout` alone.
+//   - Shell env-var assignments (`FOO=1`, `GIT_AUTHOR_DATE=2020-01-01`,
+//     `HUSKY=0`, ...). A compliant agent that inline-sets an env var ahead
+//     of `git commit` (date backdating, HUSKY=0 to skip husky hooks,
+//     GIT_EDITOR, ...) MUST NOT thereby slip past the gate — without this,
+//     `FOO=1 git commit` tokenizes with words[0] == "FOO=1" and fails the
+//     `words[0] == "git"` check.
+//   - The `env` command itself, plus its options (`-i`, `-u NAME`, ...)
+//     and inline `NAME=val` assignments, up to the command it runs
+//     (`env git commit`, `env -u HUSKY git commit`).
+//   - Process-wrapping commands (timeout/time/nice/nohup/stdbuf). Only
+//     `timeout` has a REQUIRED bare positional (its duration) ahead of the
+//     wrapped command; the others take only flag-style options (if any)
+//     before the wrapped command begins, so the single-positional skip is
+//     special-cased to `timeout` alone.
 func stripWrapperPrefix(words []string) []string {
-	for len(words) > 0 && wrapperCommands[words[0]] {
-		isTimeout := words[0] == "timeout"
-		words = words[1:]
-		for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+	for len(words) > 0 {
+		switch {
+		case isEnvAssignment(words[0]):
 			words = words[1:]
-		}
-		if isTimeout && len(words) > 0 {
-			words = words[1:] // the duration positional
+		case words[0] == "env":
+			words = words[1:]
+			for len(words) > 0 {
+				w := words[0]
+				switch {
+				case w == "-u":
+					// `-u NAME` unsets a var: consume the flag + its arg.
+					words = words[1:]
+					if len(words) > 0 {
+						words = words[1:]
+					}
+				case strings.HasPrefix(w, "-") || isEnvAssignment(w):
+					words = words[1:]
+				default:
+					// The command `env` will exec — stop consuming.
+					return stripWrapperPrefix(words)
+				}
+			}
+		case wrapperCommands[words[0]]:
+			isTimeout := words[0] == "timeout"
+			words = words[1:]
+			for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+				words = words[1:]
+			}
+			if isTimeout && len(words) > 0 {
+				words = words[1:] // the duration positional
+			}
+		default:
+			return words
 		}
 	}
 	return words
+}
+
+// isEnvAssignment reports whether word is a shell environment-variable
+// assignment of the form NAME=value, where NAME matches
+// ^[A-Za-z_][A-Za-z0-9_]*. The value part (after the first "=") is
+// unconstrained. A leading "-" (e.g. "--git-dir=x") or a "=" at position 0
+// disqualifies it, so git's own `--flag=value` options are never mistaken
+// for env assignments.
+func isEnvAssignment(word string) bool {
+	eq := strings.IndexByte(word, '=')
+	if eq <= 0 {
+		return false
+	}
+	for i := 0; i < eq; i++ {
+		c := word[i]
+		switch {
+		case c == '_':
+		case c >= 'A' && c <= 'Z':
+		case c >= 'a' && c <= 'z':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // firstGitSubcommand walks git's global options (which appear BEFORE the

--- a/internal/guardcommit/invokes_git_commit.go
+++ b/internal/guardcommit/invokes_git_commit.go
@@ -1,0 +1,332 @@
+package guardcommit
+
+import "strings"
+
+// wrapperCommands are process-wrapping binaries that invoke another
+// command as their final argument. A Bash tool call that runs
+// `timeout 30 git commit -m x` is invoking `git commit` just as much as
+// a bare `git commit -m x` — InvokesGitCommit sees through these.
+var wrapperCommands = map[string]bool{
+	"timeout": true,
+	"time":    true,
+	"nice":    true,
+	"nohup":   true,
+	"stdbuf":  true,
+}
+
+// InvokesGitCommit reports whether bashCommand would, if run by a shell,
+// execute `git commit` (exactly — not `git commit-tree`, not any other
+// git subcommand) as one of its top-level statements or inside a command
+// substitution.
+//
+// This is intentionally a hand-rolled tokenizer/splitter rather than a
+// regexp, matching this project's minimal-dependency posture (see
+// internal/gitcli's doc comment) and because shell quoting/substitution
+// isn't expressible as a single regex without producing false positives
+// on cases like `git commit -m "has && inside quotes"`.
+//
+// Algorithm:
+//
+//  1. Split bashCommand on shell statement separators (&&, ||, |&, |, &,
+//     ;, newline) while OUTSIDE single/double quotes, producing a list of
+//     top-level statements.
+//  2. Separately, extract the contents of every $(...) and `...` command
+//     substitution anywhere in the string (recursively, so a substitution
+//     nested inside another substitution is also found), and run the same
+//     split against each one. This is what makes `echo $(git commit -m x)`
+//     match even though the top-level statement starts with "echo".
+//  3. For each statement (from either source), tokenize it into
+//     whitespace-separated, quote-aware words; optionally strip a leading
+//     process-wrapper command (timeout/time/nice/nohup/stdbuf) and its own
+//     arguments; if the first remaining word isn't literally "git", the
+//     statement doesn't match.
+//  4. Walk git's global flags (-C x, -c x, --git-dir[=x], --work-tree[=x],
+//     any other -*) consuming their values as needed; the first non-flag
+//     word is git's subcommand. Match only if it is EXACTLY "commit" (a
+//     prefix match would wrongly catch `git commit-tree`).
+func InvokesGitCommit(bashCommand string) bool {
+	if statementsInvokeCommit(bashCommand) {
+		return true
+	}
+	for _, sub := range extractSubstitutions(bashCommand) {
+		if statementsInvokeCommit(sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// statementsInvokeCommit splits s on top-level shell separators and
+// checks each resulting statement independently.
+func statementsInvokeCommit(s string) bool {
+	for _, statement := range splitStatements(s) {
+		if statementInvokesCommit(statement) {
+			return true
+		}
+	}
+	return false
+}
+
+// statementInvokesCommit checks a single already-split statement (no
+// top-level && / ; / | etc. left in it — those were already split away;
+// any such tokens remaining are inside quotes and are just data).
+func statementInvokesCommit(statement string) bool {
+	words := tokenizeWords(statement)
+	words = stripWrapperPrefix(words)
+	if len(words) == 0 || words[0] != "git" {
+		return false
+	}
+	subcommand, ok := firstGitSubcommand(words[1:])
+	return ok && subcommand == "commit"
+}
+
+// stripWrapperPrefix removes a leading chain of process-wrapper commands
+// (and their own flags/positional args) so the wrapped command underneath
+// can be inspected. Repeats so `nohup timeout 30 git commit` (a wrapper
+// wrapping a wrapper) is also handled.
+//
+// Only `timeout` has a REQUIRED bare positional (its duration) ahead of
+// the wrapped command; the others (`time`, `nice`, `nohup`, `stdbuf`) take
+// only flag-style options (if any) before the wrapped command begins, so
+// we special-case the single-positional skip to `timeout` alone.
+func stripWrapperPrefix(words []string) []string {
+	for len(words) > 0 && wrapperCommands[words[0]] {
+		isTimeout := words[0] == "timeout"
+		words = words[1:]
+		for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+			words = words[1:]
+		}
+		if isTimeout && len(words) > 0 {
+			words = words[1:] // the duration positional
+		}
+	}
+	return words
+}
+
+// firstGitSubcommand walks git's global options (which appear BEFORE the
+// subcommand) and returns the first non-flag word — git's subcommand.
+// words is everything after the literal "git" token.
+func firstGitSubcommand(words []string) (string, bool) {
+	i := 0
+	for i < len(words) {
+		w := words[i]
+		switch {
+		case w == "-C" || w == "-c":
+			// Both take a mandatory, space-separated value.
+			i += 2
+		case w == "--git-dir" || w == "--work-tree":
+			i += 2
+		case strings.HasPrefix(w, "--git-dir=") || strings.HasPrefix(w, "--work-tree="):
+			i++
+		case strings.HasPrefix(w, "-"):
+			// Any other global flag (--no-pager, --bare, -p, ...):
+			// treated as a bare flag with no consumed value.
+			i++
+		default:
+			return w, true
+		}
+	}
+	return "", false
+}
+
+// splitStatements splits s on shell statement separators — && || |& | & ;
+// and newline — while outside single/double quotes. Longer separators
+// (&&, ||, |&) are matched before their single-character prefixes (&, |)
+// so e.g. "&&" isn't mistaken for two consecutive "&" separators.
+func splitStatements(s string) []string {
+	var statements []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	n := len(s)
+	flush := func() {
+		statements = append(statements, cur.String())
+		cur.Reset()
+	}
+	for i := 0; i < n; {
+		c := s[i]
+		switch {
+		case inSingle:
+			cur.WriteByte(c)
+			if c == '\'' {
+				inSingle = false
+			}
+			i++
+		case inDouble:
+			cur.WriteByte(c)
+			if c == '"' {
+				inDouble = false
+			}
+			i++
+		case c == '\'':
+			inSingle = true
+			cur.WriteByte(c)
+			i++
+		case c == '"':
+			inDouble = true
+			cur.WriteByte(c)
+			i++
+		case c == '\\' && i+1 < n:
+			// Bare-context escape: copy both bytes literally so the
+			// escaped char (e.g. "\;") doesn't get treated as a
+			// separator.
+			cur.WriteByte(c)
+			cur.WriteByte(s[i+1])
+			i += 2
+		case c == '&' && i+1 < n && s[i+1] == '&':
+			flush()
+			i += 2
+		case c == '|' && i+1 < n && (s[i+1] == '|' || s[i+1] == '&'):
+			flush()
+			i += 2
+		case c == ';' || c == '|' || c == '&' || c == '\n':
+			flush()
+			i++
+		default:
+			cur.WriteByte(c)
+			i++
+		}
+	}
+	flush()
+	return statements
+}
+
+// tokenizeWords splits a single statement into whitespace-separated
+// words, stripping (but not otherwise interpreting) single/double quote
+// delimiters so a quoted phrase becomes one word. Good enough for our
+// purposes — we only ever inspect the first few words (wrapper name, git,
+// flags, subcommand); a quoted commit message's exact contents never
+// matter to this function.
+func tokenizeWords(s string) []string {
+	var words []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	hasContent := false
+	n := len(s)
+	flush := func() {
+		if hasContent {
+			words = append(words, cur.String())
+			cur.Reset()
+			hasContent = false
+		}
+	}
+	for i := 0; i < n; {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteByte(c)
+			}
+			i++
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			} else {
+				cur.WriteByte(c)
+			}
+			i++
+		case c == '\'':
+			inSingle = true
+			hasContent = true
+			i++
+		case c == '"':
+			inDouble = true
+			hasContent = true
+			i++
+		case c == ' ' || c == '\t':
+			flush()
+			i++
+		default:
+			cur.WriteByte(c)
+			hasContent = true
+			i++
+		}
+	}
+	flush()
+	return words
+}
+
+// extractSubstitutions walks s and returns the inner contents of every
+// $(...) and `...` (backtick) command substitution, recursing into nested
+// substitutions so they're returned too (flattened, not nested). Content
+// inside single quotes is skipped (POSIX: single quotes suppress ALL
+// expansion, including command substitution); content inside double
+// quotes IS scanned, since $() and backticks still expand there.
+func extractSubstitutions(s string) []string {
+	var subs []string
+	inSingle := false
+	n := len(s)
+	for i := 0; i < n; {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+			i++
+		case c == '\'':
+			inSingle = true
+			i++
+		case c == '$' && i+1 < n && s[i+1] == '(':
+			inner, end := scanParenSubstitution(s, i+2)
+			subs = append(subs, inner)
+			subs = append(subs, extractSubstitutions(inner)...)
+			i = end
+		case c == '`':
+			end := strings.IndexByte(s[i+1:], '`')
+			if end < 0 {
+				// Unterminated backtick span — nothing more to parse.
+				i = n
+				continue
+			}
+			inner := s[i+1 : i+1+end]
+			subs = append(subs, inner)
+			subs = append(subs, extractSubstitutions(inner)...)
+			i = i + 1 + end + 1
+		default:
+			i++
+		}
+	}
+	return subs
+}
+
+// scanParenSubstitution scans a $(...)  body starting at start (the byte
+// right after "$("), tracking nested parens and quotes so an inner ")"
+// belonging to a nested substitution or a quoted string doesn't
+// prematurely close the outer one. Returns the inner text (excluding the
+// closing paren) and the index right after the closing paren (or len(s)
+// if unterminated).
+func scanParenSubstitution(s string, start int) (inner string, end int) {
+	depth := 1
+	inSingle, inDouble := false, false
+	n := len(s)
+	j := start
+	for j < n && depth > 0 {
+		c := s[j]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '(':
+			depth++
+		case c == ')':
+			depth--
+		}
+		j++
+	}
+	closeIdx := j - 1 // index of the ')' that closed depth to 0, or len(s) if unterminated
+	if depth > 0 {
+		return s[start:n], n
+	}
+	return s[start:closeIdx], j
+}

--- a/internal/guardcommit/invokes_git_commit_test.go
+++ b/internal/guardcommit/invokes_git_commit_test.go
@@ -1,0 +1,105 @@
+package guardcommit
+
+import "testing"
+
+// TestInvokesGitCommit covers every MUST/MUST-NOT case from the PR brief.
+//
+// One deliberate deviation from the brief's literal bucketing: the brief
+// lists `git commit -m "has && inside quotes"` under "MUST NOT match", with
+// the annotation "(don't mis-split on quoted &&)". Taken literally that
+// would mean InvokesGitCommit should return FALSE for a string that begins
+// with `git commit -m ...` — but that string unambiguously runs `git
+// commit` (the "&&" is just data inside a properly double-quoted -m
+// argument; a real shell executes it as one `git commit` invocation, full
+// stop). Classifying it as "does not invoke git commit" would be a genuine
+// enforcement bypass: any commit whose message happens to contain "&&"
+// would silently skip the gate. The annotation's actual intent — "don't
+// mis-split the string into two statements at the quoted &&" — is a
+// description of how to correctly recognize this as ONE unsplit `git
+// commit` statement, which is exactly what treating it as a MUST-match
+// case verifies. See TestInvokesGitCommit_QuotedAmpersandsDoNotBypassMatch
+// below; flagged here for PR review in case the brief intended the
+// opposite and this needs to be revisited.
+func TestInvokesGitCommit(t *testing.T) {
+	mustMatch := []string{
+		`git commit`,
+		`git commit -am "x"`,
+		`git -C sub commit`,
+		`npm test && git commit -m x`,
+		`echo $(git commit -m x)`,
+		`timeout 30 git commit -m x`,
+	}
+	for _, cmd := range mustMatch {
+		if !InvokesGitCommit(cmd) {
+			t.Errorf("InvokesGitCommit(%q) = false; want true", cmd)
+		}
+	}
+
+	mustNotMatch := []string{
+		`git commit-tree -m x`,
+		`gh pr merge`,
+		`git rebase --continue`,
+		`git merge --no-edit`,
+	}
+	for _, cmd := range mustNotMatch {
+		if InvokesGitCommit(cmd) {
+			t.Errorf("InvokesGitCommit(%q) = true; want false", cmd)
+		}
+	}
+}
+
+// TestInvokesGitCommit_QuotedAmpersandsDoNotBypassMatch is the flagged
+// case from the doc comment above: a quoted "&&" inside a commit message
+// must not cause a mis-split that hides the git-commit invocation. See
+// TestInvokesGitCommit's doc comment for why this is asserted as a MATCH
+// rather than a non-match.
+func TestInvokesGitCommit_QuotedAmpersandsDoNotBypassMatch(t *testing.T) {
+	cmd := `git commit -m "has && inside quotes"`
+	if !InvokesGitCommit(cmd) {
+		t.Errorf("InvokesGitCommit(%q) = false; want true (quoted && must not hide the invocation)", cmd)
+	}
+}
+
+// TestInvokesGitCommit_AdditionalCases covers a few more shapes not in the
+// original MUST/MUST-NOT list but worth pinning down given the wrapper /
+// global-flag / substitution handling this function implements.
+func TestInvokesGitCommit_AdditionalCases(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		// Chained wrappers.
+		{`nohup timeout 30 git commit -m x`, true},
+		// Backtick substitution (the other command-substitution form).
+		{"echo `git commit -m x`", true},
+		// Nested substitution.
+		{`echo $(echo $(git commit -m x))`, true},
+		// Separator variety: pipe, semicolon, background, pipe-or.
+		{`git status | cat && git commit -m x`, true},
+		{`git status; git commit -m x`, true},
+		{`git status & git commit -m x`, true},
+		{`false || git commit -m x`, true},
+		// git global flags before the subcommand.
+		{`git --git-dir=/tmp/x.git commit -m x`, true},
+		{`git --git-dir /tmp/x.git commit -m x`, true},
+		{`git -c user.name=bot commit -m x`, true},
+		{`git --work-tree=/tmp/wt commit -m x`, true},
+		// Not git at all.
+		{`echo hello`, false},
+		{`npm run build && npm test`, false},
+		// git, but not the commit subcommand.
+		{`git status`, false},
+		{`git log --oneline`, false},
+		// A subject that just mentions "commit" as data, not as the git
+		// subcommand.
+		{`echo "please commit this"`, false},
+		// Empty / whitespace-only input.
+		{``, false},
+		{`   `, false},
+	}
+	for _, c := range cases {
+		if got := InvokesGitCommit(c.cmd); got != c.want {
+			t.Errorf("InvokesGitCommit(%q) = %v; want %v", c.cmd, got, c.want)
+		}
+	}
+}

--- a/internal/guardcommit/invokes_git_commit_test.go
+++ b/internal/guardcommit/invokes_git_commit_test.go
@@ -28,6 +28,18 @@ func TestInvokesGitCommit(t *testing.T) {
 		`npm test && git commit -m x`,
 		`echo $(git commit -m x)`,
 		`timeout 30 git commit -m x`,
+		// Leading env-var assignments must not hide the invocation (a
+		// compliant agent inline-setting a var — date backdating, HUSKY=0,
+		// GIT_EDITOR — would otherwise silently bypass the gate).
+		`FOO=1 git commit -m x`,
+		`GIT_AUTHOR_DATE=2020-01-01 git commit`,
+		`HUSKY=0 git commit -m x`,
+		// The `env` command as a wrapper, with and without its options.
+		`env git commit`,
+		`env FOO=1 git commit -m x`,
+		`env -u HUSKY git commit -m x`,
+		// Env assignment stacked on a process wrapper.
+		`FOO=1 timeout 30 git commit -m x`,
 	}
 	for _, cmd := range mustMatch {
 		if !InvokesGitCommit(cmd) {
@@ -40,6 +52,11 @@ func TestInvokesGitCommit(t *testing.T) {
 		`gh pr merge`,
 		`git rebase --continue`,
 		`git merge --no-edit`,
+		// An env-assignment prefix in front of a NON-git command must not
+		// become a false positive after the assignment is stripped.
+		`FOO=1 npm test`,
+		`GIT_AUTHOR_DATE=x npm run build`,
+		`env npm test`,
 	}
 	for _, cmd := range mustNotMatch {
 		if InvokesGitCommit(cmd) {


### PR DESCRIPTION
## Summary

PR1/3 of the "force-logmind-usage enforcement" feature (plan.md §v2.0.0). This ships the shared decision engine only — **no install wiring, no hooks registered, nothing runs automatically yet**. `guard-commit` is `Hidden: true` (plumbing, not a user-facing verb) and is manually-invokable only, exactly as scoped.

- **`internal/guardcommit`** (new package, pure logic, no cobra): `Evaluate(repoRoot, subject, threshold, mode) Decision` — the ordered, first-match-wins carve-out engine (not-a-repo → env allow → `[skip-logmind]` → rebase/merge/cherry-pick/revert in progress → decision-file-staged → under-threshold → Block). `IsDecisionFile` and `SubstantiveLines` are moved verbatim from `check_decisions.go` (behavior-preserving; existing goldens pass unchanged). `InvokesGitCommit` is a hand-rolled, quote-aware, stdlib-only shell-statement splitter that recurses into `$(...)`/backtick substitutions and walks git's global flags to find the exact subcommand.
- **`DiffMode`**: `StagedOnly` (git commit-msg hook — index is final) vs. `WorkingTreeUnion` (harness PreToolUse hook — fires *before* a compound `git add -A && git commit` stages anything, so it unions staged + unstaged-tracked + untracked changes; new `gitcli.DiffNumstat`/`UntrackedFiles`/`UntrackedNumstat`/`GitDir` helpers back this).
- **`internal/cli/guard_commit.go`**: `logmind guard-commit --layer {harness|git-hook}`. Harness layer reads a PreToolUse JSON payload from stdin and — this is the one deliberate exception in the whole CLI — calls `os.Exit(2)` directly on block, bypassing the `ErrSilent`/exit-1 convention every other command uses, because PreToolUse only blocks on exit 2 (see the loud comment at the call site). git-hook layer reads `--msg-file` and blocks via the standard `ErrSilent`/exit-1 convention (git only needs nonzero).
- New config knobs: `git.enforce_commits` (default `true`, full repo off-ramp) and `git.commit_line_threshold` (default `20`) on `GitConfig`. Not yet exposed via `logmind config list/get/set` — kept out of scope to keep this diff focused on the decision engine.

One flagged deviation from the PR brief worth a second look in review: the brief lists `git commit -m "has && inside quotes"` under "MUST NOT match" for `InvokesGitCommit`. That string unambiguously runs `git commit` (the `&&` is literal data inside a properly double-quoted `-m` argument), so treating it as non-matching would be an enforcement bypass for any commit message containing `&&`. I implemented it as a MUST-match case instead — see the doc comment on `TestInvokesGitCommit` in `internal/guardcommit/invokes_git_commit_test.go` for the full reasoning, flagged here in case the brief intended the literal opposite.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` — full suite green, including unchanged `check_decisions_test.go` goldens
- [x] `internal/guardcommit`: full carve-out matrix (every carve-out × both `DiffMode`s) against temp git repos + real `.git/*` state files, including carve-out precedence ordering
- [x] The key regression: `git add -A && git commit` shape where the change is unstaged at eval time → **Block** under `WorkingTreeUnion`, **would-Allow** under `StagedOnly` (`TestEvaluate_UnstagedChange_BlockUnderUnion_AllowUnderStaged`)
- [x] Untracked-only large file → Block under `WorkingTreeUnion` (`TestEvaluate_UntrackedOnlyLargeFile_BlockUnderUnion`)
- [x] `InvokesGitCommit` table test covering every MUST/MUST-NOT case plus wrapper chaining, backticks, nested substitutions, all separator types, and git global flags
- [x] Black-box subprocess test: builds the real binary, pipes a blocking harness JSON payload to `guard-commit --layer harness`, asserts `ExitCode() == 2` (not 1); asserts the allow case exits 0 with empty stdout
- [x] `enforce_commits: false` → allow unconditionally for both layers
- [x] Confirmed `guard-commit` does not appear in `--help` (Hidden) but is directly invocable; confirmed no `.git/hooks` or harness settings are touched anywhere in this PR

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG