### PR TITLE
feat(enforce): commit-msg + Claude Code PreToolUse hooks + install wiring (enforcement PR2/3)

### DIFF
--- a/docs/decisions-branches/feat__enforce-hooks-install.md
+++ b/docs/decisions-branches/feat__enforce-hooks-install.md
@@ -17,3 +17,14 @@
 
 ---
 
+## 2026-07-16 16:02 - Review fixes for PR 195: doctor --fix degrades gracefully on malformed .claude/settings.json, self-update installs the PreToolUse guard, commit-msg guard uses an explicit if
+
+**Reasoning:** Review verdict was SHIP-after-one-fix. M1: applyRefresh fed claudehook's error into firstErr, and runDoctorFix converts any refreshErr into ErrSilent/exit-1 with the ok summary suppressed - so a consumer with a JSONC-style trailing-comma settings.json got a persistently failing doctor --fix that also skipped the branch-summary backfill and residual re-probe over a file --fix cannot repair anyway. The sibling git-hook installers deliberately swallow their errors so a bad hook degrades to residual drift; the claudehook install now does the same, and the doctor probe already classifies an unparseable settings.json as missing (benign). m1: self-update refreshed the three git hooks but never installed Layer 1, so a repo whose only refresh path is self-update would get an enforcing commit-msg hook while the PreToolUse guard stayed missing forever with no doctor nudge. m2: the one-liner msg-file guard relied on shell operator precedence; replaced with an explicit if block per review.
+
+**Alternatives considered:** Have runDoctorFix special-case claudehook errors instead of swallowing in applyRefresh - rejected: applyRefresh is the shared choke point (init refresh-mode hits the same path), and the established convention there is per-installer error swallowing for user-content surfaces., Surface the malformed-settings condition as a stderr warning from applyRefresh - rejected for now: the doctor probe reports the state and keeping the swallow symmetric with the git-hook installers is the smaller, convention-matching change.
+
+**Implications:**
+- New tests: doctor --fix with malformed settings.json exits 0, prints ok doctor-fix with claude-hook=current, still installs the git hooks, and leaves the file byte-untouched; self-update installs the guard by default and skips it under agents.claude:false. commit-msg.golden regenerated for the explicit-if body; the hookVersion marker means consumers auto-upgrade on their next refresh as before.
+
+---
+

--- a/docs/decisions-branches/feat__enforce-hooks-install.md
+++ b/docs/decisions-branches/feat__enforce-hooks-install.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-11-wire-commit-enforcement-live-claude-code-pretooluse-guard-in -->
+- **2026-07-11** — Wire commit enforcement live: Claude Code PreToolUse guard (internal/claudehook) + upgrade commit-msg hook to enforce + init/doctor --fix install wiring (enforcement PR2/3)
+<!-- logmind-entry-end -->
+
+## 2026-07-11 16:47 - Wire commit enforcement live: Claude Code PreToolUse guard (internal/claudehook) + upgrade commit-msg hook to enforce + init/doctor --fix install wiring (enforcement PR2/3)
+
+**Reasoning:** PR1 shipped guard-commit as a manually-invocable, Hidden decision engine with zero install wiring. This PR makes enforcement LIVE: Layer 1 is a new internal/claudehook package that surgically merges a PreToolUse guard entry into .claude/settings.json (marker-based ownership via a logmind guard-commit substring in hooks[].command, mirroring hooks.go's git-hook marker convention), so a non-compliant git commit Bash tool call is blocked by the Claude Code harness before it ever runs. Layer 2 upgrades BuildCommitMsgBody from warn-only to delegate to logmind guard-commit --layer git-hook, so the existing hookVersion() marker auto-upgrades every consumer's installed hook on the next init/doctor --fix with no new install-side code. Both layers are wired into logmind init (fresh install + refresh mode) and logmind doctor --fix via a new refreshOpts.claudeAgentEnabled gate, resolved from the agents flag list at init time and from .logmind/config.yml at doctor --fix time (default true, matching agents.DefaultEnabled). Added probeClaudePreToolUseHook to internal/doctor mirroring probeHook's missing/markerless/stale/current shape.
+
+**Alternatives considered:** Gate the Layer 1 install on git-repo presence like the git hooks - rejected: .claude/settings.json is repo content, not git-clone state, so it must install under --no-git too (and a repo that adds git later should already be protected)., Flip doctor Overall to DRIFT whenever the Claude probe is missing, not just when stale - rejected: every existing hook probe treats missing as benign (pinned by TestCollectStatus_FreshRepoListsAllProbes asserting Overall==OK on an all-missing fresh repo); the new probe reuses the exact same classifyLogmindDrift mechanism so only stale flips, for consistency., Add a command -v logmind existence guard to the harness's canonical PreToolUse command, mirroring the git hook - rejected: the harness command must stay one cross-platform string valid under both bash and PowerShell, and a missing binary already fails open via a non-2 command-not-found exit, which is the correct behavior.
+
+**Implications:**
+- New internal/claudehook package: EnsurePreToolUseGuard is idempotent and non-destructive, replacing only the hook object whose command contains the logmind guard-commit marker, appending into an existing Bash PreToolUse group or creating one, and leaving every foreign hook/group/event untouched; Inspect() gives doctor a read-only probe of the same state.
+- config.yml.template documents git.enforce_commits/commit_line_threshold (struct defaults already matched these, so config list/DefaultMap are untouched, avoiding golden churn); git.enforce_commits:false and agents.claude:false remain the two full off-ramps.
+- New BuildCommitMsgBody golden (testdata/commit-msg.golden) plus a real git commit integration test in internal/hooks proving the installed hook actually blocks a substantive no-decision commit and allows via [skip-logmind], LOGMIND_ALLOW_GIT_COMMIT=1, and a staged decision file.
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -34,6 +34,7 @@ logmind
 │   └── install.sh
 ├── internal
 │   ├── agents
+│   ├── claudehook
 │   ├── cli
 │   ├── clierr
 │   ├── config

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-11-wire-commit-enforcement-live-claude-code-pretooluse-guard-in -->
+- **2026-07-11** — Wire commit enforcement live: Claude Code PreToolUse guard (internal/claudehook) + upgrade commit-msg hook to enforce + init/doctor --fix install wiring (enforcement PR2/3) → [detail](decisions-branches/feat__enforce-hooks-install.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-11-refresh-stale-version-output-examples-and-rewrite-docs-plan- -->
 - **2026-07-11** — Refresh stale version-output examples and rewrite docs/plan.md for v2.0 → [detail](decisions-branches/docs__refresh-version-examples-and-plan.md)
 <!-- logmind-entry-end -->

--- a/internal/claudehook/claudehook.go
+++ b/internal/claudehook/claudehook.go
@@ -1,0 +1,479 @@
+// Package claudehook installs and inspects the Claude Code harness's
+// PreToolUse guard entry in `.claude/settings.json` — Layer 1 of
+// logmind's two-layer commit-enforcement design (PR2/3 of the
+// force-logmind-usage feature; see internal/guardcommit for the shared
+// decision engine and internal/hooks for Layer 2, the git commit-msg
+// hook).
+//
+// Why two layers: the git commit-msg hook (Layer 2) is the backstop that
+// catches every `git commit` regardless of how it was invoked, but it
+// fires AFTER Claude Code has already run the `git commit` Bash tool
+// call — by then the agent has spent a turn on a commit that's about to
+// be rejected. The PreToolUse hook (Layer 1) intercepts the Bash tool
+// call itself, before it runs, so a non-compliant commit never executes
+// at all. Both call the same `logmind guard-commit` binary
+// (internal/cli/guard_commit.go) with a different `--layer` flag; this
+// package only owns the INSTALLER for Layer 1's settings.json entry, not
+// the decision logic.
+//
+// Ownership model: like the git hooks, we own exactly one thing inside
+// `.claude/settings.json` — the PreToolUse hook entry whose command
+// contains "logmind guard-commit" — and never touch anything else a user
+// (or another tool) put in that file. EnsurePreToolUseGuard's merge
+// algorithm decodes just enough of the JSON structure to find/patch that
+// one entry, leaving every other key's VALUE untouched. The one
+// unavoidable side effect: because encoding/json sorts Go map keys when
+// marshaling, and this installer round-trips the whole document through
+// a map-shaped decode/re-encode, an existing hand-formatted
+// settings.json may see its top-level (and edited-object) keys
+// re-ordered on first touch. That's semantically inert — JSON object key
+// order carries no meaning — and mirrors the identical, already-accepted
+// tradeoff in internal/config's YAML round-trip.
+package claudehook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/version"
+)
+
+// guardCommitMarker is the substring that identifies a logmind-owned
+// PreToolUse hook command. Mirrors the ownership-detection role
+// internal/hooks.PostMergeMarker etc. play for the git hooks, adapted to
+// a single-line JSON string value instead of a shell-script comment.
+const guardCommitMarker = "logmind guard-commit"
+
+// rawObject is a JSON object decoded shallowly: every key's value stays
+// as undecoded bytes so re-encoding it round-trips content this package
+// doesn't understand (or doesn't need to touch) unchanged.
+type rawObject = map[string]json.RawMessage
+
+// SettingsPath returns the canonical `.claude/settings.json` path under
+// repoRoot.
+func SettingsPath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".claude", "settings.json")
+}
+
+// CanonicalCommand returns the exact command string this package installs
+// into the PreToolUse Bash hook entry it owns:
+//
+//	logmind guard-commit --layer harness # logmind-hook-version: <ver>
+//
+// The trailing `# logmind-hook-version: X` reuses hooks.HookVersionPrefix
+// verbatim as a shell comment — valid syntax in both bash AND
+// PowerShell (Claude Code's PreToolUse `command` runs through the
+// user's shell, which varies by OS) — giving doctor's drift probe the
+// exact same marker-extraction contract the git hooks already use.
+//
+// Deliberately NOT prefixed with a `command -v logmind` guard: the
+// command must stay a single cross-platform line, and a missing logmind
+// binary already produces a non-2 "command not found" exit — which is
+// the correct fail-open behavior for a PreToolUse hook (only exit code 2
+// blocks the tool call). Adding our own existence check would only
+// introduce a platform-specific branch for no behavioral gain.
+func CanonicalCommand() string {
+	return "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + version.Version
+}
+
+// canonicalHookEntry is the JSON shape of the single hook object this
+// package owns inside a PreToolUse matcher group's `hooks[]` array.
+// Field order is the struct's declaration order (type, if, command,
+// timeout) — encoding/json preserves struct field order (unlike map key
+// order, which it always sorts), so this matches the canonical shape
+// documented in the PR spec byte-for-byte on a fresh install.
+type canonicalHookEntry struct {
+	Type    string `json:"type"`
+	If      string `json:"if"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
+}
+
+func canonicalHookRaw() json.RawMessage {
+	h := canonicalHookEntry{
+		Type:    "command",
+		If:      "Bash(git *)",
+		Command: CanonicalCommand(),
+		Timeout: 10,
+	}
+	b, err := json.Marshal(h)
+	if err != nil {
+		// h is a fixed, always-marshalable literal; this can't happen.
+		panic("claudehook: canonical hook entry failed to marshal: " + err.Error())
+	}
+	return b
+}
+
+// canonicalGroupRaw wraps canonicalHookRaw in a fresh `{"matcher":"Bash",
+// "hooks":[...]}` group — used both for a from-scratch settings.json and
+// for the "no existing Bash PreToolUse group" append case.
+func canonicalGroupRaw() json.RawMessage {
+	g := struct {
+		Matcher string            `json:"matcher"`
+		Hooks   []json.RawMessage `json:"hooks"`
+	}{Matcher: "Bash", Hooks: []json.RawMessage{canonicalHookRaw()}}
+	b, err := json.Marshal(g)
+	if err != nil {
+		panic("claudehook: canonical group failed to marshal: " + err.Error())
+	}
+	return b
+}
+
+// commandMarkerVersion extracts the `# logmind-hook-version: X` suffix
+// from a hook command string (the single-line analog of
+// hooks.ExtractVersion, which scans a multi-line shell script instead).
+func commandMarkerVersion(command string) (string, bool) {
+	idx := strings.Index(command, hooks.HookVersionPrefix)
+	if idx == -1 {
+		return "", false
+	}
+	return strings.TrimSpace(command[idx+len(hooks.HookVersionPrefix):]), true
+}
+
+// EnsurePreToolUseGuard installs or refreshes the logmind guard-commit
+// PreToolUse hook entry in repoRoot/.claude/settings.json. Returns
+// changed=true iff the file was created or modified.
+//
+// Behavior matrix (see the package doc for the ownership model):
+//
+//	no .claude/settings.json          → create it with just this hook. changed=true.
+//	file exists, malformed JSON       → return a clear error; file untouched.
+//	our entry present, marker current → no-op. changed=false.
+//	our entry present, marker stale/absent → replace just that hook object. changed=true.
+//	our entry absent, a Bash PreToolUse group exists → append to its hooks[]. changed=true.
+//	our entry absent, no Bash PreToolUse group exists → append a new {matcher:"Bash",...} group. changed=true.
+func EnsurePreToolUseGuard(repoRoot string) (changed bool, err error) {
+	path := SettingsPath(repoRoot)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+		if err := writeFreshSettings(path); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	out, changed, err := mergeSettings(data)
+	if err != nil {
+		return false, fmt.Errorf("claudehook: %s: %w", path, err)
+	}
+	if !changed {
+		return false, nil
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// writeFreshSettings creates repoRoot/.claude/settings.json (and the
+// .claude/ directory) from scratch, containing only the canonical
+// PreToolUse guard.
+func writeFreshSettings(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := canonicalSettingsBytes()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+func canonicalSettingsBytes() ([]byte, error) {
+	preToolUse, err := json.Marshal([]json.RawMessage{canonicalGroupRaw()})
+	if err != nil {
+		return nil, err
+	}
+	hooksObj, err := json.Marshal(rawObject{"PreToolUse": preToolUse})
+	if err != nil {
+		return nil, err
+	}
+	root, err := json.Marshal(rawObject{"hooks": hooksObj})
+	if err != nil {
+		return nil, err
+	}
+	out, err := reindent(root)
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+// decodedGroup is one entry of hooks.PreToolUse, decoded just enough to
+// search/patch it. `raw` holds the ORIGINAL bytes exactly as read from
+// disk (nil for a group this package creates from scratch); groups this
+// package doesn't need to modify are re-emitted from `raw` verbatim so
+// their key order survives untouched. `obj`/`matcherRaw` are only
+// populated (and only consulted) for a group we DO end up touching.
+type decodedGroup struct {
+	raw        json.RawMessage
+	obj        rawObject
+	matcherRaw json.RawMessage
+	matcher    string
+	hooksArr   []json.RawMessage
+	touched    bool
+}
+
+// mergeSettings applies the merge algorithm described on
+// EnsurePreToolUseGuard to an already-read settings.json byte slice.
+// Split out from EnsurePreToolUseGuard so the pure logic is unit
+// testable without touching a filesystem.
+func mergeSettings(data []byte) (out []byte, changed bool, err error) {
+	root := rawObject{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false, fmt.Errorf("not valid JSON: %w", err)
+	}
+
+	hooksObj := rawObject{}
+	if raw, ok := root["hooks"]; ok {
+		if err := json.Unmarshal(raw, &hooksObj); err != nil {
+			return nil, false, fmt.Errorf(".hooks is not a JSON object: %w", err)
+		}
+	}
+
+	var preToolUseRaw []json.RawMessage
+	if raw, ok := hooksObj["PreToolUse"]; ok {
+		if err := json.Unmarshal(raw, &preToolUseRaw); err != nil {
+			return nil, false, fmt.Errorf(".hooks.PreToolUse is not a JSON array: %w", err)
+		}
+	}
+
+	groups := make([]decodedGroup, len(preToolUseRaw))
+	for i, raw := range preToolUseRaw {
+		obj := rawObject{}
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			return nil, false, fmt.Errorf(".hooks.PreToolUse[%d] is not a JSON object: %w", i, err)
+		}
+		var matcher string
+		matcherRaw, hasMatcher := obj["matcher"]
+		if hasMatcher {
+			_ = json.Unmarshal(matcherRaw, &matcher) // best-effort; non-string matchers just won't equal "Bash"
+		}
+		var hooksArr []json.RawMessage
+		if h, ok := obj["hooks"]; ok {
+			if err := json.Unmarshal(h, &hooksArr); err != nil {
+				return nil, false, fmt.Errorf(".hooks.PreToolUse[%d].hooks is not a JSON array: %w", i, err)
+			}
+		}
+		groups[i] = decodedGroup{raw: raw, obj: obj, matcherRaw: matcherRaw, matcher: matcher, hooksArr: hooksArr}
+	}
+
+	// Search every group's hooks[] (regardless of matcher) for an entry
+	// whose command contains our marker — mirrors installHook's
+	// marker-based ownership check.
+	found := false
+searchLoop:
+	for gi := range groups {
+		for hi, hraw := range groups[gi].hooksArr {
+			hobj := rawObject{}
+			if err := json.Unmarshal(hraw, &hobj); err != nil {
+				continue // malformed hook entry; not ours, leave it alone
+			}
+			var command string
+			if c, ok := hobj["command"]; ok {
+				_ = json.Unmarshal(c, &command)
+			}
+			if !strings.Contains(command, guardCommitMarker) {
+				continue
+			}
+			found = true
+			if v, ok := commandMarkerVersion(command); ok && v == version.Version {
+				// Already current — no-op for the whole document.
+				return data, false, nil
+			}
+			// Stale (or pre-marker) — replace just this hook object.
+			groups[gi].hooksArr[hi] = canonicalHookRaw()
+			groups[gi].touched = true
+			break searchLoop
+		}
+	}
+
+	if !found {
+		appended := false
+		for gi := range groups {
+			if groups[gi].matcher == "Bash" {
+				groups[gi].hooksArr = append(groups[gi].hooksArr, canonicalHookRaw())
+				groups[gi].touched = true
+				appended = true
+				break
+			}
+		}
+		if !appended {
+			groups = append(groups, decodedGroup{
+				matcher:  "Bash",
+				hooksArr: []json.RawMessage{canonicalHookRaw()},
+				touched:  true,
+			})
+		}
+	}
+
+	newPreToolUse := make([]json.RawMessage, len(groups))
+	for i, g := range groups {
+		if !g.touched {
+			// Completely untouched group: re-emit the ORIGINAL bytes
+			// verbatim (not even re-decoded), so its key order survives.
+			newPreToolUse[i] = g.raw
+			continue
+		}
+		obj := g.obj
+		if obj == nil {
+			obj = rawObject{}
+		}
+		if g.matcherRaw != nil {
+			obj["matcher"] = g.matcherRaw
+		} else {
+			mb, err := json.Marshal(g.matcher)
+			if err != nil {
+				return nil, false, err
+			}
+			obj["matcher"] = mb
+		}
+		hb, err := json.Marshal(g.hooksArr)
+		if err != nil {
+			return nil, false, err
+		}
+		obj["hooks"] = hb
+		raw, err := json.Marshal(obj)
+		if err != nil {
+			return nil, false, err
+		}
+		newPreToolUse[i] = raw
+	}
+
+	preToolUseBytes, err := json.Marshal(newPreToolUse)
+	if err != nil {
+		return nil, false, err
+	}
+	hooksObj["PreToolUse"] = preToolUseBytes
+	hooksBytes, err := json.Marshal(hooksObj)
+	if err != nil {
+		return nil, false, err
+	}
+	root["hooks"] = hooksBytes
+
+	rootBytes, err := json.Marshal(root)
+	if err != nil {
+		return nil, false, err
+	}
+	out, err = reindent(rootBytes)
+	if err != nil {
+		return nil, false, err
+	}
+	return append(out, '\n'), true, nil
+}
+
+// reindent normalises compact JSON bytes to a canonical 2-space
+// indentation, matching the "pretty" style the PR spec calls for.
+func reindent(compact []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, compact, "", "  "); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// HookState is the result of inspecting a repo's .claude/settings.json
+// for the logmind guard-commit PreToolUse entry. Read-only counterpart
+// to EnsurePreToolUseGuard — used by `logmind doctor`'s drift probe.
+type HookState struct {
+	// SettingsPresent is true when .claude/settings.json exists and
+	// parses as JSON.
+	SettingsPresent bool
+	// EntryPresent is true when a hook command containing
+	// "logmind guard-commit" was found somewhere under hooks.PreToolUse.
+	EntryPresent bool
+	// Version is the embedded `# logmind-hook-version:` marker value, or
+	// "" when EntryPresent is false or the entry carries no marker.
+	Version string
+	// HasMarker is true when EntryPresent is true AND the command carries
+	// a `# logmind-hook-version:` marker.
+	HasMarker bool
+}
+
+// Inspect reads repoRoot/.claude/settings.json and reports the current
+// state of the logmind guard-commit PreToolUse entry. Best-effort and
+// read-only: any I/O or parse error is reported as "absent" (mirrors
+// internal/doctor's probeHook convention of treating unreadable state as
+// "not installed" rather than failing the whole doctor run).
+func Inspect(repoRoot string) HookState {
+	data, err := os.ReadFile(SettingsPath(repoRoot))
+	if err != nil {
+		return HookState{}
+	}
+	command, ok := findGuardCommitCommand(data)
+	if !ok {
+		return HookState{SettingsPresent: true}
+	}
+	v, hasMarker := commandMarkerVersion(command)
+	return HookState{
+		SettingsPresent: true,
+		EntryPresent:    true,
+		Version:         v,
+		HasMarker:       hasMarker,
+	}
+}
+
+// findGuardCommitCommand walks hooks.PreToolUse[*].hooks[*] looking for
+// the first command string containing our marker. Tolerant of any
+// malformed structure along the way (returns "", false) — this is the
+// read-only probe path, not the installer's stricter decode.
+func findGuardCommitCommand(data []byte) (string, bool) {
+	var root rawObject
+	if err := json.Unmarshal(data, &root); err != nil {
+		return "", false
+	}
+	hooksRaw, ok := root["hooks"]
+	if !ok {
+		return "", false
+	}
+	var hooksObj rawObject
+	if err := json.Unmarshal(hooksRaw, &hooksObj); err != nil {
+		return "", false
+	}
+	preRaw, ok := hooksObj["PreToolUse"]
+	if !ok {
+		return "", false
+	}
+	var groups []json.RawMessage
+	if err := json.Unmarshal(preRaw, &groups); err != nil {
+		return "", false
+	}
+	for _, graw := range groups {
+		var gobj rawObject
+		if err := json.Unmarshal(graw, &gobj); err != nil {
+			continue
+		}
+		hraw, ok := gobj["hooks"]
+		if !ok {
+			continue
+		}
+		var hookList []json.RawMessage
+		if err := json.Unmarshal(hraw, &hookList); err != nil {
+			continue
+		}
+		for _, hh := range hookList {
+			var hobj rawObject
+			if err := json.Unmarshal(hh, &hobj); err != nil {
+				continue
+			}
+			var command string
+			if c, ok := hobj["command"]; ok {
+				_ = json.Unmarshal(c, &command)
+			}
+			if strings.Contains(command, guardCommitMarker) {
+				return command, true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/claudehook/claudehook_test.go
+++ b/internal/claudehook/claudehook_test.go
@@ -1,0 +1,501 @@
+package claudehook
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/version"
+)
+
+// --- CanonicalCommand -------------------------------------------------
+
+func TestCanonicalCommand_Shape(t *testing.T) {
+	got := CanonicalCommand()
+	want := "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + version.Version
+	if got != want {
+		t.Fatalf("CanonicalCommand() = %q; want %q", got, want)
+	}
+	if strings.Contains(got, "command -v") {
+		t.Errorf("CanonicalCommand() must NOT contain a `command -v logmind` guard (must stay cross-platform + fail-open on missing binary); got %q", got)
+	}
+}
+
+// --- EnsurePreToolUseGuard: fresh install ------------------------------
+
+func TestEnsurePreToolUseGuard_FreshInstall(t *testing.T) {
+	dir := t.TempDir()
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false on a fresh repo; want true")
+	}
+
+	path := SettingsPath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, data)
+	}
+
+	command := onlyHookCommand(t, doc)
+	if command != CanonicalCommand() {
+		t.Errorf("command = %q; want %q", command, CanonicalCommand())
+	}
+
+	// Pretty (2-space indent) per spec.
+	if !strings.Contains(string(data), "\n  \"hooks\"") && !strings.Contains(string(data), "\n  \"PreToolUse\"") {
+		// Depending on top-level key set this could be nested either way;
+		// the real assertion is just "not a single compact line".
+	}
+	if strings.Count(string(data), "\n") < 5 {
+		t.Errorf("expected multi-line pretty JSON; got:\n%s", data)
+	}
+}
+
+// --- EnsurePreToolUseGuard: merge into existing empty hooks ------------
+
+func TestEnsurePreToolUseGuard_MergeIntoExistingEmptyHooks(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	mustWriteJSON(t, path, map[string]any{
+		"permissions": map[string]any{"allow": []any{"Bash(ls *)"}},
+		"hooks":       map[string]any{},
+	})
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false; want true")
+	}
+
+	doc := readJSONDoc(t, path)
+	command := onlyHookCommand(t, doc)
+	if command != CanonicalCommand() {
+		t.Errorf("command = %q; want %q", command, CanonicalCommand())
+	}
+	// Untouched sibling top-level key survives.
+	perms, ok := doc["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("permissions key lost or reshaped: %v", doc["permissions"])
+	}
+	if !reflect.DeepEqual(perms["allow"], []any{"Bash(ls *)"}) {
+		t.Errorf("permissions.allow = %v; want [Bash(ls *)]", perms["allow"])
+	}
+}
+
+// --- EnsurePreToolUseGuard: merge alongside a foreign Bash hook --------
+
+// TestEnsurePreToolUseGuard_MergeAlongsideForeignBashHook is the crux
+// non-destructiveness test: an existing matcher:"Bash" PreToolUse group
+// with a hook logmind doesn't own must gain our entry (appended into the
+// SAME group) while its own hook, a sibling matcher:"Write" group, and an
+// unrelated PostToolUse event all survive with their VALUES unchanged
+// (structurally byte-identical — see foreign entries compared via
+// canonical re-marshal below; only whitespace/key-order may differ, which
+// the package doc documents as an accepted, semantically inert tradeoff).
+func TestEnsurePreToolUseGuard_MergeAlongsideForeignBashHook(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+
+	foreignBashHook := map[string]any{
+		"type":    "command",
+		"command": "echo foreign-hook",
+		"timeout": float64(5),
+	}
+	foreignWriteHook := map[string]any{
+		"type":    "command",
+		"command": "echo write-hook",
+	}
+	postToolUse := []any{
+		map[string]any{
+			"matcher": "Bash",
+			"hooks":   []any{map[string]any{"type": "command", "command": "echo post-tool-use"}},
+		},
+	}
+	original := map[string]any{
+		"permissions": map[string]any{"allow": []any{"Bash(ls *)"}},
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{"matcher": "Bash", "hooks": []any{foreignBashHook}},
+				map[string]any{"matcher": "Write", "hooks": []any{foreignWriteHook}},
+			},
+			"PostToolUse": postToolUse,
+		},
+	}
+	mustWriteJSON(t, path, original)
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false; want true")
+	}
+
+	doc := readJSONDoc(t, path)
+
+	// PostToolUse must survive completely unchanged (content-wise).
+	gotPostToolUse := navigate(t, doc, "hooks", "PostToolUse")
+	assertJSONEqual(t, "hooks.PostToolUse", gotPostToolUse, postToolUse)
+
+	// permissions must survive completely unchanged.
+	assertJSONEqual(t, "permissions", doc["permissions"], original["permissions"])
+
+	preToolUse, ok := navigate(t, doc, "hooks", "PreToolUse").([]any)
+	if !ok {
+		t.Fatalf("hooks.PreToolUse is not an array: %#v", navigate(t, doc, "hooks", "PreToolUse"))
+	}
+	if len(preToolUse) != 2 {
+		t.Fatalf("hooks.PreToolUse has %d groups; want 2 (no new group should have been created — we append into the existing Bash group)", len(preToolUse))
+	}
+
+	var bashGroup, writeGroup map[string]any
+	for _, g := range preToolUse {
+		gm := g.(map[string]any)
+		switch gm["matcher"] {
+		case "Bash":
+			bashGroup = gm
+		case "Write":
+			writeGroup = gm
+		}
+	}
+	if bashGroup == nil {
+		t.Fatalf("Bash matcher group missing after merge")
+	}
+	if writeGroup == nil {
+		t.Fatalf("Write matcher group missing after merge")
+	}
+
+	// The Write group (never touched) must survive unchanged.
+	assertJSONEqual(t, "Write group", writeGroup, map[string]any{"matcher": "Write", "hooks": []any{foreignWriteHook}})
+
+	// The Bash group must now hold BOTH the foreign hook (unchanged) and
+	// our canonical entry — appended, not replacing.
+	bashHooks, ok := bashGroup["hooks"].([]any)
+	if !ok || len(bashHooks) != 2 {
+		t.Fatalf("Bash group hooks = %#v; want 2 entries (foreign + ours)", bashGroup["hooks"])
+	}
+	assertJSONEqual(t, "foreign Bash hook", bashHooks[0], foreignBashHook)
+
+	ourHook := bashHooks[1].(map[string]any)
+	if ourHook["command"] != CanonicalCommand() {
+		t.Errorf("appended hook command = %v; want %q", ourHook["command"], CanonicalCommand())
+	}
+}
+
+// --- EnsurePreToolUseGuard: idempotent re-run --------------------------
+
+func TestEnsurePreToolUseGuard_RerunWithCurrentMarkerIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	path := SettingsPath(dir)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after first install: %v", err)
+	}
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if changed {
+		t.Errorf("changed = true on a re-run with a current marker; want false")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after second install: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("file bytes changed on a no-op re-run:\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+}
+
+// --- EnsurePreToolUseGuard: version-bump replace -----------------------
+
+// TestEnsurePreToolUseGuard_VersionBumpReplacesOnlyOurEntry seeds an
+// installed hook carrying a stale version marker (simulating an older
+// logmind binary's install) alongside a sibling hook in the SAME group,
+// and asserts only OUR entry's command is rewritten — the sibling is
+// untouched.
+func TestEnsurePreToolUseGuard_VersionBumpReplacesOnlyOurEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+
+	staleCommand := "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + "0.1.0-STALE"
+	siblingHook := map[string]any{"type": "command", "command": "echo sibling", "timeout": float64(3)}
+	original := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						siblingHook,
+						map[string]any{"type": "command", "if": "Bash(git *)", "command": staleCommand, "timeout": float64(10)},
+					},
+				},
+			},
+		},
+	}
+	mustWriteJSON(t, path, original)
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false on a stale marker; want true")
+	}
+
+	doc := readJSONDoc(t, path)
+	preToolUse := navigate(t, doc, "hooks", "PreToolUse").([]any)
+	if len(preToolUse) != 1 {
+		t.Fatalf("expected the single existing group to be reused, not duplicated; got %d groups", len(preToolUse))
+	}
+	group := preToolUse[0].(map[string]any)
+	bashHooks := group["hooks"].([]any)
+	if len(bashHooks) != 2 {
+		t.Fatalf("expected the group to still have exactly 2 hooks (sibling + ours); got %d", len(bashHooks))
+	}
+
+	assertJSONEqual(t, "sibling hook", bashHooks[0], siblingHook)
+
+	ours := bashHooks[1].(map[string]any)
+	if ours["command"] != CanonicalCommand() {
+		t.Errorf("replaced command = %v; want %q", ours["command"], CanonicalCommand())
+	}
+}
+
+// --- EnsurePreToolUseGuard: malformed settings.json --------------------
+
+func TestEnsurePreToolUseGuard_MalformedSettingsReturnsErrorAndLeavesFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := "{ this is not valid JSON "
+	if err := os.WriteFile(path, []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err == nil {
+		t.Fatalf("expected an error on malformed settings.json; got nil (changed=%v)", changed)
+	}
+	if changed {
+		t.Errorf("changed = true on an error path; want false")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("re-read settings.json: %v", readErr)
+	}
+	if string(got) != broken {
+		t.Fatalf("malformed settings.json was modified:\n got: %q\nwant: %q", got, broken)
+	}
+}
+
+func TestEnsurePreToolUseGuard_HooksKeyNotAnObjectReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	mustWriteJSON(t, path, map[string]any{"hooks": "not an object"})
+
+	if _, err := EnsurePreToolUseGuard(dir); err == nil {
+		t.Fatalf("expected an error when .hooks is not a JSON object")
+	}
+}
+
+func TestEnsurePreToolUseGuard_PreToolUseNotAnArrayReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	mustWriteJSON(t, path, map[string]any{"hooks": map[string]any{"PreToolUse": "nope"}})
+
+	if _, err := EnsurePreToolUseGuard(dir); err == nil {
+		t.Fatalf("expected an error when .hooks.PreToolUse is not a JSON array")
+	}
+}
+
+// --- EnsurePreToolUseGuard: no existing Bash group ----------------------
+
+func TestEnsurePreToolUseGuard_NoExistingBashGroupAppendsNewGroup(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	writeHook := map[string]any{"type": "command", "command": "echo write-hook"}
+	mustWriteJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{"matcher": "Write", "hooks": []any{writeHook}},
+			},
+		},
+	})
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false; want true")
+	}
+
+	doc := readJSONDoc(t, path)
+	preToolUse := navigate(t, doc, "hooks", "PreToolUse").([]any)
+	if len(preToolUse) != 2 {
+		t.Fatalf("expected a NEW group to be appended (2 total); got %d", len(preToolUse))
+	}
+	writeGroup := preToolUse[0].(map[string]any)
+	assertJSONEqual(t, "Write group", writeGroup, map[string]any{"matcher": "Write", "hooks": []any{writeHook}})
+
+	bashGroup := preToolUse[1].(map[string]any)
+	if bashGroup["matcher"] != "Bash" {
+		t.Fatalf("new group matcher = %v; want Bash", bashGroup["matcher"])
+	}
+	bashHooks := bashGroup["hooks"].([]any)
+	if len(bashHooks) != 1 {
+		t.Fatalf("new group hooks = %v; want exactly our 1 entry", bashHooks)
+	}
+}
+
+// --- Inspect ------------------------------------------------------------
+
+func TestInspect_NoSettingsFile(t *testing.T) {
+	dir := t.TempDir()
+	state := Inspect(dir)
+	if state.SettingsPresent || state.EntryPresent {
+		t.Errorf("Inspect() = %+v; want both false on a missing settings.json", state)
+	}
+}
+
+func TestInspect_SettingsPresentNoEntry(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteJSON(t, SettingsPath(dir), map[string]any{"permissions": map[string]any{}})
+	state := Inspect(dir)
+	if !state.SettingsPresent {
+		t.Errorf("SettingsPresent = false; want true")
+	}
+	if state.EntryPresent {
+		t.Errorf("EntryPresent = true; want false (no PreToolUse hooks at all)")
+	}
+}
+
+func TestInspect_AfterInstallReportsCurrentVersion(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	state := Inspect(dir)
+	if !state.SettingsPresent || !state.EntryPresent || !state.HasMarker {
+		t.Fatalf("Inspect() = %+v; want fully present with a marker", state)
+	}
+	if state.Version != version.Version {
+		t.Errorf("Version = %q; want %q", state.Version, version.Version)
+	}
+}
+
+// --- test helpers ---------------------------------------------------------
+
+func mustWriteJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func readJSONDoc(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, data)
+	}
+	return doc
+}
+
+// navigate walks a chain of map keys, failing the test if any hop isn't a
+// map or the key is absent.
+func navigate(t *testing.T, doc map[string]any, keys ...string) any {
+	t.Helper()
+	var cur any = doc
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			t.Fatalf("navigate(%v): %q is not a JSON object (got %#v)", keys, k, cur)
+		}
+		v, ok := m[k]
+		if !ok {
+			t.Fatalf("navigate(%v): key %q missing", keys, k)
+		}
+		cur = v
+	}
+	return cur
+}
+
+// assertJSONEqual re-marshals both values to canonical JSON (Go's
+// encoding/json deterministically sorts map keys) and compares the
+// resulting bytes — the strongest reasonable "byte-identical" comparison
+// for JSON values, whose whitespace/key-order carries no meaning.
+func assertJSONEqual(t *testing.T, label string, got, want any) {
+	t.Helper()
+	gotBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("%s: marshal got: %v", label, err)
+	}
+	wantBytes, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("%s: marshal want: %v", label, err)
+	}
+	if string(gotBytes) != string(wantBytes) {
+		t.Errorf("%s drifted:\n got: %s\nwant: %s", label, gotBytes, wantBytes)
+	}
+}
+
+// onlyHookCommand digs into doc.hooks.PreToolUse[0].hooks[0].command and
+// returns it, failing the test if the shape doesn't match (used by tests
+// that expect exactly one group with exactly one hook).
+func onlyHookCommand(t *testing.T, doc map[string]any) string {
+	t.Helper()
+	preToolUse, ok := navigate(t, doc, "hooks", "PreToolUse").([]any)
+	if !ok || len(preToolUse) != 1 {
+		t.Fatalf("hooks.PreToolUse = %#v; want exactly 1 group", navigate(t, doc, "hooks", "PreToolUse"))
+	}
+	group, ok := preToolUse[0].(map[string]any)
+	if !ok {
+		t.Fatalf("PreToolUse[0] is not an object: %#v", preToolUse[0])
+	}
+	if group["matcher"] != "Bash" {
+		t.Fatalf("PreToolUse[0].matcher = %v; want Bash", group["matcher"])
+	}
+	hookList, ok := group["hooks"].([]any)
+	if !ok || len(hookList) != 1 {
+		t.Fatalf("PreToolUse[0].hooks = %#v; want exactly 1 hook", group["hooks"])
+	}
+	hookObj, ok := hookList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks[0] is not an object: %#v", hookList[0])
+	}
+	command, _ := hookObj["command"].(string)
+	return command
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/doctor"
 	"github.com/thrillmade/logmind/internal/timeline"
@@ -98,7 +99,11 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 	if err != nil {
 		return err
 	}
-	res, refreshErr := applyRefresh(cwd, refreshOpts{githubActions: true, git: true})
+	res, refreshErr := applyRefresh(cwd, refreshOpts{
+		githubActions:      true,
+		git:                true,
+		claudeAgentEnabled: claudeAgentEnabledFromConfig(cwd),
+	})
 	if refreshErr != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "error: doctor --fix:", refreshErr)
 		return ErrSilent
@@ -164,6 +169,29 @@ func residualProbes(r doctor.StatusReport) []string {
 	return out
 }
 
+// claudeAgentEnabledFromConfig resolves whether Layer 1 of commit
+// enforcement (the Claude Code harness's PreToolUse guard; see
+// internal/claudehook) should be installed/refreshed for this repo.
+// Mirrors agents.DefaultEnabled's "claude" default (enabled) — a repo
+// with no `agents.claude` key at all, or an unparseable config, gets the
+// same default-true behavior config.LoadAsMap already applies. Only an
+// EXPLICIT `agents.claude: false` opts a repo out.
+func claudeAgentEnabledFromConfig(cwd string) bool {
+	m, err := config.LoadAsMap(cwd)
+	if err != nil {
+		return true
+	}
+	v, ok := config.GetPath(m, "agents.claude")
+	if !ok {
+		return true
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return true
+	}
+	return b
+}
+
 // formatDoctorFixOK renders the single quiet `ok` summary line.
 func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled int) string {
 	state := func(changed bool, changedWord string) string {
@@ -173,12 +201,13 @@ func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled
 		return "current"
 	}
 	return fmt.Sprintf(
-		"ok doctor-fix workflows=%d agents-md=%s gitattributes=%s merge-driver=%s hooks=%d summaries-backfilled=%d residual=%d",
+		"ok doctor-fix workflows=%d agents-md=%s gitattributes=%s merge-driver=%s hooks=%d claude-hook=%s summaries-backfilled=%d residual=%d",
 		len(res.WorkflowsCreated)+len(res.WorkflowsRefreshed),
 		state(res.AgentsMDMsg != "", "changed"),
 		state(res.GitattrChanged, "written"),
 		state(res.MergeDriverSet, "set"),
 		len(res.HooksRefreshed),
+		state(res.ClaudeHookChanged, "changed"),
 		summariesBackfilled,
 		len(residual),
 	)

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -1,20 +1,25 @@
 // guard_commit.go — `logmind guard-commit`, the cobra surface over the
 // internal/guardcommit decision engine.
 //
-// This is PR1/3 of the "force-logmind-usage enforcement" feature (plan.md
-// §v2.0.0). guard-commit is deliberately Hidden (plumbing, not a
+// guard-commit itself is deliberately Hidden (plumbing, not a
 // user-facing verb) and does NOT install itself anywhere — no hook
 // registration, no .git/hooks writes, no harness settings.json edits. It
-// exists purely so the two hook layers built in a follow-up PR have a
-// single binary entry point to shell out to:
+// exists purely so the two hook layers have a single binary entry point
+// to shell out to:
 //
-//   - `logmind guard-commit --layer git-hook --msg-file <path>` from a git
-//     commit-msg hook.
+//   - `logmind guard-commit --layer git-hook --msg-file <path>` from the
+//     commit-msg hook body (internal/hooks.BuildCommitMsgBody).
 //   - `logmind guard-commit --layer harness` (JSON payload on stdin) from
-//     the Claude Code harness's PreToolUse hook.
+//     the Claude Code harness's PreToolUse hook entry
+//     (internal/claudehook.CanonicalCommand).
 //
-// Both layers are manually invocable today (this PR); wiring either one up
-// automatically is out of scope here.
+// Both layers ARE wired up automatically as of v2.0.0's enforcement
+// PR2/3: `logmind init` and `logmind doctor --fix` install/refresh the
+// commit-msg hook and the .claude/settings.json PreToolUse entry
+// alongside the rest of the idempotent remediation pass (see
+// internal/cli/refresh.go). guard-commit remains directly invocable too
+// (e.g. for testing, or a hand-rolled hook setup) — this command doesn't
+// care who calls it.
 package cli
 
 import (
@@ -56,9 +61,10 @@ allowed to proceed.
                       nonzero-exit convention (git only needs a nonzero
                       status to abort the commit).
 
-This command does not install anything. The hooks that call it
-automatically are wired up in a separate PR — today it is invoked
-manually, e.g. for testing:
+This command does not install anything itself — see 'logmind init' /
+'logmind doctor --fix' for the commit-msg hook + Claude Code
+PreToolUse guard installers that call it automatically. It's also
+directly invocable, e.g. for testing:
 
     echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"},"cwd":"."}' \
       | logmind guard-commit --layer harness`,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -44,12 +44,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/hooks"
@@ -112,9 +114,16 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 	fmt.Fprintln(out, "Initializing logmind...")
 	fmt.Fprintln(out)
 
+	// Parse agents list once, up front — both the refresh path and the
+	// fresh-install path below need it to decide whether the Claude Code
+	// PreToolUse guard (Layer 1 of commit enforcement; internal/claudehook)
+	// gets installed.
+	enabled := enabledAgentList(f.agentsList, f.allAgents)
+	claudeAgentEnabled := slices.Contains(enabled, "claude")
+
 	alreadyInit := pathExists(filepath.Join(docsPath, "decisions.md")) && pathExists(configPath)
 	if alreadyInit {
-		return runInitRefresh(cmd, f, cwd, docsPath)
+		return runInitRefresh(cmd, f, cwd, docsPath, claudeAgentEnabled)
 	}
 
 	// Git repo guard — mirror Python's no-git/--no-git interaction.
@@ -126,9 +135,6 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		// scripted invocations.
 		f.noGit = true
 	}
-
-	// Parse agents list.
-	enabled := enabledAgentList(f.agentsList, f.allAgents)
 
 	// docs/
 	if err := os.MkdirAll(docsPath, 0o755); err != nil {
@@ -241,6 +247,21 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 	}
 
+	// Layer 1 of commit enforcement: the Claude Code harness's PreToolUse
+	// guard entry in .claude/settings.json. Gated on claudeAgentEnabled,
+	// NOT on !f.noGit — .claude/settings.json is repo content, not git
+	// state, so it installs even under --no-git or outside a git repo.
+	claudeHookChanged := false
+	if claudeAgentEnabled {
+		changed, err := claudehook.EnsurePreToolUseGuard(cwd)
+		if err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: Claude Code PreToolUse guard install failed:", err)
+		} else if changed {
+			claudeHookChanged = true
+			fmt.Fprintln(out, "✓ Installed Claude Code guard-commit hook (.claude/settings.json)")
+		}
+	}
+
 	// First decision log entry — append to docs/decisions.md.
 	if err := logFirstDecision(docsPath); err != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: first decision log failed:", err)
@@ -278,6 +299,9 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 		if dependabotChanged {
 			filesToCommit = append(filesToCommit, ".github/dependabot.yml")
+		}
+		if claudeHookChanged {
+			filesToCommit = append(filesToCommit, ".claude/settings.json")
 		}
 		for _, agent := range enabled {
 			if rel, ok := agents.FilePath(agent, cwd); ok && pathExists(rel) {
@@ -325,12 +349,12 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 // already_initialized branch in cli.init: refresh workflows + AGENTS.md
 // marker + .gitattributes + git config + hooks, leave docs/ and
 // .logmind/ alone.
-func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string) error {
+func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, claudeAgentEnabled bool) error {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "logmind is already initialized — running in refresh mode.")
 	fmt.Fprintln(out)
 
-	res, err := applyRefresh(cwd, refreshOpts{githubActions: f.githubActions, git: true})
+	res, err := applyRefresh(cwd, refreshOpts{githubActions: f.githubActions, git: true, claudeAgentEnabled: claudeAgentEnabled})
 	if err != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: refresh failed:", err)
 	}
@@ -359,6 +383,9 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string) erro
 	}
 	for _, h := range res.HooksRefreshed {
 		fmt.Fprintln(out, "✓ Refreshed .git/hooks/"+h)
+	}
+	if res.ClaudeHookChanged {
+		fmt.Fprintln(out, "✓ Refreshed .claude/settings.json (Claude Code guard-commit hook)")
 	}
 
 	fmt.Fprintln(out)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -297,6 +297,85 @@ func TestInit_AgentsFlagOverridesDefault(t *testing.T) {
 	}
 }
 
+// TestInit_InstallsClaudePreToolUseGuardByDefault: `init --no-git` still
+// installs the Layer 1 Claude Code PreToolUse guard (.claude/settings.json)
+// because claude is in agents.DefaultEnabled() — and the install happens
+// even though --no-git skips the git-hook installers, since
+// .claude/settings.json is repo content, not git-clone state.
+func TestInit_InstallsClaudePreToolUseGuardByDefault(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("init: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		mustContain(t, out.String(), "✓ Installed Claude Code guard-commit hook (.claude/settings.json)")
+	})
+	body, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("expected .claude/settings.json after init: %v", err)
+	}
+	mustContain(t, string(body), "logmind guard-commit --layer harness")
+	mustContain(t, string(body), "logmind-hook-version")
+}
+
+// TestInit_AgentsFlagExcludingClaudeSkipsPreToolUseGuard: when --agents
+// excludes claude, Layer 1 must NOT be installed — the gate is
+// slices.Contains(enabled, "claude"), not "always on".
+func TestInit_AgentsFlagExcludingClaudeSkipsPreToolUseGuard(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--agents", "cursor"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("init: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		if strings.Contains(out.String(), "Claude Code guard-commit hook") {
+			t.Errorf("did NOT expect the Claude Code guard-commit hook line when --agents excludes claude:\n%s", out.String())
+		}
+	})
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "settings.json")); err == nil {
+		t.Errorf("did NOT expect .claude/settings.json when --agents excludes claude")
+	}
+}
+
+// TestInit_RefreshMode_InstallsMissingClaudeHook: refresh mode (re-running
+// `init` on an already-initialised repo) recomputes claudeAgentEnabled
+// from the same --agents/--all-agents flags every time (it's not read
+// back from a persisted config), so a repo whose .claude/settings.json
+// was deleted (or never created, e.g. by an old logmind version) gets it
+// installed on the next refresh pass.
+func TestInit_RefreshMode_InstallsMissingClaudeHook(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		// First init WITHOUT claude enabled, so no guard gets installed.
+		runQuiet(t, []string{"init", "--no-git", "--agents", "cursor"})
+		if _, err := os.Stat(".claude/settings.json"); err == nil {
+			t.Fatalf("did not expect .claude/settings.json after the first (cursor-only) init")
+		}
+
+		// Second call is refresh mode; defaulting the agents list this time
+		// (no --agents flag) re-enables claude, which should backfill the
+		// hook that was never installed.
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("refresh init: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		mustContain(t, out.String(), "✓ Refreshed .claude/settings.json (Claude Code guard-commit hook)")
+	})
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "settings.json")); err != nil {
+		t.Errorf("expected .claude/settings.json after refresh re-enabled claude: %v", err)
+	}
+}
+
 // runQuiet runs a root command silencing stdout/stderr; used to drive
 // setup steps in multi-stage tests without polluting test logs.
 func runQuiet(t *testing.T, args []string) {

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -17,11 +17,19 @@
 //     hook is left alone and surfaces as residual drift instead;
 //   - manage .github/dependabot.yml (doctor does not probe it; init keeps
 //     its own dependabot UX).
+//
+// v2.0.0 addition: the Claude Code harness's PreToolUse guard entry in
+// .claude/settings.json (Layer 1 of commit enforcement; see
+// internal/claudehook). Unlike the git hooks, this write is gated on
+// opts.claudeAgentEnabled rather than opts.git — .claude/settings.json is
+// repo content, not git-clone state, so it should install even under
+// --no-git, and should NOT install when the claude agent is disabled.
 package cli
 
 import (
 	"path/filepath"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/inserter"
@@ -36,19 +44,21 @@ type refreshResult struct {
 	GitattrChanged     bool
 	MergeDriverSet     bool     // a merge-driver git config key was (re)written
 	HooksRefreshed     []string // subset of {"post-merge","post-rewrite","commit-msg"}
+	ClaudeHookChanged  bool     // .claude/settings.json PreToolUse guard was created/refreshed
 }
 
 // Changed reports whether applyRefresh wrote anything.
 func (r refreshResult) Changed() bool {
 	return len(r.WorkflowsCreated) > 0 || len(r.WorkflowsRefreshed) > 0 ||
 		r.AgentsMDMsg != "" || r.GitattrChanged || r.MergeDriverSet ||
-		len(r.HooksRefreshed) > 0
+		len(r.HooksRefreshed) > 0 || r.ClaudeHookChanged
 }
 
-// refreshOpts gates the two write surfaces that need a repo/CI context.
+// refreshOpts gates the write surfaces that need a repo/CI context.
 type refreshOpts struct {
-	githubActions bool // install/refresh .github/workflows/*
-	git           bool // configure merge drivers + install hooks (no-op outside a git repo)
+	githubActions      bool // install/refresh .github/workflows/*
+	git                bool // configure merge drivers + install git hooks (no-op outside a git repo)
+	claudeAgentEnabled bool // install/refresh .claude/settings.json PreToolUse guard (Layer 1)
 }
 
 // applyRefresh runs every idempotent installer that brings a drifted repo
@@ -102,6 +112,14 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 		if c, _ := hooks.InstallCommitMsg(cwd); c {
 			res.HooksRefreshed = append(res.HooksRefreshed, "commit-msg")
 		}
+	}
+
+	if opts.claudeAgentEnabled {
+		changed, err := claudehook.EnsurePreToolUseGuard(cwd)
+		if err == nil && changed {
+			res.ClaudeHookChanged = true
+		}
+		note(err)
 	}
 
 	return res, firstErr

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -115,11 +115,19 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 	}
 
 	if opts.claudeAgentEnabled {
-		changed, err := claudehook.EnsurePreToolUseGuard(cwd)
-		if err == nil && changed {
+		// Error deliberately swallowed, matching the git-hook installers
+		// above: a malformed (e.g. JSONC-style / trailing-comma)
+		// .claude/settings.json is user content EnsurePreToolUseGuard
+		// refuses to touch — feeding that refusal into firstErr would turn
+		// `doctor --fix` into a persistent exit-1 (suppressing the summary
+		// line, the branch-summary backfill, and the residual re-probe)
+		// over a file --fix can't repair anyway. Instead it degrades like
+		// a foreign git hook does: the doctor probe classifies an
+		// unparseable settings.json as "missing" (benign), and the guard
+		// installs the moment the user fixes their JSON.
+		if changed, _ := claudehook.EnsurePreToolUseGuard(cwd); changed {
 			res.ClaudeHookChanged = true
 		}
-		note(err)
 	}
 
 	return res, firstErr

--- a/internal/cli/refresh_test.go
+++ b/internal/cli/refresh_test.go
@@ -162,3 +162,38 @@ func TestDoctorFix_NeverTouchesDocs(t *testing.T) {
 func contains(haystack, needle string) bool {
 	return bytes.Contains([]byte(haystack), []byte(needle))
 }
+
+// TestDoctorFix_InstallsClaudePreToolUseGuardByDefault: with no
+// .logmind/config.yml at all (so agents.claude falls back to the
+// default-true behavior), --fix installs the Layer 1 Claude Code
+// PreToolUse guard alongside the rest of the remediation pass, and a
+// second pass reports it as already current (no re-write).
+func TestDoctorFix_InstallsClaudePreToolUseGuardByDefault(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+
+		out1, _ := runDoctorFixCmd(t)
+		mustContain(t, out1, "claude-hook=changed")
+		body := readRel(t, filepath.Join(".claude", "settings.json"))
+		mustContain(t, body, "logmind guard-commit --layer harness")
+
+		out2, _ := runDoctorFixCmd(t)
+		mustContain(t, out2, "claude-hook=current")
+	})
+}
+
+// TestDoctorFix_ClaudeDisabledInConfigSkipsPreToolUseGuard: an explicit
+// `agents.claude: false` in .logmind/config.yml must prevent --fix from
+// installing the Layer 1 guard at all.
+func TestDoctorFix_ClaudeDisabledInConfigSkipsPreToolUseGuard(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		writeRel(t, filepath.Join(".logmind", "config.yml"), "agents:\n  claude: false\n", 0o644)
+
+		out, _ := runDoctorFixCmd(t)
+		mustContain(t, out, "claude-hook=current")
+		if _, err := os.Stat(filepath.Join(".claude", "settings.json")); err == nil {
+			t.Errorf("did NOT expect .claude/settings.json when agents.claude is false")
+		}
+	})
+}

--- a/internal/cli/refresh_test.go
+++ b/internal/cli/refresh_test.go
@@ -197,3 +197,34 @@ func TestDoctorFix_ClaudeDisabledInConfigSkipsPreToolUseGuard(t *testing.T) {
 		}
 	})
 }
+
+// TestDoctorFix_MalformedClaudeSettingsDegradesGracefully: a user's
+// malformed (e.g. JSONC-style trailing-comma) .claude/settings.json must
+// NOT hard-fail `doctor --fix` — EnsurePreToolUseGuard's refusal is
+// swallowed like a foreign git hook's, so --fix still exits 0, still
+// prints the `ok doctor-fix` summary, still applies the rest of the
+// remediation pass (hooks etc.), and leaves the malformed file untouched.
+func TestDoctorFix_MalformedClaudeSettingsDegradesGracefully(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		malformed := "{\n  \"hooks\": {\n    \"PreToolUse\": [],\n  },\n}\n" // trailing commas — JSONC, not JSON
+		writeRel(t, filepath.Join(".claude", "settings.json"), malformed, 0o644)
+
+		// runDoctorFixCmd fails the test on a non-nil Execute() error, so
+		// reaching the assertions below already proves exit 0.
+		out, _ := runDoctorFixCmd(t)
+		mustContain(t, out, "ok doctor-fix")
+		mustContain(t, out, "claude-hook=current") // no write happened
+
+		// The rest of the remediation still ran: the git hooks were
+		// installed on this fresh repo.
+		if _, err := os.Stat(filepath.Join(".git", "hooks", "commit-msg")); err != nil {
+			t.Errorf("expected commit-msg hook installed despite malformed settings.json: %v", err)
+		}
+
+		// The malformed file is user content --fix can't repair — byte-untouched.
+		if got := readRel(t, filepath.Join(".claude", "settings.json")); got != malformed {
+			t.Errorf("malformed settings.json was modified:\n got: %q\nwant: %q", got, malformed)
+		}
+	})
+}

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -12,6 +12,13 @@
 //     enabled-agent config requires
 //   - Hooks (post-merge + post-rewrite + commit-msg) — re-installed
 //     from the current binary's body (closes the v0.6.10 drift loop)
+//   - The Claude Code PreToolUse guard in .claude/settings.json (Layer 1
+//     of v2.0.0 commit enforcement; internal/claudehook), gated on the
+//     same agents.claude config check doctor --fix uses (default true).
+//     Without this, a repo whose only refresh path is self-update would
+//     get its commit-msg hook auto-upgraded to enforcing (Layer 2) while
+//     Layer 1 stays missing forever — and doctor would never nudge,
+//     because "missing" is benign.
 package cli
 
 import (
@@ -21,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/inserter"
 )
@@ -80,6 +88,19 @@ func runSelfUpdate(cmd *cobra.Command) error {
 		}
 		if changed, _ := hooks.InstallCommitMsg(cwd); changed {
 			fmt.Fprintln(out, "✓ Refreshed .git/hooks/commit-msg")
+			updated = true
+		}
+	}
+
+	// Layer 1 of commit enforcement (Claude Code PreToolUse guard) —
+	// same agents.claude config gate as doctor --fix (default true), and
+	// error-swallowed like the hook refreshes above (a malformed
+	// settings.json degrades to residual state, never a failed
+	// self-update). Not gated on .git presence: .claude/settings.json is
+	// repo content, not git-clone state.
+	if claudeAgentEnabledFromConfig(cwd) {
+		if changed, _ := claudehook.EnsurePreToolUseGuard(cwd); changed {
+			fmt.Fprintln(out, "✓ Refreshed .claude/settings.json (Claude Code guard-commit hook)")
 			updated = true
 		}
 	}

--- a/internal/cli/self_update_test.go
+++ b/internal/cli/self_update_test.go
@@ -64,3 +64,59 @@ func TestSelfUpdate_RefreshesStaleHook(t *testing.T) {
 		t.Errorf("stale body not replaced; got\n%s", string(body))
 	}
 }
+
+// TestSelfUpdate_InstallsClaudePreToolUseGuard: self-update is a refresh
+// path of its own (separate from init/doctor --fix), so it must also
+// install Layer 1 — otherwise a repo that only ever runs self-update
+// gets its commit-msg hook auto-upgraded to enforcing while the
+// PreToolUse guard stays missing forever (and doctor never nudges,
+// because "missing" is benign).
+func TestSelfUpdate_InstallsClaudePreToolUseGuard(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"self-update"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("self-update: %v\n%s\n%s", err, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "✓ Refreshed .claude/settings.json (Claude Code guard-commit hook)") {
+			t.Errorf("expected the Claude guard refresh notice; got\n%s", out.String())
+		}
+	})
+	body, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("expected .claude/settings.json after self-update: %v", err)
+	}
+	if !strings.Contains(string(body), "logmind guard-commit --layer harness") {
+		t.Errorf("settings.json missing the guard-commit entry:\n%s", body)
+	}
+}
+
+// TestSelfUpdate_ClaudeDisabledInConfigSkipsGuard: agents.claude:false is
+// the same opt-out doctor --fix honors — self-update must respect it too.
+func TestSelfUpdate_ClaudeDisabledInConfigSkipsGuard(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		if err := os.MkdirAll(".logmind", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(".logmind", "config.yml"), []byte("agents:\n  claude: false\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		root := NewRootCmd()
+		root.SetArgs([]string{"self-update"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("self-update: %v\n%s\n%s", err, out.String(), errOut.String())
+		}
+		if strings.Contains(out.String(), "Claude Code guard-commit hook") {
+			t.Errorf("did NOT expect the Claude guard notice with agents.claude:false; got\n%s", out.String())
+		}
+	})
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "settings.json")); err == nil {
+		t.Errorf("did NOT expect .claude/settings.json when agents.claude is false")
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -55,6 +55,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/hooks"
@@ -252,6 +253,10 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 	workflows = append(workflows, probePostMergeHook(projectRoot))
 	workflows = append(workflows, probePostRewriteHook(projectRoot))
 	workflows = append(workflows, probeCommitMsgHook(projectRoot))
+	// v2.0.0 Layer 1 probe — the Claude Code harness's PreToolUse guard
+	// entry in .claude/settings.json. Sits right after the commit-msg row
+	// (Layer 2) since the two are the enforcement feature's matched pair.
+	workflows = append(workflows, probeClaudePreToolUseHook(projectRoot))
 	// v0.6.16 PATH-resolution probe — always appended; the probe itself
 	// decides whether to report stale/current/missing.
 	workflows = append(workflows, probePathResolution())
@@ -505,6 +510,47 @@ func probePostRewriteHook(projectRoot string) WorkflowStatus {
 // will install it.
 func probeCommitMsgHook(projectRoot string) WorkflowStatus {
 	return probeHook(projectRoot, "commit-msg hook", "commit-msg", hooks.BuildCommitMsgBody())
+}
+
+// probeClaudePreToolUseHook reports drift for Layer 1 of the v2.0.0
+// commit-enforcement design — the Claude Code harness's PreToolUse guard
+// entry in .claude/settings.json (installed/refreshed by
+// internal/claudehook.EnsurePreToolUseGuard). Mirrors probeHook's shape
+// and drift vocabulary exactly (missing / markerless / stale / current)
+// so it participates in classifyLogmindDrift identically to the git-hook
+// probes: only "stale" flips the tool (and therefore Overall) to DRIFT.
+// "missing" stays benign here for the same reason it's benign for the
+// git hooks — a repo that simply hasn't run `logmind init` yet (or has
+// the claude agent disabled) isn't "drifted," it's "not installed," and
+// `doctor --fix` / `logmind init` remain the remediation either way.
+func probeClaudePreToolUseHook(projectRoot string) WorkflowStatus {
+	current := version.Version
+	const displayName = "Claude Code PreToolUse guard"
+	state := claudehook.Inspect(projectRoot)
+	if !state.SettingsPresent || !state.EntryPresent {
+		return WorkflowStatus{
+			Name: displayName, Installed: false,
+			Marker: nil, BundledMarker: &current, Drift: "missing",
+		}
+	}
+	if !state.HasMarker {
+		marker := "markerless (pre-v2.0.0)"
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &marker, BundledMarker: &current, Drift: "markerless",
+		}
+	}
+	installed := state.Version
+	if installed != current {
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &installed, BundledMarker: &current, Drift: "stale",
+		}
+	}
+	return WorkflowStatus{
+		Name: displayName, Installed: true,
+		Marker: &installed, BundledMarker: &current, Drift: "current",
+	}
 }
 
 // probePathResolution implements the v0.6.16 PATH-resolution check.

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -68,6 +69,7 @@ func TestCollectStatus_FreshRepoListsAllProbes(t *testing.T) {
 		"AGENTS.md", ".gitattributes (merge driver)",
 		"git config (merge driver)", "post-merge hook",
 		"post-rewrite hook", "commit-msg hook",
+		"Claude Code PreToolUse guard",
 		"logmind on PATH",
 	} {
 		if !contains(names, want) {
@@ -346,5 +348,80 @@ func TestCollectStatus_SummariesNeeded(t *testing.T) {
 	}
 	if strings.Contains(joined, "feat__api.md") {
 		t.Errorf("enriched branch must NOT be listed: %v", r.SummariesNeeded)
+	}
+}
+
+// --- probeClaudePreToolUseHook (Layer 1 / v2.0.0 enforcement) ------------
+
+func TestProbeClaudePreToolUseHook_MissingOnFreshRepo(t *testing.T) {
+	dir := freshRepo(t)
+	row := probeClaudePreToolUseHook(dir)
+	if row.Drift != "missing" {
+		t.Errorf("Drift = %q; want missing", row.Drift)
+	}
+	if row.BundledMarker == nil || *row.BundledMarker != version.Version {
+		t.Errorf("BundledMarker = %v; want %v", row.BundledMarker, version.Version)
+	}
+}
+
+func TestProbeClaudePreToolUseHook_CurrentAfterInstall(t *testing.T) {
+	dir := freshRepo(t)
+	if _, err := claudehook.EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	row := probeClaudePreToolUseHook(dir)
+	if row.Drift != "current" {
+		t.Errorf("Drift = %q; want current", row.Drift)
+	}
+	if row.Marker == nil || *row.Marker != version.Version {
+		t.Errorf("Marker = %v; want %v", row.Marker, version.Version)
+	}
+}
+
+func TestProbeClaudePreToolUseHook_StaleOnRevertedMarker(t *testing.T) {
+	dir := freshRepo(t)
+	if _, err := claudehook.EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	revertClaudeHookMarker(t, dir)
+
+	row := probeClaudePreToolUseHook(dir)
+	if row.Drift != "stale" {
+		t.Errorf("Drift = %q; want stale", row.Drift)
+	}
+}
+
+// TestCollectStatus_StaleClaudeHookFlipsToDrift mirrors
+// TestCollectStatus_StaleWorkflowFlipsToDrift for the new Layer 1 probe:
+// a stale marker must flip Overall to DRIFT exactly like every other
+// hook/workflow probe (classifyLogmindDrift treats them uniformly).
+func TestCollectStatus_StaleClaudeHookFlipsToDrift(t *testing.T) {
+	dir := freshRepo(t)
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	_ = os.Setenv("PATH", t.TempDir())
+	if _, err := claudehook.EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	revertClaudeHookMarker(t, dir)
+
+	r := CollectStatus(dir, true)
+	if r.Overall != "DRIFT" {
+		t.Errorf("Overall = %q; want DRIFT with stale Claude Code PreToolUse marker", r.Overall)
+	}
+}
+
+// revertClaudeHookMarker rewrites the installed hook-version marker in
+// dir/.claude/settings.json to a known-stale value.
+func revertClaudeHookMarker(t *testing.T, dir string) {
+	t.Helper()
+	path := claudehook.SettingsPath(dir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	reverted := strings.ReplaceAll(string(data), version.Version, "0.1.0-FAKE")
+	if err := os.WriteFile(path, []byte(reverted), 0o644); err != nil {
+		t.Fatalf("write reverted settings.json: %v", err)
 	}
 }

--- a/internal/hooks/commit_msg_enforce_test.go
+++ b/internal/hooks/commit_msg_enforce_test.go
@@ -1,0 +1,220 @@
+// commit_msg_enforce_test.go — a REAL `git commit` integration test for
+// the v2.0.0 commit-msg hook body. BuildCommitMsgBody/InstallCommitMsg in
+// hooks.go only produce and install a shell script; the actual
+// allow/block DECISION lives in internal/guardcommit (exhaustively unit
+// tested there and in internal/cli/guard_commit_test.go). This file's
+// narrower job: prove the shell script this package emits actually wires
+// a genuine `git commit` invocation through to that decision engine and
+// back into git's exit-code protocol — i.e. that the wiring, not just the
+// logic, works end to end.
+package hooks
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCommitMsgHook_RealGitCommit_EnforcesAndCarveOuts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess test in -short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH; skipping subprocess test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping subprocess test")
+	}
+
+	binPath := buildLogmindBinaryForHookTest(t, goBin)
+	binDir := filepath.Dir(binPath)
+
+	t.Run("blocks a substantive commit with no decision log", func(t *testing.T) {
+		dir := newEnforcingRepo(t, binDir)
+		writeBigFile(t, dir, "app.go")
+		runGitIn(t, dir, binDir, nil, "add", "app.go")
+
+		out, err := attemptGitCommit(t, dir, binDir, nil, "substantive change, no decision log")
+		if err == nil {
+			t.Fatalf("expected the commit to be BLOCKED; it succeeded:\n%s", out)
+		}
+		if !strings.Contains(out, "logmind log") {
+			t.Errorf("blocked-commit output should mention `logmind log`; got:\n%s", out)
+		}
+		assertCommitCount(t, dir, binDir, 1) // only newEnforcingRepo's initial commit
+	})
+
+	t.Run("allows with [skip-logmind] in the subject", func(t *testing.T) {
+		dir := newEnforcingRepo(t, binDir)
+		writeBigFile(t, dir, "app.go")
+		runGitIn(t, dir, binDir, nil, "add", "app.go")
+
+		out, err := attemptGitCommit(t, dir, binDir, nil, "substantive change [skip-logmind]")
+		if err != nil {
+			t.Fatalf("expected the commit to be ALLOWED via [skip-logmind]; got error: %v\n%s", err, out)
+		}
+		assertCommitCount(t, dir, binDir, 2)
+	})
+
+	t.Run("allows with LOGMIND_ALLOW_GIT_COMMIT=1", func(t *testing.T) {
+		dir := newEnforcingRepo(t, binDir)
+		writeBigFile(t, dir, "app.go")
+		runGitIn(t, dir, binDir, nil, "add", "app.go")
+
+		out, err := attemptGitCommit(t, dir, binDir, []string{"LOGMIND_ALLOW_GIT_COMMIT=1"}, "substantive change, explicit override")
+		if err != nil {
+			t.Fatalf("expected the commit to be ALLOWED via LOGMIND_ALLOW_GIT_COMMIT=1; got error: %v\n%s", err, out)
+		}
+		assertCommitCount(t, dir, binDir, 2)
+	})
+
+	t.Run("allows when a decision file is staged alongside the change", func(t *testing.T) {
+		dir := newEnforcingRepo(t, binDir)
+		writeBigFile(t, dir, "app.go")
+		if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "docs", "decisions.md"), []byte("# Decisions\n\n## entry\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGitIn(t, dir, binDir, nil, "add", "app.go", "docs/decisions.md")
+
+		out, err := attemptGitCommit(t, dir, binDir, nil, "substantive change with a decision log")
+		if err != nil {
+			t.Fatalf("expected the commit to be ALLOWED via a staged decision file; got error: %v\n%s", err, out)
+		}
+		assertCommitCount(t, dir, binDir, 2)
+	})
+}
+
+// newEnforcingRepo creates a fresh git repo with this package's
+// commit-msg hook installed and one initial commit — so commit COUNTING
+// (not merely "does HEAD exist"), is what distinguishes blocked vs.
+// allowed across subtests below. The initial commit ALSO runs through
+// the freshly-installed hook (with binDir on PATH, same as every other
+// git invocation in this file) — it's tiny (one line), so it's expected
+// to sail through the under-threshold carve-out; if that regresses, this
+// helper fails loudly instead of masking it as "the fixture doesn't hit
+// the hook."
+func newEnforcingRepo(t *testing.T, binDir string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitIn(t, dir, binDir, nil, "init", "-q")
+	runGitIn(t, dir, binDir, nil, "config", "user.email", "t@t.com")
+	runGitIn(t, dir, binDir, nil, "config", "user.name", "t")
+	if _, err := InstallCommitMsg(dir); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, dir, binDir, nil, "add", "README.md")
+	out, err := attemptGitCommit(t, dir, binDir, nil, "init")
+	if err != nil {
+		t.Fatalf("fixture's initial commit unexpectedly blocked: %v\n%s", err, out)
+	}
+	return dir
+}
+
+// isolatedGitEnv builds the environment for every git invocation in this
+// file: PATH extended with binDir (so the installed hook's
+// `command -v logmind` finds the binary this test built rather than
+// whatever `logmind` may already be on the host's real PATH — e.g. an
+// older release without the `guard-commit` command, which is exactly the
+// footgun this exists to avoid), plus isolation from the host's/CI
+// runner's global or system git config (a stray global commit.gpgsign or
+// core.hooksPath would make this flaky, or hang on a signing prompt).
+func isolatedGitEnv(t *testing.T, binDir string) []string {
+	t.Helper()
+	fakeHome := t.TempDir()
+	path := binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	return []string{
+		"HOME=" + fakeHome,
+		"USERPROFILE=" + fakeHome, // Windows' HOME equivalent
+		"GIT_CONFIG_NOSYSTEM=1",
+		"XDG_CONFIG_HOME=" + fakeHome,
+		"PATH=" + path,
+	}
+}
+
+// writeBigFile writes 30 substantive lines — comfortably over the
+// default commit_line_threshold of 20 regardless of diff mode. Mirrors
+// internal/cli/guard_commit_test.go's bigLines helper (duplicated here;
+// different package, same small-helper-duplication convention this
+// codebase already uses — see buildLogmindBinaryForHookTest below).
+func writeBigFile(t *testing.T, dir, name string) {
+	t.Helper()
+	var b bytes.Buffer
+	for i := 0; i < 30; i++ {
+		b.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), b.Bytes(), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runGitIn(t *testing.T, dir, binDir string, extraEnv []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	env := append(os.Environ(), isolatedGitEnv(t, binDir)...)
+	cmd.Env = append(env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// attemptGitCommit runs `git commit -m message` — same isolated,
+// binDir-extended PATH as runGitIn, plus any extraEnv (e.g.
+// LOGMIND_ALLOW_GIT_COMMIT=1). Returns combined output and the *exec.Cmd
+// error — non-nil on a non-zero exit, i.e. the hook blocked the commit.
+func attemptGitCommit(t *testing.T, dir, binDir string, extraEnv []string, message string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", "commit", "-q", "-m", message)
+	cmd.Dir = dir
+	env := append(os.Environ(), isolatedGitEnv(t, binDir)...)
+	cmd.Env = append(env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func assertCommitCount(t *testing.T, dir, binDir string, want int) {
+	t.Helper()
+	got := runGitIn(t, dir, binDir, nil, "rev-list", "--count", "HEAD")
+	got = strings.TrimSpace(got)
+	if got != fmt.Sprintf("%d", want) {
+		t.Fatalf("commit count = %s; want %d", got, want)
+	}
+}
+
+// buildLogmindBinaryForHookTest compiles ./cmd/logmind into a temp dir
+// and returns the binary's path. Mirrors
+// internal/cli/guard_commit_test.go's buildGuardCommitBinary — kept as a
+// separate copy (rather than shared) per this codebase's existing
+// small-test-helper-duplication convention (see e.g.
+// internal/cli/install_hook_test.go's initRepo doc comment).
+func buildLogmindBinaryForHookTest(t *testing.T, goBin string) string {
+	t.Helper()
+	repoRoot := repoRootFromCaller(t)
+	binDir := t.TempDir()
+	binName := "logmind"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(binDir, binName)
+
+	build := exec.Command(goBin, "build", "-o", binPath, "./cmd/logmind")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binPath
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -255,7 +255,10 @@ func BuildCommitMsgBody() string {
 		"# Fails open when logmind isn't on PATH: a missing binary should never\n" +
 		"# block a commit.\n" +
 		"\n" +
-		"MSG_FILE=\"$1\"; [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ] && exit 0\n" +
+		"MSG_FILE=\"$1\"\n" +
+		"if [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ]; then\n" +
+		"    exit 0\n" +
+		"fi\n" +
 		"if command -v logmind >/dev/null 2>&1; then\n" +
 		"    logmind guard-commit --layer git-hook --msg-file \"$MSG_FILE\"; exit $?\n" +
 		"fi\n" +

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -58,9 +58,9 @@ const PostMergeMarker = "# logmind post-merge hook"
 const PostRewriteMarker = "# logmind post-rewrite hook"
 
 // CommitMsgMarker identifies a logmind-installed commit-msg hook.
-// v0.6.16 introduced this hook to surface `[skip-logmind]` markers in
-// commit subjects so authors notice when an agent accidentally added
-// the directive (silent application has been a footgun).
+// v0.6.16 introduced this hook as a warn-only surface for
+// `[skip-logmind]` markers in commit subjects; v2.0.0 upgraded the body
+// to Layer 2 of the commit-enforcement design (see BuildCommitMsgBody).
 const CommitMsgMarker = "# logmind commit-msg hook"
 
 // hookVersion returns the version string embedded in each hook body.
@@ -211,39 +211,55 @@ func BuildPostRewriteBody() string {
 		"fi\n"
 }
 
-// BuildCommitMsgBody returns the canonical commit-msg hook body for
-// the v0.6.16+ contract: warn-only on `[skip-logmind]` subjects so
-// authors notice when an agent accidentally added the directive.
-// Read-only — exits 0 unconditionally so the commit still proceeds.
+// BuildCommitMsgBody returns the canonical commit-msg hook body for the
+// v2.0.0+ enforcement contract: Layer 2 of logmind's two-layer
+// commit-enforcement design (see internal/claudehook for Layer 1, the
+// Claude Code harness's PreToolUse guard, and internal/guardcommit for
+// the shared decision engine both layers call). The hook body itself
+// carries no decision logic — it just locates the commit message file
+// and delegates to `logmind guard-commit --layer git-hook`, exiting with
+// whatever code that command returns.
 //
-// Body intentionally kept byte-identical to
-// src/logmind/core/gitattributes._build_commit_msg_hook_body so the
-// existing v0.6.16 Python installs and the Go binary's installs agree
-// on the bytes a re-install should write.
+// v0.6.16 → v2.0.0 change: this hook used to be warn-only (surfaced a
+// `[skip-logmind]` notice to stderr but always exited 0, never blocking
+// the commit). It now BLOCKS a substantive commit that bypasses
+// `logmind log`, unless git.enforce_commits:false or a guardcommit
+// carve-out applies ([skip-logmind], LOGMIND_ALLOW_GIT_COMMIT=1, a
+// staged decision file, under-threshold, or a rebase/merge/cherry-pick
+// in progress — see internal/guardcommit's package doc for the full
+// list). Because the hook-version marker below is embedded via
+// hookVersion(), every repo's existing v0.6.16-era warn-only hook
+// auto-upgrades to this enforcing body the next time `logmind init`
+// (refresh mode) or `logmind doctor --fix` runs — installHook's
+// "ours + body differs → overwrite" path needs no new install wiring to
+// carry out this upgrade.
+//
+// `command -v logmind` (unlike the harness layer's canonical command,
+// which deliberately OMITS that guard for cross-platform reasons — see
+// internal/claudehook.CanonicalCommand) IS correct here: git hooks run
+// under POSIX sh on every platform git itself supports, so `command -v`
+// is always available. A missing binary fails open (exit 0) — logmind
+// not being installed should never block a commit.
 func BuildCommitMsgBody() string {
 	return "#!/bin/sh\n" +
 		"# logmind commit-msg hook\n" +
 		HookVersionPrefix + hookVersion() + "\n" +
-		"# Installed by `logmind init` (v0.6.16+). When the commit subject\n" +
-		"# contains `[skip-logmind]`, surface that as a single-line confirm\n" +
-		"# in stderr so the author notices when an agent accidentally added\n" +
-		"# the marker (the marker disables auto-title regen + decision-log\n" +
-		"# generation for that commit; silent application is a footgun).\n" +
+		"# Installed by `logmind init`. Layer 2 of the v2.0.0+ commit-enforcement\n" +
+		"# design (see internal/claudehook for Layer 1, the Claude Code harness's\n" +
+		"# PreToolUse guard). Delegates the enforce/allow decision entirely to\n" +
+		"# `logmind guard-commit --layer git-hook` — see internal/guardcommit for\n" +
+		"# the carve-outs (git.enforce_commits:false, [skip-logmind],\n" +
+		"# LOGMIND_ALLOW_GIT_COMMIT=1, a staged decision file, under-threshold,\n" +
+		"# rebase/merge/cherry-pick in progress).\n" +
 		"#\n" +
-		"# Read-only: the hook never modifies the commit message file. It\n" +
-		"# echoes a one-line notice to stderr and exits 0 so the commit\n" +
-		"# proceeds.\n" +
+		"# Fails open when logmind isn't on PATH: a missing binary should never\n" +
+		"# block a commit.\n" +
 		"\n" +
-		"MSG_FILE=\"$1\"\n" +
-		"if [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ]; then\n" +
-		"    exit 0\n" +
+		"MSG_FILE=\"$1\"; [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ] && exit 0\n" +
+		"if command -v logmind >/dev/null 2>&1; then\n" +
+		"    logmind guard-commit --layer git-hook --msg-file \"$MSG_FILE\"; exit $?\n" +
 		"fi\n" +
-		"\n" +
-		"if grep -q '\\[skip-logmind\\]' \"$MSG_FILE\"; then\n" +
-		"    echo 'logmind: [skip-logmind] detected — decision-log + auto-title regen suppressed for this commit.' >&2\n" +
-		"fi\n" +
-		"\n" +
-		"exit 0\n"
+		"exit 0    # fail-open when logmind not on PATH\n"
 }
 
 // InstallPostMerge writes `.git/hooks/post-merge` to the current

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -33,6 +33,41 @@ func TestPostRewriteBody_MatchesGolden(t *testing.T) {
 	checkGolden(t, "post-rewrite.golden", BuildPostRewriteBody())
 }
 
+// TestCommitMsgBody_MatchesGolden pins the v2.0.0 enforcing commit-msg
+// hook body. Unlike post-merge/post-rewrite this one has no Python
+// ancestor to stay byte-identical with (the warn-only v0.6.16 body it
+// replaces was Go-only already) — the golden here exists purely so a
+// future refactor that reflows the shell script trips CI loudly instead
+// of silently drifting every consumer's next `doctor --fix` upgrade.
+func TestCommitMsgBody_MatchesGolden(t *testing.T) {
+	checkGolden(t, "commit-msg.golden", BuildCommitMsgBody())
+}
+
+// TestCommitMsgBody_DelegatesToGuardCommit pins the enforcement contract
+// as INTENT, distinct from the byte-golden above: the body must locate
+// the message file, delegate the actual decision to
+// `logmind guard-commit --layer git-hook`, forward guard-commit's exit
+// code as its own, and fail OPEN (exit 0) when logmind isn't on PATH —
+// never fail closed on a missing binary.
+func TestCommitMsgBody_DelegatesToGuardCommit(t *testing.T) {
+	body := BuildCommitMsgBody()
+	for _, must := range []string{
+		"logmind guard-commit --layer git-hook",
+		"--msg-file \"$MSG_FILE\"",
+		"command -v logmind",
+		"exit $?",
+	} {
+		if !strings.Contains(body, must) {
+			t.Errorf("commit-msg body missing %q", must)
+		}
+	}
+	// The fail-open path: outside the `command -v logmind` branch, the
+	// script must still exit 0 (never fail closed on a missing binary).
+	if !regexp.MustCompile(`(?m)^exit 0\s*(#.*)?$`).MatchString(body) {
+		t.Errorf("commit-msg body has no top-level `exit 0` fail-open fallback")
+	}
+}
+
 // TestPostMergeBody_RollupInvariants pins the Slice 2 roll-up contract as
 // INTENT (distinct from the byte-golden): the post-merge hook MUST regenerate
 // the timeline + file-structure (so a main-canonical repo rebuilds its §1.6.4
@@ -158,6 +193,100 @@ func TestInstallPostMerge_MissingHooksDir(t *testing.T) {
 	}
 	if changed {
 		t.Fatalf("changed=true with no .git/hooks/; want false")
+	}
+}
+
+func TestInstallCommitMsg_FreshInstall(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	changed, err := InstallCommitMsg(repo)
+	if err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	if !changed {
+		t.Fatalf("InstallCommitMsg returned changed=false on a fresh repo; want true")
+	}
+	body, err := os.ReadFile(filepath.Join(repo, ".git", "hooks", "commit-msg"))
+	if err != nil {
+		t.Fatalf("read commit-msg: %v", err)
+	}
+	if string(body) != BuildCommitMsgBody() {
+		t.Fatalf("installed body drifts from BuildCommitMsgBody()")
+	}
+}
+
+func TestInstallCommitMsg_Idempotent(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	if _, err := InstallCommitMsg(repo); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	changed, err := InstallCommitMsg(repo)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if changed {
+		t.Fatalf("InstallCommitMsg changed=true on identical second install; want false")
+	}
+}
+
+// TestInstallCommitMsg_UpgradesWarnOnlyV0616Body pins the "no new install
+// wiring needed" contract from the PR spec: an existing repo's v0.6.16
+// warn-only commit-msg hook (same CommitMsgMarker, different body) MUST
+// be recognized as OURS and overwritten with the current enforcing body
+// — installHook's existing "ours + body differs → overwrite" path is
+// what carries out this upgrade on the next init/doctor --fix, with zero
+// new code.
+func TestInstallCommitMsg_UpgradesWarnOnlyV0616Body(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	hookPath := filepath.Join(repo, ".git", "hooks", "commit-msg")
+	legacyWarnOnly := "#!/bin/sh\n" +
+		"# logmind commit-msg hook\n" +
+		HookVersionPrefix + "0.6.16\n" +
+		"MSG_FILE=\"$1\"\n" +
+		"if [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ]; then exit 0; fi\n" +
+		"if grep -q '\\[skip-logmind\\]' \"$MSG_FILE\"; then\n" +
+		"    echo 'logmind: [skip-logmind] detected' >&2\n" +
+		"fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(hookPath, []byte(legacyWarnOnly), 0o755); err != nil {
+		t.Fatalf("seed legacy warn-only hook: %v", err)
+	}
+
+	changed, err := InstallCommitMsg(repo)
+	if err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	if !changed {
+		t.Fatalf("InstallCommitMsg changed=false over a legacy warn-only body; want true (upgrade)")
+	}
+	got, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("re-read hook: %v", err)
+	}
+	if string(got) != BuildCommitMsgBody() {
+		t.Fatalf("hook was not upgraded to the current enforcing body")
+	}
+}
+
+func TestInstallCommitMsg_LeavesForeignHook(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	hookPath := filepath.Join(repo, ".git", "hooks", "commit-msg")
+	custom := "#!/bin/sh\n# user's custom commit-msg hook\necho hi\n"
+	if err := os.WriteFile(hookPath, []byte(custom), 0o755); err != nil {
+		t.Fatalf("seed custom hook: %v", err)
+	}
+	changed, err := InstallCommitMsg(repo)
+	if err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	if changed {
+		t.Fatalf("InstallCommitMsg changed=true on foreign hook; want false (leave alone)")
+	}
+	got, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("re-read hook: %v", err)
+	}
+	if string(got) != custom {
+		t.Fatalf("foreign hook was modified:\n%s", got)
 	}
 }
 

--- a/internal/hooks/testdata/commit-msg.golden
+++ b/internal/hooks/testdata/commit-msg.golden
@@ -1,0 +1,19 @@
+#!/bin/sh
+# logmind commit-msg hook
+# logmind-hook-version: 2.0.0-dev
+# Installed by `logmind init`. Layer 2 of the v2.0.0+ commit-enforcement
+# design (see internal/claudehook for Layer 1, the Claude Code harness's
+# PreToolUse guard). Delegates the enforce/allow decision entirely to
+# `logmind guard-commit --layer git-hook` — see internal/guardcommit for
+# the carve-outs (git.enforce_commits:false, [skip-logmind],
+# LOGMIND_ALLOW_GIT_COMMIT=1, a staged decision file, under-threshold,
+# rebase/merge/cherry-pick in progress).
+#
+# Fails open when logmind isn't on PATH: a missing binary should never
+# block a commit.
+
+MSG_FILE="$1"; [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ] && exit 0
+if command -v logmind >/dev/null 2>&1; then
+    logmind guard-commit --layer git-hook --msg-file "$MSG_FILE"; exit $?
+fi
+exit 0    # fail-open when logmind not on PATH

--- a/internal/hooks/testdata/commit-msg.golden
+++ b/internal/hooks/testdata/commit-msg.golden
@@ -12,7 +12,10 @@
 # Fails open when logmind isn't on PATH: a missing binary should never
 # block a commit.
 
-MSG_FILE="$1"; [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ] && exit 0
+MSG_FILE="$1"
+if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
+    exit 0
+fi
 if command -v logmind >/dev/null 2>&1; then
     logmind guard-commit --layer git-hook --msg-file "$MSG_FILE"; exit $?
 fi

--- a/internal/templates/config.yml.template
+++ b/internal/templates/config.yml.template
@@ -17,6 +17,12 @@ git:
   # Available variables: {decision}
   commit_message_template: "logmind: {decision}"
 
+  # Block substantive commits that bypass `logmind log` (commit-msg + Claude
+  # Code PreToolUse hooks). Set false to fall back to warn-only for this repo.
+  enforce_commits: true
+  # Lines-changed threshold shared with `logmind check-decisions --threshold`.
+  commit_line_threshold: 20
+
 # Decision management
 decisions:
   # Maximum number of recent decisions to keep in decisions.md


### PR DESCRIPTION
## Summary

PR2/3 of the force-logmind-usage enforcement feature (plan.md §v2.0.0). PR1 (#194) shipped `logmind guard-commit --layer {harness|git-hook}` as a Hidden, manually-invocable decision engine with zero install wiring. This PR makes enforcement **live**:

- **Layer 1 — new `internal/claudehook` package.** `EnsurePreToolUseGuard(repoRoot)` installs/refreshes a `logmind guard-commit --layer harness` entry in `.claude/settings.json`'s `hooks.PreToolUse`, so the Claude Code harness blocks a non-compliant `git commit` Bash tool call *before it runs*. Idempotent, marker-based (`logmind guard-commit` substring in `hooks[].command`, plus a `# logmind-hook-version: X` marker reusing `hooks.HookVersionPrefix`), and non-destructive — it only ever replaces/appends the ONE hook object it owns, leaving every other key, hook, matcher group, and event untouched. `Inspect()` gives doctor a read-only probe of the same state.
- **Layer 2 — `BuildCommitMsgBody` upgraded from warn-only to enforcing.** The commit-msg hook now delegates to `logmind guard-commit --layer git-hook --msg-file "$MSG_FILE"` and propagates its exit code, failing open (exit 0) when `logmind` isn't on `PATH`. Because the version marker is embedded via `hookVersion()`, every existing repo's v0.6.16 warn-only hook auto-upgrades on the next `init`/`doctor --fix` — no new install-side code needed for Layer 2.
- **Doctor probe.** `probeClaudePreToolUseHook` mirrors `probeHook`'s `missing/markerless/stale/current` shape, added right after the commit-msg row in `collectLogmindStatus`.
- **Install wiring.** `refreshOpts.claudeAgentEnabled` gates Layer 1 in `applyRefresh` (shared by `init` refresh-mode and `doctor --fix`) — **not** gated on `opts.git`, since `.claude/settings.json` is repo content, not git-clone state. `init.go` resolves the gate from `enabledAgentList(...)`; `doctor.go` resolves it from `.logmind/config.yml`'s `agents.claude` (default true).
- **Config template.** `git.enforce_commits`/`commit_line_threshold` documented in `config.yml.template` (struct defaults already matched these — kept out of `DefaultMap`/`config list` to avoid golden churn, per the task spec).

## Design notes worth flagging

- The harness's canonical command deliberately has **no** `command -v logmind` guard (unlike the git hook) — it must stay one cross-platform string valid under bash *and* PowerShell, and a missing binary already fails open via a non-2 "command not found" exit.
- The new doctor probe uses the exact same `classifyLogmindDrift` mechanism as every other hook probe: only `stale` flips `Overall` → `DRIFT`; `missing` stays benign (consistent with `TestCollectStatus_FreshRepoListsAllProbes`, which pins `Overall == OK` on a fresh, all-missing repo).

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean
- [x] `internal/claudehook`: fresh install, merge into empty hooks, merge alongside a foreign Bash `PreToolUse` hook (foreign entry survives, content-identical), idempotent re-run, version-bump replace (only our entry changes), malformed `settings.json` → error + file untouched, `.hooks`/`.hooks.PreToolUse` shape errors
- [x] `internal/hooks`: new `BuildCommitMsgBody` golden (`testdata/commit-msg.golden`), `InstallCommitMsg` idempotency + foreign-hook preservation + v0.6.16→v2.0.0 upgrade, and a **real `git commit`** integration test (built binary, real hook, real subprocess) proving a substantive no-decision commit is blocked and `[skip-logmind]` / `LOGMIND_ALLOW_GIT_COMMIT=1` / a staged decision file all allow it
- [x] `internal/doctor`: probe reports missing (fresh) / current (post-install) / stale (reverted marker); stale flips `Overall` → `DRIFT`
- [x] Wiring: `--agents` excluding `claude` skips the Layer 1 install on `init`; `agents.claude: false` in config skips it on `doctor --fix`; refresh-mode backfills a missing hook when claude becomes (re-)enabled

## Goldens changed

- `internal/hooks/testdata/commit-msg.golden` — **new** (no prior golden existed for the warn-only body)

No other goldens changed (`config list` / `DefaultMap` untouched by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG