### PR TITLE
chore(release): SpecVersion → 1.5.0 (the pulse) + version-string sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ LOGMIND_VERSION=v2.0.0 curl -fsSL https://logmind.dev/install.sh | bash
 Verify the install:
 
 ```bash
-logmind --version  # logmind 2.0.0 (spec 1.4.0)
+logmind --version  # logmind 2.0.0 (spec 1.5.0)
 ```
 
 The curl installer is idempotent — re-running it when the same version

--- a/docs/install.md
+++ b/docs/install.md
@@ -146,7 +146,7 @@ same path as macOS) cover the trust gap.
 
 ```bash
 logmind --version
-# logmind 2.0.0 (spec 1.4.0)
+# logmind 2.0.0 (spec 1.5.0)
 ```
 
 The `--version` line is the protocol contract — downstream tooling

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,7 +9,7 @@
 logmind's canonical, forward-looking contract is the SkDD protocol SPEC:
 <https://github.com/thrillmade/protocol/blob/main/SPEC.md>
 
-logmind v2.0.0 implements SPEC 1.4.0+ (see `internal/version.SpecVersion`),
-including §15 (decision-logging enforcement) and §16 (this canonical
-spec-file contract). The near-term target is the v2.0.0 release:
+logmind v2.0.0 implements SPEC 1.5.0+ (see `internal/version.SpecVersion`),
+including §15 (decision-logging enforcement), §16 (this canonical
+spec-file contract), and the §3.1.1 pulse. The near-term target is the v2.0.0 release:
 see [docs/plan.md](plan.md) for the current roadmap.

--- a/internal/cli/testdata/version.golden
+++ b/internal/cli/testdata/version.golden
@@ -1,1 +1,1 @@
-logmind 2.0.0-dev (spec 1.4.0)
+logmind 2.0.0-dev (spec 1.5.0)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -55,4 +55,4 @@ var Version = "2.0.0-dev"
 // this binary implements. Reported via `logmind --version` so downstream
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
-var SpecVersion = "1.4.0"
+var SpecVersion = "1.5.0"


### PR DESCRIPTION
SPEC 1.5.0 (§3.1.1 pulse) merged in protocol #38; the pulse shipped in #203. This syncs the full cascade in one PR: `SpecVersion` constant + version.golden + README/install `--version` examples + the `docs/spec.md` pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)