### PR TITLE
docs: v2.0.0 truth sweep — retire Python-era surfaces, teach the v2 surface

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -123,11 +123,15 @@ changelog:
   # for the wave they shipped in, which the agent author already wrote).
   sort: asc
   filters:
+    # Scope-aware: conventional commits with a scope (`docs(readme): ...`,
+    # `chore(release): ...`) don't match a bare `^docs:` anchor, so the
+    # optional `(\(.+\))?` group covers both `type:` and `type(scope):`.
+    # RE2 (Go's regexp), same engine GoReleaser compiles these against.
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
-      - "^ci:"
+      - '^docs(\(.+\))?:'
+      - '^test(\(.+\))?:'
+      - '^chore(\(.+\))?:'
+      - '^ci(\(.+\))?:'
       - "Merge pull request"
       - "Merge branch"
 
@@ -149,8 +153,8 @@ release:
 
     ## Install
 
-    - **Homebrew (macOS / Linux):** `brew install thrillmade/tap/logmind`
-    - **Curl:** `curl -fsSL logmind.dev/install.sh | sh`
+    - **Homebrew (macOS):** `brew install thrillmade/tap/logmind`
+    - **Curl (macOS / Linux):** `curl -fsSL logmind.dev/install.sh | sh`
     - **Manual:** download the matching `logmind_VERSION_OS_ARCH.tar.gz`
       from the assets below, extract `logmind`, drop into `$PATH`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Requires Go 1.22+ (matches `go.mod`'s floor).
 - `.goreleaser.yaml` — release pipeline (cross-compile, sign, brew bump)
 - `docs/` — project documentation (regenerated artifacts under
   `docs/timeline.md`, `docs/file-structure.md`, …)
-- `skill/` — content for the standalone `logmind-skill` repo published
-  via skills.sh; not shipped in the binary
+- `skill/` — source for the `logmind` skill published in the
+  thrillmade/agent-skills catalog (skills.sh); not shipped in the binary
 - `site/` — marketing site (Next.js, deploys via Vercel)
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -18,8 +18,20 @@ aggregation.
 **Key concept:** Install once, init anywhere, log everything. Feature
 branches get their own decision file; on PR merge a GitHub Action appends
 a one-line summary to `docs/decisions.md` linking the PR + the branch
-detail. AGENTS.md is the canonical agent-instruction file; per-tool files
+detail. `docs/timeline.md` is the main-canonical, source-derived union of
+every decision file in the repo — the one start-here doc for a cold agent.
+AGENTS.md is the canonical agent-instruction file; per-tool files
 (CLAUDE.md, .cursorrules, ...) are 2-line stubs pointing to it.
+
+`logmind log` *is* the commit primitive, not a wrapper around one. A
+commit-msg hook plus a Claude Code PreToolUse hook (both installed by
+`logmind init` / refreshed by `logmind doctor --fix`) block a substantive
+raw `git commit` and steer you back to `logmind log` — escape hatches are
+`[skip-logmind]`, `LOGMIND_ALLOW_GIT_COMMIT=1`, and `git.enforce_commits:
+false`. After every log, stderr may carry an advisory pulse — a stale
+component or a spec that's drifted 20+ decisions behind — worth a
+`logmind doctor --fix` or a look at the project's spec file
+(`context.spec_file`, scaffolded via `logmind init --spec`).
 
 ## Install
 
@@ -138,17 +150,23 @@ logmind log "Use PostgreSQL for database" \
 logmind show
 logmind search "postgres"
 
-# Log with a built-in template (pre-fills reasoning, alternatives, implications)
-logmind log --template database "Use PostgreSQL"
-logmind templates   # list all available templates
+# One-read agent cold-start context: file-structure + timeline in one go
+logmind context
+logmind context --stats     # token receipt instead of the payload
 
-# Analytics and stats
-logmind stats
-logmind stats --months 6
+# Repo signature skeleton (Go + TS/JS, function bodies dropped)
+logmind repomap
+logmind repomap --map-tokens 4000   # pack to a token budget, ranked by importance
 
-# Aggregate decisions across multiple projects
-logmind aggregate ~/projects/api ~/projects/frontend
-logmind aggregate --summary ~/work/*/
+# Health check — version drift, hook drift, missing timeline markers
+logmind doctor
+logmind doctor --fix
+
+# Set the branch's one-sentence timeline headline
+logmind headline "Added JWT session auth with refresh-token rotation"
+
+# Terse, chainable machine output for scripted/agent invocations
+LOGMIND_QUIET=1 logmind log "Use PostgreSQL" -r "Need ACID compliance"
 
 # Enforce decision logging with a pre-commit hook
 logmind install-hook          # installs .git/hooks/pre-commit
@@ -230,9 +248,19 @@ tests, release workflow).
 ## How It Works
 
 1. **Install** the `logmind` binary (brew / curl)
-2. **Init** creates `docs/` folder and inserts instructions into `AGENTS.md` (preserving existing content)
-3. **Log** a decision — appends, archives old ones (keeps 20 recent), regenerates tree, commits, and pushes
-4. **Context** AI agents read the 20 most recent decisions and current file structure
+2. **Init** creates `docs/` folder, inserts the canonical block into
+   `AGENTS.md` (2-line stubs for per-tool files), and installs the
+   commit-msg + Claude Code PreToolUse hooks that block a substantive
+   raw `git commit`
+3. **Log** a decision — `logmind log` *is* the commit: appends the entry,
+   archives old ones (keeps 20 recent), regenerates `docs/timeline.md`
+   (the main-canonical, cross-branch union) and `docs/file-structure.md`,
+   commits, and pushes. Stderr may carry a pulse advisory afterward — a
+   stale component or a spec falling behind.
+4. **Context** — `logmind context` gives an agent the file structure +
+   timeline in one cache-friendly read instead of reconstructing state
+   from `git log` / `ls -R` / `grep`; `logmind repomap` adds the API
+   surface on top
 
 ## Why logmind?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,20 @@
 
 ## Supported versions
 
-logmind follows semantic versioning. Until 1.0, only the latest minor
-version on the `main` branch receives security fixes.
+logmind follows semantic versioning. Only the 2.x line (the Go binary)
+receives security fixes.
 
-| Version | Supported          |
-|---------|--------------------|
-| 0.1.x   | :white_check_mark: |
-| < 0.1   | :x:                |
+| Version                | Supported          |
+|-------------------------|--------------------|
+| 2.x                     | :white_check_mark: |
+| 1.x                     | :x:                |
+| 0.6.x (Python, frozen)  | :x:                |
+| < 0.6                   | :x:                |
+
+The Python wheel is frozen at v0.6.16 — the last published Python release
+before the Go rewrite. It receives no further updates, including security
+backports. New installs should use the Go binary; see
+[docs/install.md](docs/install.md) for the migration path.
 
 ## Reporting a vulnerability
 
@@ -21,7 +28,8 @@ disclosure.
 **Alternate:** email **security@logmind.dev** with:
 - A description of the issue and its impact
 - Steps to reproduce (a minimal repro is best)
-- The logmind version and Python version
+- The `logmind --version` output (`logmind X.Y.Z (spec A.B.C)`) and your
+  OS/architecture
 
 We will acknowledge within 3 business days, target an initial assessment
 within 7 days, and aim to publish a fixed release plus advisory within 30
@@ -29,14 +37,18 @@ days for high-severity issues.
 
 ## What's in scope
 
-- The `logmind` package itself (CLI, library, GitHub Actions installed by
-  `logmind init`).
-- Default `.github/workflows/*.yml.template` content shipped in the wheel.
+- The `logmind` Go binary (CLI + the packages under `internal/`).
+- The GitHub Actions workflows, git hooks, and `.gitattributes` /
+  merge-driver config installed by `logmind init` / `logmind doctor --fix`.
+- The curl installer (`installer/install.sh`, served from
+  `logmind.dev/install.sh`) and its checksum verification.
 
 ## What's out of scope
 
-- The user's own code that calls `logmind.log()`.
-- Third-party dependencies (`click`, `pyyaml`, `langchain-core`) — please
-  report those upstream; we will pull the fix in once it's released.
-- Vulnerabilities only reproducible with `auto_commit: false` and no git
-  remote configured (logmind never makes network calls in that mode).
+- The user's own code and decision content logged via `logmind log`.
+- Third-party Go module dependencies — please report those to the
+  upstream project; we will pull the fix in once it's released.
+- The frozen Python wheel (`pip install logmind==0.6.16`) — unsupported,
+  see [Supported versions](#supported-versions) above.
+- Vulnerabilities only reproducible with `git.auto_commit: false` and no
+  git remote configured (logmind never makes network calls in that mode).

--- a/docs/ai-agent-files.md
+++ b/docs/ai-agent-files.md
@@ -2,7 +2,12 @@
 
 ## Goal
 
-When `logmind init` runs, it inserts logmind usage instructions into existing AI agent instruction files without overwriting existing content.
+`AGENTS.md` is the canonical instruction file. `logmind init` creates (or
+refreshes) it with the logmind decision-logging block, then writes a
+2-line **stub** for every enabled per-tool file (`CLAUDE.md`,
+`.cursorrules`, ...) that just points back at `AGENTS.md`. The guidance
+lives in one place; per-tool files never carry a second copy that can
+drift out of sync.
 
 ## Supported AI Agents
 
@@ -22,80 +27,89 @@ logmind supports the following AI coding assistants:
 | Cline | `.clinerules` | Supported |
 | OpenAI Codex | `AGENTS.md` | Supported |
 
+Which agents get a stub is controlled by the `agents:` block in
+`.logmind/config.yml` (`claude` and `cursor` default `true`; the rest
+default `false`) or overridden per-run with `--agents` / `--all-agents`.
+Codex's file *is* `AGENTS.md`, so it's always "configured" once init has
+run — there's no separate stub to write.
+
 ## Insertion Strategy
 
-### If an AI instruction file exists:
+### AGENTS.md (canonical)
 
-Check if it already contains logmind instructions by searching for a marker:
-```markdown
-<!-- logmind-start -->
+`logmind init` inserts the logmind block between
+`<!-- logmind-start -->` / `<!-- logmind-end -->` markers, versioned via
+`<!-- logmind-block-version: v9-pointer -->`. If the marker is already
+present, the block is left alone on a plain re-run (`logmind doctor --fix`
+or a version bump refreshes a *stale* block in place); any other existing
+content in `AGENTS.md` — `## Project Overview`, `## Development Commands`,
+etc. — is preserved as-is.
+
+### Per-tool files (stubs)
+
+For every enabled agent, `logmind init` / `logmind agents add <name>`
+writes (or overwrites) a 2-line stub:
+
+```
+<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
+See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
+the decision-logging requirement (logmind) and required reading.
 ```
 
-**If marker exists:** Skip (already initialized)
+If a per-tool file already exists with real hand-written content (not yet
+a stub), `logmind agents add <name>` falls back to splicing a
+`<!-- logmind-start -->` / `<!-- logmind-end -->` section into that file
+in place (the legacy, pre-AGENTS.md insertion path) rather than clobbering
+it. `logmind agents migrate` consolidates any such files into stubs.
 
-**If marker doesn't exist:** Insert section after the title/first heading:
+### Context files
 
-```markdown
-# CLAUDE.md
+The required-reading list an agent should read before starting work,
+pointed to from the `AGENTS.md` block:
 
-This file provides guidance to Claude Code...
-
-<!-- logmind-start -->
-## Decision Logging (logmind)
-
-This project uses [logmind](https://logmind.dev) for decision tracking.
-
-### For AI Agents
-
-When making significant decisions or writing important code:
-
-```bash
-logmind log "Decision summary" \
-  -r "Why this approach" \
-  -a "Option A" -a "Option B" \
-  -i "Impact 1" -i "Impact 2"
-```
-
-### Context Files
-
-- **[docs/decisions.md](decisions.md)** - 20 most recent decisions
-- **[docs/decisions-archive.md](decisions-archive.md)** - Historical decisions
-- **[docs/file-structure.md](file-structure.md)** - Current project structure
-
-Read these files to understand project history and architecture.
-<!-- logmind-end -->
-
-[Rest of existing content]
-```
-
-### If no AI instruction file exists:
-
-Create `CLAUDE.md` with the full template (Claude Code is the default).
+- **[docs/timeline.md](timeline.md)** — auto-generated, main-canonical
+  union of every decision across every branch; start here
+- **[docs/decisions.md](decisions.md)** — 20 most recent decisions on the
+  default branch
+- **[docs/decisions-branches/](decisions-branches/)** — per-branch
+  decision logs for in-flight feature work
+- **[docs/file-structure.md](file-structure.md)** — current project tree
 
 ## CLI Commands
 
 ### View Agent Status
 
 ```bash
-logmind agents              # List all agents with status
+logmind agents list         # List all agents with status
 ```
 
 Example output:
 ```
 AI Agent Status:
-  ✓ claude      CLAUDE.md (configured)
-  ✓ cursor      .cursorrules (configured)
-  ✗ copilot     .github/copilot-instructions.md (not configured)
-  ✗ windsurf    .windsurfrules (not configured)
-  ...
+
+  ✓ claude       CLAUDE.md                                (configured)
+  ✓ cursor       .cursorrules                              (configured)
+  ✗ copilot      .github/copilot-instructions.md          (not configured)
+  ✗ windsurf     .windsurfrules                            (not configured)
+  ✗ aider        CONVENTIONS.md                            (not configured)
+  ✗ continue     .continuerules                            (not configured)
+  ✗ cody         .sourcegraph/cody.json                    (not configured)
+  ✗ zed          .zed/settings.json                        (not configured)
+  ✗ amazonq      .amazonq/rules.md                         (not configured)
+  ✗ cline        .clinerules                               (not configured)
+  ✓ codex        AGENTS.md                                 (configured)
+
+Supported agents: claude, cursor, copilot, windsurf, aider, continue, cody, zed, amazonq, cline, codex
 ```
 
-### Add/Remove Agents
+### Add/Remove/Migrate Agents
 
 ```bash
-logmind agents add cursor   # Create .cursorrules with logmind section
-logmind agents add windsurf # Create .windsurfrules with logmind section
+logmind agents add cursor    # Write .cursorrules as a stub pointing to AGENTS.md
+logmind agents add windsurf  # Write .windsurfrules as a stub pointing to AGENTS.md
 logmind agents remove cursor # Remove .cursorrules
+logmind agents update        # Refresh stale logmind blocks + CI workflow pins
+logmind agents migrate       # Consolidate any full per-agent files into stubs
 ```
 
 ### Initialize with Specific Agents
@@ -108,51 +122,88 @@ logmind init --all-agents              # All supported agents
 ## Edge Cases
 
 1. **File exists but is empty:** Treat as new file
-2. **File has no headings:** Insert at very top
-3. **Multiple AI instruction files exist:** Insert into all of them
-4. **File is not writable:** Show error, continue with other files
-5. **Already initialized:** Skip silently (idempotent)
+2. **File has no headings:** Insert at very top (legacy splice path)
+3. **File is not writable:** Show error, continue with other files
+4. **Already initialized:** Refresh mode — templates/hooks refreshed in
+   place, decision docs and `.logmind/config.yml` left untouched
 
 ## User Experience
 
 ### First initialization:
-```bash
+
+```
 $ logmind init
 
 Initializing logmind...
+
+✓ Created docs/
 ✓ Created docs/decisions.md
 ✓ Created docs/decisions-archive.md
 ✓ Created docs/file-structure.md
-✓ Added logmind instructions to CLAUDE.md
+✓ Created docs/timeline.md
+✓ Created .logmind/config.yml
+Created AGENTS.md (canonical agent instructions)
+✓ Created CLAUDE.md
+✓ Created .cursorrules
+✓ Created .github/workflows/check-decisions.yml
+✓ Created .github/workflows/check-doc-links.yml
+✓ Created .github/workflows/logmind-self-update.yml
+✓ Created .github/workflows/regen-timeline.yml
+✓ Created .github/dependabot.yml
+✓ Added logmind block to .gitignore
+✓ Added logmind block to .gitattributes
+✓ Installed Claude Code guard-commit hook (.claude/settings.json)
 ✓ Logged first decision: "Initialize logmind decision tracking"
-✓ Committed changes: "logmind: Initialize decision tracking"
 
 logmind initialized successfully!
+
+Start logging decisions with:
+  logmind log "Your decision here" -r "why" -a "alternative" -i "implication"
 ```
 
 ### With specific agents:
-```bash
+
+```
 $ logmind init --agents claude,cursor,windsurf
 
 Initializing logmind...
+
+✓ Created docs/
 ✓ Created docs/decisions.md
 ✓ Created docs/decisions-archive.md
 ✓ Created docs/file-structure.md
-✓ Added logmind instructions to CLAUDE.md
-✓ Created .cursorrules with logmind instructions
-✓ Created .windsurfrules with logmind instructions
+✓ Created docs/timeline.md
+✓ Created .logmind/config.yml
+Created AGENTS.md (canonical agent instructions)
+✓ Created CLAUDE.md
+✓ Created .cursorrules
+✓ Created .windsurfrules
+✓ Created .github/workflows/check-decisions.yml
+✓ Created .github/workflows/check-doc-links.yml
+✓ Created .github/workflows/logmind-self-update.yml
+✓ Created .github/workflows/regen-timeline.yml
+✓ Created .github/dependabot.yml
+✓ Added logmind block to .gitignore
+✓ Added logmind block to .gitattributes
+✓ Installed Claude Code guard-commit hook (.claude/settings.json)
 ✓ Logged first decision: "Initialize logmind decision tracking"
-✓ Committed changes: "logmind: Initialize decision tracking"
 
 logmind initialized successfully!
 ```
 
-### Already initialized:
-```bash
+### Already initialized (refresh mode):
+
+```
 $ logmind init
 
-✓ docs/ already exists
-✓ CLAUDE.md already has logmind instructions
+Initializing logmind...
 
-logmind is already initialized in this project.
+logmind is already initialized — running in refresh mode.
+
+  All workflow templates already current.
+✓ Refreshed .git/hooks/post-merge
+✓ Refreshed .git/hooks/post-rewrite
+✓ Refreshed .git/hooks/commit-msg
+
+Done. docs/ and .logmind/ left untouched.
 ```

--- a/docs/custom-integrations.md
+++ b/docs/custom-integrations.md
@@ -1,5 +1,10 @@
 # Building Custom Integrations
 
+> **Historical — Python v0.6.x era (frozen).** The `BaseIntegration` API
+> described below does not exist in the Go binary (v1.0+). It is kept for
+> historical reference only; see [docs/plan.md](plan.md) for the current
+> (Go) architecture.
+
 This guide explains how to build a logmind integration for any AI framework.
 
 ## Overview

--- a/docs/decisions-branches/docs__v2-truth-sweep.md
+++ b/docs/decisions-branches/docs__v2-truth-sweep.md
@@ -1,0 +1,18 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-v2-0-0-truth-sweep-retired-python-era-doc-examples-taught-th -->
+- **2026-07-16** — v2.0.0 truth sweep: retired Python-era doc examples, taught the real v2 CLI surface (context/repomap/doctor --fix/headline/enforcement/the pulse) across README, SECURITY, ai-agent-files, plan, skill, and release tooling docs
+<!-- logmind-entry-end -->
+
+## 2026-07-16 23:00 - v2.0.0 truth sweep: retire Python-era doc examples, teach the real v2 CLI surface
+
+**Reasoning:** Pre-tag sweep found docs still teaching v1/Python-era commands (log --template, stats, aggregate, pip install) that fail with unknown command in the real v2 binary, plus other stale references (SECURITY.md version table, custom-integrations.md BaseIntegration, config.yml.template's inverted --stage default, goreleaser changelog filters that miss scoped conventional commits) ahead of the v2.0.0 tag
+
+**Alternatives considered:** Leave the docs stale until users hit confused post-tag issues, Patch only the MUST-FIX items and skip the cheap nice-to-haves
+
+**Implications:**
+- README Quick Start, SECURITY.md, docs/ai-agent-files.md, docs/plan.md, config.yml.template, and skill/SKILL.md now match the real v2 CLI surface (context, repomap, doctor --fix, headline, LOGMIND_QUIET, enforcement, the pulse)
+- goreleaser changelog filters are now scope-aware and the release footer no longer claims Linux Homebrew support
+
+---
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ that matches your platform and preferences.
 > branch). v0.6.x Python users — see the
 > [Deprecated: Python install](#deprecated-python-install) section.
 
-## Homebrew (recommended on macOS and Linux)
+## Homebrew (recommended on macOS)
 
 ```bash
 brew install thrillmade/tap/logmind
@@ -15,8 +15,9 @@ brew install thrillmade/tap/logmind
 
 This installs the latest signed + notarized release from
 [`thrillmade/homebrew-tap`](https://github.com/thrillmade/homebrew-tap),
-keyed to your CPU architecture (Apple Silicon, Intel, ARM64 Linux, x86_64
-Linux). Brew handles `$PATH` setup for you.
+keyed to your CPU architecture (Apple Silicon, Intel). Brew handles
+`$PATH` setup for you. The tap ships a macOS-only cask — on Linux, use the
+[curl one-liner](#curl-one-liner) below.
 
 The fully-qualified name (`thrillmade/tap/logmind`) auto-trusts the cask
 under Homebrew 6.0.0's [tap trust](https://docs.brew.sh/Tap-Trust) rules,
@@ -133,14 +134,16 @@ binaries.
 |------------|--------------|---------------------|----------|
 | macOS      | Apple Silicon | brew, curl, manual | Yes      |
 | macOS      | Intel        | brew, curl, manual  | Yes      |
-| Linux      | x86_64       | brew, curl, manual  | No*      |
-| Linux      | ARM64        | brew, curl, manual  | No*      |
+| Linux      | x86_64       | curl, manual        | No*      |
+| Linux      | ARM64        | curl, manual        | No*      |
 | Windows    | x86_64       | manual              | No*      |
 
 *Code signing for Linux/Windows isn't established yet — the releases
 ship plain binaries with SHA256 checksums for integrity verification.
-Linux distros' package manager signatures (Homebrew on Linux uses the
-same path as macOS) cover the trust gap.
+The curl installer verifies the download against `SHA256SUMS` before
+installing, which covers the trust gap. Homebrew is a macOS-only
+distribution path here — the `thrillmade/tap/logmind` cask does not
+target Linux.
 
 ## Verifying your install
 
@@ -168,9 +171,6 @@ The deprecated path is documented for users on long-lived consumer
 repos that haven't yet swapped pip-install for brew/curl in their
 workflow YAML. Migration is a one-line change in your CI: replace
 `pip install logmind==0.6.X` with `brew install thrillmade/tap/logmind`.
-
-A full consumer-repo migration recipe lands alongside the v1.0 cutover
-PR (Phase 3) — it will live in `docs/migrate-from-pip.md` once published.
 
 ## Troubleshooting
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -39,12 +39,15 @@ internal/
 ├── tree/          # deterministic, gitignore-aware file-structure tree
 ├── linkcheck/     # markdown link integrity (broken + orphaned links)
 ├── hooks/         # post-merge / post-rewrite git hook bodies
+├── guardcommit/   # shared decision engine: should this git commit be blocked for bypassing `logmind log`?
+├── claudehook/    # installs/inspects the Claude Code PreToolUse guard entry in .claude/settings.json
 ├── gitattr/       # .gitattributes block + merge-driver git-config
 ├── gitcli/        # thin exec.Command wrapper over git porcelain
 ├── inserter/      # AGENTS.md / per-agent-stub / dependabot scaffolding
 ├── agents/        # registry of supported AI agent instruction files
 ├── templates/     # embedded canonical templates (embed.FS)
 ├── skill/         # `logmind skill` — skill authoring/test/bench/audit
+├── clierr/        # shared error sentinels crossing package boundaries (skill ↔ cli)
 └── version/       # build-time Version / SpecVersion constants
 ```
 
@@ -143,23 +146,29 @@ consumer repos, and a 3-layer markdown self-healing gate on `logmind log`
 (interactive retry loop locally, deterministic CI comment / Anthropic
 auto-fix in the `check-doc-links` workflow).
 
-### v2.0.0 (in progress)
+### v2.0.0
 
 - **Shipped:** main-canonical is now the sole timeline model
   (branch-divergent removed, see Core Features above); the token-killer
   surface (`context`, `repomap` with ranking + `--map-tokens`,
   `LOGMIND_QUIET`, protocol §14); `show`, `search`, `headline`, and
   `doctor --fix` are all live.
-- **In progress — two features before the v2.0.0 tag:**
-  1. **Force-logmind-usage enforcement** — harness + git-hook changes
-     that steer substantive commits through `logmind log` rather than a
-     raw `git commit`.
-  2. **Canonical spec-file contract** — an optional, forward-looking spec
-     document surfaced via `logmind context`, defined SkDD-wide (shared
-     across logmind, clud-bug, and agent-skills) rather than
-     logmind-specific. logmind's own spec is the pointer doc
-     [docs/spec.md](spec.md) (`context.spec_file: docs/spec.md`).
-- Once both land, the release is tagged `v2.0.0`.
+- **Force-logmind-usage enforcement (SPEC §15):** the commit-msg hook
+  (git layer) and the Claude Code PreToolUse hook (harness layer) block a
+  substantive raw `git commit` that bypasses `logmind log`
+  (`internal/guardcommit` + `internal/claudehook`); escape hatches are
+  `[skip-logmind]`, `LOGMIND_ALLOW_GIT_COMMIT=1`, and
+  `git.enforce_commits: false`. The git layer signals a block via exit
+  65 and fails open on any other error.
+- **Canonical spec-file contract (SPEC §16):** an optional,
+  forward-looking spec document surfaced via `logmind context`, defined
+  SkDD-wide (shared across logmind, clud-bug, and agent-skills) rather
+  than logmind-specific. logmind's own spec is the pointer doc
+  [docs/spec.md](spec.md) (`context.spec_file: docs/spec.md`).
+- **The pulse (SPEC §3.1.1):** `logmind log` prints stderr advisories
+  after every commit — stale components (per `logmind doctor`) and spec
+  staleness (the spec file hasn't been touched in 20+ decisions).
+  Advisory only; it never blocks the commit that already landed.
 
 ## Technical Decisions
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -11,5 +11,6 @@ logmind's canonical, forward-looking contract is the SkDD protocol SPEC:
 
 logmind v2.0.0 implements SPEC 1.5.0+ (see `internal/version.SpecVersion`),
 including §15 (decision-logging enforcement), §16 (this canonical
-spec-file contract), and the §3.1.1 pulse. The near-term target is the v2.0.0 release:
-see [docs/plan.md](plan.md) for the current roadmap.
+spec-file contract), and the §3.1.1 pulse. logmind v2.0.0 is the current
+release line; see [docs/plan.md](plan.md) for architecture and the
+forward roadmap.

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-16-v2-0-0-truth-sweep-retired-python-era-doc-examples-taught-th -->
+- **2026-07-16** — v2.0.0 truth sweep: retired Python-era doc examples, taught the real v2 CLI surface (context/repomap/doctor --fix/headline/enforcement/the pulse) across README, SECURITY, ai-agent-files, plan, skill, and release tooling docs → [detail](decisions-branches/docs__v2-truth-sweep.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-routes-the-non-interactive-link-advisory-to-stderr-closing-t -->
 - **2026-07-16** — Routes the non-interactive link advisory to stderr, closing the 206a section 3.1.1 stdout-exactness gap before the v2.0.0 tag → [detail](decisions-branches/fix__selfheal-advisory-stderr.md)
 <!-- logmind-entry-end -->

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -7,10 +7,10 @@
 # Usage:
 #   curl -fsSL logmind.dev/install.sh | bash
 #   curl -fsSL logmind.dev/install.sh | bash -s -- --prefix=$HOME/.local
-#   curl -fsSL logmind.dev/install.sh | bash -s -- --version=v1.0.0
+#   curl -fsSL logmind.dev/install.sh | bash -s -- --version=v2.0.0
 #
 #   # Pin via env var (preserved for back-compat — see v1.1.0 notes):
-#   LOGMIND_VERSION=v1.0.0 curl -fsSL logmind.dev/install.sh | bash
+#   LOGMIND_VERSION=v2.0.0 curl -fsSL logmind.dev/install.sh | bash
 #
 # What it does:
 #   1. Detect OS (darwin | linux) + arch (x86_64 | arm64).
@@ -122,8 +122,8 @@ Env:
 Examples:
   curl -fsSL logmind.dev/install.sh | bash
   curl -fsSL logmind.dev/install.sh | bash -s -- --prefix=/usr/local
-  curl -fsSL logmind.dev/install.sh | bash -s -- --version=v1.0.0
-  LOGMIND_VERSION=v1.0.0 curl -fsSL logmind.dev/install.sh | bash
+  curl -fsSL logmind.dev/install.sh | bash -s -- --version=v2.0.0
+  LOGMIND_VERSION=v2.0.0 curl -fsSL logmind.dev/install.sh | bash
 
 Report install bugs to https://github.com/${REPO}/issues
 EOF

--- a/internal/templates/config.yml.template
+++ b/internal/templates/config.yml.template
@@ -3,14 +3,20 @@
 
 # Git integration
 git:
-  # Auto-commit the decision after `logmind log`. Stages ONLY the decision
-  # log and its companion files (file-structure.md, decisions-archive.md
-  # if rotated). Use `logmind log ... --stage all` to stage everything in
-  # the working tree (the pre-v0.1.2 behavior).
+  # Auto-commit the decision after `logmind log`. Default `--stage all`
+  # sweeps the WHOLE working tree into the decision commit (the decision
+  # and the code that prompted it travel together, one commit, no
+  # follow-up `git add`/`git commit`). Pass `logmind log ... --stage
+  # scoped` to limit the commit to the decision log + its companion
+  # files (file-structure.md, decisions-archive.md if rotated) when you
+  # have unrelated WIP you don't want swept in.
   auto_commit: true
 
-  # Push automatically after committing. Safe with scoped staging above —
-  # unrelated working-tree changes do not piggyback on the decision commit.
+  # Push automatically after committing. With the default `--stage all`,
+  # anything else in the working tree rides along in the same commit —
+  # push follows accordingly. Use `--stage scoped` (or set this false) if
+  # you want to review/split unrelated changes before they leave your
+  # machine.
   auto_push: true
 
   # Commit message template

--- a/internal/templates/logmind-section.md
+++ b/internal/templates/logmind-section.md
@@ -44,10 +44,13 @@ logmind search "database" --no-archive
 ### Required Reading
 
 **READ THESE FILES FIRST** before starting any work:
+- **[docs/timeline.md](docs/timeline.md)** - Main-canonical decision timeline across every branch (REQUIRED, start here)
 - **[docs/decisions.md](docs/decisions.md)** - 20 most recent decisions on the default branch (REQUIRED)
 - **[docs/file-structure.md](docs/file-structure.md)** - Current project structure (REQUIRED)
 
 These files contain critical context about why the project is structured the way it is.
+
+**Enforcement:** a substantive raw `git commit` that bypasses `logmind log` is blocked (commit-msg + Claude Code PreToolUse hooks) — use `logmind log` instead.
 
 ### Additional Reference
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,15 +2,18 @@
 //
 // v1.0.0 shipped 2026-06-03 via the v1-go-rewrite → main cutover (#132).
 // Local `go build` and `make build` produce a binary reporting the
-// "1.0.0-dev" default; tagged release builds running through
+// "2.0.0-dev" default; tagged release builds running through
 // `.goreleaser.yaml` override via `-ldflags
 // "-X 'github.com/thrillmade/logmind/internal/version.Version=v1.2.3'"`
 // to inject the actual tag.
 //
-// SpecVersion tracks the thrillmade/protocol SPEC.md document — bumped
-// to "1.0.0" 2026-07-04 (the coordinated SPEC 1.0.0 that REMOVES the
-// branch-divergent timeline model: §1.6.4 main-canonical union assembly
-// is now the sole, unconditional timeline. See v2.0.0 below).
+// SpecVersion tracks the thrillmade/protocol SPEC.md document. It was
+// bumped to "1.0.0" 2026-07-04 (the coordinated SPEC 1.0.0 that REMOVES
+// the branch-divergent timeline model: §1.6.4 main-canonical union
+// assembly is now the sole, unconditional timeline. See v2.0.0 below),
+// then advanced to the current "1.5.0" ahead of the v2.0.0 tag (§15
+// decision-logging enforcement, §16 the canonical spec-file contract,
+// §3.1.1 the pulse — see docs/spec.md).
 package version
 
 // Version is the logmind binary's semantic version. Bumped at release.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -42,6 +42,11 @@ logmind log "Use PostgreSQL for primary database" \
   -i "Schema migrations needed"
 ```
 
+`logmind log` *is* the commit primitive: default `--stage all` sweeps the
+whole working tree into one commit (the decision and the code that
+prompted it, together). Pass `--stage scoped` to commit only the decision
+file + its companion docs when you have unrelated WIP.
+
 ## Branch-aware logging
 
 When you are on a feature branch (anything other than the project's default
@@ -53,38 +58,87 @@ not need to manage this routing — `logmind log` does it automatically.
 
 ## Reading prior context
 
-Before starting non-trivial work, read:
+Before starting non-trivial work, read in order:
 
-- `docs/decisions.md` — 20 most recent decisions on the default branch
-- `docs/decisions-branches/<your-branch>.md` (if present) — decisions made
-  earlier on the same feature branch
-- `docs/file-structure.md` — current project tree
+1. **`docs/timeline.md`** — the main-canonical, source-derived union of
+   every decision across every branch; start here.
+2. **`docs/decisions.md`** — direct-on-main decisions in detail (20 most
+   recent).
+3. **`docs/decisions-branches/<your-branch>.md`** (if present) — decisions
+   made earlier on the same feature branch.
+4. **`docs/file-structure.md`** — current project tree.
+5. The project's **spec file**, if configured (`context.spec_file` in
+   `.logmind/config.yml`, typically `docs/spec.md`) — the forward-looking
+   contract to build toward, not just the history behind you.
+
+`logmind context` bundles the file structure + timeline (and the spec
+file, when configured) into one cache-friendly read — prefer it over
+piecing this together by hand.
 
 ```bash
 logmind show               # recent decisions on the current branch
 logmind show --all         # include archive
-logmind search "postgres"  # full-text across both files
+logmind search "postgres"  # full-text across recent + archive
 ```
 
 As an agent, set `LOGMIND_QUIET=1` for terse, chainable machine output: each
 verb suppresses progress chatter and prints a single `ok <key=value>` line.
+
+## Enforcement: raw `git commit` is blocked
+
+A substantive commit that bypasses `logmind log` is **blocked**, not just
+discouraged. Two layers enforce it: the git `commit-msg` hook, and (inside
+Claude Code) a PreToolUse hook that intercepts the `git commit` Bash call
+before it runs. Use `logmind log` in place of `git add` + `git commit` +
+`git push`.
+
+Escape hatches, for genuinely no-decision commits (typo fixes, dependency
+bumps):
+- Add `[skip-logmind]` to the commit subject.
+- Set `LOGMIND_ALLOW_GIT_COMMIT=1` for one command.
+- `git.enforce_commits: false` in `.logmind/config.yml` disables
+  enforcement for the whole repo.
+
+## Branch summaries (headline)
+
+Set a one-sentence, plain-English summary of what the **whole branch**
+does — the canonical timeline shows this line for the branch, and it's the
+first thing the next agent reads:
+
+```bash
+logmind headline "Add JWT session auth with refresh-token rotation"
+
+# or bundle it into a decision commit:
+logmind log "Wire refresh-token rotation" -r "..." -H "Add JWT session auth with refresh-token rotation"
+```
+
+A no-op on the default branch. `logmind doctor --fix` backfills a headline
+for any branch file that's missing one.
+
+## The pulse: read the advisories after `logmind log`
+
+After a successful commit, `logmind log` may print advisories to stderr —
+a stale component (workflow/hook/AGENTS.md drift; run `logmind doctor
+--fix`) or spec staleness (the spec file hasn't been touched in 20+
+decisions; worth a review). These never block the commit that already
+landed — act on them anyway.
 
 ## Setup (one-time, per project)
 
 If the project doesn't yet have logmind:
 
 ```bash
-pip install logmind
-logmind init               # scaffolds docs/, AGENTS.md, GH Actions, .gitignore block
+brew install thrillmade/tap/logmind   # or: curl -fsSL https://logmind.dev/install.sh | bash
+logmind init                          # scaffolds docs/, AGENTS.md, GH Actions, hooks
+logmind doctor                        # confirm a clean install
 ```
 
 ## Don'ts
 
-- **Don't use `git add` + `git commit` directly** for changes that carry a
-  decision. `logmind log` writes the decision file, stages every change in
-  the working tree, and creates the commit in one step. Manual `git commit`
-  bypasses the logging entirely or splits it across two commits — both lose
-  the value of reasoning attached to the code.
+- **Don't run `git add` + `git commit` directly** for changes that carry a
+  decision — the enforcement hooks above will block it anyway. `logmind
+  log` writes the decision file, stages the working tree, and creates the
+  commit in one step.
 - Don't log every tiny edit. The 20-line rule is a guideline; use judgement.
 - Don't write the decision after the fact in past tense for trivial code.
 - Don't reword a decision someone else already logged — link or extend it.


### PR DESCRIPTION
## Summary

Pre-tag documentation sweep ahead of v2.0.0: verified every finding against the real v2 CLI (`go build -o /tmp/lm ./cmd/logmind`; `/tmp/lm --help`) and against real command transcripts (`logmind init`, `logmind context --stats`, etc.) captured in a scratch repo, then fixed each one.

**MUST-FIX**
- `README.md` — Quick Start no longer teaches nonexistent v1 commands (`log --template`, `templates`, `stats`, `aggregate`); replaced with the real v2 surface (`context --stats`, `repomap`, `doctor --fix`, `headline`, `LOGMIND_QUIET=1`). Key concept / How It Works now cover the main-canonical timeline, commit-enforcement hooks, the spec file, and the pulse.
- `SECURITY.md` — full rewrite off the Python era: supported = 2.x, report via `logmind --version` + OS/arch, scope = Go binary + init-installed hooks/workflows + curl installer.
- `docs/ai-agent-files.md` — rewritten around the v2 model (AGENTS.md canonical + 2-line per-tool stubs via `templates.Stub()`); example transcripts captured live from `/tmp/lm init` (fresh, `--agents`, and refresh-mode).
- `docs/plan.md` — `### v2.0.0 (in progress)` → `### v2.0.0`; enforcement + spec-file contract moved into "shipped," the pulse (§3.1.1) added, the "once both land" line removed; `internal/guardcommit`, `internal/claudehook`, `internal/clierr` added to the architecture tree (verified all three exist).
- `internal/templates/config.yml.template` — the `git.auto_commit`/`auto_push` comments were inverted (implied scoped-by-default); corrected to match the real default (`--stage all` sweeps the tree, `--stage scoped` is the limiter). No golden/test pins the comment prose (checked `templates_test.go` + `testdata/`) — only the YAML value lines are asserted, which are untouched.
- `skill/SKILL.md` — brought to superset of the catalog copy (checked `agent-skills/skills/logmind/SKILL.md` first — it has timeline/headline but was missing the spec-file step and enforcement, so both are original here): brew/curl setup, timeline-first reading order + spec-file step + `logmind context` mention, new enforcement section, headline section, the pulse section.

**Fold-ins**
- `docs/install.md` — deleted the never-published `migrate-from-pip.md` promise; Homebrew is macOS-only (heading + platform matrix + trust-gap footnote corrected; Linux points at curl).
- `docs/spec.md` — "near-term target" line reworded to "current release line."
- `CONTRIBUTING.md` — `skill/` description now points at the agent-skills catalog.
- `docs/custom-integrations.md` — added a "Historical — Python v0.6.x era (frozen)" banner.
- `internal/templates/logmind-section.md` — Required Reading now leads with `docs/timeline.md` + a one-line enforcement note.
- `internal/version/version.go` — comments only: `SpecVersion` docstring and the dev-build default now say 1.5.0 / 2.0.0-dev (constants were already correct).
- `installer/install.sh` — header + usage example version pins bumped v1.0.0 → v2.0.0 (comments/examples only; the separate `thrillmade/setup-logmind@v1.0.0` action pin is untouched — different product's version).
- `.goreleaser.yaml` — changelog exclude filters are now scope-aware RE2 (`^docs(\(.+\))?:` etc., matching `docs(x): ...` conventional commits); release-notes footer no longer claims Linux Homebrew support (Linux now points at curl).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — no output
- [x] `go test ./... -count=1` — all packages pass (no goldens touched; confirmed no golden/test pins the edited template prose)
- [x] `goreleaser check` — `.goreleaser.yaml` validates
- [x] `/tmp/lm check-links` (fresh build) — `All markdown links resolve and no orphans found.`
- [x] Logged via `logmind log` (branch-aware → `docs/decisions-branches/docs__v2-truth-sweep.md`), pushed with no rebase needed (origin/main unchanged)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG