### PR TITLE
feat(context): canonical spec file — context.spec_file fold-in + init --spec + doctor advisories

### DIFF
--- a/docs/decisions-branches/feat__canonical-spec-file.md
+++ b/docs/decisions-branches/feat__canonical-spec-file.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-add-canonical-spec-file-support-context-spec-file-fold-in-lo -->
+- **2026-07-16** — Add canonical spec file support: context.spec_file fold-in, logmind init --spec scaffolding, and doctor advisories
+<!-- logmind-entry-end -->
+
+## 2026-07-16 16:32 - Add canonical spec file support: context.spec_file fold-in, logmind init --spec scaffolding, and doctor advisories
+
+**Reasoning:** Agents need a hand-authored, forward-looking spec doc alongside the derived file-structure (what) and timeline (why) docs. Folding it into the context payload as the first, most-stable document maximizes prompt-cache prefix stability while keeping the existing payload byte-identical when spec_file is unset.
+
+**Alternatives considered:** Allow an absolute spec_file path -- rejected: repo-relative keeps the config portable across checkouts and worktrees, and closes an out-of-root read vector, Let doctor --fix auto-create a missing spec file -- rejected: there is no honest mechanical content to author automatically, so --fix stays read-only for spec content and logmind init --spec is the explicit opt-in, Surface context.spec_file in config list defaults (DefaultMap) -- rejected: mirrors the existing context.repomap precedent of staying out of DefaultMap to preserve config list byte-parity
+
+**Implications:**
+- context.spec_file defaults to unset, so byte-parity with the pre-feature payload is proven by golden-file tests captured from the pre-feature binary
+- logmind init --spec scaffolds docs/spec.md and sets context.spec_file only when both are absent/unset respectively, so repeated runs and refresh mode are both idempotent
+- doctor surfaces four advisory conditions (configured-but-missing, configured-but-empty, unsafe path, and an unset-but-file-exists nudge) but never flips Overall to DRIFT, and --fix deliberately never creates or edits spec content
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -22,6 +22,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-16** — Complete the enforcement dogfood: commit the doctor --fix artifacts → [detail](decisions.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-16-add-canonical-spec-file-support-context-spec-file-fold-in-lo -->
+- **2026-07-16** — Add canonical spec file support: context.spec_file fold-in, logmind init --spec scaffolding, and doctor advisories → [detail](decisions-branches/feat__canonical-spec-file.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-11-wire-commit-enforcement-live-claude-code-pretooluse-guard-in -->
 - **2026-07-11** — Wire commit enforcement live: Claude Code PreToolUse guard (internal/claudehook) + upgrade commit-msg hook to enforce + init/doctor --fix install wiring (enforcement PR2/3) → [detail](decisions-branches/feat__enforce-hooks-install.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -66,6 +66,12 @@ signature skeleton (see 'logmind repomap') as a third, stable document — the
 repo's API surface, placed between the file map and the timeline. Default off
 keeps the payload byte-identical.
 
+Set 'context.spec_file: docs/spec.md' (repo-relative; see 'logmind init
+--spec') to fold in the project's canonical, forward-looking spec as the
+FIRST document — it's the most stable doc, so it makes the best cache
+prefix. Missing, empty, or a path outside the repo root is silently omitted
+(never an error). Default "" keeps the payload byte-identical.
+
 --stats prints a deterministic token receipt (est. ~4 chars/token) instead of
 the payload.`,
 		Args: cobra.NoArgs,
@@ -101,13 +107,39 @@ type contextDoc struct {
 }
 
 // contextDocs is the ordered payload, most-stable first so the cacheable
-// prefix stays byte-identical for as long as possible: the file map (what) →
-// the repomap API surface (also stable; opt-in) → the volatile newest-first
-// timeline (why).
+// prefix stays byte-identical for as long as possible: the hand-authored spec
+// (opt-in; most stable of all — it's never regenerated) → the file map
+// (what) → the repomap API surface (also stable; opt-in) → the volatile
+// newest-first timeline (why).
 var contextDocs = []contextDoc{
+	{typ: "spec", gen: specDoc, enabled: func(c config.Config) bool { return c.Context.SpecFile != "" }},
 	{rel: "docs/file-structure.md", typ: "file-structure", regen: "logmind file-structure --write docs/file-structure.md"},
 	{typ: "repomap", gen: repomapDoc, enabled: func(c config.Config) bool { return c.Context.Repomap }},
 	{rel: "docs/timeline.md", typ: "decision-timeline", regen: "logmind timeline --write docs/timeline.md"},
+}
+
+// specDoc renders the canonical spec file (context.spec_file) for the
+// context payload. config.ResolveSpecFile already enforces the path-safety
+// rule (unset/absolute/out-of-root all collapse to "not resolved"); this
+// function additionally treats a missing or all-whitespace file as nothing
+// to contribute. Every one of those cases is a silent, error-free omission —
+// mirroring repomapDoc's gen-returning-empty convention, NOT the file-backed
+// doc's absent-element branch below (a spec is a nice-to-have fold-in, never
+// a gate, and its absence carries no actionable "regenerate" command since
+// it's hand-authored). The body is never truncated.
+func specDoc(cwd string, cfg config.Config) (body, source string) {
+	path, ok := config.ResolveSpecFile(cwd, cfg)
+	if !ok {
+		return "", ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ""
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", ""
+	}
+	return string(data), cfg.Context.SpecFile
 }
 
 // repomapDoc renders the Go signature skeleton for the context payload. An
@@ -189,6 +221,16 @@ func runContextStats(cwd string, stdout io.Writer) error {
 
 	fmt.Fprint(stdout, "logmind context — token receipt (est. ~4 chars/token, deterministic)\n\n")
 
+	// The spec term appears only when spec_file actually contributed to the
+	// payload (configured, resolved in-root, present, non-whitespace) —
+	// matching what contextPayload/specDoc emits. Unlike repomap/timeline, a
+	// spec distills nothing (it's hand-authored, not derived from a larger
+	// source) so there is deliberately no density claim for it below.
+	specTok := 0
+	if body, _ := specDoc(cwd, cfg); body != "" {
+		specTok = tokens.Estimate(body)
+	}
+
 	// The repomap term appears only when it is enabled AND has symbols to
 	// contribute (matching what contextPayload actually emits).
 	mapTok, rawGo := 0, 0
@@ -200,13 +242,19 @@ func runContextStats(cwd string, stdout io.Writer) error {
 			}
 		}
 	}
-	if mapTok > 0 {
-		fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + repomap %d + timeline %d + framing)\n",
-			tokens.Estimate(payload), fsTok, mapTok, tlTok)
-	} else {
-		fmt.Fprintf(stdout, "  payload total:  %6d tok  (file-structure %d + timeline %d + framing)\n",
-			tokens.Estimate(payload), fsTok, tlTok)
+
+	var parts []string
+	if specTok > 0 {
+		parts = append(parts, fmt.Sprintf("spec %d", specTok))
 	}
+	parts = append(parts, fmt.Sprintf("file-structure %d", fsTok))
+	if mapTok > 0 {
+		parts = append(parts, fmt.Sprintf("repomap %d", mapTok))
+	}
+	parts = append(parts, fmt.Sprintf("timeline %d", tlTok))
+	parts = append(parts, "framing")
+	fmt.Fprintf(stdout, "  payload total:  %6d tok  (%s)\n", tokens.Estimate(payload), strings.Join(parts, " + "))
+
 	// Only claim density when the skeleton is genuinely smaller than the source
 	// it summarizes — on a trivial repo the `# Repomap` framing can exceed a
 	// one-file source, and "0.6x denser" reads worse than saying nothing.

--- a/internal/cli/context_spec_test.go
+++ b/internal/cli/context_spec_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// specFixture seeds the minimal docs/ pair every context test in this file
+// needs. Deterministic content so the golden captures stay stable.
+func specFixture(t *testing.T, d string) {
+	t.Helper()
+	mustWriteUnder(t, d, "docs/file-structure.md", "FSTREE\n")
+	mustWriteUnder(t, d, "docs/timeline.md", "TLBODY\n")
+}
+
+// checkGoldenIn is checkGolden's shape but resolves testdata/ under an
+// explicit baseDir rather than the process cwd. Needed here because
+// withTempCwd chdirs into a t.TempDir() for the life of the whole test (the
+// restore is a t.Cleanup, which fires after the test body returns) — a
+// plain checkGolden call made after withTempCwd returns would still resolve
+// "testdata/..." against the temp fixture dir, not the package's real
+// testdata/.
+func checkGoldenIn(t *testing.T, baseDir, name, got string) {
+	t.Helper()
+	path := filepath.Join(baseDir, "testdata", name)
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("updated %s", path)
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run `make snapshot` to create it)", path, err)
+	}
+	if string(want) != got {
+		t.Fatalf("drift vs %s\n--- want ---\n%s\n--- got ---\n%s", path, string(want), got)
+	}
+}
+
+// TestContext_SpecUnset_ByteParityToMain is the load-bearing parity gate for
+// H1.5: with context.spec_file unset (the default — no .logmind/config.yml
+// at all here), `logmind context` must be BYTE-IDENTICAL to the payload
+// main produced before the canonical-spec-file feature existed. The golden
+// fixture was captured by running this exact test with `-update` against
+// the pre-feature code (see the PR description) — a live drift here means
+// the fold-in broke the default (disabled) path, not just a stale golden.
+func TestContext_SpecUnset_ByteParityToMain(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	var got string
+	withTempCwd(t, func(d string) {
+		specFixture(t, d)
+		got = runContextCapture(t)
+	})
+	checkGoldenIn(t, origWD, "context_spec_unset.golden", got)
+}
+
+// TestContextStats_SpecUnset_ByteParityToMain is the --stats counterpart —
+// same parity guarantee for the token receipt.
+func TestContextStats_SpecUnset_ByteParityToMain(t *testing.T) {
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	var got string
+	withTempCwd(t, func(d string) {
+		specFixture(t, d)
+		got = runContextCapture(t, "--stats")
+	})
+	checkGoldenIn(t, origWD, "context_stats_spec_unset.golden", got)
+}
+
+// TestContext_Spec_EnabledPresent_FirstPosition: configured + present +
+// non-whitespace → the spec doc is emitted FIRST — before file-structure,
+// repomap, and the timeline (H1.3's "most stable doc first" placement).
+func TestContext_Spec_EnabledPresent_FirstPosition(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		specFixture(t, d)
+		mustWriteUnder(t, d, "docs/spec.md", "SPECMARKER\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+		s := runContextCapture(t)
+		if !strings.Contains(s, `<document type="spec">`) {
+			t.Fatalf("spec doc missing when enabled+present:\n%s", s)
+		}
+		if !strings.Contains(s, "<source>docs/spec.md</source>") {
+			t.Errorf("spec doc source not the configured path:\n%s", s)
+		}
+		if !strings.Contains(s, "SPECMARKER") {
+			t.Errorf("spec body missing:\n%s", s)
+		}
+		iSpec := strings.Index(s, `type="spec"`)
+		iFS := strings.Index(s, `type="file-structure"`)
+		iTL := strings.Index(s, `type="decision-timeline"`)
+		if !(iSpec >= 0 && iSpec < iFS && iFS < iTL) {
+			t.Errorf("spec not first (spec=%d fs=%d tl=%d):\n%s", iSpec, iFS, iTL, s)
+		}
+	})
+}
+
+// TestContext_Spec_EnabledPresent_StatsTerm: --stats breaks out the spec
+// term (size only — no density claim, since a spec distills nothing).
+func TestContext_Spec_EnabledPresent_StatsTerm(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		specFixture(t, d)
+		mustWriteUnder(t, d, "docs/spec.md", "SPECMARKER\n")
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+		s := runContextCapture(t, "--stats")
+		if !strings.Contains(s, "spec ") {
+			t.Errorf("--stats missing the spec term:\n%s", s)
+		}
+		if strings.Contains(s, "spec distills") || strings.Contains(s, "x denser") && strings.Contains(s, "spec") {
+			t.Errorf("--stats must not claim spec density:\n%s", s)
+		}
+	})
+}
+
+// TestContext_Spec_OmissionCases_ByteIdenticalToDisabled: every omission
+// path (missing file, empty/whitespace file, absolute path, out-of-root
+// relative path) must produce a payload BYTE-IDENTICAL to spec_file being
+// entirely unset — no absent-marker, no error, no partial fold-in.
+func TestContext_Spec_OmissionCases_ByteIdenticalToDisabled(t *testing.T) {
+	var disabled string
+	withTempCwd(t, func(d string) {
+		specFixture(t, d)
+		disabled = runContextCapture(t)
+	})
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, d string)
+	}{
+		{
+			name: "configured-but-missing",
+			setup: func(t *testing.T, d string) {
+				mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+				// docs/spec.md intentionally absent.
+			},
+		},
+		{
+			name: "configured-but-empty",
+			setup: func(t *testing.T, d string) {
+				mustWriteUnder(t, d, "docs/spec.md", "")
+				mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+			},
+		},
+		{
+			name: "configured-but-whitespace-only",
+			setup: func(t *testing.T, d string) {
+				mustWriteUnder(t, d, "docs/spec.md", "   \n\t\n  \n")
+				mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+			},
+		},
+		{
+			name: "configured-absolute-path",
+			setup: func(t *testing.T, d string) {
+				mustWriteUnder(t, d, "docs/spec.md", "SPECMARKER\n")
+				mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: "+filepath.Join(d, "docs", "spec.md")+"\n")
+			},
+		},
+		{
+			name: "configured-out-of-root-escape",
+			setup: func(t *testing.T, d string) {
+				mustWriteUnder(t, d, "docs/spec.md", "SPECMARKER\n")
+				mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: ../evil.md\n")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			withTempCwd(t, func(d string) {
+				specFixture(t, d)
+				tc.setup(t, d)
+				got = runContextCapture(t)
+			})
+			if got != disabled {
+				t.Errorf("%s: payload not byte-identical to spec_file-unset\n--- disabled ---\n%s\n--- got ---\n%s",
+					tc.name, disabled, got)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -115,6 +115,16 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 	// agent's job (doctor's advisory lists the placeholders to enrich).
 	summariesBackfilled := backfillBranchSummaries(cwd, cmd.ErrOrStderr())
 
+	// Deliberate scope boundary: --fix does NOT create or modify docs/spec.md
+	// content, and does NOT write context.spec_file to .logmind/config.yml.
+	// Unlike the branch-summary backfill above (a deterministic marker) or
+	// the workflow/hook refresh (bytes we bundle and own), there is no
+	// honest mechanical fallback here — "which of SPEC.md / spec.md /
+	// docs/spec.md did the user mean" and "what should a missing spec say"
+	// are both judgment calls only a human or an authoring agent can make.
+	// doctor's advisory (collectSpecAdvisories) surfaces the nudge;
+	// `logmind init --spec` is the deliberate, explicit opt-in that acts on it.
+
 	// Re-probe to compute the residual drift that --fix cannot address.
 	after := doctor.CollectStatus(cwd, offline)
 	residual := residualProbes(after)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -98,3 +98,42 @@ func firstLineForTest(s string) string {
 	}
 	return s
 }
+
+// TestDoctor_SpecAdvisory_HumanTableAndJSON: the `logmind doctor` cobra
+// wiring surfaces the H2 spec advisory in BOTH the human table and --json,
+// and Overall stays OK (advisory, not drift) end-to-end through the command.
+func TestDoctor_SpecAdvisory_HumanTableAndJSON(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline", "--exit-zero"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor: %v\n%s", err, errOut.String())
+		}
+		body := out.String()
+		mustContain(t, body, "Canonical spec file")
+		mustContain(t, body, "missing")
+		mustContain(t, body, "Stack status: OK")
+	})
+
+	withTempCwd(t, func(d string) {
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/spec.md\n")
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline", "--exit-zero", "--json"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor --json: %v\n%s", err, errOut.String())
+		}
+		body := out.String()
+		mustContain(t, body, `"spec_advisories"`)
+		mustContain(t, body, "missing")
+		mustContain(t, body, `"overall": "OK"`)
+	})
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -30,6 +30,9 @@
 //	--install-hook        Also install the local pre-commit hook
 //	--with-skdd           Subprocess to `npx clud-bug init` after logmind setup
 //	--configure-github    Apply the canonical-v1 ruleset via the GitHub API
+//	--spec                Scaffold docs/spec.md (if absent) and point
+//	                       context.spec_file at it (if unset). Idempotent;
+//	                       works in both fresh-install and refresh mode.
 //
 // SCOPE NOTE: this implementation lands the core scaffolding paths
 // (file writes, hook installs, workflow templates, AGENTS.md). The
@@ -52,6 +55,7 @@ import (
 
 	"github.com/thrillmade/logmind/internal/agents"
 	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/hooks"
@@ -71,6 +75,7 @@ type initFlags struct {
 	installHook      bool
 	withSkdd         bool
 	configureGithub  bool
+	spec             bool
 }
 
 func newInitCmd() *cobra.Command {
@@ -98,6 +103,8 @@ func newInitCmd() *cobra.Command {
 	// String flag accepts "" | "yes" | "no" to mirror Python's tri-state
 	// --skill-install / --no-skill-install / default-unset semantics.
 	cmd.Flags().StringVar(&f.skillInstallFlag, "skill-install", "", "Install (yes) or skip (no) the logmind agent skill. Default: skip when non-interactive.")
+	cmd.Flags().BoolVar(&f.spec, "spec", false,
+		"Scaffold docs/spec.md (only if absent) and set context.spec_file: docs/spec.md in .logmind/config.yml (only if unset). Idempotent; works in both fresh-install and refresh mode.")
 	return cmd
 }
 
@@ -177,6 +184,13 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		return err
 	}
 	fmt.Fprintln(out, "✓ Created .logmind/config.yml")
+
+	// docs/spec.md + context.spec_file — opt-in (H2 of the canonical-spec-file
+	// feature). specCreated gates whether it joins the commit-file list below.
+	var specCreated bool
+	if f.spec {
+		specCreated = applyInitSpec(cmd, cwd)
+	}
 
 	// Agent files — for now, ensure AGENTS.md slim block + per-agent stubs.
 	// The Python init runs insert_into_all_ai_files; we delegate to the
@@ -303,6 +317,9 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		if claudeHookChanged {
 			filesToCommit = append(filesToCommit, ".claude/settings.json")
 		}
+		if specCreated {
+			filesToCommit = append(filesToCommit, "docs/spec.md")
+		}
 		for _, agent := range enabled {
 			if rel, ok := agents.FilePath(agent, cwd); ok && pathExists(rel) {
 				if relPath, err := filepath.Rel(cwd, rel); err == nil {
@@ -353,6 +370,13 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "logmind is already initialized — running in refresh mode.")
 	fmt.Fprintln(out)
+
+	// docs/spec.md + context.spec_file — --spec works in refresh mode too
+	// (H2 design point): a repo that ran `logmind init` before this feature
+	// existed can still opt in later without a fresh install.
+	if f.spec {
+		applyInitSpec(cmd, cwd)
+	}
 
 	res, err := applyRefresh(cwd, refreshOpts{githubActions: f.githubActions, git: true, claudeAgentEnabled: claudeAgentEnabled})
 	if err != nil {
@@ -585,6 +609,47 @@ func buildFirstDecisionEntry() string {
 			"---",
 		now,
 	)
+}
+
+// applyInitSpec implements `logmind init --spec` (H2 of the canonical-spec-
+// file feature): scaffolds docs/spec.md from the embedded template ONLY if
+// it's absent (never overwrites hand-edited content), and points
+// context.spec_file at it in .logmind/config.yml ONLY if that key isn't
+// already set (never overrides an explicit user choice — including a user
+// who deliberately configured a DIFFERENT spec path). Both halves are
+// independently idempotent, and both run the same way whether called from
+// the fresh-install path or runInitRefresh — --spec is designed to work in
+// either mode. Returns whether docs/spec.md was freshly created (the
+// fresh-install caller uses this to decide whether to stage it for commit;
+// refresh mode does not commit anything itself, so its caller ignores the
+// return value).
+func applyInitSpec(cmd *cobra.Command, cwd string) (specCreated bool) {
+	out := cmd.OutOrStdout()
+	specPath := filepath.Join(cwd, "docs", "spec.md")
+	if pathExists(specPath) {
+		// Present already — never overwrite (it may be hand-edited).
+	} else if err := writeFile(specPath, templates.SpecTemplate()); err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: create docs/spec.md failed:", err)
+	} else {
+		specCreated = true
+		fmt.Fprintln(out, "✓ Created docs/spec.md")
+	}
+
+	merged, err := config.LoadAsMap(cwd)
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: load config for --spec failed:", err)
+		return specCreated
+	}
+	if _, alreadySet := config.GetPath(merged, "context.spec_file"); alreadySet {
+		return specCreated // key already present (any value) — leave it alone
+	}
+	config.SetPath(merged, "context.spec_file", "docs/spec.md")
+	if err := config.SaveMap(configPath(cwd), merged); err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: set context.spec_file failed:", err)
+		return specCreated
+	}
+	fmt.Fprintln(out, "✓ Set context.spec_file: docs/spec.md in .logmind/config.yml")
+	return specCreated
 }
 
 // applyDependabotInit calls into inserter.EnsureDependabot and prints

--- a/internal/cli/init_spec_test.go
+++ b/internal/cli/init_spec_test.go
@@ -1,0 +1,206 @@
+// init_spec_test.go — exercises `logmind init --spec` (H2 of the
+// canonical-spec-file feature): docs/spec.md scaffolding + context.spec_file
+// wiring, in both fresh-install and refresh mode, and idempotency of both.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/config"
+)
+
+// TestInitSpec_FreshInstall_CreatesFileAndSetsConfig: a fresh `init --spec`
+// scaffolds docs/spec.md from the template and sets context.spec_file in
+// .logmind/config.yml.
+func TestInitSpec_FreshInstall_CreatesFileAndSetsConfig(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--spec"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("init --spec: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		mustContain(t, out.String(), "✓ Created docs/spec.md")
+		mustContain(t, out.String(), "✓ Set context.spec_file: docs/spec.md in .logmind/config.yml")
+	})
+
+	body, err := os.ReadFile(filepath.Join(dir, "docs", "spec.md"))
+	if err != nil {
+		t.Fatalf("read docs/spec.md: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"<!--", "-->",
+		"# <Project> — Spec",
+		"**Status:** Draft",
+		"## What this project is building toward",
+		"## Current contract",
+		"## Open questions / not yet decided",
+		"## Non-goals",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("docs/spec.md missing %q:\n%s", want, text)
+		}
+	}
+
+	merged, err := config.LoadAsMap(dir)
+	if err != nil {
+		t.Fatalf("LoadAsMap: %v", err)
+	}
+	got, ok := config.GetPath(merged, "context.spec_file")
+	if !ok || got != "docs/spec.md" {
+		t.Errorf("context.spec_file = %v (ok=%v); want docs/spec.md", got, ok)
+	}
+}
+
+// TestInitSpec_WithoutFlag_NoSpecArtifacts: plain `init` (no --spec) leaves
+// docs/spec.md unwritten and context.spec_file unset — the flag is opt-in.
+func TestInitSpec_WithoutFlag_NoSpecArtifacts(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})
+	})
+	if _, err := os.Stat(filepath.Join(dir, "docs", "spec.md")); err == nil {
+		t.Errorf("docs/spec.md should not exist without --spec")
+	}
+	merged, err := config.LoadAsMap(dir)
+	if err != nil {
+		t.Fatalf("LoadAsMap: %v", err)
+	}
+	if _, ok := config.GetPath(merged, "context.spec_file"); ok {
+		t.Errorf("context.spec_file should not be set without --spec")
+	}
+}
+
+// TestInitSpec_Idempotent_SecondRunTouchesNothing: running `init --spec`
+// again after hand-editing docs/spec.md must not overwrite it, and must not
+// disturb an already-set context.spec_file (even a customised one).
+func TestInitSpec_Idempotent_SecondRunTouchesNothing(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git", "--spec"})
+		// Hand-edit the scaffolded spec — a second --spec run must preserve it.
+		specPath := filepath.Join(".", "docs", "spec.md")
+		if err := os.WriteFile(specPath, []byte("# My Project — Spec\n\nHand-written content.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--spec"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("second init --spec: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		// Second pass must NOT report re-creating the file or re-setting config.
+		if strings.Contains(out.String(), "✓ Created docs/spec.md") {
+			t.Errorf("second --spec run re-created docs/spec.md; want idempotent no-op:\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "✓ Set context.spec_file") {
+			t.Errorf("second --spec run re-set context.spec_file; want idempotent no-op:\n%s", out.String())
+		}
+	})
+	body, err := os.ReadFile(filepath.Join(dir, "docs", "spec.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "Hand-written content.") {
+		t.Errorf("second --spec run overwrote hand-edited docs/spec.md:\n%s", body)
+	}
+}
+
+// TestInitSpec_DoesNotOverrideExplicitSpecFile: if the user already pointed
+// context.spec_file at a DIFFERENT path, `--spec` must not clobber that
+// choice, even though docs/spec.md itself may still get scaffolded (it's
+// independently "only if absent").
+func TestInitSpec_DoesNotOverrideExplicitSpecFile(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		runQuiet(t, []string{"init", "--no-git"})
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: docs/custom-spec.md\n")
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--spec"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("init --spec: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		if strings.Contains(out.String(), "✓ Set context.spec_file") {
+			t.Errorf("--spec overrode an already-set context.spec_file:\n%s", out.String())
+		}
+	})
+	merged, err := config.LoadAsMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := config.GetPath(merged, "context.spec_file")
+	if got != "docs/custom-spec.md" {
+		t.Errorf("context.spec_file = %v; want the user's custom docs/custom-spec.md preserved", got)
+	}
+}
+
+// TestInitSpec_RefreshMode_WorksAfterAlreadyInitialized: --spec must work
+// when applied to an ALREADY-initialized repo (refresh mode), not just fresh
+// installs — a repo that ran `logmind init` before this feature existed can
+// still opt in later.
+func TestInitSpec_RefreshMode_WorksAfterAlreadyInitialized(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		// First init WITHOUT --spec.
+		runQuiet(t, []string{"init", "--no-git"})
+		if _, err := os.Stat("docs/spec.md"); err == nil {
+			t.Fatalf("docs/spec.md should not exist after the plain first init")
+		}
+		// Second call is refresh mode (docs/ + .logmind/ already exist); adds --spec.
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--spec"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("refresh init --spec: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		mustContain(t, out.String(), "logmind is already initialized — running in refresh mode.")
+		mustContain(t, out.String(), "✓ Created docs/spec.md")
+		mustContain(t, out.String(), "✓ Set context.spec_file: docs/spec.md in .logmind/config.yml")
+	})
+	if _, err := os.Stat(filepath.Join(dir, "docs", "spec.md")); err != nil {
+		t.Errorf("expected docs/spec.md after refresh --spec: %v", err)
+	}
+	merged, err := config.LoadAsMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := config.GetPath(merged, "context.spec_file")
+	if !ok || got != "docs/spec.md" {
+		t.Errorf("context.spec_file = %v (ok=%v); want docs/spec.md after refresh --spec", got, ok)
+	}
+}
+
+// TestInitSpec_RefreshMode_IdempotentSecondRun: refresh-mode --spec run
+// twice in a row must be a no-op the second time (same idempotency contract
+// as fresh-install).
+func TestInitSpec_RefreshMode_IdempotentSecondRun(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})           // fresh, no spec
+		runQuiet(t, []string{"init", "--no-git", "--spec"}) // refresh, adds spec
+		root := NewRootCmd()
+		root.SetArgs([]string{"init", "--no-git", "--spec"}) // refresh again
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("third init --spec: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		if strings.Contains(out.String(), "✓ Created docs/spec.md") {
+			t.Errorf("third --spec run re-created docs/spec.md:\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "✓ Set context.spec_file") {
+			t.Errorf("third --spec run re-set context.spec_file:\n%s", out.String())
+		}
+	})
+	_ = dir
+}

--- a/internal/cli/refresh_test.go
+++ b/internal/cli/refresh_test.go
@@ -159,6 +159,45 @@ func TestDoctorFix_NeverTouchesDocs(t *testing.T) {
 	})
 }
 
+// TestDoctorFix_NeverCreatesSpecFile: context.spec_file configured but the
+// file is missing (doctor's advisory condition (a)) — --fix must NOT
+// materialize docs/spec.md. There is no honest mechanical fallback for
+// "what should a missing spec say" (see runDoctorFix's comment); the
+// deliberate remediation path is `logmind init --spec`, a human/agent
+// decision, never a --fix side effect.
+func TestDoctorFix_NeverCreatesSpecFile(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		writeRel(t, filepath.Join(".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n", 0o644)
+
+		runDoctorFixCmd(t)
+
+		if _, err := os.Stat(filepath.Join("docs", "spec.md")); err == nil {
+			t.Errorf("--fix must not create docs/spec.md")
+		}
+	})
+}
+
+// TestDoctorFix_NeverSetsSpecFileFromNudge: the doctor NUDGE (unset
+// context.spec_file but a conventional spec file already exists on disk)
+// must not be auto-applied by --fix — setting context.spec_file is an
+// explicit user/agent choice (`logmind init --spec` or a manual config
+// edit), never a --fix side effect.
+func TestDoctorFix_NeverSetsSpecFileFromNudge(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		writeRel(t, filepath.Join("docs", "spec.md"), "# Spec\n\nHand-written.\n", 0o644)
+		configBefore := "git:\n  auto_commit: false\n"
+		writeRel(t, filepath.Join(".logmind", "config.yml"), configBefore, 0o644)
+
+		runDoctorFixCmd(t)
+
+		if got := readRel(t, filepath.Join(".logmind", "config.yml")); got != configBefore {
+			t.Errorf("--fix modified .logmind/config.yml off the spec nudge:\n got: %q\nwant: %q", got, configBefore)
+		}
+	})
+}
+
 func contains(haystack, needle string) bool {
 	return bytes.Contains([]byte(haystack), []byte(needle))
 }

--- a/internal/cli/testdata/context_spec_unset.golden
+++ b/internal/cli/testdata/context_spec_unset.golden
@@ -1,0 +1,16 @@
+Pre-baked repo cold-start context: the file map (what) + the decision timeline (why). Read this to orient instead of running git log / ls / grep; open a linked source file for detail. Byte-stable — cache it as a prefix ABOVE your task.
+
+<repo_context>
+<document type="file-structure">
+<source>docs/file-structure.md</source>
+<document_content>
+FSTREE
+</document_content>
+</document>
+<document type="decision-timeline">
+<source>docs/timeline.md</source>
+<document_content>
+TLBODY
+</document_content>
+</document>
+</repo_context>

--- a/internal/cli/testdata/context_stats_spec_unset.golden
+++ b/internal/cli/testdata/context_stats_spec_unset.golden
@@ -1,0 +1,5 @@
+logmind context — token receipt (est. ~4 chars/token, deterministic)
+
+  payload total:     133 tok  (file-structure 2 + timeline 2 + framing)
+  reading this pre-baked payload replaces a git log / ls -R / grep cold-start.
+  cache it as a stable prefix -> every re-read costs ~0.1x (about 90% off).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -137,6 +138,50 @@ type ContextConfig struct {
 	// file tree, before the volatile timeline). Default false preserves the
 	// current two-doc payload byte-for-byte; the v1.0 flip turns it on.
 	Repomap bool `yaml:"repomap"`
+
+	// SpecFile designates a repo-relative path to the project's canonical,
+	// forward-looking spec — a hand-authored doc distinct from the derived
+	// file-structure ("what") and timeline ("why"): it's the "where this is
+	// headed" doc, edited via normal PRs and never regenerated. When set (and
+	// the resolved file exists and is non-empty), `logmind context` folds it
+	// in as a <document type="spec">, first in the payload — it's the most
+	// stable doc, so it makes the best cache prefix. Default "" preserves the
+	// existing payload byte-for-byte. See ResolveSpecFile for the path-safety
+	// rule: an absolute path, or one that escapes the repo root, is UNSET.
+	SpecFile string `yaml:"spec_file"`
+}
+
+// ResolveSpecFile resolves cfg.Context.SpecFile against repoRoot per the
+// canonical-spec-file path rule (NORMATIVE):
+//
+//   - "" (unset) → ("", false).
+//   - An absolute path → treated as UNSET. We never honor an absolute
+//     spec_file, even one that happens to live inside repoRoot — the config
+//     value is documented as repo-relative, and accepting an absolute path
+//     would invite a config that "looks relative" on one machine and points
+//     somewhere else entirely on another.
+//   - A relative path that, after filepath.Join(repoRoot, rel) + Clean,
+//     resolves OUTSIDE repoRoot (e.g. "../evil.md") → treated as UNSET.
+//
+// Both "unset" reasons collapse to the same ("", false) result: a
+// misconfigured or hostile spec_file must never cause a read outside
+// repoRoot, and must degrade silently (no error, no partial read) rather
+// than surface as a gate failure — `logmind context` is a convenience.
+func ResolveSpecFile(repoRoot string, cfg Config) (path string, ok bool) {
+	rel := cfg.Context.SpecFile
+	if rel == "" {
+		return "", false
+	}
+	if filepath.IsAbs(rel) {
+		return "", false
+	}
+	root := filepath.Clean(repoRoot)
+	joined := filepath.Join(root, rel) // filepath.Join already Cleans the result.
+	relToRoot, err := filepath.Rel(root, joined)
+	if err != nil || relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return joined, true
 }
 
 // DefaultConfig returns a fresh Config populated with the same values
@@ -177,8 +222,12 @@ func DefaultConfig() Config {
 		// Context.Repomap default false → `logmind context` emits today's
 		// two-doc payload byte-for-byte. NOT added to DefaultMap (below); the
 		// v1.0 flip turns it on and surfaces it in `config list`.
+		// Context.SpecFile default "" → the spec fold-in stays disabled and
+		// the payload byte-for-byte unchanged. Also NOT added to DefaultMap —
+		// `logmind init --spec` sets it explicitly via SetPath/SaveMap.
 		Context: ContextConfig{
-			Repomap: false,
+			Repomap:  false,
+			SpecFile: "",
 		},
 		Agents: map[string]bool{
 			"claude":   true,

--- a/internal/config/spec_test.go
+++ b/internal/config/spec_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSpecFile_DefaultUnset(t *testing.T) {
+	if got := DefaultConfig().Context.SpecFile; got != "" {
+		t.Errorf("default Context.SpecFile = %q; want \"\" (fold-in disabled, byte-parity)", got)
+	}
+}
+
+func TestSpecFile_RoundTrip(t *testing.T) {
+	cfg, err := LoadPath(writeTimelineCfg(t, "context:\n  spec_file: docs/spec.md\n"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if cfg.Context.SpecFile != "docs/spec.md" {
+		t.Errorf("Context.SpecFile = %q; want docs/spec.md", cfg.Context.SpecFile)
+	}
+	// Leafwise deep-merge guard: setting spec_file must not disturb the
+	// sibling repomap default.
+	if cfg.Context.Repomap {
+		t.Errorf("setting spec_file flipped Repomap on; deep-merge should be leafwise")
+	}
+}
+
+// TestResolveSpecFile_Unset covers the "" (never configured) case.
+func TestResolveSpecFile_Unset(t *testing.T) {
+	root := t.TempDir()
+	cfg := DefaultConfig()
+	if _, ok := ResolveSpecFile(root, cfg); ok {
+		t.Errorf("ResolveSpecFile with unset spec_file returned ok=true; want false")
+	}
+}
+
+// TestResolveSpecFile_RelativeInRoot is the happy path: a plain
+// repo-relative path resolves to repoRoot/<rel>.
+func TestResolveSpecFile_RelativeInRoot(t *testing.T) {
+	root := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Context.SpecFile = "docs/spec.md"
+	path, ok := ResolveSpecFile(root, cfg)
+	if !ok {
+		t.Fatalf("ResolveSpecFile: want ok=true for a plain relative path")
+	}
+	want := filepath.Join(root, "docs", "spec.md")
+	if path != want {
+		t.Errorf("path = %q; want %q", path, want)
+	}
+}
+
+// TestResolveSpecFile_NoOutOfRootRead is the NORMATIVE security assertion:
+// an absolute path, and a relative path that escapes repoRoot via `..`, MUST
+// both be treated as unset — logmind must never read a spec_file outside
+// the repo root, regardless of what a (possibly untrusted, possibly
+// merge-conflicted) .logmind/config.yml says.
+func TestResolveSpecFile_NoOutOfRootRead(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name string
+		rel  string
+	}{
+		{"parent-escape", "../evil.md"},
+		{"deep-parent-escape", "../../../../etc/hosts"},
+		{"absolute-etc-hosts", "/etc/hosts"},
+		{"absolute-inside-root-looking", filepath.Join(root, "docs", "spec.md")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Context.SpecFile = tc.rel
+			path, ok := ResolveSpecFile(root, cfg)
+			if ok {
+				t.Errorf("ResolveSpecFile(%q) = (%q, true); want unset (false) — must never escape/absolute-read", tc.rel, path)
+			}
+			if path != "" {
+				t.Errorf("ResolveSpecFile(%q) returned non-empty path %q on the unset branch", tc.rel, path)
+			}
+		})
+	}
+}
+
+// TestResolveSpecFile_SiblingDirNameNotConfusedForEscape guards against a
+// naive string-prefix check: a sibling directory that merely SHARES a
+// prefix with repoRoot (e.g. repoRoot="/tmp/repo" vs "/tmp/repo-evil") must
+// not be treated as "inside" repoRoot just because HasPrefix would say so.
+func TestResolveSpecFile_SiblingDirNameNotConfusedForEscape(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "repo")
+	evilSibling := filepath.Join(parent, "repo-evil", "spec.md")
+	rel, err := filepath.Rel(root, evilSibling)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	cfg := DefaultConfig()
+	cfg.Context.SpecFile = rel
+	if path, ok := ResolveSpecFile(root, cfg); ok {
+		t.Errorf("ResolveSpecFile(%q) = (%q, true); want unset — resolves to a sibling dir, not inside root", rel, path)
+	}
+}

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -59,6 +59,16 @@ func TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity(t *testing.T) {
 	if _, ok := m.Get("context"); ok {
 		t.Errorf("DefaultMap contains `context` — breaks `config list` byte-parity")
 	}
+	// Explicit dotted-path checks (in addition to the whole-section check
+	// above) so a future PR that adds a `context:` section for one reason
+	// (e.g. surfacing `repomap`) can't silently smuggle `spec_file` in
+	// alongside it without tripping this test.
+	if _, ok := GetPath(m, "context.repomap"); ok {
+		t.Errorf("DefaultMap exposes `context.repomap` — breaks `config list` byte-parity")
+	}
+	if _, ok := GetPath(m, "context.spec_file"); ok {
+		t.Errorf("DefaultMap exposes `context.spec_file` — breaks `config list` byte-parity")
+	}
 	fs, ok := m.Get("file_structure")
 	if !ok {
 		t.Fatal("file_structure missing from DefaultMap")

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -56,6 +56,7 @@ import (
 	"time"
 
 	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/hooks"
@@ -117,6 +118,14 @@ type StatusReport struct {
 	// headline (== the first decision's title). It is a graceful best-practice
 	// nudge for the agent to enrich — it NEVER affects Overall (not drift).
 	SummariesNeeded []string `json:"summaries_needed"`
+
+	// SpecAdvisories is an ADVISORY list (H2 of the canonical-spec-file
+	// feature) of context.spec_file hygiene notes: configured-but-missing,
+	// configured-but-empty, configured-with-an-unsafe-path, or a nudge to
+	// configure it when a conventional spec file already exists on disk but
+	// spec_file is unset. Like SummariesNeeded, this NEVER affects Overall —
+	// the spec fold-in is a nice-to-have, not a gate.
+	SpecAdvisories []string `json:"spec_advisories"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -188,6 +197,7 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		NetworkUsed:     false,
 		Suggestions:     suggestions,
 		SummariesNeeded: collectSummariesNeeded(projectRoot),
+		SpecAdvisories:  collectSpecAdvisories(projectRoot),
 	}
 }
 
@@ -225,6 +235,73 @@ func collectSummariesNeeded(projectRoot string) []string {
 		}
 	}
 	return needed
+}
+
+// specNudgeCandidates lists the conventional spec-file names probed for the
+// unset-but-a-file-exists nudge, in priority order.
+var specNudgeCandidates = []string{"SPEC.md", "spec.md", "docs/spec.md"}
+
+// collectSpecAdvisories returns the ADVISORY list of context.spec_file
+// hygiene notes (H2 of the canonical-spec-file feature):
+//
+//   - configured but the resolved file is missing
+//   - configured but the file is empty/whitespace-only
+//   - configured with an absolute or out-of-root path (the same path-safety
+//     rule config.ResolveSpecFile enforces for the actual fold-in — this
+//     advisory and the real behavior can never disagree)
+//   - NUDGE: unset, but a conventional spec file (SPEC.md, spec.md, then
+//     docs/spec.md) already exists on disk
+//
+// At most one condition can apply at a time (spec_file is a single scalar),
+// but the return stays a slice for shape-parity with collectSummariesNeeded
+// and room to grow. Purely informational — like SummariesNeeded, this NEVER
+// affects Overall (a spec fold-in is a nice-to-have, not a gate).
+//
+// `doctor --fix` deliberately does NOT act on any of these: there is no
+// honest mechanical fallback for "which candidate file did the user mean"
+// or "what should the missing spec say" — see runDoctorFix's scope-boundary
+// comment in the cli package. This function only reports; it never writes.
+func collectSpecAdvisories(projectRoot string) []string {
+	cfg, err := config.Load(projectRoot)
+	if err != nil {
+		return nil
+	}
+	rel := cfg.Context.SpecFile
+	if rel == "" {
+		for _, candidate := range specNudgeCandidates {
+			if _, err := os.Stat(filepath.Join(projectRoot, filepath.FromSlash(candidate))); err == nil {
+				return []string{
+					candidate + " exists but context.spec_file is unset — set `context.spec_file: " + candidate +
+						"` in .logmind/config.yml (or run `logmind init --spec`) to fold it into `logmind context`.",
+				}
+			}
+		}
+		return nil
+	}
+
+	if _, ok := config.ResolveSpecFile(projectRoot, cfg); !ok {
+		reason := "an absolute path"
+		if !filepath.IsAbs(rel) {
+			reason = "a path that escapes the repo root"
+		}
+		return []string{
+			fmt.Sprintf("context.spec_file (%s) is %s — logmind treats this as UNSET; use a repo-relative path that stays inside the repo.", rel, reason),
+		}
+	}
+
+	path := filepath.Join(projectRoot, filepath.FromSlash(rel))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []string{
+			"context.spec_file is configured (" + rel + ") but the file is missing — create it (e.g. `logmind init --spec`) or unset context.spec_file.",
+		}
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return []string{
+			"context.spec_file (" + rel + ") is empty — add content, or unset context.spec_file.",
+		}
+	}
+	return nil
 }
 
 var prSuffixRe = regexp.MustCompile(` \(#\d+\)$`)
@@ -712,6 +789,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Branch summaries needing attention (%d) — enrich the important ones:", len(r.SummariesNeeded)))
 		for _, s := range r.SummariesNeeded {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
+		}
+	}
+	if len(r.SpecAdvisories) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Canonical spec file (%d):", len(r.SpecAdvisories)))
+		for _, s := range r.SpecAdvisories {
 			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}

--- a/internal/doctor/spec_advisory_test.go
+++ b/internal/doctor/spec_advisory_test.go
@@ -1,0 +1,167 @@
+// spec_advisory_test.go — exercises collectSpecAdvisories / the
+// CollectStatus.SpecAdvisories field (H2 of the canonical-spec-file
+// feature): configured-but-missing, configured-but-empty,
+// configured-with-an-unsafe-path, and the unset-but-a-conventional-file-
+// exists nudge. Every case is ADVISORY ONLY — Overall must stay OK.
+package doctor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSpecAdvisories_Unset_NoConventionalFile_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 0 {
+		t.Errorf("SpecAdvisories = %v; want none (unset, nothing on disk)", r.SpecAdvisories)
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the spec advisory must never be drift")
+	}
+}
+
+// TestSpecAdvisories_Unset_NudgeChecksCandidates exercises the nudge's
+// candidate scan. Note: SPEC.md and spec.md are DELIBERATELY not
+// distinguished here — on the case-insensitive filesystems most developer
+// machines use (macOS default, Windows), the two names refer to the same
+// inode, so pinning one over the other would be testing OS behavior, not
+// logmind's. What IS meaningfully testable regardless of filesystem
+// case-sensitivity is: (a) docs/spec.md alone is found, and (b) a top-level
+// candidate (SPEC.md/spec.md) takes priority over docs/spec.md when both
+// exist.
+func TestSpecAdvisories_Unset_NudgeChecksCandidates(t *testing.T) {
+	cases := []struct {
+		name        string
+		filesUp     []string
+		wantSubstr  string // matched case-insensitively
+		mustNotHave string
+	}{
+		{name: "docs-spec-only", filesUp: []string{"docs/spec.md"}, wantSubstr: "docs/spec.md"},
+		{name: "top-level-spec-only", filesUp: []string{"SPEC.md"}, wantSubstr: "spec.md"},
+		{name: "top-level-wins-over-docs", filesUp: []string{"SPEC.md", "docs/spec.md"}, wantSubstr: "spec.md", mustNotHave: "docs/spec.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := freshRepo(t)
+			for _, f := range tc.filesUp {
+				mustWrite(t, filepath.Join(dir, filepath.FromSlash(f)), "content\n")
+			}
+			r := CollectStatus(dir, true)
+			if len(r.SpecAdvisories) != 1 {
+				t.Fatalf("SpecAdvisories = %v; want exactly 1 nudge", r.SpecAdvisories)
+			}
+			got := r.SpecAdvisories[0]
+			if !strings.Contains(strings.ToLower(got), strings.ToLower(tc.wantSubstr)) {
+				t.Errorf("nudge = %q; want it to mention %q (case-insensitive)", got, tc.wantSubstr)
+			}
+			if tc.mustNotHave != "" && strings.Contains(got, tc.mustNotHave) {
+				t.Errorf("nudge = %q; must not mention %q (a top-level candidate should win)", got, tc.mustNotHave)
+			}
+			mustContainSubstr(t, got, "context.spec_file")
+			if r.Overall == "DRIFT" {
+				t.Errorf("Overall = DRIFT; the spec advisory must never be drift")
+			}
+		})
+	}
+}
+
+func TestSpecAdvisories_ConfiguredButMissing(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 1 {
+		t.Fatalf("SpecAdvisories = %v; want 1 (configured but missing)", r.SpecAdvisories)
+	}
+	mustContainSubstr(t, r.SpecAdvisories[0], "missing")
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the spec advisory must never be drift")
+	}
+}
+
+func TestSpecAdvisories_ConfiguredButEmpty(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, "docs", "spec.md"), "")
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 1 {
+		t.Fatalf("SpecAdvisories = %v; want 1 (configured but empty)", r.SpecAdvisories)
+	}
+	mustContainSubstr(t, r.SpecAdvisories[0], "empty")
+}
+
+func TestSpecAdvisories_ConfiguredButWhitespaceOnly(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, "docs", "spec.md"), "   \n\t\n")
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 1 {
+		t.Fatalf("SpecAdvisories = %v; want 1 (whitespace-only counts as empty)", r.SpecAdvisories)
+	}
+	mustContainSubstr(t, r.SpecAdvisories[0], "empty")
+}
+
+func TestSpecAdvisories_ConfiguredAbsolutePath(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, "docs", "spec.md"), "content\n")
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"),
+		"context:\n  spec_file: "+filepath.Join(dir, "docs", "spec.md")+"\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 1 {
+		t.Fatalf("SpecAdvisories = %v; want 1 (absolute path)", r.SpecAdvisories)
+	}
+	mustContainSubstr(t, r.SpecAdvisories[0], "absolute")
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the spec advisory must never be drift")
+	}
+}
+
+func TestSpecAdvisories_ConfiguredOutOfRootEscape(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: ../evil.md\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 1 {
+		t.Fatalf("SpecAdvisories = %v; want 1 (out-of-root escape)", r.SpecAdvisories)
+	}
+	mustContainSubstr(t, r.SpecAdvisories[0], "escapes the repo root")
+}
+
+func TestSpecAdvisories_ConfiguredAndPresentAndNonEmpty_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, "docs", "spec.md"), "# Spec\n\nReal content.\n")
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	if len(r.SpecAdvisories) != 0 {
+		t.Errorf("SpecAdvisories = %v; want none (healthy configuration)", r.SpecAdvisories)
+	}
+}
+
+func TestSpecAdvisories_JSONFieldPresent(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	js, err := r.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	mustContainSubstr(t, js, `"spec_advisories"`)
+	mustContainSubstr(t, js, "missing")
+}
+
+func TestSpecAdvisories_RenderStatus_HumanTable(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "context:\n  spec_file: docs/spec.md\n")
+	r := CollectStatus(dir, true)
+	body := RenderStatus(r)
+	mustContainSubstr(t, body, "Canonical spec file")
+	mustContainSubstr(t, body, "missing")
+	mustContainSubstr(t, body, "Stack status: OK")
+}
+
+func mustContainSubstr(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected %q to contain %q", haystack, needle)
+	}
+}

--- a/internal/templates/spec.md.template
+++ b/internal/templates/spec.md.template
@@ -1,0 +1,33 @@
+<!--
+  This is the project's canonical, forward-looking spec. It complements the
+  two derived docs `logmind` already keeps in sync:
+
+    docs/file-structure.md   the WHAT — the repo tree (derived, regenerated)
+    docs/timeline.md         the WHY  — decision history (derived, regenerated)
+    docs/spec.md (this file) the WHERE THIS IS HEADED — hand-authored, never regenerated
+
+  Set `context.spec_file: docs/spec.md` in .logmind/config.yml (done
+  automatically by `logmind init --spec`, unless already set) to fold this
+  file into `logmind context`'s cold-start payload — first in the payload,
+  since it's the most stable of the three and makes the best prompt-cache
+  prefix.
+
+  Edit this file via normal PRs as the project's direction firms up. Nothing
+  in logmind writes to it automatically.
+-->
+
+# <Project> — Spec
+
+**Status:** Draft
+
+## What this project is building toward
+(the north star — what "done" looks like, even if it's still far off)
+
+## Current contract
+(what's true and load-bearing right now — the interfaces/behavior other code already depends on)
+
+## Open questions / not yet decided
+(known unknowns — name them instead of quietly guessing)
+
+## Non-goals
+(what this project deliberately will not do — the scope boundary)

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -38,6 +38,7 @@ import (
 //go:embed config.yml.template decisions.md.template decisions-archive.md.template file-structure.md.template
 //go:embed decisions-branch-header.md.template
 //go:embed dependabot.yml.template
+//go:embed spec.md.template
 //go:embed github/*.yml.template
 var embedFS embed.FS
 
@@ -191,6 +192,15 @@ func DecisionsBranchHeader() string {
 // semantics when the consumer repo already has a dependabot.yml.
 func DependabotTemplate() string {
 	return readEmbed("dependabot.yml.template")
+}
+
+// SpecTemplate returns the bundled docs/spec.md seed — the skeleton for the
+// project's canonical, forward-looking spec (see `logmind init --spec`).
+// Unlike every other file this package seeds, the spec is never
+// regenerated: `logmind init --spec` writes this template ONLY when
+// docs/spec.md is absent, then the file is edited by hand via normal PRs.
+func SpecTemplate() string {
+	return readEmbed("spec.md.template")
 }
 
 // Workflow returns the embedded body of a single .github/workflows/<name>.yml

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -379,6 +379,31 @@ func TestDecisionsBranchHeader_Shape(t *testing.T) {
 	}
 }
 
+// TestSpecTemplate_HasExpectedSections pins the docs/spec.md skeleton
+// (`logmind init --spec`): the explanatory HTML comment plus the four
+// required sections. Any of these drifting would silently change what
+// every newly-scaffolded spec.md looks like.
+func TestSpecTemplate_HasExpectedSections(t *testing.T) {
+	body := SpecTemplate()
+	if !strings.HasPrefix(body, "<!--") {
+		t.Fatalf("spec template should open with an explanatory HTML comment")
+	}
+	for _, want := range []string{
+		"context.spec_file",
+		"never regenerated",
+		"# <Project> — Spec",
+		"**Status:** Draft",
+		"## What this project is building toward",
+		"## Current contract",
+		"## Open questions / not yet decided",
+		"## Non-goals",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("spec template missing %q", want)
+		}
+	}
+}
+
 // pythonTemplatesDir walks up from the running test file's location
 // to find the repo root, then returns src/logmind/templates/. Returns
 // "" when the Python tree is absent.


### PR DESCRIPTION
## Summary

- **Config (H1.1/H1.2):** `context.spec_file` (`""` default) added to `ContextConfig`; NOT added to `DefaultMap` (keeps `config list` byte-stable, mirroring `context.repomap`). `config.ResolveSpecFile(repoRoot, cfg)` implements the NORMATIVE path rule: unset, absolute, or a relative path that escapes the repo root (via `filepath.Join`+`Clean`+`Rel`) all collapse to `("", false)` — never a read outside the repo root.
- **Fold-in (H1.3/H1.4):** when configured, resolved in-root, present, and non-whitespace, the spec is emitted as `<document type="spec">` **first** in the `logmind context` payload (most stable → best cache prefix), via the same `gen`-returning-empty convention as `repomapDoc` (silent omission, no absent-marker, no error, never truncated). `--stats` adds a `spec N` term to the payload breakdown only when it contributed — no density claim (a spec distills nothing).
- **Byte-parity (H1.5):** golden fixtures (`internal/cli/testdata/context_spec_unset.golden`, `context_stats_spec_unset.golden`) were captured by running the parity test with `-update` against the **pre-feature** code, then re-verified byte-identical after the feature landed — proof `spec_file` unset never changes existing output.
- **`logmind init --spec` (H2.6):** scaffolds `docs/spec.md` from a new embedded template only if absent (never overwrites), and sets `context.spec_file: docs/spec.md` via `config.SetPath`/`SaveMap` only if the key isn't already set. Works in both fresh-install and refresh mode; idempotent.
- **`doctor` advisories (H2.7):** four ADVISORY-only conditions (configured-but-missing, configured-but-empty/whitespace, configured-with-an-absolute-or-out-of-root-path, and a nudge when unset but `SPEC.md`/`spec.md`/`docs/spec.md` already exists) surfaced in both the human table and `--json`. Overall never flips to DRIFT. `--fix` deliberately never creates/modifies spec content (no honest mechanical fallback exists — commented at the call site).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./... -count=1` (all packages pass)
- [x] New tests: `internal/config/spec_test.go` (path rule + security: `../evil.md`, `/etc/hosts`, sibling-dir-prefix confusion all rejected), `internal/config/timeline_test.go` (DefaultMap absence for `context.spec_file` + `context.repomap`), `internal/cli/context_spec_test.go` (byte-parity golden, first-position, `--stats` term, all 5 omission cases byte-identical to disabled), `internal/cli/init_spec_test.go` (fresh/refresh/idempotency/no-override-of-explicit-config), `internal/doctor/spec_advisory_test.go` + `internal/cli/doctor_test.go`/`refresh_test.go` (all 4 advisories, JSON+table, `--fix` never touches spec content), `internal/templates/templates_test.go` (spec template shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG