### PR TITLE
fix(pulse): subprocess-free hot path + local-time comparison (adversarial-review findings)

### DIFF
--- a/docs/decisions-branches/fix__pulse-hotpath-tz-skew.md
+++ b/docs/decisions-branches/fix__pulse-hotpath-tz-skew.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-16-fix-pulse-subprocess-free-hot-path-local-time-comparison-adv -->
+- **2026-07-16** — fix(pulse): subprocess-free hot path + local-time comparison (adversarial-review findings)
+<!-- logmind-entry-end -->
+
+## 2026-07-16 23:40 - fix(pulse): subprocess-free hot path + local-time comparison (adversarial-review findings)
+
+**Reasoning:** Adversarial review found 4 defects in the v2.0.0 log pulse: (1) the drift pulse ran doctor's full probe set on every logmind log, including a PATH lookup plus a live --version subprocess with no WaitDelay, so a hung or daemonizing PATH binary could stall or hang the log outright; (2) the spec pulse compared local-wall-clock decision headers (parsed as UTC by decisions.Iter) directly against a real git commit instant, skewing the comparison by the full UTC offset (false fires in positive zones, missed fires in negative zones); (3) the spec pulse could nag about a spec file the same log call was mid-editing; (4) printAdvisory's docstring still claimed stdout-only after PR 207 moved non-interactive advisories to stderr
+
+**Alternatives considered:** Keep StaleCount unchanged and only add a subprocess timeout - rejected, still pays PATH-lookup and subprocess latency on every single log, Relabel decisions.Iter's time.Parse to time.Local globally - rejected, Iter output also feeds timeline dedupeAndSuffix which compares Iter-derived dates against entry-block-marker dates always parsed as bare UTC, so relabeling would change docs/timeline.md byte output on non-UTC hosts
+
+**Implications:**
+- doctor.StaleCountFast/collectLogmindStatusFast is the new hot-path probe subset: every workflow marker, AGENTS.md block, git hook, and the Claude PreToolUse guard, all file reads only; PATH resolution and merge-driver git config are excluded and only surface via on-demand logmind doctor
+- probePathResolution now sets cmd.WaitDelay = 2 seconds so doctor itself is bounded even against a daemonizing PATH wrapper
+- specPulseLine reinterprets decision headers as local time via localizeDecisionDate before comparing to the git commit instant, and skips entirely when gitcli.StatusPorcelain reports uncommitted changes on the spec file
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -30,6 +30,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-16** — Harden git-hook layer against stale logmind binaries + bump AGENTS enforcement prose to v8/v9-pointer → [detail](decisions-branches/feat__enforce-stale-binary-hardening.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-16-fix-pulse-subprocess-free-hot-path-local-time-comparison-adv -->
+- **2026-07-16** — fix(pulse): subprocess-free hot path + local-time comparison (adversarial-review findings) → [detail](decisions-branches/fix__pulse-hotpath-tz-skew.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-feat-log-the-pulse-doctor-drift-spec-staleness-advisories-on -->
 - **2026-07-16** — feat(log): the pulse - doctor-drift + spec-staleness advisories on every log → [detail](decisions-branches/feat__log-pulse.md)
 <!-- logmind-entry-end -->

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -770,13 +770,19 @@ func runSelfHealLayer1(cwd string, forceNonInteractive, quiet bool, stdin io.Rea
 	return ErrSilent
 }
 
-// printAdvisory renders the Layer 1 advisory format. Pulled out as a
-// helper so it can be invoked both on initial detection and after
-// each failed retry.
+// printAdvisory renders the Layer 1 advisory format to whichever writer the
+// caller hands it. Pulled out as a helper so it can be invoked both on
+// initial detection and after each failed retry.
 //
-// Output goes to stdout (the human surface). stderr is reserved for
-// real errors so consumers piping `logmind log` into a log file don't
-// see advisories twice.
+// The destination is NOT fixed to stdout: the interactive-TTY retry loop
+// (runSelfHealLayer1) writes it to stdout, since that path is a live
+// back-and-forth with a human at the terminal. Every non-interactive case —
+// --quiet, --no-interactive, or no TTY on stdin — writes it to stderr
+// instead, so the §3.1 stdout contract (three fixed lines) and the --quiet
+// single-`ok`-line contract both stay byte-exact; the advisory is a
+// recovery hint on those paths, not part of either contract (see issue
+// #206(a) / PR #207). Callers choose the writer; this function has no
+// opinion of its own.
 func printAdvisory(stdout io.Writer, report linkcheck.CheckReport) {
 	count := len(report.Broken) + len(report.Orphans)
 	fmt.Fprintln(stdout)

--- a/internal/cli/pulse.go
+++ b/internal/cli/pulse.go
@@ -4,16 +4,16 @@
 // Two independent, best-effort advisories, printed in this order (drift
 // before spec) when applicable:
 //
-//   - Drift pulse: any doctor probe classified STALE (the drift class that
-//     flips doctor's Overall — stale hooks / stale AGENTS.md block / stale
-//     Claude PreToolUse guard; NOT missing, NOT markerless — see
-//     doctor.StaleCount):
+//   - Drift pulse: any FILE-READ-ONLY doctor probe classified STALE (the
+//     drift class that flips doctor's Overall — stale hooks / stale
+//     AGENTS.md block / stale Claude PreToolUse guard; NOT missing, NOT
+//     markerless — see doctor.StaleCountFast):
 //     `logmind: <n> component(s) stale — run 'logmind doctor --fix'`
 //
 //   - Spec pulse: context.spec_file is configured, resolves
-//     (config.ResolveSpecFile), the resolved file is git-TRACKED, and at
-//     least specPulseThreshold decision entries postdate the spec's last
-//     git commit:
+//     (config.ResolveSpecFile), the resolved file is git-TRACKED and has no
+//     uncommitted modifications, and at least specPulseThreshold decision
+//     entries postdate the spec's last git commit:
 //     `logmind: <spec-path> unchanged for <n> decisions — still accurate?`
 //
 // STDERR ONLY, unconditionally. This is deliberate and load-bearing:
@@ -31,12 +31,21 @@
 // Emitted in every mode — TTY, non-TTY, --quiet — with no gating on any of
 // them: only the STDOUT destination is contract-sensitive, and this package
 // never writes there.
+//
+// HOT-PATH BUDGET: emitPulse runs on EVERY `logmind log`, so every probe it
+// calls transitively must be subprocess-free (file reads / stats only). The
+// drift pulse uses doctor.StaleCountFast specifically because doctor's full
+// probe set (doctor.StaleCount, used by `logmind doctor` itself) includes a
+// PATH lookup + a live `<binary> --version` subprocess — a hung or
+// daemonizing PATH binary can stall or hang that call outright. See
+// doctor.StaleCountFast's doc comment for the exact excluded-probe list.
 package cli
 
 import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/decisions"
@@ -85,12 +94,19 @@ func emitPulse(cwd string, stderr io.Writer) {
 }
 
 // driftPulseLine reports the doctor-drift advisory. Reuses
-// doctor.StaleCount, which runs the identical probe set
-// collectLogmindStatus uses internally, so the count here is EXACTLY the
-// number of components that would flip a `logmind doctor` run on this repo
-// to DRIFT — no re-derivation of doctor's classification rules.
+// doctor.StaleCountFast — the subprocess-free subset of doctor's probes —
+// NOT doctor.StaleCount. `logmind log` runs on every commit; doctor's full
+// probe set includes a PATH lookup + a live `<binary> --version`
+// subprocess (probePathResolution) and a `git config` shell-out
+// (probeMergeDriverConfig), either of which can add real latency or, in
+// the pathological case of a hung/daemonizing PATH binary, hang the log
+// outright. StaleCountFast excludes exactly those two probes; everything
+// else is a plain file read, so the count here can differ from what
+// `logmind doctor` itself reports (PATH / merge-driver-config drift is
+// invisible to the pulse) — that gap is intentional, see StaleCountFast's
+// doc comment. Run `logmind doctor` for the complete picture.
 func driftPulseLine(cwd string) (string, bool) {
-	n := doctor.StaleCount(cwd)
+	n := doctor.StaleCountFast(cwd)
 	if n <= 0 {
 		return "", false
 	}
@@ -108,11 +124,17 @@ func driftPulseLine(cwd string) (string, bool) {
 //     (unset, absolute, or path-escaping values are already treated as
 //     UNSET there — same rule the real `logmind context` fold-in uses, so
 //     this advisory and that behavior can never disagree).
-//   - the resolved file is git-TRACKED. An untracked or uncommitted spec
-//     file has no deterministic last-touched date across clones (mtime
-//     isn't preserved by git, isn't preserved across clones/CI checkouts),
-//     so git history is the only source of truth here and an untracked
-//     file silently skips the pulse rather than guessing from mtime.
+//   - the resolved file is git-TRACKED. An untracked spec file has no
+//     deterministic last-touched date across clones (mtime isn't preserved
+//     by git, isn't preserved across clones/CI checkouts), so git history
+//     is the only source of truth here and an untracked file silently
+//     skips the pulse rather than guessing from mtime.
+//   - the tracked file has NO uncommitted modifications (working-tree or
+//     staged) right now. This log call may be the one editing the spec —
+//     `--stage scoped` or `--no-commit` can leave that edit uncommitted at
+//     the point emitPulse runs — and the very commit that updates the spec
+//     shouldn't turn around and ask "is this still accurate?" about the
+//     file it's mid-edit on. See gitcli.StatusPorcelain.
 //   - at least specPulseThreshold decision entries — collected from
 //     docs/decisions.md, docs/decisions-archive.md, and
 //     docs/decisions-branches/*.md via decisions.Collect, the same
@@ -132,6 +154,12 @@ func specPulseLine(cwd string) (string, bool) {
 	if !gitcli.IsTrackedFile(cwd, relSpec) {
 		return "", false
 	}
+	if gitcli.StatusPorcelain(cwd, relSpec) != "" {
+		// Uncommitted changes (staged or working-tree) — the spec is
+		// mid-edit right now; skip rather than nag about the file this
+		// very log might be updating.
+		return "", false
+	}
 	specTime, ok := gitcli.LastCommitTime(cwd, relSpec)
 	if !ok {
 		return "", false
@@ -143,7 +171,34 @@ func specPulseLine(cwd string) (string, bool) {
 	}
 	count := 0
 	for _, e := range entries {
-		if e.Date.After(specTime) {
+		// decisions.Iter parses `## YYYY-MM-DD HH:MM` decision headers with
+		// a zoneless time.Parse, which Go labels UTC — but those headers
+		// are written from time.Now().Format(...) (buildDecisionEntry in
+		// log.go), i.e. LOCAL wall-clock time. specTime, by contrast, is a
+		// true instant (gitcli.LastCommitTime parses git's %cI, strict
+		// ISO 8601 with an explicit offset). Comparing e.Date.After(specTime)
+		// directly mixes a local-wall-clock-mislabeled-as-UTC value against
+		// a real instant, skewing the comparison by the full local UTC
+		// offset — a false fire in positive-offset zones (e.g. UTC+12: a
+		// decision logged BEFORE the spec commit reads as hours AFTER it),
+		// a missed fire in negative-offset zones (e.g. UTC-7: a decision
+		// logged AFTER the spec commit reads as hours BEFORE it).
+		//
+		// The fix is deliberately LOCAL to this comparison rather than
+		// changing decisions.Iter's parse itself: Iter's output also feeds
+		// internal/timeline/canonical.go's dedupeAndSuffix, which compares
+		// Iter-derived dates against entry-block-marker dates (always
+		// parsed as bare UTC via time.Parse("2006-01-02", ...)) using
+		// Time.Equal/After for sorting and same-entry dedup. Relabeling
+		// Iter's zone to Local would make those two date sources disagree
+		// on the same calendar date's instant whenever the host isn't UTC,
+		// changing docs/timeline.md's byte output (dedup collisions no
+		// longer collapse, sort order shifts) for the COMMON case — direct
+		// decisions.md / decisions-archive.md entries always take the
+		// Iter-derived path since those files never carry entry-block
+		// markers. So Iter stays UTC-labeled; only this comparison
+		// re-interprets the wall clock as local time before comparing.
+		if localizeDecisionDate(e.Date).After(specTime) {
 			count++
 		}
 	}
@@ -151,4 +206,16 @@ func specPulseLine(cwd string) (string, bool) {
 		return "", false
 	}
 	return fmt.Sprintf("logmind: %s unchanged for %d decisions — still accurate?", relSpec, count), true
+}
+
+// localizeDecisionDate reinterprets a decisions.Iter-parsed Entry.Date's
+// wall-clock components (year/month/day/hour/minute) as LOCAL time instead
+// of Iter's default UTC label. Decision headers are written by
+// buildDecisionEntry (log.go) via time.Now().Format("2006-01-02 15:04") —
+// local wall time, by construction, always — so re-labeling as time.Local
+// recovers the real instant the decision was logged at. See the comment at
+// specPulseLine's e.Date.After(specTime) call site for why this fix is
+// scoped to the pulse rather than to decisions.Iter itself.
+func localizeDecisionDate(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
 }

--- a/internal/cli/pulse_hotpath_test.go
+++ b/internal/cli/pulse_hotpath_test.go
@@ -1,0 +1,256 @@
+// pulse_hotpath_test.go — subprocess-level proofs for the pulse hot-path
+// hardening (adversarial-review findings, items 1 and 2 of the pulse fix):
+//
+//   - item 1 (hang-proof): `logmind log`'s drift pulse must never touch the
+//     subprocess-bearing PATH-resolution probe. Proven end-to-end against
+//     the REAL built binary with a hostile `logmind` planted FIRST on
+//     PATH — one variant that just sleeps, and a "daemonizing wrapper"
+//     variant that backgrounds a sleeping grandchild and exits immediately
+//     itself (the shape that defeats a naive context-timeout-only bound;
+//     see internal/doctor/doctor_test.go's WaitDelay tests for the
+//     on-demand `doctor` path's version of this same fix). Both must
+//     complete in well under the ctx timeout doctor's PATH probe would
+//     have used (5s) — comfortably inside 3s — because the pulse's
+//     drift-count call (doctor.StaleCountFast) never invokes that probe.
+//
+//   - item 2 (TZ skew): the spec pulse compares decisions.Iter-parsed
+//     entry dates against gitcli.LastCommitTime's real instant.
+//     decisions.Iter parses `## YYYY-MM-DD HH:MM` headers with a zoneless
+//     time.Parse (Go labels these UTC by default), but those headers are
+//     LOCAL wall-clock time by construction — log.go's buildDecisionEntry
+//     writes time.Now().Format("2006-01-02 15:04"). Comparing the
+//     UTC-mislabeled value directly against a real instant skews the
+//     comparison by the full local UTC offset: a false fire in
+//     positive-offset zones, a missed fire in negative-offset zones.
+//     Reproducing this needs a process whose time.Local actually reflects
+//     a target zone — Go resolves time.Local once, at process
+//     initialization, from the TZ environment variable, and setting
+//     TZ inside an already-running test process does NOT reload it. Hence
+//     real `go build` + subprocess invocations with TZ set on the
+//     child's environment, not t.Setenv in-process.
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// requireHotpathSubprocessTools skips the calling test when the go
+// toolchain or git aren't available, or when -short was requested — same
+// gating convention as guard_commit_test.go / version_test.go's subprocess
+// tests. Returns the resolved `go` binary path.
+func requireHotpathSubprocessTools(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping subprocess test in -short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH; skipping subprocess test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping subprocess test")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("hostile-PATH-binary fixtures below are POSIX shell scripts")
+	}
+	return goBin
+}
+
+// prependPathEnv builds a subprocess environment with dir placed FIRST on
+// PATH (the rest of the real PATH follows). A single PATH entry is
+// synthesized (rather than appending a second PATH= to os.Environ()) so
+// there's no ambiguity about which one a libc getenv-style lookup honors
+// inside the child.
+func prependPathEnv(dir string) []string {
+	out := []string{"PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH")}
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "PATH=") {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// TestLogBinary_HangProof_HostilePathBinary is the release-bar proof for
+// item 1: with the REAL built `logmind` binary, `logmind log
+// --no-interactive --no-push` must complete in well under 3s even when a
+// hostile `logmind` shell script sits FIRST on PATH — whether it just
+// hangs, or daemonizes (forks a sleeping grandchild and exits). The pulse
+// must ALSO still be functional: a stale post-merge hook (a file-read-only
+// probe) must still surface a drift line, proving the fix didn't
+// accidentally disable the whole pulse rather than just its
+// subprocess-bearing probe.
+func TestLogBinary_HangProof_HostilePathBinary(t *testing.T) {
+	goBin := requireHotpathSubprocessTools(t)
+	binPath := buildGuardCommitBinary(t, goBin)
+
+	scenarios := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "hard sleep",
+			body: "#!/bin/sh\nsleep 30\n",
+		},
+		{
+			name: "daemonizing wrapper (grandchild sleeps, wrapper exits immediately)",
+			body: "#!/bin/sh\n(sleep 30 &)\nexit 0\n",
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			initLogTestGitRepo(t, repo)
+
+			initCmd := exec.Command(binPath, "init", "--no-git")
+			initCmd.Dir = repo
+			if out, err := initCmd.CombinedOutput(); err != nil {
+				t.Fatalf("logmind init --no-git: %v\n%s", err, out)
+			}
+			writeStaleHook(t, repo) // stale post-merge hook — proves file-read probes still run
+
+			fakeBinDir := t.TempDir()
+			fake := filepath.Join(fakeBinDir, "logmind")
+			if err := os.WriteFile(fake, []byte(sc.body), 0o755); err != nil {
+				t.Fatalf("write hostile logmind: %v", err)
+			}
+
+			cmd := exec.Command(binPath, "log", "hang proof test", "-r", "why", "--no-interactive", "--no-push")
+			cmd.Dir = repo
+			cmd.Env = prependPathEnv(fakeBinDir)
+			cmd.Stdin = strings.NewReader("")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			start := time.Now()
+			runErr := cmd.Run()
+			elapsed := time.Since(start)
+
+			if elapsed > 3*time.Second {
+				t.Fatalf("logmind log took %v with a hostile logmind FIRST on PATH (%s); want < 3s — the pulse must never touch the PATH-resolution subprocess.\nstdout=%q\nstderr=%q",
+					elapsed, sc.name, stdout.String(), stderr.String())
+			}
+			if runErr != nil {
+				t.Fatalf("logmind log failed (%v): %v\nstdout=%s\nstderr=%s", sc.name, runErr, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "component") || !strings.Contains(stderr.String(), "stale") {
+				t.Fatalf("expected a drift pulse line (proving the file-read probes still ran) on stderr; got stdout=%q stderr=%q",
+					stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+// TestLogBinary_TZSkew_SpecPulse is the release-bar proof for item 2: the
+// spec pulse's local-time comparison, exercised through the REAL built
+// binary with TZ set on the subprocess environment (see file docstring for
+// why this can't be an in-process t.Setenv test).
+func TestLogBinary_TZSkew_SpecPulse(t *testing.T) {
+	goBin := requireHotpathSubprocessTools(t)
+	binPath := buildGuardCommitBinary(t, goBin)
+
+	t.Run("UTC+12: decisions 2h BEFORE the spec commit must stay silent", func(t *testing.T) {
+		loc := mustLoadTZLocation(t, "Pacific/Auckland")
+		// NZ winter (June): NZST, a fixed UTC+12 — no DST straddling.
+		specInstant := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		decisionInstant := specInstant.Add(-2 * time.Hour) // genuinely BEFORE the commit
+		runTZSkewSpecPulseCase(t, binPath, "Pacific/Auckland", loc, specInstant, decisionInstant, false)
+	})
+
+	t.Run("UTC-7: decisions 2h AFTER the spec commit must fire", func(t *testing.T) {
+		loc := mustLoadTZLocation(t, "America/Los_Angeles")
+		// CA summer (July): PDT, a fixed UTC-7 — no DST straddling.
+		specInstant := time.Date(2024, 7, 15, 0, 0, 0, 0, time.UTC)
+		decisionInstant := specInstant.Add(2 * time.Hour) // genuinely AFTER the commit
+		runTZSkewSpecPulseCase(t, binPath, "America/Los_Angeles", loc, specInstant, decisionInstant, true)
+	})
+}
+
+func mustLoadTZLocation(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Skipf("tzdata for %s unavailable on this host: %v", name, err)
+	}
+	return loc
+}
+
+// runTZSkewSpecPulseCase builds a repo with a spec file committed at
+// specInstant (a real, TZ-independent instant) and specPulseThreshold
+// decision entries whose headers carry the LOCAL wall-clock rendering of
+// decisionInstant in `loc` — exactly what log.go's buildDecisionEntry would
+// have written had `time.Now()` returned decisionInstant while the process
+// ran under `loc`. It then runs the real `logmind log` binary with TZ=tz on
+// its environment and asserts the spec pulse fires (or doesn't) per
+// wantFire — the ground truth being decisionInstant.After(specInstant),
+// which is independent of any timezone.
+func runTZSkewSpecPulseCase(t *testing.T, binPath, tz string, loc *time.Location, specInstant, decisionInstant time.Time, wantFire bool) {
+	t.Helper()
+	repo := t.TempDir()
+	initLogTestGitRepo(t, repo)
+
+	initCmd := exec.Command(binPath, "init", "--no-git")
+	initCmd.Dir = repo
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("logmind init --no-git: %v\n%s", err, out)
+	}
+
+	mustWriteUnder(t, repo, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+	commitFileWithDate(t, repo, "SPEC.md", "# Spec\n", specInstant.UTC().Format(time.RFC3339))
+
+	// Overwrite the init-scaffolded decisions.md (which carries init's own
+	// "first decision", logged at real current wall-clock time and
+	// irrelevant to this reproduction) with `specPulseThreshold` entries,
+	// all sharing the SAME contrived wall-clock header.
+	wallClock := decisionInstant.In(loc).Format("2006-01-02 15:04")
+	var b strings.Builder
+	b.WriteString("# Decisions\n\n")
+	for i := 0; i < specPulseThreshold; i++ {
+		fmt.Fprintf(&b, "## %s - tz skew filler decision %d\n\n**Reasoning:** filler\n\n---\n\n", wallClock, i)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "docs", "decisions.md"), []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("overwrite decisions.md: %v", err)
+	}
+
+	cmd := exec.Command(binPath, "log", "tz skew probe", "-r", "why", "--no-commit", "--no-interactive")
+	cmd.Dir = repo
+	cmd.Env = envWithTZ(tz)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("logmind log: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	fired := strings.Contains(stderr.String(), "logmind: SPEC.md unchanged for")
+	if fired != wantFire {
+		t.Fatalf("TZ=%s: spec pulse fired=%v; want %v (ground truth: decisionInstant %s spec commit's instant).\nspecInstant=%s decisionInstant=%s wallClock(in %s)=%q\nstderr=%q",
+			tz, fired, wantFire, map[bool]string{true: "IS after", false: "is NOT after"}[wantFire],
+			specInstant, decisionInstant, tz, wallClock, stderr.String())
+	}
+}
+
+// envWithTZ returns a subprocess environment identical to the current
+// process's, except any existing TZ is dropped and replaced with a single
+// "TZ=tz" entry — avoiding the ambiguity of two TZ= entries in Env (getenv
+// implementations conventionally honor the FIRST match, so a naive append
+// after os.Environ() risks being silently ignored if TZ is already set).
+func envWithTZ(tz string) []string {
+	out := []string{"TZ=" + tz}
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "TZ=") {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/internal/cli/pulse_test.go
+++ b/internal/cli/pulse_test.go
@@ -259,6 +259,88 @@ func TestLog_Pulse_SpecUntracked_Silent(t *testing.T) {
 	})
 }
 
+// TestLog_Pulse_SpecUncommittedWorkingTreeEdit_Silent: the spec file IS
+// tracked and has a real last-commit date, but it also has an uncommitted
+// working-tree edit right now (e.g. this same `logmind log` was invoked
+// with --no-commit, or --stage scoped, while the author is mid-edit on the
+// spec). The pulse must skip — the log that's touching the spec shouldn't
+// turn around and ask whether the spec is still accurate.
+func TestLog_Pulse_SpecUncommittedWorkingTreeEdit_Silent(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		commitFileWithDate(t, d, "SPEC.md", "# Spec\n", "2020-01-01T00:00:00Z")
+
+		// Comfortably over specPulseThreshold against the 2020 commit date,
+		// so if this test fails it's unambiguously because the uncommitted
+		// edit was ignored — not because the count was too low.
+		addFillerDecisions(t, 25)
+
+		// Now edit SPEC.md WITHOUT committing — a dirty working tree.
+		if err := os.WriteFile(filepath.Join(d, "SPEC.md"), []byte("# Spec\n\nmid-edit.\n"), 0o644); err != nil {
+			t.Fatalf("edit SPEC.md: %v", err)
+		}
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			// --no-commit: nothing (including the SPEC.md edit) gets
+			// committed, so the edit is still dirty when emitPulse runs.
+			root.SetArgs([]string{"log", "mid-spec-edit test", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\n%s", err, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "unchanged for") {
+				t.Fatalf("spec pulse fired while SPEC.md has an uncommitted working-tree edit; stderr:\n%s", errBuf.String())
+			}
+		})
+	})
+}
+
+// TestLog_Pulse_SpecUncommittedStagedEdit_Silent: same as the working-tree
+// variant above, but the spec edit is STAGED (git add'ed) rather than left
+// in the working tree — `git status --porcelain` reports it either way, so
+// the pulse must skip here too.
+func TestLog_Pulse_SpecUncommittedStagedEdit_Silent(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		neutralizePathProbe(t)
+		mustWriteUnder(t, d, ".logmind/config.yml", "context:\n  spec_file: SPEC.md\n")
+		commitFileWithDate(t, d, "SPEC.md", "# Spec\n", "2020-01-01T00:00:00Z")
+
+		addFillerDecisions(t, 25)
+
+		if err := os.WriteFile(filepath.Join(d, "SPEC.md"), []byte("# Spec\n\nstaged edit.\n"), 0o644); err != nil {
+			t.Fatalf("edit SPEC.md: %v", err)
+		}
+		addCmd := exec.Command("git", "add", "SPEC.md")
+		addCmd.Dir = d
+		if out, err := addCmd.CombinedOutput(); err != nil {
+			t.Fatalf("git add SPEC.md: %v\n%s", err, out)
+		}
+		// Deliberately NOT committed — staged only.
+
+		withFakeTTY(t, false, func() {
+			root := NewRootCmd()
+			root.SetArgs([]string{"log", "staged-spec-edit test", "-r", "why", "--no-commit", "--no-interactive"})
+			var out, errBuf bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errBuf)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("log: %v\n%s", err, errBuf.String())
+			}
+			if strings.Contains(errBuf.String(), "unchanged for") {
+				t.Fatalf("spec pulse fired while SPEC.md has a staged-but-uncommitted edit; stderr:\n%s", errBuf.String())
+			}
+		})
+	})
+}
+
 // TestLog_Pulse_SpecUnset_Silent: context.spec_file is left at its default
 // ("") — config.ResolveSpecFile reports unset, so the pulse must never
 // even attempt the git/decision-count work.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -358,14 +358,71 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 // "does this repo need `doctor --fix`" should only count the same signal
 // doctor itself gates on.
 //
-// Exported for `logmind log`'s pulse advisory (internal/cli/pulse.go),
-// which wants doctor's exact stale-count without paying for
-// CollectStatus's extra SummariesNeeded / SpecAdvisories walks — this
-// calls collectLogmindStatus directly, the same probe set, nothing more.
+// This is the FULL probe set — including probePathResolution (a PATH lookup
+// + a live subprocess) and probeMergeDriverConfig (a `git config` shell-out)
+// — meant for on-demand callers like `logmind doctor` itself, which can
+// afford a subprocess or two. `logmind log`'s hot path cannot: see
+// StaleCountFast below.
 func StaleCount(projectRoot string) int {
 	status := collectLogmindStatus(projectRoot)
 	count := 0
 	for _, wf := range status.Workflows {
+		if wf.Drift == "stale" {
+			count++
+		}
+	}
+	return count
+}
+
+// collectLogmindStatusFast runs the FILE-READ-ONLY subset of
+// collectLogmindStatus's probes — every probe here does nothing but stat/
+// read a local file (or parse embedded template bytes already resident in
+// the binary). No probe here forks a subprocess, so the whole set costs a
+// handful of stat/read syscalls: single-digit milliseconds, safe to run on
+// EVERY `logmind log` invocation.
+//
+// EXCLUDED, and why:
+//
+//   - probePathResolution: does `exec.LookPath("logmind")` followed by a
+//     live `<path> --version` subprocess. A hung PATH binary — or a
+//     daemonizing wrapper whose grandchild inherits the output pipe past
+//     the parent's own exit — can stall this for seconds or hang it
+//     outright, exactly the failure mode the hot path must never risk. See
+//     probePathResolution's WaitDelay hardening below, which bounds this
+//     for the on-demand `doctor` path (which CAN tolerate a bounded
+//     subprocess wait; `logmind log` cannot tolerate any).
+//   - probeMergeDriverConfig: shells out to `git config --get` (via
+//     gitattr.DriverConfigured) — a subprocess, the same category of risk
+//     as above even though `git` itself is normally well-behaved.
+//
+// Both excluded signals — on-PATH version drift and merge-driver config
+// drift — still surface via an on-demand `logmind doctor` run (the full
+// probe set, StaleCount above); they're simply not worth paying a
+// subprocess for on every single `logmind log`.
+func collectLogmindStatusFast(projectRoot string) []WorkflowStatus {
+	var workflows []WorkflowStatus
+	for _, name := range LogmindWorkflows {
+		workflows = append(workflows, probeWorkflow(projectRoot, name, bundledLogmindMarker(name)))
+	}
+	workflows = append(workflows, probeAgentsMD(projectRoot))
+	workflows = append(workflows, probeMergeDriverAttrs(projectRoot)) // file read only (.gitattributes) — safe
+	workflows = append(workflows, probePostMergeHook(projectRoot))
+	workflows = append(workflows, probePostRewriteHook(projectRoot))
+	workflows = append(workflows, probeCommitMsgHook(projectRoot))
+	workflows = append(workflows, probeClaudePreToolUseHook(projectRoot))
+	return workflows
+}
+
+// StaleCountFast is StaleCount's subprocess-free subset, built from
+// collectLogmindStatusFast — see that function's doc comment for exactly
+// which probes are excluded and why. This is what `logmind log`'s pulse
+// advisory calls (internal/cli/pulse.go driftPulseLine): the hot-path
+// budget is single-digit milliseconds, not "however long a PATH binary
+// takes to answer `--version`, if it answers at all."
+func StaleCountFast(projectRoot string) int {
+	workflows := collectLogmindStatusFast(projectRoot)
+	count := 0
+	for _, wf := range workflows {
 		if wf.Drift == "stale" {
 			count++
 		}
@@ -684,6 +741,17 @@ func probePathResolution() WorkflowStatus {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, pathBin, "--version")
+	// WaitDelay bounds how long Wait (called internally by CombinedOutput)
+	// keeps blocking on the command's I/O pipes AFTER ctx's timeout kills
+	// the direct child. Without it, a wrapper script that daemonizes —
+	// forks a grandchild and exits — leaves that grandchild holding the
+	// stdout/stderr pipe open; CombinedOutput blocks reading from the pipe
+	// until EOF, which never arrives, so the 5s context timeout (which only
+	// SIGKILLs the direct child) doesn't actually bound this call. WaitDelay
+	// (Go 1.20+) forces the pipe closed and Wait to return once this grace
+	// period elapses after the context kill signal, capping the worst case
+	// at ctx-timeout + WaitDelay instead of unbounded.
+	cmd.WaitDelay = 2 * time.Second
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil && len(out) == 0 {
 		marker := fmt.Sprintf("%s (cannot exec --version)", pathBin)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/version"
@@ -152,6 +153,122 @@ func TestStaleCount_MatchesDriftClassification(t *testing.T) {
 
 	if n := StaleCount(dir); n != 1 {
 		t.Errorf("StaleCount(one stale workflow) = %d; want 1", n)
+	}
+}
+
+// TestCollectLogmindStatusFast_ExcludesSubprocessProbes pins the shape
+// contract of the hot-path probe subset: the PATH-resolution row and the
+// git-config merge-driver row must NEVER appear (both fork a subprocess),
+// while every file-read-only probe row still does.
+func TestCollectLogmindStatusFast_ExcludesSubprocessProbes(t *testing.T) {
+	dir := freshRepo(t)
+	rows := collectLogmindStatusFast(dir)
+	names := workflowNames(rows)
+	if contains(names, "logmind on PATH") {
+		t.Errorf("collectLogmindStatusFast must not include the PATH-resolution probe row; got %v", names)
+	}
+	if contains(names, "git config (merge driver)") {
+		t.Errorf("collectLogmindStatusFast must not include the git-config merge-driver probe row; got %v", names)
+	}
+	for _, want := range []string{
+		"regen-timeline.yml", "check-doc-links.yml", "logmind-self-update.yml", "check-decisions.yml",
+		"AGENTS.md", ".gitattributes (merge driver)",
+		"post-merge hook", "post-rewrite hook", "commit-msg hook",
+		"Claude Code PreToolUse guard",
+	} {
+		if !contains(names, want) {
+			t.Errorf("collectLogmindStatusFast missing expected file-read probe %q; got %v", want, names)
+		}
+	}
+}
+
+// prependFakeBinDir puts dir FIRST on PATH (keeping the rest of the real
+// PATH after it) and restores the original PATH on test cleanup. Prepending
+// rather than replacing matters here: several of these fixtures write
+// wrapper shell scripts that themselves shell out to `sleep` / `touch` —
+// external binaries the script's own PATH lookup needs to find. Replacing
+// PATH wholesale (as a naive `os.Setenv("PATH", dir)` would) leaves those
+// binaries unresolvable, so the wrapper's shell fails instantly with
+// "command not found" instead of actually blocking — a false pass that
+// would silently defeat the whole point of these hang-proof tests.
+func prependFakeBinDir(t *testing.T, dir string) {
+	t.Helper()
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	_ = os.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+}
+
+// TestStaleCountFast_IgnoresStalePathBinary proves StaleCountFast's count
+// can legitimately differ from StaleCount's: a stale on-PATH `logmind`
+// binary flips the full probe set's count to 1, but the fast subset must
+// stay at 0 since it never runs that probe at all.
+func TestStaleCountFast_IgnoresStalePathBinary(t *testing.T) {
+	dir := freshRepo(t)
+	tmp := t.TempDir()
+	fake := filepath.Join(tmp, "logmind")
+	body := "#!/bin/sh\necho 'logmind, version 0.1.0'\n"
+	if err := os.WriteFile(fake, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	prependFakeBinDir(t, tmp)
+
+	if n := StaleCount(dir); n != 1 {
+		t.Fatalf("StaleCount (full probe set) = %d; want 1 (stale on-PATH binary)", n)
+	}
+	if n := StaleCountFast(dir); n != 0 {
+		t.Errorf("StaleCountFast = %d; want 0 — PATH-resolution drift must never surface on the hot-path subset", n)
+	}
+}
+
+// TestStaleCountFast_DoesNotBlockOnHungPathBinary is the unit-level
+// hang-proof: with a `logmind` on PATH that sleeps for 30s, StaleCountFast
+// must return near-instantly, proving it never touches probePathResolution
+// (the subprocess probe). The full end-to-end proof — through `logmind
+// log`'s actual pulse — lives in internal/cli/pulse_hotpath_test.go.
+func TestStaleCountFast_DoesNotBlockOnHungPathBinary(t *testing.T) {
+	dir := freshRepo(t)
+	tmp := t.TempDir()
+	fake := filepath.Join(tmp, "logmind")
+	body := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(fake, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	prependFakeBinDir(t, tmp)
+
+	start := time.Now()
+	StaleCountFast(dir)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("StaleCountFast took %v with a hung logmind on PATH; want near-instant (no subprocess probe on this path)", elapsed)
+	}
+}
+
+// TestProbePathResolution_DaemonizingWrapper_WaitDelayBounds exercises the
+// on-demand `doctor` path's hardening (item 1(b)): a PATH binary that
+// forks a background grandchild (inheriting the CombinedOutput pipe) and
+// exits immediately itself. Without cmd.WaitDelay, CombinedOutput's
+// internal Wait blocks reading that pipe until EOF — which never arrives
+// while the grandchild lives — regardless of the 5s context timeout
+// (which only kills the direct child). WaitDelay bounds the wait to a
+// couple of seconds after the direct child exits.
+func TestProbePathResolution_DaemonizingWrapper_WaitDelayBounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess timing test; skip in -short mode")
+	}
+	tmp := t.TempDir()
+	fake := filepath.Join(tmp, "logmind")
+	// The wrapper backgrounds a long sleep (inheriting stdout/stderr, i.e.
+	// the shared pipe) and returns immediately itself — the daemonizing
+	// pattern that defeats a naive ctx-timeout-only bound.
+	body := "#!/bin/sh\n(sleep 30 &)\nexit 0\n"
+	if err := os.WriteFile(fake, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	prependFakeBinDir(t, tmp)
+
+	start := time.Now()
+	_ = probePathResolution()
+	if elapsed := time.Since(start); elapsed > 6*time.Second {
+		t.Fatalf("probePathResolution with a daemonizing PATH wrapper took %v; want bounded (WaitDelay=2s after the near-instant direct-child exit), not the grandchild's full 30s sleep", elapsed)
 	}
 }
 

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -428,7 +428,10 @@ func ConfigSet(repoRoot, key, value string) error {
 // the raw stdout (trimmed). Empty string means clean (no
 // modifications/untracked); non-empty means there's something to
 // commit. Used by `logmind log` (B3) to detect changed agent files
-// before staging.
+// before staging, and by the spec pulse (internal/cli/pulse.go) to skip
+// the staleness advisory when the tracked spec file has uncommitted
+// changes right now (the log that's editing the spec shouldn't nag about
+// it).
 func StatusPorcelain(repoRoot, path string) string {
 	cmd := exec.Command("git", "status", "--porcelain", "--", path)
 	cmd.Dir = repoRoot


### PR DESCRIPTION
## Summary

Fixes 4 adversarially-confirmed defects in the v2.0.0 `logmind log` pulse feature (pre-tag release quality bar):

1. **MAJOR — PATH-binary exec off the log hot path.** `emitPulse -> doctor.StaleCount -> collectLogmindStatus -> probePathResolution` ran `exec.LookPath("logmind")` plus a live `logmind --version` subprocess (5s context timeout, no `WaitDelay`) on **every** `logmind log`. A hung PATH binary added a multi-second stall; a daemonizing wrapper (forks a grandchild, exits itself) could hang the log outright, since the grandchild holds the `CombinedOutput` pipe open past the parent's SIGKILL. Fixed both ends:
   - `doctor.StaleCountFast` / `collectLogmindStatusFast` — a new subprocess-free probe subset (every workflow-template marker, AGENTS.md block, git hooks, the Claude PreToolUse guard — all file reads). `pulse.go`'s `driftPulseLine` now calls this instead of `doctor.StaleCount`. PATH-resolution and merge-driver `git config` drift are excluded and only surface via on-demand `logmind doctor` (which uses the full probe set).
   - `probePathResolution` (the on-demand `doctor` path) now sets `cmd.WaitDelay = 2 * time.Second` so a daemonizing wrapper's orphaned grandchild can no longer hold the pipe unboundedly.

2. **MAJOR — timezone skew in the spec pulse.** Decision headers are local wall time (`log.go` writes `time.Now().Format(...)`), but `decisions.Iter` parses them with a zoneless `time.Parse` (labeled UTC by Go's default), while `gitcli.LastCommitTime` returns a true instant. Comparing them directly skewed by the full UTC offset — false fire in positive-offset zones, missed fire in negative-offset zones. Investigated relabeling `decisions.Iter` itself to `time.Local`, but that's provably unsafe: `Iter`'s output also feeds `internal/timeline/canonical.go`'s `dedupeAndSuffix`, which compares Iter-derived dates against entry-block-marker dates (always parsed as bare UTC) via `Time.Equal`/`After` for sort order and same-entry dedup — relabeling would change `docs/timeline.md`'s byte output on non-UTC hosts, and direct `decisions.md`/`decisions-archive.md` entries always take the Iter-derived path (no entry-block markers), so this isn't a corner case. Fix is contained to `pulse.go`: a new `localizeDecisionDate` helper re-interprets the parsed wall-clock as local time before comparing to the spec commit's instant.

3. **MINOR — don't nag about a spec the author is mid-edit on.** `specPulseLine` now skips when `gitcli.StatusPorcelain` reports uncommitted changes (staged or working-tree) for the tracked spec file — the log that's updating the spec shouldn't ask "still accurate?" about the very file it's touching.

4. **MINOR — stale `printAdvisory` docstring.** Rewrote to match reality post-#207: destination is caller-chosen (stdout on the interactive TTY path, stderr for `--quiet`/non-interactive/no-TTY), not the stdout-only text it used to claim.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1` — all clean
- [x] `TestLogBinary_HangProof_HostilePathBinary` (subprocess, real built binary): a hostile `logmind` FIRST on PATH — plain `sleep 30` and a daemonizing wrapper (`(sleep 30 &); exit 0`) — `logmind log --no-interactive --no-push` completes in well under 3s either way, and the drift pulse still fires from a stale post-merge hook (proving the file-read probes still run). Verified this test fails without the fix (30s hang on the daemonizing variant).
- [x] `TestLogBinary_TZSkew_SpecPulse` (subprocess, real built binary, TZ set on the child env since Go only reads TZ once at process init): spec committed at a controlled instant, `specPulseThreshold` decisions written with the LOCAL wall-clock rendering of an instant 2h before (UTC+12, Pacific/Auckland) → stays silent; 2h after (UTC-7, America/Los_Angeles) → fires. Verified both subtests fail without the fix (reproducing the exact false-fire / missed-fire described).
- [x] `TestLog_Pulse_SpecUncommittedWorkingTreeEdit_Silent` / `TestLog_Pulse_SpecUncommittedStagedEdit_Silent`: uncommitted spec edits (working-tree and staged) suppress the spec pulse. Verified both fail without the fix.
- [x] `doctor` package: `TestCollectLogmindStatusFast_ExcludesSubprocessProbes`, `TestStaleCountFast_IgnoresStalePathBinary`, `TestStaleCountFast_DoesNotBlockOnHungPathBinary`, `TestProbePathResolution_DaemonizingWrapper_WaitDelayBounds` (verified this one fails — 30s — without `WaitDelay`, passes in ~2s with it).
- [x] All pre-existing pulse boundary tests stay green (byte-exact stdout contract, threshold boundary, ordering, quiet mode, git-absent-from-PATH failure safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG