### PR TITLE
fix(ci): authenticate setup-logmind + un-brick the self-update wave (#212-adjacent, setup-logmind#4/#5)

### DIFF
--- a/.github/workflows/logmind-self-update.yml
+++ b/.github/workflows/logmind-self-update.yml
@@ -1,10 +1,51 @@
-# logmind-template-version: v9
+# logmind-template-version: v10
 name: logmind / self-update
 
 # Weekly check that the bundled logmind workflow templates are still on
 # the current template-version marker. When `logmind init` ships a new
 # template body (marker bump v3→v4 etc.), this workflow runs `logmind
 # init` in refresh mode and opens a PR with the marker-driven changes.
+#
+# v10 (2026-07-17) — un-bricked this workflow, which had failed 100% of
+# runs since it started using the setup-logmind action (setup-logmind#4,
+# setup-logmind#5):
+#
+#   - The `thrillmade/setup-logmind@…` step made an ANONYMOUS
+#     api.github.com call. Composite actions can't default an input to
+#     `github.token`, so every call site must pass `token:` explicitly
+#     or the release lookup runs unauthenticated — shared GitHub-hosted-
+#     runner IP ranges routinely exhaust the 60-req/hour unauthenticated
+#     budget and 403 before logmind is even installed. Fixed: `token:
+#     ${{ github.token }}` on the setup-logmind step.
+#   - The old `fetch_latest()` stripped the release tag's leading `v`
+#     before feeding it to setup-logmind's `version:` input, which
+#     REQUIRES the v-prefix (`^v[0-9]+\.[0-9]+\.[0-9]+`). Every run that
+#     reached the install step failed with "unrecognized version input
+#     '1.2.0'". Fixed: the `v` is kept end to end.
+#   - The old INSTALLED/LATEST comparison parsed the setup-logmind
+#     ACTION's own version pin (e.g. `v1.0.1`) out of this repo's other
+#     workflow files and compared it directly against the logmind CLI's
+#     latest release tag (e.g. `v1.5.0`). Those are two independently
+#     versioned repos — the numbers were never comparable, so the PR
+#     title's "INSTALLED → LATEST" was meaningless, and (once the
+#     v-prefix bug above is also fixed) it would have made this workflow
+#     open a spurious "update" PR on effectively every run.
+#
+#     Since v1.1.0, every `setup-logmind` call installs `latest` by
+#     default and no consumer repo persists a CLI-version pin to compare
+#     against (Dependabot only bumps the ACTION pin — a different axis).
+#     So there is no meaningful "was this repo behind" version check to
+#     make: whatever gets installed IS the latest. INSTALLED is now read
+#     honestly off the install step's own `outputs.version` and used —
+#     together with LATEST, still fetched from the release API — purely
+#     for the PR title / branch name / log line, not as a pass/fail
+#     gate. The one signal that can't lie about whether a refresh is
+#     actually needed is, and always was, the `git diff` after `logmind
+#     init` runs below, so that's now the sole gate (besides the
+#     `pinVersion` opt-out). We removed the version-equality pre-gate it
+#     replaced: a same-job comparison of two fresh "latest" look-ups is
+#     equal by construction, and keeping that gate would have made this
+#     workflow permanently silent post-fix instead of merely broken.
 #
 # v8 / logmind v1.1.0 (2026-06-05) — distribution lock changed how
 # version pinning works for consumer repos:
@@ -16,9 +57,6 @@ name: logmind / self-update
 #     ecosystem entry (also shipped by `logmind init` via
 #     `.github/dependabot.yml`). Dependabot's job: keep the action pin
 #     current. This workflow's job: keep the template BODY current.
-#   - Pure version-pin bumps no longer flow through this workflow —
-#     Dependabot handles them, no PAT required, no smart-skip needed.
-#     We only run when a template body (marker line + content) shifts.
 #
 # To pin to a specific logmind version and stop self-updates, add a
 # `pinVersion: "X.Y.Z"` field to `.logmind/config.yml`. The cron will
@@ -57,30 +95,10 @@ jobs:
           # workflow-file changes (handled in the push step below).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Compare installed vs released
-        id: compare
+      - name: Check pin override
+        id: pin
         run: |
           set -euo pipefail
-          # Installed action ref: parsed from any workflow file's
-          # `uses: thrillmade/setup-logmind@vX.Y.Z` line. Since v1.1.0
-          # all logmind-installed workflows use the action; pre-v1.1.0
-          # installs still pin via `pip install logmind==X.Y.Z`.
-          INSTALLED=""
-          for f in .github/workflows/check-doc-links.yml .github/workflows/regen-timeline.yml; do
-            if [ -f "$f" ]; then
-              INSTALLED=$(grep -oE 'thrillmade/setup-logmind@v[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/thrillmade\/setup-logmind@v//') || true
-              if [ -n "$INSTALLED" ]; then break; fi
-              # Fall back to legacy pip pin so pre-v1.1.0 installs upgrade once.
-              INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/logmind==//') || true
-              if [ -n "$INSTALLED" ]; then break; fi
-            fi
-          done
-          if [ -z "$INSTALLED" ]; then
-            echo "::notice::Installed logmind version not detected in workflow files. Re-run \`logmind init\` once locally to land the current install style, then self-update will work from then on."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           # Optional pin override from .logmind/config.yml. Flat grep
           # because the runner can't be relied on to have a third-party
           # YAML lib importable.
@@ -91,18 +109,50 @@ jobs:
               | sed -E 's/^[[:space:]]*pinVersion:[[:space:]]*//; s/^["'\''](.*)["'\'']$/\1/; s/[[:space:]]*$//' \
               || echo "")
           fi
+          if [ -n "$PIN" ]; then
+            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-          # Latest release: fetched from the GitHub /releases/latest
-          # JSON. CDN-aware retry (3 attempts: 0s / 30s / 60s) covers
-          # the ~30-60s lag between a release publish and the JSON
-          # endpoint reflecting the new tag_name. Lifted from the v7
-          # PyPI-side retry — same logic, different endpoint.
+      # Installs the latest logmind CLI so `logmind init` (the refresh,
+      # below) runs against the same binary version consumer repos will
+      # see after this workflow lands its PR. `token:` is REQUIRED —
+      # composite actions can't default an input to `github.token`;
+      # without it this call is anonymous and shared-runner IPs 403
+      # against api.github.com (setup-logmind#4).
+      - uses: thrillmade/setup-logmind@v1.0.0
+        id: install
+        if: steps.pin.outputs.skip == 'false'
+        with:
+          token: ${{ github.token }}
+          version: latest
+
+      - name: Resolve installed + latest versions
+        id: compare
+        if: steps.pin.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          # Honest INSTALLED: the version the setup-logmind step above
+          # actually resolved and installed (its `outputs.version`), NOT
+          # parsed from a workflow file's `thrillmade/setup-logmind@…`
+          # action pin — that pin versions a DIFFERENT repo and is not
+          # comparable to a logmind CLI release tag.
+          INSTALLED="${{ steps.install.outputs.version }}"
+
+          # Latest release tag, straight off the GitHub API. KEEP the
+          # `v` prefix — setup-logmind's `version:` input REQUIRES it
+          # (`^v[0-9]+\.[0-9]+\.[0-9]+`); a bare `1.2.0` fails with
+          # "unrecognized version input" (setup-logmind#5). CDN-aware
+          # retry (3 attempts: 0s / 30s / 60s) covers the ~30-60s lag
+          # between a release publish and the JSON endpoint reflecting
+          # the new tag_name.
           fetch_latest() {
             local v
             v=$(curl -fsSL https://api.github.com/repos/thrillmade/logmind/releases/latest 2>/dev/null \
               | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' \
-              | head -1 \
-              | sed 's/^v//') || true
+              | head -1) || true
             echo "$v"
           }
           LATEST=$(fetch_latest)
@@ -116,35 +166,18 @@ jobs:
               LATEST="$CANDIDATE"
             fi
           done
+          if [ -z "$LATEST" ]; then
+            # Release API was unreachable across every retry — fall back
+            # to what we just installed rather than an empty string.
+            LATEST="$INSTALLED"
+          fi
 
           echo "installed=$INSTALLED" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST"       >> "$GITHUB_OUTPUT"
-          echo "pin=$PIN"              >> "$GITHUB_OUTPUT"
-          echo "Installed: $INSTALLED  Latest: $LATEST  Pin: ${PIN:-(none)}"
-
-          if [ -n "$PIN" ]; then
-            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$INSTALLED" = "$LATEST" ]; then
-            echo "Already on latest ($INSTALLED). Nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      # v1.1.0+ installs logmind itself via the setup-logmind action so
-      # `logmind init` (the refresh) runs against the same binary
-      # version consumer repos will see after this workflow lands its
-      # PR. The action's version tracks the LATEST step output.
-      - uses: thrillmade/setup-logmind@v1.0.0
-        if: steps.compare.outputs.skip == 'false'
-        with:
-          version: ${{ steps.compare.outputs.latest }}
+          echo "Installed: $INSTALLED  Latest: $LATEST"
 
       - name: Run logmind init + open PR
-        if: steps.compare.outputs.skip == 'false'
+        if: steps.pin.outputs.skip == 'false'
         env:
           INSTALLED: ${{ steps.compare.outputs.installed }}
           LATEST:    ${{ steps.compare.outputs.latest }}
@@ -159,7 +192,9 @@ jobs:
 
           # Refresh mode rewrites stale workflow templates by the
           # `# logmind-template-version:` marker, leaves docs/ +
-          # .logmind/ + agent files untouched. Idempotent.
+          # .logmind/ + agent files untouched. Idempotent. This is the
+          # ONE signal that decides whether a refresh is actually
+          # needed — see the git-diff gate immediately below.
           logmind init --no-git --no-skill-install || logmind init
 
           # SMART WORKFLOW-SKIP. Decouples action-pin bumps (now

--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ action. It handles platform detection, version pinning, and step
 caching:
 
 ```yaml
-- uses: thrillmade/setup-logmind@v1.0.0
+- uses: thrillmade/setup-logmind@v1
+  with:
+    token: ${{ github.token }}
 - run: logmind check-links
 ```
+
+The `token: ${{ github.token }}` line matters: composite actions can't
+default an input to `github.token`, so without it setup-logmind's
+release-lookup call is anonymous — shared GitHub-hosted-runner IP
+ranges routinely exhaust the unauthenticated `api.github.com` rate
+limit and 403 before logmind installs. Pass it explicitly.
 
 `logmind init` (v1.1.0+) installs a `.github/dependabot.yml` block that
 tells Dependabot to bump the action ref on every new logmind release.

--- a/docs/decisions-branches/fix__setup-logmind-auth-and-self-update.md
+++ b/docs/decisions-branches/fix__setup-logmind-auth-and-self-update.md
@@ -1,0 +1,18 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-17-authenticated-every-setup-logmind-call-site-and-un-bricked-t -->
+- **2026-07-17** — Authenticated every setup-logmind call site and un-bricked the dead self-update workflow (v-prefix + apples-to-oranges version compare).
+<!-- logmind-entry-end -->
+
+## 2026-07-17 00:24 - fix(ci): authenticate setup-logmind calls + un-brick the self-update workflow
+
+**Reasoning:** setup-logmind#4/#5: every uses: thrillmade/setup-logmind@... call site omitted token:, so the release-lookup call went out anonymous and 403'd on shared-runner IPs before logmind installed. Separately, logmind-self-update.yml.template's fetch_latest() stripped the release tag's v prefix before feeding it to setup-logmind's version: input, which requires the v-prefix -- every run failed with unrecognized version input. Its INSTALLED/LATEST comparison also parsed the setup-logmind ACTION's own pin (independently versioned from the logmind CLI) as a proxy for the installed CLI version, which is never a valid comparison.
+
+**Alternatives considered:** Add a composite-action default for token: -- not possible; GitHub Actions composite actions cannot default an input to github.token, the fix has to live at each call site., Keep the old same-job version-equality skip gate after fixing INSTALLED's source -- rejected: since v1.1.0 every setup-logmind call installs latest by default, so a same-job INSTALLED-vs-LATEST comparison is equal by construction and would have made the workflow permanently silent instead of merely broken. Replaced with the pre-existing git-diff-after-init check as the sole gate (plus the pinVersion opt-out).
+
+**Implications:**
+- internal/templates/github/{check-doc-links,regen-timeline,logmind-self-update}.yml.template and the live .github/workflows/logmind-self-update.yml all gained token: on every setup-logmind step; marker bumps v7->v8, v6->v7, v9->v10 respectively so doctor --fix / self-update refresh consumers onto the fix.
+- Consumers only heal via a refresh pass (self-update itself has been dead ~6 weeks) -- a one-time doctor --fix / init-refresh on agent-skills + clud-bug-app is a follow-up coordination item, not part of this PR.
+
+---
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,9 +72,17 @@ For CI use the [`thrillmade/setup-logmind`](https://github.com/thrillmade/setup-
 action instead of curl-install:
 
 ```yaml
-- uses: thrillmade/setup-logmind@v1.0.0
+- uses: thrillmade/setup-logmind@v1
+  with:
+    token: ${{ github.token }}
 - run: logmind check-links
 ```
+
+The `token: ${{ github.token }}` line matters: composite actions can't
+default an input to `github.token`, so without it setup-logmind's
+release-lookup call is anonymous — shared GitHub-hosted-runner IP
+ranges routinely exhaust the unauthenticated `api.github.com` rate
+limit and 403 before logmind installs. Pass it explicitly.
 
 `logmind init` (v1.1.0+) installs a `.github/dependabot.yml` block that
 groups `thrillmade/*` action bumps, so Dependabot opens one PR per

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -18,6 +18,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-17** — fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212) → [detail](decisions-branches/fix__check-decisions-live-pr-title-212.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-17-authenticated-every-setup-logmind-call-site-and-un-bricked-t -->
+- **2026-07-17** — Authenticated every setup-logmind call site and un-bricked the dead self-update workflow (v-prefix + apples-to-oranges version compare). → [detail](decisions-branches/fix__setup-logmind-auth-and-self-update.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-16-v2-0-0-truth-sweep-retired-python-era-doc-examples-taught-th -->
 - **2026-07-16** — v2.0.0 truth sweep: retired Python-era doc examples, taught the real v2 CLI surface (context/repomap/doctor --fix/headline/enforcement/the pulse) across README, SECURITY, ai-agent-files, plan, skill, and release tooling docs → [detail](decisions-branches/docs__v2-truth-sweep.md)
 <!-- logmind-entry-end -->

--- a/internal/templates/github/check-doc-links.yml.template
+++ b/internal/templates/github/check-doc-links.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v7
+# logmind-template-version: v8
 name: logmind / check-links
 
 # Flag broken or orphaned markdown links so agents stay in context when
@@ -41,6 +41,13 @@ name: logmind / check-links
 # The jobs always run (no actor filter). Filtering a required check out
 # for bot/fork PRs would itself strand it as "Expected — Waiting…"; bots
 # and forks simply take the advisory / mode-B comment path.
+#
+# v8 — every `thrillmade/setup-logmind@…` step now passes `token:
+# ${{ github.token }}`. Composite actions can't default an input to
+# `github.token`; without it, setup-logmind's release-lookup call is
+# anonymous, and shared GitHub-hosted-runner IP ranges routinely blow
+# through the 60-req/hour unauthenticated api.github.com budget, 403ing
+# before logmind is even installed (setup-logmind#4).
 
 on:
   pull_request:
@@ -75,6 +82,8 @@ jobs:
       # `github-actions` ecosystem block in `.github/dependabot.yml` (also
       # installed by `logmind init`).
       - uses: thrillmade/setup-logmind@v1.0.0
+        with:
+          token: ${{ github.token }}
 
       - name: Check markdown link integrity (advisory)
         id: check
@@ -127,6 +136,8 @@ jobs:
           persist-credentials: false
 
       - uses: thrillmade/setup-logmind@v1.0.0
+        with:
+          token: ${{ github.token }}
 
       # Mode A — auto-fix. Requires ANTHROPIC_API_KEY AND a same-repo PAT:
       # the PAT does the push (GITHUB_TOKEN would strand the PR), so without

--- a/internal/templates/github/logmind-self-update.yml.template
+++ b/internal/templates/github/logmind-self-update.yml.template
@@ -1,10 +1,51 @@
-# logmind-template-version: v9
+# logmind-template-version: v10
 name: logmind / self-update
 
 # Weekly check that the bundled logmind workflow templates are still on
 # the current template-version marker. When `logmind init` ships a new
 # template body (marker bump v3→v4 etc.), this workflow runs `logmind
 # init` in refresh mode and opens a PR with the marker-driven changes.
+#
+# v10 (2026-07-17) — un-bricked this workflow, which had failed 100% of
+# runs since it started using the setup-logmind action (setup-logmind#4,
+# setup-logmind#5):
+#
+#   - The `thrillmade/setup-logmind@…` step made an ANONYMOUS
+#     api.github.com call. Composite actions can't default an input to
+#     `github.token`, so every call site must pass `token:` explicitly
+#     or the release lookup runs unauthenticated — shared GitHub-hosted-
+#     runner IP ranges routinely exhaust the 60-req/hour unauthenticated
+#     budget and 403 before logmind is even installed. Fixed: `token:
+#     ${{ github.token }}` on the setup-logmind step.
+#   - The old `fetch_latest()` stripped the release tag's leading `v`
+#     before feeding it to setup-logmind's `version:` input, which
+#     REQUIRES the v-prefix (`^v[0-9]+\.[0-9]+\.[0-9]+`). Every run that
+#     reached the install step failed with "unrecognized version input
+#     '1.2.0'". Fixed: the `v` is kept end to end.
+#   - The old INSTALLED/LATEST comparison parsed the setup-logmind
+#     ACTION's own version pin (e.g. `v1.0.1`) out of this repo's other
+#     workflow files and compared it directly against the logmind CLI's
+#     latest release tag (e.g. `v1.5.0`). Those are two independently
+#     versioned repos — the numbers were never comparable, so the PR
+#     title's "INSTALLED → LATEST" was meaningless, and (once the
+#     v-prefix bug above is also fixed) it would have made this workflow
+#     open a spurious "update" PR on effectively every run.
+#
+#     Since v1.1.0, every `setup-logmind` call installs `latest` by
+#     default and no consumer repo persists a CLI-version pin to compare
+#     against (Dependabot only bumps the ACTION pin — a different axis).
+#     So there is no meaningful "was this repo behind" version check to
+#     make: whatever gets installed IS the latest. INSTALLED is now read
+#     honestly off the install step's own `outputs.version` and used —
+#     together with LATEST, still fetched from the release API — purely
+#     for the PR title / branch name / log line, not as a pass/fail
+#     gate. The one signal that can't lie about whether a refresh is
+#     actually needed is, and always was, the `git diff` after `logmind
+#     init` runs below, so that's now the sole gate (besides the
+#     `pinVersion` opt-out). We removed the version-equality pre-gate it
+#     replaced: a same-job comparison of two fresh "latest" look-ups is
+#     equal by construction, and keeping that gate would have made this
+#     workflow permanently silent post-fix instead of merely broken.
 #
 # v8 / logmind v1.1.0 (2026-06-05) — distribution lock changed how
 # version pinning works for consumer repos:
@@ -16,9 +57,6 @@ name: logmind / self-update
 #     ecosystem entry (also shipped by `logmind init` via
 #     `.github/dependabot.yml`). Dependabot's job: keep the action pin
 #     current. This workflow's job: keep the template BODY current.
-#   - Pure version-pin bumps no longer flow through this workflow —
-#     Dependabot handles them, no PAT required, no smart-skip needed.
-#     We only run when a template body (marker line + content) shifts.
 #
 # To pin to a specific logmind version and stop self-updates, add a
 # `pinVersion: "X.Y.Z"` field to `.logmind/config.yml`. The cron will
@@ -57,30 +95,10 @@ jobs:
           # workflow-file changes (handled in the push step below).
           token: ${{ secrets.LOGMIND_AUTO_REGEN_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Compare installed vs released
-        id: compare
+      - name: Check pin override
+        id: pin
         run: |
           set -euo pipefail
-          # Installed action ref: parsed from any workflow file's
-          # `uses: thrillmade/setup-logmind@vX.Y.Z` line. Since v1.1.0
-          # all logmind-installed workflows use the action; pre-v1.1.0
-          # installs still pin via `pip install logmind==X.Y.Z`.
-          INSTALLED=""
-          for f in .github/workflows/check-doc-links.yml .github/workflows/regen-timeline.yml; do
-            if [ -f "$f" ]; then
-              INSTALLED=$(grep -oE 'thrillmade/setup-logmind@v[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/thrillmade\/setup-logmind@v//') || true
-              if [ -n "$INSTALLED" ]; then break; fi
-              # Fall back to legacy pip pin so pre-v1.1.0 installs upgrade once.
-              INSTALLED=$(grep -oE 'logmind==[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 | sed 's/logmind==//') || true
-              if [ -n "$INSTALLED" ]; then break; fi
-            fi
-          done
-          if [ -z "$INSTALLED" ]; then
-            echo "::notice::Installed logmind version not detected in workflow files. Re-run \`logmind init\` once locally to land the current install style, then self-update will work from then on."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           # Optional pin override from .logmind/config.yml. Flat grep
           # because the runner can't be relied on to have a third-party
           # YAML lib importable.
@@ -91,18 +109,50 @@ jobs:
               | sed -E 's/^[[:space:]]*pinVersion:[[:space:]]*//; s/^["'\''](.*)["'\'']$/\1/; s/[[:space:]]*$//' \
               || echo "")
           fi
+          if [ -n "$PIN" ]; then
+            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-          # Latest release: fetched from the GitHub /releases/latest
-          # JSON. CDN-aware retry (3 attempts: 0s / 30s / 60s) covers
-          # the ~30-60s lag between a release publish and the JSON
-          # endpoint reflecting the new tag_name. Lifted from the v7
-          # PyPI-side retry — same logic, different endpoint.
+      # Installs the latest logmind CLI so `logmind init` (the refresh,
+      # below) runs against the same binary version consumer repos will
+      # see after this workflow lands its PR. `token:` is REQUIRED —
+      # composite actions can't default an input to `github.token`;
+      # without it this call is anonymous and shared-runner IPs 403
+      # against api.github.com (setup-logmind#4).
+      - uses: thrillmade/setup-logmind@v1.0.0
+        id: install
+        if: steps.pin.outputs.skip == 'false'
+        with:
+          token: ${{ github.token }}
+          version: latest
+
+      - name: Resolve installed + latest versions
+        id: compare
+        if: steps.pin.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          # Honest INSTALLED: the version the setup-logmind step above
+          # actually resolved and installed (its `outputs.version`), NOT
+          # parsed from a workflow file's `thrillmade/setup-logmind@…`
+          # action pin — that pin versions a DIFFERENT repo and is not
+          # comparable to a logmind CLI release tag.
+          INSTALLED="${{ steps.install.outputs.version }}"
+
+          # Latest release tag, straight off the GitHub API. KEEP the
+          # `v` prefix — setup-logmind's `version:` input REQUIRES it
+          # (`^v[0-9]+\.[0-9]+\.[0-9]+`); a bare `1.2.0` fails with
+          # "unrecognized version input" (setup-logmind#5). CDN-aware
+          # retry (3 attempts: 0s / 30s / 60s) covers the ~30-60s lag
+          # between a release publish and the JSON endpoint reflecting
+          # the new tag_name.
           fetch_latest() {
             local v
             v=$(curl -fsSL https://api.github.com/repos/thrillmade/logmind/releases/latest 2>/dev/null \
               | sed -n 's/.*"tag_name": "\(.*\)".*/\1/p' \
-              | head -1 \
-              | sed 's/^v//') || true
+              | head -1) || true
             echo "$v"
           }
           LATEST=$(fetch_latest)
@@ -116,35 +166,18 @@ jobs:
               LATEST="$CANDIDATE"
             fi
           done
+          if [ -z "$LATEST" ]; then
+            # Release API was unreachable across every retry — fall back
+            # to what we just installed rather than an empty string.
+            LATEST="$INSTALLED"
+          fi
 
           echo "installed=$INSTALLED" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST"       >> "$GITHUB_OUTPUT"
-          echo "pin=$PIN"              >> "$GITHUB_OUTPUT"
-          echo "Installed: $INSTALLED  Latest: $LATEST  Pin: ${PIN:-(none)}"
-
-          if [ -n "$PIN" ]; then
-            echo "::notice::Pinned to $PIN via .logmind/config.yml — skipping update check."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$INSTALLED" = "$LATEST" ]; then
-            echo "Already on latest ($INSTALLED). Nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      # v1.1.0+ installs logmind itself via the setup-logmind action so
-      # `logmind init` (the refresh) runs against the same binary
-      # version consumer repos will see after this workflow lands its
-      # PR. The action's version tracks the LATEST step output.
-      - uses: thrillmade/setup-logmind@v1.0.0
-        if: steps.compare.outputs.skip == 'false'
-        with:
-          version: ${{ steps.compare.outputs.latest }}
+          echo "Installed: $INSTALLED  Latest: $LATEST"
 
       - name: Run logmind init + open PR
-        if: steps.compare.outputs.skip == 'false'
+        if: steps.pin.outputs.skip == 'false'
         env:
           INSTALLED: ${{ steps.compare.outputs.installed }}
           LATEST:    ${{ steps.compare.outputs.latest }}
@@ -159,7 +192,9 @@ jobs:
 
           # Refresh mode rewrites stale workflow templates by the
           # `# logmind-template-version:` marker, leaves docs/ +
-          # .logmind/ + agent files untouched. Idempotent.
+          # .logmind/ + agent files untouched. Idempotent. This is the
+          # ONE signal that decides whether a refresh is actually
+          # needed — see the git-diff gate immediately below.
           logmind init --no-git --no-skill-install || logmind init
 
           # SMART WORKFLOW-SKIP. Decouples action-pin bumps (now

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v6
+# logmind-template-version: v7
 name: logmind / check-derived-docs
 
 # Self-healing derived-doc gate (v5 — advisory model).
@@ -29,6 +29,13 @@ name: logmind / check-derived-docs
 # The job always runs (no actor filter). Filtering a required check out for
 # bot/fork PRs would itself strand it as "Expected — Waiting…"; bots and
 # forks simply take the advisory path.
+#
+# v7 — the `thrillmade/setup-logmind@…` step now passes `token:
+# ${{ github.token }}`. Composite actions can't default an input to
+# `github.token`; without it, setup-logmind's release-lookup call is
+# anonymous, and shared GitHub-hosted-runner IP ranges routinely blow
+# through the 60-req/hour unauthenticated api.github.com budget, 403ing
+# before logmind is even installed (setup-logmind#4).
 #
 # Setup for the PAT (auto-push) path:
 #   1. Create a fine-grained PAT scoped to THIS repo (not org-wide, to bound
@@ -61,6 +68,8 @@ jobs:
           persist-credentials: false
 
       - uses: thrillmade/setup-logmind@v1.0.0
+        with:
+          token: ${{ github.token }}
 
       - name: Regenerate derived docs
         run: |

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -173,16 +173,13 @@ func TestDependabotTemplate_HasMarkerAndShape(t *testing.T) {
 // TestWorkflowTemplates_UseSetupLogmindAction pins the v1.1.0
 // distribution-lock change: workflow templates must use the new
 // `thrillmade/setup-logmind@vX.Y.Z` action and NOT the legacy
-// `pip install logmind==X.Y.Z` line. Both check-doc-links and
-// regen-timeline are user-facing CI workflows under
-// `# logmind-template-version:` markers; the self-update workflow
-// uses the action too but is allowed to grep for the legacy pin (so
-// pre-v1.1.0 installs can upgrade once). We only assert the consumer-
-// CI workflows here.
+// `pip install logmind==X.Y.Z` line. check-doc-links, regen-timeline,
+// and logmind-self-update are all asserted here.
 func TestWorkflowTemplates_UseSetupLogmindAction(t *testing.T) {
 	for _, name := range []string{
 		"check-doc-links.yml.template",
 		"regen-timeline.yml.template",
+		"logmind-self-update.yml.template",
 	} {
 		body := Workflow(name)
 		if !strings.Contains(body, "thrillmade/setup-logmind@v") {
@@ -197,159 +194,201 @@ func TestWorkflowTemplates_UseSetupLogmindAction(t *testing.T) {
 	}
 }
 
-// TestRegenTimelineTemplate_V6_Advisory pins the Slice-1 de-friction
+// TestWorkflowTemplates_SetupLogmindStepsCarryToken pins the
+// setup-logmind#4 fix: EVERY `uses: thrillmade/setup-logmind@…` step,
+// in every workflow template, must pass `token: ${{ github.token }}`.
+// Composite actions cannot default an input to `github.token` — that
+// has to happen at each call site — so an anonymous setup-logmind call
+// hits api.github.com unauthenticated and shared-runner IP ranges
+// routinely blow through the 60-req/hour budget before logmind is even
+// installed. This test walks every `uses:` occurrence individually (not
+// just "the token string appears somewhere in the file") so a future
+// setup-logmind call site added without `token:` trips it.
+func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
+	const usesPrefix = "uses: thrillmade/setup-logmind@"
+	for _, name := range []string{
+		"check-doc-links.yml.template",
+		"regen-timeline.yml.template",
+		"logmind-self-update.yml.template",
+	} {
+		body := Workflow(name)
+		lines := strings.Split(body, "\n")
+		found := 0
+		for i, line := range lines {
+			if !strings.Contains(line, usesPrefix) {
+				continue
+			}
+			found++
+			// The `token:` input must appear within the next few lines
+			// (the `with:` block immediately following this step).
+			window := lines[i:]
+			if len(window) > 6 {
+				window = window[:6]
+			}
+			block := strings.Join(window, "\n")
+			if !strings.Contains(block, "token: ${{ github.token }}") {
+				t.Errorf("%s: setup-logmind step at line %d missing `token: ${{ github.token }}` (setup-logmind#4)", name, i+1)
+			}
+		}
+		if found == 0 {
+			t.Errorf("%s: expected at least one setup-logmind call site", name)
+		}
+	}
+}
+
+// TestRegenTimelineTemplate_V7_Advisory pins the Slice-1 de-friction
 // contract: the derived-doc gate must NEVER hard-block a PR and must NEVER
 // push with the default GITHUB_TOKEN (a GITHUB_TOKEN push moves the PR head
 // SHA without re-triggering checks, stranding every required check). On
 // stale docs it either pushes via LOGMIND_AUTO_REGEN_PAT (which re-triggers
 // checks) or emits an advisory ::warning:: and exits 0.
-func TestRegenTimelineTemplate_V6_Advisory(t *testing.T) {
+func TestRegenTimelineTemplate_V7_Advisory(t *testing.T) {
 	body := Workflow("regen-timeline.yml.template")
 
-	// Marker bump v4 → v5.
-	if !strings.Contains(body, "# logmind-template-version: v6") {
-		t.Errorf("regen-timeline template missing v6 marker")
+	// Marker bump v6 → v7 (setup-logmind#4: added `token: ${{ github.token }}`).
+	if !strings.Contains(body, "# logmind-template-version: v7") {
+		t.Errorf("regen-timeline template missing v7 marker")
 	}
 	// Advisory, never fail-fast: no literal `exit 1`. Staleness must not
 	// red-light the PR (a real tool crash still fails the job via `set -e`).
 	if strings.Contains(body, "exit 1") {
-		t.Errorf("regen-timeline v6 must not `exit 1` — the gate is advisory and must never block a PR")
+		t.Errorf("regen-timeline v7 must not `exit 1` — the gate is advisory and must never block a PR")
 	}
 	// The no-PAT / fork path must warn and pass.
 	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
-		t.Errorf("regen-timeline v6 missing the advisory warn + exit 0 path")
+		t.Errorf("regen-timeline v7 missing the advisory warn + exit 0 path")
 	}
 	// The PAT auto-push path is retained (the only path that pushes).
 	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
-		t.Errorf("regen-timeline v6 missing the LOGMIND_AUTO_REGEN_PAT auto-push path")
+		t.Errorf("regen-timeline v7 missing the LOGMIND_AUTO_REGEN_PAT auto-push path")
 	}
 	// Regen commits carry the [skip-logmind] convention (SPEC §5.1/§5.2).
 	if !strings.Contains(body, "[skip-logmind]") {
-		t.Errorf("regen-timeline v6 PAT-push commit missing the [skip-logmind] prefix")
+		t.Errorf("regen-timeline v7 PAT-push commit missing the [skip-logmind] prefix")
 	}
 	// The job must NOT filter itself out by actor: a filtered required check
 	// strands as "Expected — Waiting…". Bots/forks take the advisory path.
 	if strings.Contains(body, "github.actor != ") {
-		t.Errorf("regen-timeline v6 must not filter the job by actor (a filtered required check hangs forever)")
+		t.Errorf("regen-timeline v7 must not filter the job by actor (a filtered required check hangs forever)")
 	}
 	// Fork PRs must reach the advisory path, not die at checkout: the
 	// checkout MUST set `repository:` to the PR head repo (a fork's head_ref
 	// does not exist on the base repo, so checkout would otherwise fail red).
 	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
-		t.Errorf("regen-timeline v6 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
+		t.Errorf("regen-timeline v7 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
 	}
 	// The advisory diff display MUST be SIGPIPE/pipefail-guarded: a large
 	// stale diff piped into `head` exits 141 under `set -euo pipefail` and
 	// would abort the job before `exit 0` — re-blocking on big diffs.
 	if !strings.Contains(body, "| head -80 || true") {
-		t.Errorf("regen-timeline v6 advisory diff must be `|| true`-guarded against SIGPIPE/pipefail")
+		t.Errorf("regen-timeline v7 advisory diff must be `|| true`-guarded against SIGPIPE/pipefail")
 	}
 	// GITHUB_TOKEN must never push: the workflow token stays read-only and
 	// the push (if any) uses the explicit PAT-credentialed URL.
 	if !strings.Contains(body, "contents: read") {
-		t.Errorf("regen-timeline v6 must keep the workflow token read-only (contents: read)")
+		t.Errorf("regen-timeline v7 must keep the workflow token read-only (contents: read)")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("regen-timeline v6 PAT push must use the explicit PAT URL, not a persisted/GITHUB_TOKEN credential")
+		t.Errorf("regen-timeline v7 PAT push must use the explicit PAT URL, not a persisted/GITHUB_TOKEN credential")
 	}
 	// The PAT/token must not be persisted into .git during regeneration/build.
 	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("regen-timeline v6 checkout must set persist-credentials: false")
+		t.Errorf("regen-timeline v7 checkout must set persist-credentials: false")
 	}
 }
 
-// TestCheckDocLinksTemplate_V7_AdvisoryNoStrand pins the v1.2.0 advisory
+// TestCheckDocLinksTemplate_V8_AdvisoryNoStrand pins the v1.2.0 advisory
 // contract for the doc-link gate: like regen-timeline, it must NEVER
 // hard-block a PR and must NEVER push with the default GITHUB_TOKEN (a
 // GITHUB_TOKEN push moves the PR head SHA without re-triggering checks,
 // stranding every required check). check-links is advisory (warn +
 // exit 0); the dual-mode self-heal either PAT-pushes a Claude fix
 // (mode A) or posts a deterministic PR comment (mode B).
-func TestCheckDocLinksTemplate_V7_AdvisoryNoStrand(t *testing.T) {
+func TestCheckDocLinksTemplate_V8_AdvisoryNoStrand(t *testing.T) {
 	body := Workflow("check-doc-links.yml.template")
 
-	// Marker bump v5 → v6.
-	if !strings.Contains(body, "# logmind-template-version: v7") {
-		t.Errorf("check-doc-links template missing v7 marker")
+	// Marker bump v7 → v8 (setup-logmind#4: added `token: ${{ github.token }}`).
+	if !strings.Contains(body, "# logmind-template-version: v8") {
+		t.Errorf("check-doc-links template missing v8 marker")
 	}
 
 	// Advisory: the old `exit $rc` (re-raise the linkcheck exit) red-lit
 	// the PR — it must be gone, replaced by an advisory warning + exit 0.
 	if strings.Contains(body, "exit $rc") {
-		t.Errorf("check-doc-links v7 must not `exit $rc` — check-links is advisory and must never block a PR")
+		t.Errorf("check-doc-links v8 must not `exit $rc` — check-links is advisory and must never block a PR")
 	}
 	if !strings.Contains(body, "::warning") {
-		t.Errorf("check-doc-links v7 missing the advisory ::warning:: on broken links")
+		t.Errorf("check-doc-links v8 missing the advisory ::warning:: on broken links")
 	}
 
 	// No GITHUB_TOKEN push: the old `git push origin HEAD:<head-ref>`
 	// (authenticated by GITHUB_TOKEN) stranded the PR. Any push must go
 	// through the explicit PAT-credentialed URL.
 	if strings.Contains(body, "git push origin") {
-		t.Errorf("check-doc-links v7 must not `git push origin` (a GITHUB_TOKEN push strands the PR's required checks)")
+		t.Errorf("check-doc-links v8 must not `git push origin` (a GITHUB_TOKEN push strands the PR's required checks)")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("check-doc-links v7 mode-A push must use the explicit PAT URL, not a GITHUB_TOKEN credential")
+		t.Errorf("check-doc-links v8 mode-A push must use the explicit PAT URL, not a GITHUB_TOKEN credential")
 	}
 
 	// Mode A is PAT-gated: without LOGMIND_AUTO_REGEN_PAT there is no safe
 	// push, so mode A must require it (and fall through to mode B otherwise).
 	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
-		t.Errorf("check-doc-links v7 missing the LOGMIND_AUTO_REGEN_PAT push gate")
+		t.Errorf("check-doc-links v8 missing the LOGMIND_AUTO_REGEN_PAT push gate")
 	}
 	if !strings.Contains(body, "env.PAT != ''") {
-		t.Errorf("check-doc-links v7 mode-A must be gated on a configured PAT (env.PAT != '')")
+		t.Errorf("check-doc-links v8 mode-A must be gated on a configured PAT (env.PAT != '')")
 	}
 
 	// Workflow token stays read-only; the PAT does any push.
 	if !strings.Contains(body, "contents: read") {
-		t.Errorf("check-doc-links v7 must keep the workflow token read-only (contents: read)")
+		t.Errorf("check-doc-links v8 must keep the workflow token read-only (contents: read)")
 	}
 	if strings.Contains(body, "contents: write") {
-		t.Errorf("check-doc-links v7 must not grant contents: write (the PAT, not GITHUB_TOKEN, pushes)")
+		t.Errorf("check-doc-links v8 must not grant contents: write (the PAT, not GITHUB_TOKEN, pushes)")
 	}
 
 	// No actor filter: a filtered required check strands as "Expected —
 	// Waiting…". Bots/forks take the advisory / mode-B path.
 	if strings.Contains(body, "github.actor != ") {
-		t.Errorf("check-doc-links v7 must not filter a job by actor (a filtered required check hangs forever)")
+		t.Errorf("check-doc-links v8 must not filter a job by actor (a filtered required check hangs forever)")
 	}
 
 	// Fork PRs must reach the advisory path, not die at checkout.
 	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
-		t.Errorf("check-doc-links v7 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
+		t.Errorf("check-doc-links v8 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
 	}
 	// No token persisted into .git; the PAT is injected only at push time.
 	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("check-doc-links v7 checkout must set persist-credentials: false")
+		t.Errorf("check-doc-links v8 checkout must set persist-credentials: false")
 	}
 
 	// Dual-mode self-heal preserved: mode A (Claude auto-fix) + mode B
 	// (deterministic PR comment), both keyed off the check-links report.
 	if !strings.Contains(body, "Mode A") || !strings.Contains(body, "Mode B") {
-		t.Errorf("check-doc-links v7 missing a self-heal mode (both mode A and mode B required)")
+		t.Errorf("check-doc-links v8 missing a self-heal mode (both mode A and mode B required)")
 	}
 	if !strings.Contains(body, "secrets.ANTHROPIC_API_KEY") || !strings.Contains(body, "ANTHROPIC_API_KEY != ''") {
-		t.Errorf("check-doc-links v7 missing the mode-A ANTHROPIC_API_KEY gate")
+		t.Errorf("check-doc-links v8 missing the mode-A ANTHROPIC_API_KEY gate")
 	}
 	if !strings.Contains(body, "gh pr comment") {
-		t.Errorf("check-doc-links v7 missing `gh pr comment` (mode B deterministic path)")
+		t.Errorf("check-doc-links v8 missing `gh pr comment` (mode B deterministic path)")
 	}
 	if !strings.Contains(body, "logmind check-links --json") {
-		t.Errorf("check-doc-links v7 missing `logmind check-links --json` invocation")
+		t.Errorf("check-doc-links v8 missing `logmind check-links --json` invocation")
 	}
 
 	// Self-heal fires on pull_request when check-links reported issues
 	// (keyed off the `failed` output, since check-links now always exits 0).
 	if !strings.Contains(body, "github.event_name == 'pull_request'") {
-		t.Errorf("check-doc-links v7 self-heal must be gated on pull_request events")
+		t.Errorf("check-doc-links v8 self-heal must be gated on pull_request events")
 	}
 	if !strings.Contains(body, "needs.check-links.outputs.failed != '0'") {
-		t.Errorf("check-doc-links v7 self-heal must key off the check-links `failed` output")
+		t.Errorf("check-doc-links v8 self-heal must key off the check-links `failed` output")
 	}
 	// pull-requests:write is still needed for the mode-B comment.
 	if !strings.Contains(body, "pull-requests: write") {
-		t.Errorf("check-doc-links v7 missing pull-requests:write permission (mode B comment)")
+		t.Errorf("check-doc-links v8 missing pull-requests:write permission (mode B comment)")
 	}
 
 	// Both self-heal modes are best-effort advisory: a transient auto-fix
@@ -357,10 +396,10 @@ func TestCheckDocLinksTemplate_V7_AdvisoryNoStrand(t *testing.T) {
 	// to a ::warning:: and never red-light the helper job. Guarding these is
 	// what keeps the header's "forks take the mode-B path" promise honest.
 	if !strings.Contains(body, "if ! python3") {
-		t.Errorf("check-doc-links v7 mode A must guard the Claude auto-fix (a transient failure must not red the self-heal job)")
+		t.Errorf("check-doc-links v8 mode A must guard the Claude auto-fix (a transient failure must not red the self-heal job)")
 	}
 	if !strings.Contains(body, "if ! gh pr comment") {
-		t.Errorf("check-doc-links v7 mode B must guard `gh pr comment` (a fork 403 must not red the self-heal job)")
+		t.Errorf("check-doc-links v8 mode B must guard `gh pr comment` (a fork 403 must not red the self-heal job)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Pre-v2.0.0-tag maintenance fixing two verified integration bugs between logmind's CI templates/workflows and the `thrillmade/setup-logmind` action.

**(a) Missing `token:` on every call site (setup-logmind#4 / setup-logmind#5).** Composite actions cannot default an input to `github.token` — every `uses: thrillmade/setup-logmind@…` step must pass it explicitly, or the release-lookup call goes out anonymous and shared GitHub-hosted-runner IP ranges routinely blow through the unauthenticated `api.github.com` rate limit, 403ing before logmind even installs.

Added `with: token: ${{ github.token }}` to every call site:
- `internal/templates/github/check-doc-links.yml.template` — 2 steps (check-links job, self-heal job)
- `internal/templates/github/regen-timeline.yml.template` — 1 step
- `internal/templates/github/logmind-self-update.yml.template` — 1 step
- `.github/workflows/logmind-self-update.yml` (this repo's live copy of the above)
- README.md + docs/install.md quick-start snippets (plus a short explanatory note so copy-pasters understand why it's there)

**(b) `logmind-self-update.yml.template`'s v-prefix bug — 100% failure since creation.** `fetch_latest()` stripped the release tag's `v` prefix (`sed 's/^v//'`) before feeding it to setup-logmind's `version:` input, which *requires* the v-prefix (`^v[0-9]+\.[0-9]+\.[0-9]+`). Every run that reached the install step failed with `unrecognized version input '1.2.0'`. Fixed by keeping the `v` end to end.

**(c) The INSTALLED/LATEST comparison compared the wrong axis.** The old code parsed the setup-logmind *action's* own version pin (e.g. `v1.0.1`) out of the repo's other workflow files and compared it directly against the logmind *CLI's* latest release tag (e.g. `v1.5.0`) — two independently versioned repos, never comparable, and (once bug (b) is also fixed) it would have opened a spurious "update" PR on effectively every run.

Since v1.1.0, every `setup-logmind` call installs `latest` by default and no consumer repo persists a CLI-version pin to compare against (Dependabot only bumps the *action* pin — a different axis). A same-job comparison of two freshly-resolved "latest" look-ups is equal by construction, so keeping a version-equality pre-gate after honestly sourcing INSTALLED would have made this workflow **permanently silent** post-fix instead of merely broken — worse than doing nothing. So:
- INSTALLED is now read honestly off the install step's own `outputs.version` (previously exposed, unused); LATEST still comes from the release-tag API (retry-guarded against publish-lag, v-prefix preserved).
- Both are used for the PR title / branch name / log line only.
- The actual "is a refresh needed" gate is — and always was — the `git diff` after `logmind init` runs, which can't lie about staleness. This is a deliberate architecture call, documented at length in the template's own header comment; flagging it explicitly here in case reviewers want to push back.

## Marker bumps

| Template | Old | New |
|---|---|---|
| `check-doc-links.yml.template` | v7 | v8 |
| `regen-timeline.yml.template` | v6 | v7 |
| `logmind-self-update.yml.template` | v9 | v10 |

`internal/templates/templates_test.go` updated: marker assertions bumped, a new `TestWorkflowTemplates_SetupLogmindStepsCarryToken` walks every `uses: thrillmade/setup-logmind@…` occurrence individually and fails if `token: ${{ github.token }}` isn't in its `with:` block — a future call site added without it trips this test.

## Prose pins

README.md / docs/install.md: `uses: thrillmade/setup-logmind@v1.0.0` → `@v1`. Verified `v1` is a real floating tag in `thrillmade/setup-logmind` (currently resolving to the same commit as `v1.0.1`, the latest release) via `git ls-remote --tags`, not a guess.

## Note for reviewers

Consumers (agent-skills, clud-bug-app, tokenomics, reporulez, rezgen) only heal via a refresh — the self-update workflow has been dead ~6 weeks (bug (b) above), so this fix doesn't retroactively repair anything already merged. **A one-time `doctor --fix` / `logmind init` refresh pass on those repos is needed post-merge** — tracked as a coordination item, not part of this PR.

Also found but **not** touched here (out of scope / self-heals): `internal/templates/github/*.yml.template`'s `uses: thrillmade/setup-logmind@v1.0.0` pin itself silently regressed from `@v1.0.1` back to `@v1.0.0` in #172 (the template v6 rewrite likely branched from a pre-#148 base). Dependabot's `thrillmade/*` group (already configured) should pick this back up on its own schedule; flagging for awareness.

Refs: setup-logmind#4, setup-logmind#5

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./... -count=1` (all packages pass)
- [x] `actionlint` clean on the live workflow and on all three templates (copied into a scratch `.github/workflows/`)
- [x] Every touched workflow YAML-parses via `python3 yaml.safe_load`
- [ ] Post-merge: one-time refresh pass on downstream consumer repos (coordination item, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r55C7k8PbCKfQKhsaVkvG