### PR TITLE
chore(release): v2.0.0 prep — SpecVersion 1.4.0, goreleaser-check on main, v2 pins

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -5,7 +5,7 @@ name: goreleaser-check
 # misconfigured GoReleaser block BEFORE the first real tag push, where
 # a config bug would burn an irreversible version number.
 #
-# Runs on PRs targeting v1-go-rewrite (and later main, post-cutover)
+# Runs on PRs targeting main (and later main, post-cutover)
 # whose diff touches the release-pipeline surface area. Doesn't run on
 # every PR — the snapshot build takes ~30s of runner time, no need to
 # pay it on doc-only / unrelated PRs.
@@ -16,7 +16,7 @@ name: goreleaser-check
 on:
   push:
     branches:
-      - v1-go-rewrite
+      - main
     paths:
       - '.goreleaser.yaml'
       - '.github/workflows/goreleaser-check.yml'
@@ -27,7 +27,7 @@ on:
       - 'internal/version/**'
   pull_request:
     branches:
-      - v1-go-rewrite
+      - main
     paths:
       - '.goreleaser.yaml'
       - '.github/workflows/goreleaser-check.yml'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ brew install thrillmade/tap/logmind
 curl -fsSL https://logmind.dev/install.sh | bash
 
 # Pin to a specific version on either path:
-LOGMIND_VERSION=v1.0.0 curl -fsSL https://logmind.dev/install.sh | bash
+LOGMIND_VERSION=v2.0.0 curl -fsSL https://logmind.dev/install.sh | bash
 ```
 
 Verify the install:

--- a/docs/decisions-branches/chore__release-prep-v2.md
+++ b/docs/decisions-branches/chore__release-prep-v2.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-release-prep-specversion-1-4-0-goreleaser-check-filter-moved -->
+- **2026-07-16** — Release prep: SpecVersion 1.4.0, goreleaser-check filter moved to main, install pins and stale narrative updated to v2.0.0
+<!-- logmind-entry-end -->
+
+## 2026-07-16 17:20 - Release prep for v2.0.0: SpecVersion 1.4.0, goreleaser-check on main, v2 install pins
+
+**Reasoning:** The binary still declared SpecVersion 1.0.0 while the protocol SPEC advanced to 1.4.0 with sections 15 and 16; the goreleaser smoke-test was branch-filtered to the retired v1-go-rewrite branch so the release pipeline had no CI proof; install docs pinned the never-tagged v1.0.0
+
+**Alternatives considered:** Bump SpecVersion at tag time via ldflags, which would leave the committed constant and version golden stale
+
+**Implications:**
+- logmind --version now reports spec 1.4.0; the goreleaser config check runs on main PRs; setup-logmind action pins stay at that repos own v1 tags
+
+---
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,12 +3,9 @@
 logmind ships as a single self-contained binary. Pick the install method
 that matches your platform and preferences.
 
-> **Heads up:** the v1.0 binary release lives on the `v1-go-rewrite`
-> branch and ships when the cutover PR merges to `main`. Until then the
-> `brew install thrillmade/tap/logmind` and `curl logmind.dev/install.sh`
-> paths described below are wired up but the v1.0 tag hasn't been pushed
-> yet. v0.6.x users — see the [Deprecated: Python install](#deprecated-python-install)
-> section.
+> **Heads up:** v2.0.0 is the current release line (Go binary, main
+> branch). v0.6.x Python users — see the
+> [Deprecated: Python install](#deprecated-python-install) section.
 
 ## Homebrew (recommended on macOS and Linux)
 
@@ -54,10 +51,10 @@ Override defaults:
 curl -fsSL logmind.dev/install.sh | bash -s -- --prefix=/usr/local
 
 # Pin to a specific version (flag form)
-curl -fsSL logmind.dev/install.sh | bash -s -- --version=v1.0.0
+curl -fsSL logmind.dev/install.sh | bash -s -- --version=v2.0.0
 
 # Pin to a specific version (env form — equivalent, lower precedence than --version)
-LOGMIND_VERSION=v1.0.0 curl -fsSL logmind.dev/install.sh | bash
+LOGMIND_VERSION=v2.0.0 curl -fsSL logmind.dev/install.sh | bash
 ```
 
 Re-running the installer when the same version is already installed
@@ -112,7 +109,7 @@ Builds the latest tagged release into `$(go env GOPATH)/bin/logmind`.
 For a specific tag:
 
 ```bash
-go install github.com/thrillmade/logmind/cmd/logmind@v1.0.0
+go install github.com/thrillmade/logmind/cmd/logmind@v2.0.0
 ```
 
 Or clone + build:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,7 +9,7 @@
 logmind's canonical, forward-looking contract is the SkDD protocol SPEC:
 <https://github.com/thrillmade/protocol/blob/main/SPEC.md>
 
-logmind v2.0.0 implements SPEC 1.3.0+ (see `internal/version.SpecVersion`),
+logmind v2.0.0 implements SPEC 1.4.0+ (see `internal/version.SpecVersion`),
 including §15 (decision-logging enforcement) and §16 (this canonical
 spec-file contract). The near-term target is the v2.0.0 release:
 see [docs/plan.md](plan.md) for the current roadmap.

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-16-release-prep-specversion-1-4-0-goreleaser-check-filter-moved -->
+- **2026-07-16** — Release prep: SpecVersion 1.4.0, goreleaser-check filter moved to main, install pins and stale narrative updated to v2.0.0 → [detail](decisions-branches/chore__release-prep-v2.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-harden-git-hook-layer-against-stale-logmind-binaries-bump-ag -->
 - **2026-07-16** — Harden git-hook layer against stale logmind binaries + bump AGENTS enforcement prose to v8/v9-pointer → [detail](decisions-branches/feat__enforce-stale-binary-hardening.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/testdata/version.golden
+++ b/internal/cli/testdata/version.golden
@@ -1,1 +1,1 @@
-logmind 2.0.0-dev (spec 1.0.0)
+logmind 2.0.0-dev (spec 1.4.0)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -55,4 +55,4 @@ var Version = "2.0.0-dev"
 // this binary implements. Reported via `logmind --version` so downstream
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
-var SpecVersion = "1.0.0"
+var SpecVersion = "1.4.0"


### PR DESCRIPTION
Pre-tag housekeeping:
- `SpecVersion` 1.0.0 → **1.4.0** (+ version.golden regen) — `logmind --version` now reports the protocol version it actually implements (§15 enforcement + §16 spec file).
- `goreleaser-check.yml` branch filter `v1-go-rewrite` → `main` — the release smoke-test runs again (was filtered to a retired branch since the cutover).
- Install pins `v1.0.0` → `v2.0.0` (curl/LOGMIND_VERSION/go install); `setup-logmind@v1.0.0` action pins untouched (that repo's own tag line). Stale 'v1-go-rewrite cutover' narrative replaced.
- `docs/spec.md` pointer: SPEC 1.3.0+ → 1.4.0+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)