### PR TITLE
feat(log): the pulse — doctor-drift + spec-staleness advisories on every log (v2.0.0)

### DIFF
--- a/docs/decisions-branches/feat__log-pulse.md
+++ b/docs/decisions-branches/feat__log-pulse.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-feat-log-the-pulse-doctor-drift-spec-staleness-advisories-on -->
+- **2026-07-16** — feat(log): the pulse - doctor-drift + spec-staleness advisories on every log
+<!-- logmind-entry-end -->
+
+## 2026-07-16 21:48 - feat(log): the pulse - doctor-drift + spec-staleness advisories on every log
+
+**Reasoning:** Agents burn tokens rediscovering repo-health problems (stale hooks, a spec nobody updated) that logmind already has the data to surface for free at the one moment every session touches: logmind log. Putting the signal on stderr, outside both the byte-exact 3-line stdout contract and the quiet single-ok-line contract, means every caller gets it for free without any output-parsing risk.
+
+**Alternatives considered:** A separate logmind pulse subcommand agents would have to remember to run, Folding the checks into doctor's Overall so log fails/warns loudly, Polling repo health on a timer via a background process
+
+**Implications:**
+- New internal/doctor.StaleCount and internal/gitcli.IsTrackedFile/LastCommitTime exported helpers, reused rather than duplicated logic
+- specPulseThreshold=20 is a hardcoded package const, not a config key, until real usage shows it needs to be tunable
+- Pulse computation is fully best-effort: any git/file error silently skips the pulse rather than failing or slowing logmind log
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -22,6 +22,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-16** — Harden git-hook layer against stale logmind binaries + bump AGENTS enforcement prose to v8/v9-pointer → [detail](decisions-branches/feat__enforce-stale-binary-hardening.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-16-feat-log-the-pulse-doctor-drift-spec-staleness-advisories-on -->
+- **2026-07-16** — feat(log): the pulse - doctor-drift + spec-staleness advisories on every log → [detail](decisions-branches/feat__log-pulse.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-dogfoods-the-canonical-spec-file-pointer-doc-context-spec-fi -->
 - **2026-07-16** — Dogfoods the canonical spec file (pointer doc + context.spec_file) and refreshes the clud-bug reviewContext to the v2 invariants → [detail](decisions-branches/chore__spec-dogfood-and-reviewcontext.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -37,6 +37,13 @@
 //     found AND not interactive → print advisory and exit 0 (CI's
 //     check-doc-links workflow Layer 3 will catch it).
 //
+//   - Pulse (v2.0.0). After everything above, `emitPulse` (pulse.go)
+//     prints ZERO, ONE, or TWO repo-health advisory lines to STDERR: a
+//     doctor-drift pulse and/or a spec-staleness pulse. Unconditional
+//     across TTY / non-TTY / --quiet — stderr sits outside both the §3.1
+//     stdout contract and the --quiet single-`ok`-line contract. See
+//     pulse.go for the exact line formats and failure-safety wrapper.
+//
 // SPEC §3.1 stdout contract (reconciled, salvaged from retired #154):
 //
 // On success stdout's first three lines are, byte-exact:
@@ -427,6 +434,15 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	if quiet {
 		q.ok("logged path=%s committed=%t pushed=%t", relTarget, committed, pushed)
 	}
+
+	// v2.0.0 pulse — repo-health advisories, STDERR ONLY, always last on
+	// stderr. See pulse.go for the two probes (doctor drift + spec
+	// staleness) and the failure-safety wrapper. Runs unconditionally in
+	// every mode (TTY, non-TTY, --quiet): stderr sits outside both the
+	// §3.1 stdout contract above and the --quiet single-`ok`-line contract,
+	// so emitting here never touches either.
+	emitPulse(cwd, stderr)
+
 	return nil
 }
 

--- a/internal/cli/pulse.go
+++ b/internal/cli/pulse.go
@@ -1,0 +1,154 @@
+// pulse.go — the v2.0.0 "pulse" feature: `logmind log` surfaces repo-health
+// advisories on STDERR after everything else has printed.
+//
+// Two independent, best-effort advisories, printed in this order (drift
+// before spec) when applicable:
+//
+//   - Drift pulse: any doctor probe classified STALE (the drift class that
+//     flips doctor's Overall — stale hooks / stale AGENTS.md block / stale
+//     Claude PreToolUse guard; NOT missing, NOT markerless — see
+//     doctor.StaleCount):
+//     `logmind: <n> component(s) stale — run 'logmind doctor --fix'`
+//
+//   - Spec pulse: context.spec_file is configured, resolves
+//     (config.ResolveSpecFile), the resolved file is git-TRACKED, and at
+//     least specPulseThreshold decision entries postdate the spec's last
+//     git commit:
+//     `logmind: <spec-path> unchanged for <n> decisions — still accurate?`
+//
+// STDERR ONLY, unconditionally. This is deliberate and load-bearing:
+//
+//   - The §3.1 stdout contract (see log.go) is byte-exact for non-TTY
+//     invocations — three lines, no more, no less. Pulse output must never
+//     touch stdout or that contract breaks.
+//   - Under --quiet / LOGMIND_QUIET, stdout carries exactly one `ok ...`
+//     receipt line. Pulse output must never touch stdout there either —
+//     but stderr is explicitly OUTSIDE both contracts, and an agent running
+//     in quiet mode is the primary audience for a low-noise health signal,
+//     so the pulse still fires under --quiet (just on stderr, same as
+//     always).
+//
+// Emitted in every mode — TTY, non-TTY, --quiet — with no gating on any of
+// them: only the STDOUT destination is contract-sensitive, and this package
+// never writes there.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
+	"github.com/thrillmade/logmind/internal/doctor"
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+// specPulseThreshold is the number of decision entries that must postdate
+// context.spec_file's last git commit before the spec pulse fires.
+// Implementation-defined (no SPEC-mandated value, hence no config key): 20
+// mirrors decisions.max_recent's default archive-rotation size — roughly
+// "an archive-rotation's worth of decisions have landed since anyone
+// touched the spec" is a reasonable staleness bar for a hand-authored,
+// forward-looking doc that (unlike timeline.md / file-structure.md) is
+// never auto-regenerated.
+const specPulseThreshold = 20
+
+// emitPulse prints ZERO, ONE, or TWO advisory lines to stderr — drift
+// pulse first, then spec pulse — and is the LAST thing `logmind log`
+// writes to stderr. Called unconditionally at the very end of runLog,
+// after the §3.1 stdout contract lines, the branch-summary nudge, the
+// commit/push lines, and the --quiet `ok` receipt.
+//
+// Failure-safety is the entire point of this function's shape: pulse
+// computation must NEVER fail or slow down `logmind log`. Every probe
+// underneath (git subprocess calls, file reads, decision-file parsing) is
+// already best-effort and returns a zero value / false on any error rather
+// than an error type — there is deliberately nothing here to check or
+// propagate. The recover() is a defensive backstop for the unexpected
+// case (a nil-map access, a slice-index bug introduced later), not an
+// expected path: even a genuine bug in pulse computation must degrade to
+// "no pulse this run," never to a failed or slowed `logmind log`. No
+// probe here makes a network call — every read is local (git log/ls-files
+// against the local repo, local file reads, local config/decisions
+// parsing).
+func emitPulse(cwd string, stderr io.Writer) {
+	defer func() {
+		_ = recover()
+	}()
+	if line, ok := driftPulseLine(cwd); ok {
+		fmt.Fprintln(stderr, line)
+	}
+	if line, ok := specPulseLine(cwd); ok {
+		fmt.Fprintln(stderr, line)
+	}
+}
+
+// driftPulseLine reports the doctor-drift advisory. Reuses
+// doctor.StaleCount, which runs the identical probe set
+// collectLogmindStatus uses internally, so the count here is EXACTLY the
+// number of components that would flip a `logmind doctor` run on this repo
+// to DRIFT — no re-derivation of doctor's classification rules.
+func driftPulseLine(cwd string) (string, bool) {
+	n := doctor.StaleCount(cwd)
+	if n <= 0 {
+		return "", false
+	}
+	plural := "s"
+	if n == 1 {
+		plural = ""
+	}
+	return fmt.Sprintf("logmind: %d component%s stale — run 'logmind doctor --fix'", n, plural), true
+}
+
+// specPulseLine reports the spec-staleness advisory. Fires only when ALL
+// of the following hold:
+//
+//   - context.spec_file is configured AND resolves per config.ResolveSpecFile
+//     (unset, absolute, or path-escaping values are already treated as
+//     UNSET there — same rule the real `logmind context` fold-in uses, so
+//     this advisory and that behavior can never disagree).
+//   - the resolved file is git-TRACKED. An untracked or uncommitted spec
+//     file has no deterministic last-touched date across clones (mtime
+//     isn't preserved by git, isn't preserved across clones/CI checkouts),
+//     so git history is the only source of truth here and an untracked
+//     file silently skips the pulse rather than guessing from mtime.
+//   - at least specPulseThreshold decision entries — collected from
+//     docs/decisions.md, docs/decisions-archive.md, and
+//     docs/decisions-branches/*.md via decisions.Collect, the same
+//     aggregator `logmind timeline` uses — carry a `## YYYY-MM-DD HH:MM`
+//     header timestamp strictly AFTER the spec file's last commit
+//     (committer date, git log -1 --format=%cI).
+func specPulseLine(cwd string) (string, bool) {
+	cfg, err := config.Load(cwd)
+	if err != nil {
+		return "", false
+	}
+	if _, ok := config.ResolveSpecFile(cwd, cfg); !ok {
+		return "", false
+	}
+	relSpec := cfg.Context.SpecFile
+
+	if !gitcli.IsTrackedFile(cwd, relSpec) {
+		return "", false
+	}
+	specTime, ok := gitcli.LastCommitTime(cwd, relSpec)
+	if !ok {
+		return "", false
+	}
+
+	entries, err := decisions.Collect(filepath.Join(cwd, "docs"), io.Discard)
+	if err != nil {
+		return "", false
+	}
+	count := 0
+	for _, e := range entries {
+		if e.Date.After(specTime) {
+			count++
+		}
+	}
+	if count < specPulseThreshold {
+		return "", false
+	}
+	return fmt.Sprintf("logmind: %s unchanged for %d decisions — still accurate?", relSpec, count), true
+}

--- a/internal/cli/pulse_test.go
+++ b/internal/cli/pulse_test.go
@@ -1,0 +1,389 @@
+// pulse_test.go — exercises the v2.0.0 "pulse" feature: `logmind log`'s
+// stderr-only repo-health advisories (drift pulse + spec pulse, pulse.go).
+//
+// Coverage:
+//   - byte-exact §3.1 stdout contract holds even when a drift pulse fires
+//     on stderr (the load-bearing "pulse never touches stdout" guarantee)
+//   - drift pulse: fires with the correct count on a deliberately-staled
+//     hook, stays silent on a fully-current (nothing-stale) repo
+//   - spec pulse: fires exactly at the specPulseThreshold boundary (19
+//     silent, 20 fires), with the correct count + path; stays silent when
+//     the spec is untracked or context.spec_file is unset
+//   - ordering: drift pulse prints before spec pulse when both fire
+//   - --quiet: the single `ok ...` stdout contract holds; pulse still
+//     lands on stderr
+//   - failure-safety: git absent from PATH → log still succeeds, pulse
+//     silently skips, no error
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/hooks"
+)
+
+// neutralizePathProbe points PATH at a directory containing ONLY a `git`
+// symlink (resolved from the real PATH) so doctor's PATH-resolution probe
+// deterministically reports "missing" instead of picking up whatever
+// `logmind` binary (if any, and at whatever version) happens to be
+// installed on the test runner's PATH. Without this, TestLog_Pulse tests
+// that assert an EXACT stale count or an EXACT-empty stderr would be
+// flaky across developer machines / CI images. `git` stays resolvable
+// because `logmind log` itself needs it for the commit flow.
+func neutralizePathProbe(t *testing.T) {
+	t.Helper()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not on PATH; skipping")
+	}
+	binDir := t.TempDir()
+	if err := os.Symlink(gitPath, filepath.Join(binDir, "git")); err != nil {
+		t.Fatalf("symlink git: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	_ = os.Setenv("PATH", binDir)
+}
+
+// writeStaleHook installs a `.git/hooks/post-merge` body carrying a
+// deliberately-wrong `# logmind-hook-version:` marker, so doctor's
+// probeHook classifies it "stale" (installed marker != the running
+// binary's version.Version) — the one drift class the pulse counts.
+func writeStaleHook(t *testing.T, dir string) {
+	t.Helper()
+	hookPath := filepath.Join(dir, ".git", "hooks", "post-merge")
+	body := "#!/bin/sh\n# logmind post-merge hook\n" + hooks.HookVersionPrefix + "v0-FAKE\necho fake\n"
+	if err := os.WriteFile(hookPath, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stale hook: %v", err)
+	}
+}
+
+// commitFileWithDate writes content to relPath under dir, stages it, and
+// commits it with a fixed author+committer date (RFC3339). Used to give a
+// spec file a deterministic, far-in-the-past "last touched" commit so the
+// spec pulse's decision-count comparison is reproducible.
+func commitFileWithDate(t *testing.T, dir, relPath, content, date string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", relPath, err)
+	}
+	addCmd := exec.Command("git", "add", relPath)
+	addCmd.Dir = dir
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add %s: %v\n%s", relPath, err, out)
+	}
+	commitCmd := exec.Command("git", "commit", "-q", "-m", "add "+relPath)
+	commitCmd.Dir = dir
+	commitCmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE="+date,
+		"GIT_COMMITTER_DATE="+date,
+	)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit %s: %v\n%s", relPath, err, out)
+	}
+}
+
+// addFillerDecisions runs `logmind log` n times against the process's
+// current directory (set by withTempCwd) with --no-commit so each call is
+// just a fast markdown-file write — no git overhead. Used to pad
+// docs/decisions.md up to (or just under) specPulseThreshold.
+func addFillerDecisions(t *testing.T, n int) {
+	t.Helper()
+	withFakeTTY(t, false, func() {
+		for i := 0; i < n; i++ {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", fmt.Sprintf("filler decision %d", i), "-r", "why", "--no-commit", "--no-interactive"})
+			var sink bytes.Buffer
+			root.SetOut(&sink)
+			root.SetErr(&sink)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("filler log #%d: %v\n%s", i, err, sink.String())
+			}
+		}
+	})
+}
+
+// TestLog_Pulse_ByteExactStdout_NonTTY_DriftPresent is the release-bar
+// proof that the pulse NEVER touches stdout: a drift pulse fires on
+// stderr, and stdout is still the §3.1 three-line contract, byte-for-byte
+// (bytes.Equal, not a substring match — a rogue extra byte anywhere would
+// fail this).
+func TestLog_Pulse_ByteExactStdout_NonTTY_DriftPresent(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		writeStaleHook(t, d)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "byte exact decision", "-r", "why", "--no-push", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\nstderr:\n%s", err, errBuf.String())
+			}
+
+			wantStdout := []byte("ℹ Staging all changes (use --stage scoped to limit)\n" +
+				`✓ Logged decision: "byte exact decision"` + "\n" +
+				"✓ Committed changes\n")
+			gotStdout := out.Bytes()
+			if !bytes.Equal(gotStdout, wantStdout) {
+				t.Fatalf("stdout not byte-exact.\nwant (%d bytes) % x\nwant text: %q\ngot  (%d bytes) % x\ngot  text: %q",
+					len(wantStdout), wantStdout, wantStdout, len(gotStdout), gotStdout, gotStdout)
+			}
+
+			wantStderr := "logmind: 1 component stale — run 'logmind doctor --fix'\n"
+			if errBuf.String() != wantStderr {
+				t.Fatalf("stderr = %q; want exactly %q", errBuf.String(), wantStderr)
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_NoDriftLine_WhenNothingStale: a freshly-scaffolded repo
+// (nothing installed beyond docs/) has zero STALE components — "missing"
+// isn't drift — so the drift pulse must stay silent. No spec_file is
+// configured either, so stderr should be entirely empty.
+func TestLog_Pulse_NoDriftLine_WhenNothingStale(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "clean decision", "-r", "why", "--no-push", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\nstderr:\n%s", err, errBuf.String())
+			}
+			if errBuf.Len() != 0 {
+				t.Fatalf("stderr should be empty (nothing stale, no spec configured); got %q", errBuf.String())
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_SpecLine_ThresholdBoundary pins the exact
+// specPulseThreshold gate: scaffoldDocs already logs one decision (init's
+// "first decision"); 17 filler entries bring the total to 18, so the next
+// log call lands the 19th entry (still below threshold — must stay
+// silent) and the one after that lands the 20th (meets the threshold —
+// must fire, with the exact count and the spec's path).
+func TestLog_Pulse_SpecLine_ThresholdBoundary(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t) // logs 1 pre-existing decision (init's own "first decision")
+		neutralizePathProbe(t)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		commitFileWithDate(t, d, "SPEC.md", "# Spec\n", "2020-01-01T00:00:00Z")
+
+		addFillerDecisions(t, 17) // 1 (init) + 17 = 18 total so far
+
+		withFakeTTY(t, false, func() {
+			// 19th entry — one short of specPulseThreshold (20). Must stay silent.
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "checkpoint 19", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log (19th entry): %v\n%s", err, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "unchanged for") {
+				t.Fatalf("spec pulse fired at 19 decisions (below threshold); stderr:\n%s", errBuf.String())
+			}
+
+			// 20th entry — meets specPulseThreshold. Must fire with count=20.
+			root = NewRootCmd()
+			root.SetArgs([]string{"log", "checkpoint 20", "-r", "why", "--no-commit", "--no-interactive"})
+			out.Reset()
+			errBuf.Reset()
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log (20th entry): %v\n%s", err, errBuf.String())
+			}
+			mustContain(t, errBuf.String(), "logmind: SPEC.md unchanged for 20 decisions — still accurate?")
+		})
+	})
+}
+
+// TestLog_Pulse_SpecUntracked_Silent: context.spec_file resolves to a real
+// file on disk, but it was never `git add`ed/committed. Untracked/
+// uncommitted has no deterministic last-touched date across clones, so the
+// pulse must skip it — regardless of how many decisions have piled up.
+func TestLog_Pulse_SpecUntracked_Silent(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		if err := os.WriteFile(filepath.Join(d, "SPEC.md"), []byte("# Spec\n"), 0o644); err != nil {
+			t.Fatalf("write SPEC.md: %v", err)
+		}
+		// Deliberately NOT added/committed — SPEC.md stays untracked.
+
+		// Comfortably over specPulseThreshold, so if this test fails it's
+		// unambiguously because untracked status was ignored — not because
+		// the count was too low.
+		addFillerDecisions(t, 25)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "untracked spec test", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\n%s", err, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "unchanged for") {
+				t.Fatalf("spec pulse fired for an untracked spec file; stderr:\n%s", errBuf.String())
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_SpecUnset_Silent: context.spec_file is left at its default
+// ("") — config.ResolveSpecFile reports unset, so the pulse must never
+// even attempt the git/decision-count work.
+func TestLog_Pulse_SpecUnset_Silent(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "spec unset test", "-r", "why", "--no-push", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\n%s", err, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "unchanged for") {
+				t.Fatalf("spec pulse fired with spec_file unset; stderr:\n%s", errBuf.String())
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_OrderingDriftBeforeSpec: when both pulses fire in the same
+// invocation, the drift line must print FIRST, spec line SECOND — and
+// nothing else lands on stderr.
+func TestLog_Pulse_OrderingDriftBeforeSpec(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		writeStaleHook(t, d)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		commitFileWithDate(t, d, "SPEC.md", "# Spec\n", "2020-01-01T00:00:00Z")
+		addFillerDecisions(t, 25) // comfortably over specPulseThreshold
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "ordering test", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\n%s", err, errBuf.String())
+			}
+			stderr := errBuf.String()
+			driftIdx := strings.Index(stderr, "component")
+			specIdx := strings.Index(stderr, "unchanged for")
+			if driftIdx == -1 || specIdx == -1 {
+				t.Fatalf("expected both drift and spec pulses to fire; stderr:\n%s", stderr)
+			}
+			if driftIdx > specIdx {
+				t.Fatalf("drift pulse must print BEFORE spec pulse; stderr:\n%s", stderr)
+			}
+			lines := strings.Split(strings.TrimRight(stderr, "\n"), "\n")
+			if len(lines) != 2 {
+				t.Fatalf("expected exactly 2 pulse lines on stderr; got %d:\n%s", len(lines), stderr)
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_QuietMode_StdoutSingleOK_StderrHasDriftPulse: --quiet's
+// single-`ok`-line stdout contract must hold exactly as it does without a
+// pulse; the drift pulse still lands on stderr, since stderr sits outside
+// that contract.
+func TestLog_Pulse_QuietMode_StdoutSingleOK_StderrHasDriftPulse(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		writeStaleHook(t, d)
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "quiet pulse test", "-r", "why", "--no-push", "--no-interactive", "--quiet"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log --quiet: %v\n%s", err, errBuf.String())
+			}
+			assertSingleOK(t, out.String(), "logged", "committed=true", "pushed=false")
+			mustContain(t, errBuf.String(), "logmind: 1 component stale — run 'logmind doctor --fix'")
+		})
+	})
+}
+
+// TestLog_Pulse_GitAbsentFromPath_NoErrorNoPulse is the failure-safety
+// proof: a spec file tracked+committed long ago, comfortably over
+// specPulseThreshold decisions on top — every ingredient the spec pulse
+// needs — but with `git` removed from PATH for the actual `logmind log`
+// invocation. gitcli.IsTrackedFile / LastCommitTime fail closed (best-
+// effort false/zero-value, never a panic), so the pulse silently skips
+// and the log still succeeds with exit 0. Proves the "never fail or slow
+// the log" guarantee holds even when the underlying git calls error out.
+func TestLog_Pulse_GitAbsentFromPath_NoErrorNoPulse(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		commitFileWithDate(t, d, "SPEC.md", "# Spec\n", "2020-01-01T00:00:00Z")
+		addFillerDecisions(t, 25) // over threshold — would fire if git worked
+
+		// Strip PATH down to nothing — no git, no logmind. Must happen AFTER
+		// the setup above, which needs a real git on PATH.
+		origPath := os.Getenv("PATH")
+		t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+		_ = os.Setenv("PATH", t.TempDir())
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "git-absent test", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log should succeed even with git absent from PATH: %v\nstderr:\n%s", err, errBuf.String())
+			}
+			mustContain(t, out.String(), `✓ Logged decision: "git-absent test"`)
+			if strings.Contains(errBuf.String(), "logmind:") {
+				t.Fatalf("pulse should be silent when git is absent from PATH; stderr:\n%s", errBuf.String())
+			}
+		})
+	})
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -349,6 +349,30 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 	}
 }
 
+// StaleCount runs the same probe set collectLogmindStatus uses (workflow /
+// hook / marker drift classification) and returns how many components are
+// classified STALE — the one drift class that flips Overall to DRIFT.
+// "missing" (never installed) and "markerless" (hand-edited, pre-marker)
+// are deliberately excluded: both are benign by design elsewhere in this
+// package (see classifyLogmindDrift), so a caller that only cares about
+// "does this repo need `doctor --fix`" should only count the same signal
+// doctor itself gates on.
+//
+// Exported for `logmind log`'s pulse advisory (internal/cli/pulse.go),
+// which wants doctor's exact stale-count without paying for
+// CollectStatus's extra SummariesNeeded / SpecAdvisories walks — this
+// calls collectLogmindStatus directly, the same probe set, nothing more.
+func StaleCount(projectRoot string) int {
+	status := collectLogmindStatus(projectRoot)
+	count := 0
+	for _, wf := range status.Workflows {
+		if wf.Drift == "stale" {
+			count++
+		}
+	}
+	return count
+}
+
 // classifyLogmindDrift aggregates per-workflow drift into the tool-level
 // drift. ANY stale workflow/hook/probe row flips the tool to "stale";
 // remaining unknowns flip to "unknown"; otherwise "ok". (The version

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -134,6 +134,27 @@ func TestCollectStatus_StaleWorkflowFlipsToDrift(t *testing.T) {
 	}
 }
 
+// TestStaleCount_MatchesDriftClassification: StaleCount must count exactly
+// the "stale"-classified rows and nothing else (missing rows on a fresh
+// repo — e.g. every git hook, every workflow — must NOT be counted).
+func TestStaleCount_MatchesDriftClassification(t *testing.T) {
+	dir := freshRepo(t)
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	_ = os.Setenv("PATH", t.TempDir())
+
+	if n := StaleCount(dir); n != 0 {
+		t.Errorf("StaleCount(fresh repo) = %d; want 0 (missing != stale)", n)
+	}
+
+	body := "# logmind-template-version: v0-FAKE\n# rest of file\n"
+	mustWrite(t, filepath.Join(dir, ".github", "workflows", "regen-timeline.yml"), body)
+
+	if n := StaleCount(dir); n != 1 {
+		t.Errorf("StaleCount(one stale workflow) = %d; want 1", n)
+	}
+}
+
 func TestCollectStatus_InstalledWorkflowMarkerMatchesBundled(t *testing.T) {
 	dir := freshRepo(t)
 	// Write an installed workflow whose marker matches what we ship.

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // ErrGitNotFound is returned when the `git` binary is missing from PATH.
@@ -438,6 +439,49 @@ func StatusPorcelain(repoRoot, path string) string {
 		return ""
 	}
 	return strings.TrimSpace(stdout.String())
+}
+
+// IsTrackedFile reports whether relPath (repo-relative; forward slashes
+// work regardless of OS since git normalizes them) is tracked in
+// repoRoot's index (`git ls-files --error-unmatch`). Returns false on any
+// failure path — not a repo, no git binary, or the path simply isn't
+// tracked — matching this package's best-effort posture. Used by the
+// `logmind log` spec pulse: an untracked or uncommitted spec file has no
+// deterministic "last touched" date across clones, so the pulse skips
+// rather than guessing from mtime.
+func IsTrackedFile(repoRoot, relPath string) bool {
+	cmd := exec.Command("git", "ls-files", "--error-unmatch", "--", relPath)
+	cmd.Dir = repoRoot
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &bytes.Buffer{}
+	return cmd.Run() == nil
+}
+
+// LastCommitTime returns the committer date of the most recent commit that
+// touched relPath (`git log -1 --format=%cI`, the committer date in strict
+// ISO 8601 — parseable with time.RFC3339). Returns the zero Time + false on
+// any failure: no commit history for the path, not a repo, or no git
+// binary. Committer date (not author date) is deliberate — it reflects
+// when the change actually landed on this history, which is what "has the
+// spec been touched since these decisions were logged" wants to know.
+func LastCommitTime(repoRoot, relPath string) (time.Time, bool) {
+	cmd := exec.Command("git", "log", "-1", "--format=%cI", "--", relPath)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return time.Time{}, false
+	}
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, out)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // DefaultBranch resolves the repo's default branch following the same

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -136,6 +136,64 @@ func TestConfigGet_MissingKey(t *testing.T) {
 	}
 }
 
+func TestIsTrackedFile_TrueForCommittedFile(t *testing.T) {
+	dir := initRepo(t)
+	if !IsTrackedFile(dir, "README.md") {
+		t.Fatalf("IsTrackedFile(README.md) = false; want true (committed by initRepo)")
+	}
+}
+
+func TestIsTrackedFile_FalseForUntrackedFile(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "untracked.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write untracked.md: %v", err)
+	}
+	if IsTrackedFile(dir, "untracked.md") {
+		t.Fatalf("IsTrackedFile(untracked.md) = true; want false (never added)")
+	}
+}
+
+func TestIsTrackedFile_FalseOutsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write x.md: %v", err)
+	}
+	if IsTrackedFile(dir, "x.md") {
+		t.Fatalf("IsTrackedFile outside a repo = true; want false")
+	}
+}
+
+func TestLastCommitTime_ReturnsCommitterDate(t *testing.T) {
+	dir := initRepo(t)
+	cmd := exec.Command("git", "commit", "--allow-empty", "-q", "-m", "second")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE=2020-06-15T12:00:00Z",
+		"GIT_COMMITTER_DATE=2020-06-15T12:00:00Z",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+	// README.md's last touch is still the FIRST commit (initRepo), not the
+	// empty second commit — LastCommitTime follows the file's own history,
+	// not HEAD.
+	got, ok := LastCommitTime(dir, "README.md")
+	if !ok {
+		t.Fatalf("LastCommitTime(README.md) ok=false; want true")
+	}
+	if got.IsZero() {
+		t.Fatalf("LastCommitTime(README.md) returned zero time")
+	}
+}
+
+func TestLastCommitTime_FalseForNeverCommittedPath(t *testing.T) {
+	dir := initRepo(t)
+	_, ok := LastCommitTime(dir, "never-existed.md")
+	if ok {
+		t.Fatalf("LastCommitTime(never-existed.md) ok=true; want false")
+	}
+}
+
 func TestCurrentBranch_ReturnsBranchName(t *testing.T) {
 	dir := initRepo(t)
 	branch := CurrentBranch(dir)


### PR DESCRIPTION
## Summary

- `logmind log` now emits ZERO, ONE, or TWO repo-health advisory lines to **stderr**, after everything else — a drift pulse (any doctor probe classified STALE) and/or a spec pulse (`context.spec_file` configured, tracked, and ≥20 decisions logged since its last commit).
- Line formats:
  - `logmind: <n> component(s) stale — run 'logmind doctor --fix'`
  - `logmind: <spec-path> unchanged for <n> decisions — still accurate?`
- STDERR only, in every mode (TTY, non-TTY, `--quiet`) — the §3.1 byte-exact 3-line stdout contract and the `--quiet` single-`ok`-line contract are provably unaffected (byte-exact test included).
- New exported helpers, reused rather than re-derived: `doctor.StaleCount(projectRoot) int` (runs the same probes `collectLogmindStatus` uses) and `gitcli.IsTrackedFile` / `gitcli.LastCommitTime`.
- Pulse computation is fully best-effort — wrapped so any git/file error (missing git, unreadable file, parse failure) silently skips the pulse; `logmind log`'s exit code and output are never affected.

## Test plan

- [x] `TestLog_Pulse_ByteExactStdout_NonTTY_DriftPresent` — `bytes.Equal` proof that stdout stays the exact 3-line contract while a drift pulse fires on stderr
- [x] `TestLog_Pulse_NoDriftLine_WhenNothingStale` — fully-current repo emits nothing
- [x] `TestLog_Pulse_SpecLine_ThresholdBoundary` — 19 decisions silent, 20 fires with the exact count
- [x] `TestLog_Pulse_SpecUntracked_Silent`, `TestLog_Pulse_SpecUnset_Silent`
- [x] `TestLog_Pulse_OrderingDriftBeforeSpec` — drift line before spec line, nothing else
- [x] `TestLog_Pulse_QuietMode_StdoutSingleOK_StderrHasDriftPulse` — quiet's single-`ok`-line contract holds
- [x] `TestLog_Pulse_GitAbsentFromPath_NoErrorNoPulse` — failure-safety: git missing from PATH → log still succeeds, pulse silently skips
- [x] Unit tests for `gitcli.IsTrackedFile` / `LastCommitTime` and `doctor.StaleCount`
- [x] `go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG