### PR TITLE
fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212)

### DIFF
--- a/.github/workflows/check-decisions.yml
+++ b/.github/workflows/check-decisions.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # fetch the live PR title (Enforce step) so a retitle+rerun honors [skip-logmind]
 
 jobs:
   check-decisions:
@@ -25,6 +26,9 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ github.token }}
           THRESHOLD: "20"
         run: |
           set -euo pipefail
@@ -52,16 +56,44 @@ jobs:
             decision_touched=1
           fi
 
-          echo "total_lines=$total" >> "$GITHUB_OUTPUT"
-          echo "decision_touched=$decision_touched" >> "$GITHUB_OUTPUT"
+          # [skip-logmind] is a NORMATIVE maintainer override (protocol SPEC
+          # §15.3 / Appendix A.2), not just a convenience. github.event.
+          # pull_request.title is frozen at trigger time, so re-running a
+          # failed check after a maintainer retitles the PR would still
+          # judge the STALE title — the override would silently not take
+          # effect (issue #212). Fetch the LIVE title instead. PR_NUMBER
+          # comes from the event too, but it IS stable across reruns (a PR
+          # keeps its number for life; only the title payload goes stale).
+          # This workflow only triggers on `pull_request`, so there's no
+          # non-PR event to guard against. Fail OPEN to the event payload
+          # title if the API call errors (rate limit, transient outage,
+          # etc.) — a `gh` hiccup must never crash this check.
+          live_title="$(gh pr view "$PR_NUMBER" --json title -q .title 2>/dev/null)" || live_title=""
+          if [ -z "$live_title" ]; then
+            live_title="$EVENT_TITLE"
+          fi
+          skip_logmind=false
+          case "$live_title" in
+            *"[skip-logmind]"*) skip_logmind=true ;;
+          esac
+
+          {
+            echo "total_lines=$total"
+            echo "decision_touched=$decision_touched"
+            echo "skip_logmind=$skip_logmind"
+          } >> "$GITHUB_OUTPUT"
           echo "Non-docs lines changed: $total (threshold: $THRESHOLD)"
           echo "Decision log touched: $decision_touched"
+          echo "skip-logmind override: $skip_logmind"
 
       - name: Enforce
         # Gate trips when the PR exceeds THRESHOLD non-docs lines without
         # touching a decision log. `[skip-logmind]` in the PR title bypasses
-        # the gate for one-off overrides (handled by maintainers).
-        if: steps.diff.outputs.total_lines >= fromJSON(env.THRESHOLD) && steps.diff.outputs.decision_touched == '0' && !contains(github.event.pull_request.title, '[skip-logmind]')
+        # the gate for one-off overrides (handled by maintainers). Reads
+        # steps.diff.outputs.skip_logmind, resolved from the LIVE PR title
+        # above — NOT github.event.pull_request.title, which is frozen at
+        # trigger time and would miss a retitle+rerun (issue #212).
+        if: steps.diff.outputs.total_lines >= fromJSON(env.THRESHOLD) && steps.diff.outputs.decision_touched == '0' && steps.diff.outputs.skip_logmind != 'true'
         env:
           THRESHOLD: "20"
         run: |

--- a/docs/decisions-branches/fix__check-decisions-live-pr-title-212.md
+++ b/docs/decisions-branches/fix__check-decisions-live-pr-title-212.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-17-fix-ci-check-decisions-honors-skip-logmind-on-rerun-fetch-th -->
+- **2026-07-17** — fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212)
+<!-- logmind-entry-end -->
+
+## 2026-07-17 00:09 - fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212)
+
+**Reasoning:** check-decisions.yml read the skip-logmind override from github.event.pull_request.title, which is frozen at trigger time. Rerunning a failed check after a maintainer retitles the PR replays the original payload, so the override silently does not take effect. Protocol SPEC section 15.3 and Appendix A.2 make skip-logmind a normative escape hatch, so this is a conformance bug, not just an inconvenience. The fix fetches the live title at run time via gh pr view using the PR number from the event, which stays stable across reruns, and computes a skip_logmind step output the Enforce step gates on instead. A gh API failure fails open to the old event-payload title so a transient hiccup never crashes the check.
+
+**Alternatives considered:** Tell maintainers to close and reopen the PR instead of rerunning — rejected, error-prone and contradicts the documented rerun workflow, Add a brand-new dedicated step just for the title fetch — rejected in favor of folding it into the existing Compute diff vs base step to keep the diff minimal
+
+**Implications:**
+- Template version bumped v3 to v4 on check-decisions.yml.template; consumers refresh via the Monday self-update wave
+- Workflow permissions gained pull-requests: read so gh pr view can succeed on private consumer repos
+- agent-skills is still on template v2 for this workflow and needs the self-update wave or a manual refresh to pick this up
+
+---
+

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -14,6 +14,10 @@ PR's CI run, so this file is always coherent with current `main`.
 
 ## 2026-07
 
+<!-- logmind-entry-start: 2026-07-17-fix-ci-check-decisions-honors-skip-logmind-on-rerun-fetch-th -->
+- **2026-07-17** — fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212) → [detail](decisions-branches/fix__check-decisions-live-pr-title-212.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-v2-0-0-truth-sweep-retired-python-era-doc-examples-taught-th -->
 - **2026-07-16** — v2.0.0 truth sweep: retired Python-era doc examples, taught the real v2 CLI surface (context/repomap/doctor --fix/headline/enforcement/the pulse) across README, SECURITY, ai-agent-files, plan, skill, and release tooling docs → [detail](decisions-branches/docs__v2-truth-sweep.md)
 <!-- logmind-entry-end -->

--- a/internal/templates/github/check-decisions.yml.template
+++ b/internal/templates/github/check-decisions.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v3
+# logmind-template-version: v4
 name: logmind / check-decisions
 
 # Fail PRs that introduce >20 lines of non-docs code changes without
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # fetch the live PR title (Enforce step) so a retitle+rerun honors [skip-logmind]
 
 jobs:
   check-decisions:
@@ -26,6 +27,9 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ github.token }}
           THRESHOLD: "20"
         run: |
           set -euo pipefail
@@ -53,16 +57,44 @@ jobs:
             decision_touched=1
           fi
 
-          echo "total_lines=$total" >> "$GITHUB_OUTPUT"
-          echo "decision_touched=$decision_touched" >> "$GITHUB_OUTPUT"
+          # [skip-logmind] is a NORMATIVE maintainer override (protocol SPEC
+          # §15.3 / Appendix A.2), not just a convenience. github.event.
+          # pull_request.title is frozen at trigger time, so re-running a
+          # failed check after a maintainer retitles the PR would still
+          # judge the STALE title — the override would silently not take
+          # effect (issue #212). Fetch the LIVE title instead. PR_NUMBER
+          # comes from the event too, but it IS stable across reruns (a PR
+          # keeps its number for life; only the title payload goes stale).
+          # This workflow only triggers on `pull_request`, so there's no
+          # non-PR event to guard against. Fail OPEN to the event payload
+          # title if the API call errors (rate limit, transient outage,
+          # etc.) — a `gh` hiccup must never crash this check.
+          live_title="$(gh pr view "$PR_NUMBER" --json title -q .title 2>/dev/null)" || live_title=""
+          if [ -z "$live_title" ]; then
+            live_title="$EVENT_TITLE"
+          fi
+          skip_logmind=false
+          case "$live_title" in
+            *"[skip-logmind]"*) skip_logmind=true ;;
+          esac
+
+          {
+            echo "total_lines=$total"
+            echo "decision_touched=$decision_touched"
+            echo "skip_logmind=$skip_logmind"
+          } >> "$GITHUB_OUTPUT"
           echo "Non-docs lines changed: $total (threshold: $THRESHOLD)"
           echo "Decision log touched: $decision_touched"
+          echo "skip-logmind override: $skip_logmind"
 
       - name: Enforce
         # Gate trips when the PR exceeds THRESHOLD non-docs lines without
         # touching a decision log. `[skip-logmind]` in the PR title bypasses
-        # the gate for one-off overrides (handled by maintainers).
-        if: steps.diff.outputs.total_lines >= fromJSON(env.THRESHOLD) && steps.diff.outputs.decision_touched == '0' && !contains(github.event.pull_request.title, '[skip-logmind]')
+        # the gate for one-off overrides (handled by maintainers). Reads
+        # steps.diff.outputs.skip_logmind, resolved from the LIVE PR title
+        # above — NOT github.event.pull_request.title, which is frozen at
+        # trigger time and would miss a retitle+rerun (issue #212).
+        if: steps.diff.outputs.total_lines >= fromJSON(env.THRESHOLD) && steps.diff.outputs.decision_touched == '0' && steps.diff.outputs.skip_logmind != 'true'
         env:
           THRESHOLD: "20"
         run: |

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -364,6 +364,56 @@ func TestCheckDocLinksTemplate_V7_AdvisoryNoStrand(t *testing.T) {
 	}
 }
 
+// TestCheckDecisionsTemplate_V4_LivePRTitle pins the issue #212 fix: the
+// `[skip-logmind]` override (a NORMATIVE escape hatch — protocol SPEC
+// §15.3 / Appendix A.2) must be read from the LIVE PR title at run time,
+// not from github.event.pull_request.title, which is frozen at trigger
+// time and goes stale across a maintainer retitle+rerun.
+func TestCheckDecisionsTemplate_V4_LivePRTitle(t *testing.T) {
+	body := Workflow("check-decisions.yml.template")
+
+	// Marker bump v3 → v4.
+	if !strings.Contains(body, "# logmind-template-version: v4") {
+		t.Errorf("check-decisions template missing v4 marker")
+	}
+
+	// The Enforce step's `if:` must no longer trust the frozen event
+	// payload title for the skip-logmind check — that's the bug: a
+	// re-run after a retitle replays the ORIGINAL payload.
+	if strings.Contains(body, "contains(github.event.pull_request.title, '[skip-logmind]')") {
+		t.Errorf("check-decisions v4 Enforce step must not gate on the frozen github.event.pull_request.title (issue #212)")
+	}
+	// Instead it must key off a step output resolved from the live title.
+	if !strings.Contains(body, "steps.diff.outputs.skip_logmind != 'true'") {
+		t.Errorf("check-decisions v4 Enforce step must gate on steps.diff.outputs.skip_logmind (resolved from the live PR title)")
+	}
+
+	// The live title must be fetched via `gh pr view` using the PR number
+	// from the event (stable across reruns) — not the title.
+	if !strings.Contains(body, `gh pr view "$PR_NUMBER" --json title -q .title`) {
+		t.Errorf("check-decisions v4 missing the live-title fetch via `gh pr view \"$PR_NUMBER\" --json title -q .title`")
+	}
+	if !strings.Contains(body, "PR_NUMBER: ${{ github.event.pull_request.number }}") {
+		t.Errorf("check-decisions v4 missing PR_NUMBER sourced from the event (stable across reruns, unlike the title)")
+	}
+
+	// A `gh` API hiccup must fail OPEN to the old behavior (the event
+	// payload title), never crash the check.
+	if !strings.Contains(body, `live_title="$EVENT_TITLE"`) {
+		t.Errorf("check-decisions v4 missing the fail-open fallback to the event payload title on a `gh pr view` error")
+	}
+	if !strings.Contains(body, "EVENT_TITLE: ${{ github.event.pull_request.title }}") {
+		t.Errorf("check-decisions v4 missing EVENT_TITLE (the fail-open fallback source)")
+	}
+
+	// `gh pr view` needs read access to pull request data; the workflow
+	// token must grant it explicitly (the block already restricts
+	// everything else to none).
+	if !strings.Contains(body, "pull-requests: read") {
+		t.Errorf("check-decisions v4 missing pull-requests: read permission (required for `gh pr view`)")
+	}
+}
+
 // TestDecisionsBranchHeader_Shape pins the v1.2.0 backlink header
 // template (plan §8.7 deliverable 3). The single-line shape +
 // trailing blank line + relative ../timeline.md path are


### PR DESCRIPTION
## Summary
- `check-decisions.yml` read the `[skip-logmind]` override from `github.event.pull_request.title`, which is frozen at the triggering event. Re-running a failed check after a maintainer retitles the PR replays the *original* payload, so the override silently doesn't take effect — the exact failure mode reported in agent-skills#150 (retitle → rerun → still red).
- `[skip-logmind]` is a NORMATIVE escape hatch per protocol SPEC §15.3 / Appendix A.2, so this was a conformance bug, not just friction.
- Fix (in both `.github/workflows/check-decisions.yml` and `internal/templates/github/check-decisions.yml.template`): the `Compute diff vs base` step now fetches the *live* PR title at run time via `gh pr view "$PR_NUMBER" --json title -q .title` (PR number comes from the event too, but it's stable across reruns — only the title payload goes stale) and emits a `skip_logmind` output. The `Enforce` step's `if:` gates on that output instead of the frozen `github.event.pull_request.title`. A `gh` API failure (rate limit, transient outage) fails OPEN to the old event-payload title — it never crashes the check. Added `pull-requests: read` to the workflow permissions so `gh pr view` works on private consumer repos.
- Template marker bumped `v3` → `v4`; `templates_test.go` gained `TestCheckDecisionsTemplate_V4_LivePRTitle`, which pins the marker bump, the live-title fetch, the fail-open fallback, and the new permission (so a future revert trips it).

## Evidence / corrections
- The consuming repo cited in issue #212, `thrillmade/agent-skills`, carries `check-decisions.yml` at `# logmind-template-version: v2` — several versions behind `v4` shipped here. It'll pick up this fix via the Monday self-update wave, or a manual `logmind doctor --fix` refresh in the meantime.
- Correction to the issue's version note: **logmind v2.0.0 is not yet tagged.** The latest release is v1.2.0; `main` here is `2.0.0-dev` (confirmed via `logmind --version` on a build from this branch's source). The issue's "note logmind v2.0.0 tagged since" is not accurate as of this PR.

## Test plan
- [x] `go build ./... && go vet ./... && gofmt -l . && go test ./... -count=1` — all clean
- [x] `actionlint` on both the live workflow and the template body (stripped of the marker comment line) — clean (fixed a pre-existing-adjacent shellcheck SC2129 style nit introduced by the new `GITHUB_OUTPUT` writes by grouping them into a single `{ ...; } >> "$GITHUB_OUTPUT"` block)
- [x] Confirmed `doctor.go`'s `LogmindWorkflows` / marker-drift machinery is generic (reads the marker via regex) — no other hardcoded version references needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)