### PR TITLE
docs: version-output examples → spec 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ LOGMIND_VERSION=v2.0.0 curl -fsSL https://logmind.dev/install.sh | bash
 Verify the install:
 
 ```bash
-logmind --version  # logmind 2.0.0 (spec 1.0.0)
+logmind --version  # logmind 2.0.0 (spec 1.4.0)
 ```
 
 The curl installer is idempotent — re-running it when the same version

--- a/docs/install.md
+++ b/docs/install.md
@@ -146,7 +146,7 @@ same path as macOS) cover the trust gap.
 
 ```bash
 logmind --version
-# logmind 2.0.0 (spec 1.0.0)
+# logmind 2.0.0 (spec 1.4.0)
 ```
 
 The `--version` line is the protocol contract — downstream tooling


### PR DESCRIPTION
Two-line fix: #193 set the `--version` examples to `spec 1.0.0` (correct then); #201 bumped `SpecVersion` to 1.4.0 and missed re-syncing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)