### PR TITLE
fix(log): route the non-interactive link advisory to stderr (§3.1.1, issue #206a)

### DIFF
--- a/docs/decisions-branches/fix__selfheal-advisory-stderr.md
+++ b/docs/decisions-branches/fix__selfheal-advisory-stderr.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-routes-the-non-interactive-link-advisory-to-stderr-closing-t -->
+- **2026-07-16** — Routes the non-interactive link advisory to stderr, closing the 206a section 3.1.1 stdout-exactness gap before the v2.0.0 tag
+<!-- logmind-entry-end -->
+
+## 2026-07-16 22:42 - Route the non-interactive link advisory to stderr for section 3.1.1 exactness
+
+**Reasoning:** Under no-interactive or non-TTY the link-health advisory printed to stdout, breaking the byte-exact three-line contract for agents and CI in repos with broken doc links; v2 made that contract a headline so shipping with a known violation of it is wrong
+
+**Alternatives considered:** Defer to a post-release patch, which would ship v2.0.0 knowingly violating the clause it just polished
+
+**Implications:**
+- Fixes half of issue 206; the TTY nudge ordering half stays open as a product call since the headline answer must precede the commit line by design
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-16-routes-the-non-interactive-link-advisory-to-stderr-closing-t -->
+- **2026-07-16** — Routes the non-interactive link advisory to stderr, closing the 206a section 3.1.1 stdout-exactness gap before the v2.0.0 tag → [detail](decisions-branches/fix__selfheal-advisory-stderr.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-release-prep-specversion-1-4-0-goreleaser-check-filter-moved -->
 - **2026-07-16** — Release prep: SpecVersion 1.4.0, goreleaser-check filter moved to main, install pins and stale narrative updated to v2.0.0 → [detail](decisions-branches/chore__release-prep-v2.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -701,14 +701,18 @@ func runSelfHealLayer1(cwd string, forceNonInteractive, quiet bool, stdin io.Rea
 
 	interactive := !forceNonInteractive && isTerminalFunc()
 
-	printAdvisory(stdout, report)
-
 	if !interactive {
-		fmt.Fprintln(stdout)
-		fmt.Fprintln(stdout, "Non-interactive context — decision is saved but docs may be stale.")
-		fmt.Fprintln(stdout, "The check-doc-links workflow's Layer 3 self-heal will catch this at PR time.")
+		// §3.1.1: non-TTY / --no-interactive stdout MUST stay exactly the
+		// three §3.1 lines. The advisory is a recovery hint, not part of the
+		// contract — route it to stderr, mirroring the quiet path above and
+		// the headline nudge (PR #173). Fixes issue #206(a).
+		printAdvisory(stderr, report)
+		fmt.Fprintln(stderr, "Non-interactive context — decision is saved but docs may be stale.")
+		fmt.Fprintln(stderr, "The check-doc-links workflow's Layer 3 self-heal will catch this at PR time.")
 		return nil
 	}
+
+	printAdvisory(stdout, report)
 
 	const maxTries = 3
 	reader := bufio.NewReader(stdin)

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -367,17 +367,22 @@ func TestLog_TTYAutodetect_PipedStdinSkipsPrompt(t *testing.T) {
 		withFakeTTY(t, false, func() {
 			root := NewRootCmd()
 			root.SetArgs([]string{"log", "decision", "-r", "test", "--no-commit"})
-			var out bytes.Buffer
+			// Separate buffers: §3.1.1 requires the advisory on STDERR for
+			// non-TTY callers — stdout stays contract-only (issue #206a).
+			var out, errBuf bytes.Buffer
 			root.SetOut(&out)
-			root.SetErr(&out)
+			root.SetErr(&errBuf)
 			if err := root.Execute(); err != nil {
-				t.Fatalf("non-tty should exit 0; got %v\noutput:\n%s", err, out.String())
+				t.Fatalf("non-tty should exit 0; got %v\noutput:\n%s%s", err, out.String(), errBuf.String())
 			}
-			body := out.String()
-			mustContain(t, body, "⚠ Standard markdown links need attention")
-			mustContain(t, body, "Non-interactive context")
-			if strings.Contains(body, "reply [y to re-check") {
-				t.Fatalf("non-tty should NOT enter prompt loop\noutput:\n%s", body)
+			mustContain(t, errBuf.String(), "⚠ Standard markdown links need attention")
+			mustContain(t, errBuf.String(), "Non-interactive context")
+			if strings.Contains(out.String(), "Standard markdown links") ||
+				strings.Contains(out.String(), "Non-interactive context") {
+				t.Fatalf("advisory leaked to stdout (must be stderr-only, §3.1.1)\nstdout:\n%s", out.String())
+			}
+			if strings.Contains(out.String(), "reply [y to re-check") || strings.Contains(errBuf.String(), "reply [y to re-check") {
+				t.Fatalf("non-tty should NOT enter prompt loop")
 			}
 		})
 	})


### PR DESCRIPTION
Closes the (a) half of #206 before the tag: under `--no-interactive`/non-TTY, `runSelfHealLayer1` printed the link-health advisory + notice to **stdout**, violating §3.1.1's byte-exact three-line contract whenever the repo had broken doc links. Now routed to stderr — the same shape as the quiet path and the headline nudge (#173). The existing test was strengthened to split-buffer assertions (advisory on stderr, stdout contract-only).

The (b) half (TTY nudge ordering) stays open in #206 — it's a deliberate same-commit UX design, human-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)