### PR TITLE
fix: audit batch — CRLF determinism, push timeout, atomic config writes, quiet help, §1.2.1/§3.7 conformance

### DIFF
--- a/docs/decisions-branches/fix__adversarial-audit-batch-v2.md
+++ b/docs/decisions-branches/fix__adversarial-audit-batch-v2.md
@@ -1,0 +1,20 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-17-fix-audit-batch-crlf-determinism-push-timeout-atomic-config- -->
+- **2026-07-17** — fix: audit batch - CRLF determinism, push timeout, atomic config writes, quiet help, spec 1.2.1/3.7 conformance
+<!-- logmind-entry-end -->
+
+## 2026-07-17 09:12 - fix: audit batch - CRLF determinism, push timeout, atomic config writes, quiet help, spec 1.2.1/3.7 conformance
+
+**Reasoning:** Six adversarially-confirmed defects found ahead of the v2.0.0 tag: (1) extractEntryBlocks left a trailing CR on CRLF-sourced body lines, breaking docs/timeline.md's own byte-determinism invariant and the dedupeAndSuffix same-body carve-out; (2) gitcli.Push had no context timeout/WaitDelay so a wedged remote could hang every 'logmind log' (auto_push defaults true); (3) claudehook/hooks/inserter each overwrote an EXISTING file with a bare os.WriteFile (O_TRUNC then write), risking a truncated file on a crash mid-write; (4) the --quiet persistent flag's help text promised 'one ok line per verb' but only 9 of 22 subcommands honor it; (5) DefaultConfig's ignore_patterns omitted SPEC section-1.2.1's .next, .turbo, .DS_Store; (6) self-update had no pinVersion field at all, so SPEC section-3.7's 'no-op when pinned' requirement was unimplemented.
+
+**Alternatives considered:** Wire --quiet through all 13 remaining verbs now instead of just fixing the help text - rejected, explicitly out of scope and a much larger surface, Skip a shared atomic-write helper and patch each of the 3 call sites ad hoc - rejected, the codebase already has two near-identical helpers (writeAtomic, realAtomicWriteFile); a third bespoke copy would be the same drift risk this fix is closing, Copy the SPEC prose's trailing-slash pattern format (.next/, .turbo/) verbatim into the Go defaults - rejected, internal/tree's matcher does a literal filepath.Match against the basename/component so a trailing slash would silently never match; used the no-trailing-slash form every sibling default already uses
+
+**Implications:**
+- New internal/atomicio package (temp-sibling + rename, mode preserved) now backs claudehook.EnsurePreToolUseGuard, hooks.installHook, and inserter.InsertLogmindSection
+- gitcli.Push gained package-level pushTimeout (45s) / pushWaitDelay (2s) vars so tests can shrink them for a hermetic hang test
+- Config gained a top-level PinVersion field (deliberately omitted from DefaultMap to preserve config-list Python-parity, same precedent as root_label/context.repomap/context.spec_file)
+- DefaultConfig/DefaultMap ignore_patterns and the config_test.go golden both grew the three new entries; TestConfigList_DefaultsMatchPython is a spot-check so it was untouched
+
+---
+

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -36,6 +36,7 @@ logmind
 │   └── install.sh
 ├── internal
 │   ├── agents
+│   ├── atomicio
 │   ├── claudehook
 │   ├── cli
 │   ├── clierr

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -18,6 +18,10 @@ PR's CI run, so this file is always coherent with current `main`.
 - **2026-07-17** — fix(ci): check-decisions honors [skip-logmind] on rerun — fetch the live PR title (#212) → [detail](decisions-branches/fix__check-decisions-live-pr-title-212.md)
 <!-- logmind-entry-end -->
 
+<!-- logmind-entry-start: 2026-07-17-fix-audit-batch-crlf-determinism-push-timeout-atomic-config- -->
+- **2026-07-17** — fix: audit batch - CRLF determinism, push timeout, atomic config writes, quiet help, spec 1.2.1/3.7 conformance → [detail](decisions-branches/fix__adversarial-audit-batch-v2.md)
+<!-- logmind-entry-end -->
+
 <!-- logmind-entry-start: 2026-07-17-authenticated-every-setup-logmind-call-site-and-un-bricked-t -->
 - **2026-07-17** — Authenticated every setup-logmind call site and un-bricked the dead self-update workflow (v-prefix + apples-to-oranges version compare). → [detail](decisions-branches/fix__setup-logmind-auth-and-self-update.md)
 <!-- logmind-entry-end -->

--- a/internal/atomicio/atomicio.go
+++ b/internal/atomicio/atomicio.go
@@ -1,0 +1,63 @@
+// Package atomicio provides a single crash-safe file-write primitive:
+// write to a temp sibling in the file's own directory, then atomically
+// rename it into place.
+//
+// Why this matters: os.WriteFile on an EXISTING path opens with O_TRUNC,
+// then writes — two separate syscalls. A crash (power loss, OOM kill,
+// SIGKILL) between the truncate and the write completing leaves the file
+// empty or partially written on disk. WriteFile here never touches the
+// destination path directly: the temp file is written and fsync'd-by-Close
+// in full, then os.Rename swaps it in — a single filesystem operation that
+// is atomic on the platforms Go supports (same-directory rename). The
+// destination either has its OLD full content or its NEW full content,
+// never a partial one.
+//
+// This consolidates a pattern that already existed twice in this codebase
+// under different names — internal/skill/sync.go's realAtomicWriteFile and
+// internal/cli/timeline.go's writeAtomic — so callers across packages share
+// one implementation instead of each re-deriving the temp+rename dance
+// (and, per audit, three sites — internal/claudehook, internal/hooks,
+// internal/inserter — hadn't derived it at all, using a bare os.WriteFile
+// against an existing file).
+package atomicio
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteFile atomically writes data to path with permission bits perm,
+// whether path already exists or not. On any failure the temp file is
+// removed and path is left completely untouched.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
+}

--- a/internal/atomicio/atomicio_test.go
+++ b/internal/atomicio/atomicio_test.go
@@ -1,0 +1,157 @@
+package atomicio
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestWriteFile_CreatesNewFile covers the "file doesn't exist yet" path:
+// content and mode land correctly, and no temp file is left behind.
+func TestWriteFile_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fresh.json")
+
+	if err := WriteFile(path, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	assertContent(t, path, `{"a":1}`)
+	assertMode(t, path, 0o644)
+	assertNoTmpResidue(t, dir)
+}
+
+// TestWriteFile_OverwritesExistingFile is the core guard for the MAJOR
+// fix: overwriting an EXISTING file must land the new content in full,
+// with the right mode, and leave no temp residue behind.
+func TestWriteFile_OverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := WriteFile(path, []byte("new content, longer than old"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	assertContent(t, path, "new content, longer than old")
+	assertMode(t, path, 0o644)
+	assertNoTmpResidue(t, dir)
+}
+
+// TestWriteFile_RenameSemantics_DoesNotFollowSymlink proves WriteFile
+// actually takes the temp-file-plus-rename path rather than an in-place
+// truncate+write in disguise: os.Rename replaces the destination NAME
+// itself (swapping a symlink for a regular file) instead of following the
+// symlink and writing through to its target — which is exactly what a
+// bare os.WriteFile(path, ...) on a symlinked path WOULD do. This is the
+// same rename-is-atomic property that makes the technique crash-safe: the
+// destination path only ever changes via one atomic filesystem op.
+func TestWriteFile_RenameSemantics_DoesNotFollowSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	if err := os.WriteFile(target, []byte("original target content"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	link := filepath.Join(dir, "settings.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := WriteFile(link, []byte("new content"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", link, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("%s is still a symlink after WriteFile; want it replaced by a regular file (rename semantics)", link)
+	}
+	assertContent(t, link, "new content")
+
+	targetContent, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(targetContent) != "original target content" {
+		t.Errorf("target content = %q; want unchanged (a naive truncate+write would have followed the symlink and clobbered it)", targetContent)
+	}
+}
+
+// TestWriteFile_PreservesExecutableMode covers the git-hook call site
+// (0o755) — the mode argument must round-trip exactly, matching the
+// executable-bit contract installHook relies on.
+func TestWriteFile_PreservesExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "post-merge")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := WriteFile(path, []byte("#!/bin/sh\necho new\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	assertContent(t, path, "#!/bin/sh\necho new\n")
+	assertMode(t, path, 0o755)
+	assertNoTmpResidue(t, dir)
+}
+
+// TestWriteFile_CreatesMissingParentDir mirrors writeFreshSettings'
+// .claude/ directory creation — WriteFile must create the parent dir like
+// os.MkdirAll + os.WriteFile did before.
+func TestWriteFile_CreatesMissingParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deeper", "file.md")
+
+	if err := WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	assertContent(t, path, "hello")
+}
+
+func assertContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("content = %q; want %q", got, want)
+	}
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return // POSIX permission bits don't map cleanly on Windows.
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if fi.Mode().Perm() != want {
+		t.Errorf("mode = %o; want %o", fi.Mode().Perm(), want)
+	}
+}
+
+// assertNoTmpResidue confirms WriteFile cleaned up: no "<base>.tmp-*"
+// sibling is left in dir once the rename lands.
+func assertNoTmpResidue(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}

--- a/internal/claudehook/claudehook.go
+++ b/internal/claudehook/claudehook.go
@@ -41,6 +41,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/version"
 )
@@ -169,7 +170,10 @@ func EnsurePreToolUseGuard(repoRoot string) (changed bool, err error) {
 	if !changed {
 		return false, nil
 	}
-	if err := os.WriteFile(path, out, 0o644); err != nil {
+	// path already exists here (we're on the post-ReadFile-success branch) —
+	// use the atomic writer so a crash mid-write can't leave the user's
+	// settings.json truncated/corrupt.
+	if err := atomicio.WriteFile(path, out, 0o644); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/claudehook/claudehook_test.go
+++ b/internal/claudehook/claudehook_test.go
@@ -280,6 +280,55 @@ func TestEnsurePreToolUseGuard_VersionBumpReplacesOnlyOurEntry(t *testing.T) {
 	}
 }
 
+// TestEnsurePreToolUseGuard_OverwriteLeavesNoTmpResidue guards the atomic-
+// write fix: updating an EXISTING settings.json (the stale-marker path
+// above) must go through atomicio's temp-sibling-plus-rename, not a bare
+// os.WriteFile truncate-then-write. A leftover ".tmp-*" file would mean the
+// rename didn't happen (or failed silently); its absence plus valid JSON
+// is the observable proof the atomic path landed cleanly.
+func TestEnsurePreToolUseGuard_OverwriteLeavesNoTmpResidue(t *testing.T) {
+	dir := t.TempDir()
+	path := SettingsPath(dir)
+	staleCommand := "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + "0.1.0-STALE"
+	mustWriteJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks":   []any{map[string]any{"type": "command", "if": "Bash(git *)", "command": staleCommand, "timeout": float64(10)}},
+				},
+			},
+		},
+	})
+
+	changed, err := EnsurePreToolUseGuard(dir)
+	if err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false on a stale marker; want true")
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Dir(path), err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file after overwrite: %s", e.Name())
+		}
+	}
+	// The final file must still be valid, complete JSON — not truncated.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("settings.json is not valid JSON after overwrite: %v\n%s", err, data)
+	}
+}
+
 // --- EnsurePreToolUseGuard: malformed settings.json --------------------
 
 func TestEnsurePreToolUseGuard_MalformedSettingsReturnsErrorAndLeavesFileUntouched(t *testing.T) {

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -38,6 +38,44 @@ func assertSingleOK(t *testing.T, out string, wantTokens ...string) {
 	}
 }
 
+// TestQuietFlagHelp_DoesNotOverpromiseUnwiredVerbs guards the MINOR fix:
+// cobra renders --quiet's Usage string identically under every
+// subcommand's "Global Flags" section (it's a persistent flag on root),
+// including the 13 verbs that don't read it at all. The help text must not
+// make the unqualified "one ok line per verb" promise; it must instead
+// name the actual wired subset (or otherwise scope the claim) so a verb
+// that ignores --quiet doesn't look broken against its own --help output.
+func TestQuietFlagHelp_DoesNotOverpromiseUnwiredVerbs(t *testing.T) {
+	root := NewRootCmd()
+	f := root.PersistentFlags().Lookup(quietFlagName)
+	if f == nil {
+		t.Fatal("--quiet flag not registered on root")
+	}
+	usage := f.Usage
+
+	// The unqualified promise this fix removes: "per verb" / "every verb"
+	// with no scoping. cobra shows this same sentence on ALL 22
+	// subcommands, but only 9 currently wire quietEnabled/qout in.
+	if strings.Contains(usage, "per verb") && !strings.Contains(usage, "read/emit verb") {
+		t.Errorf("usage still says %q; the unqualified 'per verb' promise must be scoped to the verbs that actually honor it", usage)
+	}
+
+	// The wired set the fix documents (see quiet.go's newQout callers +
+	// doctor.go's inline quietEnabled use) must be named somewhere in the
+	// help text, so an agent reading --help learns the real surface.
+	for _, verb := range []string{"doctor", "file-structure", "guard-commit", "headline", "log", "repomap", "search", "show", "timeline"} {
+		if !strings.Contains(usage, verb) {
+			t.Errorf("usage %q does not name wired verb %q", usage, verb)
+		}
+	}
+
+	// And it must signal, in some form, that other verbs are out of scope —
+	// otherwise a reader still can't tell the list above is exhaustive.
+	if !strings.Contains(strings.ToLower(usage), "other verbs") && !strings.Contains(strings.ToLower(usage), "ignore this flag") {
+		t.Errorf("usage %q does not disclose that unwired verbs ignore --quiet", usage)
+	}
+}
+
 func TestQuietEnvSet(t *testing.T) {
 	cases := map[string]bool{
 		"1": true, "true": true, "TRUE": true, "yes": true, "on": true, "anything": true,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,16 +48,22 @@ func NewRootCmd() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	// Persistent --quiet flag (token-killer Phase 1b). Inherited by every
-	// subcommand; wired verbs (log, timeline, file-structure, doctor,
-	// headline) then suppress progress chatter and emit a single chainable
-	// `ok <k=v>` line. Opt-in twin of the LOGMIND_QUIET env var — the default
-	// (unset) path stays byte-identical. See quiet.go.
+	// Persistent --quiet flag (token-killer Phase 1b). Registered on root so
+	// cobra accepts it ahead of every subcommand's own flags, but only the
+	// WIRED verbs (doctor, file-structure, guard-commit, headline, log,
+	// repomap, search, show, timeline) actually read it — §14.1 makes quiet
+	// a SHOULD, not a MUST, so the remaining verbs are free to ignore it.
+	// Opt-in twin of the LOGMIND_QUIET env var — the default (unset) path
+	// stays byte-identical. See quiet.go.
 	// NB: no back-quotes in this usage string — pflag's UnquoteUsage treats a
 	// back-quoted span as the flag's value placeholder, which would make this
 	// boolean flag render misleadingly as `--quiet ok <k=v>` in --help.
+	//
+	// The help text below deliberately does NOT promise "one ok line per
+	// verb" unqualified: cobra shows this same text under every subcommand's
+	// Global Flags section, including the 13 verbs that don't honor it yet.
 	root.PersistentFlags().Bool(quietFlagName, false,
-		"Terse machine output: suppress progress chatter, emit one chainable 'ok <k=v>' line per verb (env: LOGMIND_QUIET=1). Errors still go to stderr.")
+		"Terse machine output on the read/emit verbs (doctor, file-structure, guard-commit, headline, log, repomap, search, show, timeline): suppress progress chatter, emit one chainable 'ok <k=v>' line (env: LOGMIND_QUIET=1). Errors still go to stderr. Other verbs currently ignore this flag.")
 
 	root.AddCommand(newVersionCmd())
 	// B2: git integration + hooks subcommands.

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -19,6 +19,11 @@
 //     get its commit-msg hook auto-upgraded to enforcing (Layer 2) while
 //     Layer 1 stays missing forever — and doctor would never nudge,
 //     because "missing" is benign.
+//
+// pinVersion (SPEC §1.2.1 / §3.7): when `.logmind/config.yml` sets a
+// non-empty top-level `pinVersion`, self-update no-ops entirely — none of
+// the refreshes above run. This is checked FIRST, before any refresh
+// work, so a pinned repo never partially refreshes.
 package cli
 
 import (
@@ -29,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/inserter"
 )
@@ -53,6 +59,16 @@ func runSelfUpdate(cmd *cobra.Command) error {
 		return err
 	}
 	out := cmd.OutOrStdout()
+
+	// pinVersion floor (SPEC §1.2.1 / §3.7): a repo that pins below the
+	// running binary's version wants NO refresh at all — checked before any
+	// file is touched, so a pin is a true, complete no-op.
+	if cfg, _ := config.Load(cwd); cfg.PinVersion != "" {
+		fmt.Fprintf(out, "logmind self-update: pinned to %s, skipping (unset pinVersion in .logmind/config.yml to resume updates)\n", cfg.PinVersion)
+		fmt.Fprintln(out, "ok self-update pinned")
+		return nil
+	}
+
 	updated := false
 
 	if msg, err := inserter.EnsureAgentsMD(cwd); err == nil && msg != "" {

--- a/internal/cli/self_update_test.go
+++ b/internal/cli/self_update_test.go
@@ -94,6 +94,92 @@ func TestSelfUpdate_InstallsClaudePreToolUseGuard(t *testing.T) {
 	}
 }
 
+// TestSelfUpdate_PinVersionSet_NoOps pins the MINOR fix (SPEC §1.2.1 /
+// §3.7): a `.logmind/config.yml` with a non-empty top-level `pinVersion`
+// makes self-update a complete no-op — not even a stale, clearly-outdated
+// hook gets refreshed. Reuses TestSelfUpdate_RefreshesStaleHook's fixture
+// shape so the contrast is direct: same stale hook, but pinned this time.
+func TestSelfUpdate_PinVersionSet_NoOps(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		if err := os.MkdirAll(".logmind", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(".logmind", "config.yml"), []byte("pinVersion: \"1.2.3\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(".git", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stale := "#!/bin/sh\n# logmind post-merge hook\n# logmind-hook-version: 0.1.0\necho stale\n"
+		if err := os.WriteFile(filepath.Join(".git", "hooks", "post-merge"), []byte(stale), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"self-update"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("self-update: %v\n%s\n%s", err, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "pinned to 1.2.3") {
+			t.Errorf("expected a clear pinned-version message; got\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "Refreshed") {
+			t.Errorf("pinned self-update must not refresh anything; got\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "ok self-update applied") {
+			t.Errorf("pinned self-update must not emit the normal-run ok line; got\n%s", out.String())
+		}
+	})
+	// The stale hook body must be untouched — no refresh happened at all.
+	body, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "post-merge"))
+	if err != nil {
+		t.Fatalf("read post-merge: %v", err)
+	}
+	if !strings.Contains(string(body), "echo stale") {
+		t.Errorf("pinned self-update must leave the stale hook alone; got\n%s", string(body))
+	}
+	// No .claude/settings.json either — Layer 1 install is also skipped.
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "settings.json")); err == nil {
+		t.Errorf("pinned self-update must not install .claude/settings.json")
+	}
+}
+
+// TestSelfUpdate_PinVersionUnset_RunsNormally is the direct contrast: the
+// default (no pinVersion key at all) must still refresh exactly as before
+// — the fix must not accidentally gate the unset case.
+func TestSelfUpdate_PinVersionUnset_RunsNormally(t *testing.T) {
+	dir := withTempCwd(t, func(_ string) {
+		if err := os.MkdirAll(filepath.Join(".git", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stale := "#!/bin/sh\n# logmind post-merge hook\n# logmind-hook-version: 0.1.0\necho stale\n"
+		if err := os.WriteFile(filepath.Join(".git", "hooks", "post-merge"), []byte(stale), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		root := NewRootCmd()
+		root.SetArgs([]string{"self-update"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("self-update: %v\n%s\n%s", err, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "ok self-update applied") {
+			t.Errorf("expected the normal-run ok line; got\n%s", out.String())
+		}
+	})
+	body, err := os.ReadFile(filepath.Join(dir, ".git", "hooks", "post-merge"))
+	if err != nil {
+		t.Fatalf("read post-merge: %v", err)
+	}
+	if strings.Contains(string(body), "echo stale") {
+		t.Errorf("stale body not replaced when pinVersion is unset; got\n%s", string(body))
+	}
+}
+
 // TestSelfUpdate_ClaudeDisabledInConfigSkipsGuard: agents.claude:false is
 // the same opt-out doctor --fix honors — self-update must respect it too.
 func TestSelfUpdate_ClaudeDisabledInConfigSkipsGuard(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,14 @@ type Config struct {
 	// check records the visibility shape but doesn't block; layers
 	// 1-3 still run unchanged.
 	AllowPromoteFromPrivate bool `yaml:"allow_promote_from_private"`
+
+	// PinVersion is the SPEC §1.2.1 / §3.7 self-update floor: when set to
+	// a non-empty version string, `logmind self-update` MUST no-op instead
+	// of refreshing templates/hooks to the running binary's version. A
+	// top-level key (not nested under a section), camelCase per the SPEC's
+	// own naming — matches how the SPEC's example config.yml renders it
+	// (`pinVersion: null`). Default "" (unset) = self-update runs normally.
+	PinVersion string `yaml:"pinVersion"`
 }
 
 // PrivacyScannerConfig is the typed shape of the `privacy_scanner:`
@@ -216,6 +224,18 @@ func DefaultConfig() Config {
 				"dist",
 				"build",
 				"*.egg-info",
+				// SPEC §1.2.1's default list MUST also include these three
+				// (.next/, .turbo/, .DS_Store) — added without the SPEC
+				// prose's trailing "/" because internal/tree's matcher
+				// (patternSetMatches) does a literal filepath.Match against
+				// the basename/path component; every OTHER default pattern
+				// here is already written without a trailing slash for the
+				// same reason (a literal ".next/" would never match the
+				// directory component ".next" and so would silently ignore
+				// nothing).
+				".next",
+				".turbo",
+				".DS_Store",
 			},
 			RootLabel: "",
 		},
@@ -253,6 +273,15 @@ func DefaultConfig() Config {
 		// source → public catalog push gets blocked unless the user
 		// explicitly opts in.
 		AllowPromoteFromPrivate: false,
+		// PinVersion: "" (unset) — `logmind self-update` runs normally.
+		// Deliberately NOT added to DefaultMap (below): like root_label /
+		// context.repomap / context.spec_file, it's a key with no Python
+		// v0.6.14 ancestor, and DefaultMap must stay byte-for-byte
+		// Python-parity for `config list` (see
+		// TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity).
+		// Reads/writes via config.yml (LoadPath/GetPath/`config get
+		// pinVersion`) work regardless of listing.
+		PinVersion: "",
 	}
 }
 
@@ -326,6 +355,9 @@ func DefaultMap() *OrderedMap {
 		"dist",
 		"build",
 		"*.egg-info",
+		".next",
+		".turbo",
+		".DS_Store",
 	}
 	fileStructure.Set("ignore_patterns", patterns)
 	root.Set("file_structure", fileStructure)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,8 @@ func TestDefaultConfig(t *testing.T) {
 		"__pycache__", ".git", "node_modules", "venv", ".venv",
 		"env", ".env", "*.pyc", ".pytest_cache", ".mypy_cache",
 		"dist", "build", "*.egg-info",
+		// SPEC §1.2.1 additions: .next/, .turbo/, .DS_Store.
+		".next", ".turbo", ".DS_Store",
 	}
 	if !reflect.DeepEqual(c.FileStructure.IgnorePatterns, wantPatterns) {
 		t.Errorf("FileStructure.IgnorePatterns =\n  %q\nwant\n  %q", c.FileStructure.IgnorePatterns, wantPatterns)
@@ -50,6 +52,65 @@ func TestDefaultConfig(t *testing.T) {
 	// user's `logmind skill push` somewhere else.
 	if c.CatalogTarget != "thrillmade/agent-skills" {
 		t.Errorf("CatalogTarget default = %q; want thrillmade/agent-skills", c.CatalogTarget)
+	}
+}
+
+// TestDefaultConfig_IgnorePatterns_IncludesSpecRequiredDefaults pins the
+// MINOR fix: SPEC §1.2.1 states the default file_structure.ignore_patterns
+// "MUST include at least" .git/, node_modules/, venv/, __pycache__/,
+// .next/, dist/, build/, .turbo/, *.pyc, .DS_Store. .next/.turbo/.DS_Store
+// were missing entirely. (Checked here without the SPEC prose's trailing
+// "/" — see the doc comment on DefaultConfig's IgnorePatterns literal for
+// why: internal/tree's matcher does a literal component match, and every
+// sibling default pattern already omits the trailing slash for the same
+// reason.)
+func TestDefaultConfig_IgnorePatterns_IncludesSpecRequiredDefaults(t *testing.T) {
+	got := DefaultConfig().FileStructure.IgnorePatterns
+	set := map[string]bool{}
+	for _, p := range got {
+		set[p] = true
+	}
+	for _, want := range []string{".next", ".turbo", ".DS_Store"} {
+		if !set[want] {
+			t.Errorf("DefaultConfig().FileStructure.IgnorePatterns = %q; missing SPEC §1.2.1-required default %q", got, want)
+		}
+	}
+}
+
+// TestDefaultMap_IgnorePatterns_MatchesDefaultConfig guards against the
+// two hand-maintained pattern lists (DefaultConfig's typed slice and
+// DefaultMap's `config list`/get/set-facing []any slice) drifting apart —
+// `logmind config list` must show the same ignore_patterns file-structure
+// tree generation actually uses.
+func TestDefaultMap_IgnorePatterns_MatchesDefaultConfig(t *testing.T) {
+	typed := DefaultConfig().FileStructure.IgnorePatterns
+	fileStructure, ok := DefaultMap().Get("file_structure")
+	if !ok {
+		t.Fatal("DefaultMap() has no file_structure key")
+	}
+	om, ok := fileStructure.(*OrderedMap)
+	if !ok {
+		t.Fatalf("file_structure value is %T; want *OrderedMap", fileStructure)
+	}
+	rawPatterns, ok := om.Get("ignore_patterns")
+	if !ok {
+		t.Fatal("DefaultMap() file_structure has no ignore_patterns key")
+	}
+	anyPatterns, ok := rawPatterns.([]any)
+	if !ok {
+		t.Fatalf("ignore_patterns value is %T; want []any", rawPatterns)
+	}
+	if len(anyPatterns) != len(typed) {
+		t.Fatalf("DefaultMap ignore_patterns has %d entries; DefaultConfig has %d", len(anyPatterns), len(typed))
+	}
+	for i, p := range anyPatterns {
+		s, ok := p.(string)
+		if !ok {
+			t.Fatalf("ignore_patterns[%d] = %T; want string", i, p)
+		}
+		if s != typed[i] {
+			t.Errorf("DefaultMap ignore_patterns[%d] = %q; DefaultConfig has %q", i, s, typed[i])
+		}
 	}
 }
 

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -48,6 +48,32 @@ func TestFileStructureRootLabel_DefaultAndRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPinVersion_DefaultAndRoundTrip pins the MINOR fix (SPEC §1.2.1 /
+// §3.7): pinVersion is a top-level (not nested) config key, default "" so
+// self-update runs normally, and a set value round-trips through
+// LoadPath into the typed Config the CLI layer reads.
+func TestPinVersion_DefaultAndRoundTrip(t *testing.T) {
+	if got := DefaultConfig().PinVersion; got != "" {
+		t.Errorf("default PinVersion = %q; want \"\" (self-update runs normally)", got)
+	}
+	cfg, err := LoadPath(writeTimelineCfg(t, "pinVersion: \"1.2.3\"\n"))
+	if err != nil {
+		t.Fatalf("LoadPath: %v", err)
+	}
+	if cfg.PinVersion != "1.2.3" {
+		t.Errorf("PinVersion = %q; want 1.2.3", cfg.PinVersion)
+	}
+	// A `pinVersion: null` config (the SPEC's own example) must resolve to
+	// the same "" default, not error or leave a literal "null" string.
+	nullCfg, err := LoadPath(writeTimelineCfg(t, "pinVersion: null\n"))
+	if err != nil {
+		t.Fatalf("LoadPath with pinVersion:null: %v", err)
+	}
+	if nullCfg.PinVersion != "" {
+		t.Errorf("PinVersion with YAML null = %q; want \"\"", nullCfg.PinVersion)
+	}
+}
+
 func TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity(t *testing.T) {
 	// THE load-bearing guard for PR2: the new typed keys must NOT appear in
 	// DefaultMap. DefaultMap is what `logmind config list` serializes, and

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -31,6 +31,7 @@ package gitcli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -660,14 +661,35 @@ func Commit(repoRoot, message string) error {
 //     "authenticity of host" prompts (https + git's ssh prompts).
 //   - GIT_SSH_COMMAND=ssh -oBatchMode=yes tells OpenSSH never to prompt
 //     for a passphrase / password (ssh remotes).
+//
+// pushTimeout bounds how long a single `git push` may run before it is
+// killed. Push is the first NETWORK op in this package, and `logmind log`
+// runs it on the hot path (git.auto_push defaults true) — a wedged remote
+// (dead TCP connection, hung auth handshake, etc.) must not hang every log
+// forever. Var (not const) so tests can shrink it for a fast, hermetic
+// hang test.
+var pushTimeout = 45 * time.Second
+
+// pushWaitDelay bounds how long Run's internal Wait keeps blocking on the
+// command's I/O pipes AFTER pushTimeout's context kills the direct child —
+// mirrors doctor.probePathResolution's WaitDelay hardening (see that
+// function's comment for the full daemonizing-wrapper rationale: a context
+// timeout only signals the direct child, so a process that leaves a
+// grandchild holding the stdout/stderr pipe open can still block Wait
+// indefinitely without this). Var so tests can shrink it too.
+var pushWaitDelay = 2 * time.Second
+
 func Push(repoRoot string, args ...string) error {
 	gitArgs := append([]string{"push"}, args...)
-	cmd := exec.Command("git", gitArgs...)
+	ctx, cancel := context.WithTimeout(context.Background(), pushTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_SSH_COMMAND=ssh -oBatchMode=yes",
 	)
+	cmd.WaitDelay = pushWaitDelay
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/gitcli/gitcli_push_test.go
+++ b/internal/gitcli/gitcli_push_test.go
@@ -97,6 +97,45 @@ func TestPush_BadRemoteReturnsErrorFast(t *testing.T) {
 	}
 }
 
+// TestPush_HangingRemoteTimesOut guards the MAJOR fix: Push previously used
+// a plain cmd.Run() with no context timeout and no WaitDelay, so a wedged
+// `git push` (dead connection, hung auth handshake) would block forever —
+// on `logmind log`'s default hot path (git.auto_push defaults true). This
+// fakes out `git` itself via PATH with a script that just hangs, and
+// shrinks pushTimeout/pushWaitDelay so the test stays fast and hermetic
+// (no real network, no real git needed at all).
+func TestPush_HangingRemoteTimesOut(t *testing.T) {
+	tmp := t.TempDir()
+	fakeGit := filepath.Join(tmp, "git")
+	// A direct hang — simulates a wedged network call, not a daemonizing
+	// wrapper. pushTimeout's context must kill it.
+	body := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(fakeGit, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	if err := os.Setenv("PATH", tmp+string(os.PathListSeparator)+origPath); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+
+	origTimeout, origWaitDelay := pushTimeout, pushWaitDelay
+	pushTimeout = 200 * time.Millisecond
+	pushWaitDelay = 200 * time.Millisecond
+	t.Cleanup(func() { pushTimeout, pushWaitDelay = origTimeout, origWaitDelay })
+
+	start := time.Now()
+	err := Push(t.TempDir())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Push against a hanging git binary returned nil; want a timeout error")
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("Push took %v; want bounded by pushTimeout+pushWaitDelay (~400ms), not the fake binary's 30s sleep", elapsed)
+	}
+}
+
 // --- small local helpers (kept here so the push tests are self-contained) ---
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -371,12 +372,13 @@ func installHook(hookPath, body, marker string) (bool, error) {
 			return false, nil // already current
 		}
 	}
-	if err := os.WriteFile(hookPath, []byte(body), 0o755); err != nil {
-		return false, err
-	}
-	// WriteFile honours the perm bits only when creating the file —
-	// re-chmod explicitly so updates also keep the executable bit.
-	if err := os.Chmod(hookPath, 0o755); err != nil {
+	// Write atomically (temp sibling + rename): a bare os.WriteFile here
+	// would O_TRUNC an EXISTING hook before writing the new body, so a
+	// crash mid-write could leave a truncated/corrupt git hook behind.
+	// atomicio.WriteFile also chmods the temp file before the rename, so
+	// the executable bit lands correctly whether hookPath is new or being
+	// updated — no separate re-chmod needed.
+	if err := atomicio.WriteFile(hookPath, []byte(body), 0o755); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -280,6 +280,27 @@ func TestInstallCommitMsg_UpgradesWarnOnlyV0616Body(t *testing.T) {
 	if string(got) != BuildCommitMsgBody() {
 		t.Fatalf("hook was not upgraded to the current enforcing body")
 	}
+
+	fi, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("stat upgraded hook: %v", err)
+	}
+	if fi.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %o; want 0755 (executable bit must survive the atomic rewrite)", fi.Mode().Perm())
+	}
+
+	// Guards the atomic-write fix: overwriting this EXISTING hook must go
+	// through atomicio's temp-sibling-plus-rename, leaving no ".tmp-*"
+	// residue in .git/hooks/ behind.
+	entries, err := os.ReadDir(filepath.Dir(hookPath))
+	if err != nil {
+		t.Fatalf("read hooks dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file after hook upgrade: %s", e.Name())
+		}
+	}
 }
 
 func TestInstallCommitMsg_LeavesForeignHook(t *testing.T) {

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -48,6 +48,7 @@ import (
 	"strings"
 
 	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/templates"
 )
 
@@ -250,7 +251,10 @@ func InsertLogmindSection(filePath string) (bool, error) {
 	newLines = append(newLines, lines[insertIndex:]...)
 
 	out := strings.Join(newLines, "\n")
-	if err := os.WriteFile(filePath, []byte(out), 0o644); err != nil {
+	// filePath is an EXISTING file (read successfully above) — write
+	// atomically so a crash mid-write can't leave the user's AGENTS.md/etc.
+	// truncated or partial.
+	if err := atomicio.WriteFile(filePath, []byte(out), 0o644); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/inserter/inserter_test.go
+++ b/internal/inserter/inserter_test.go
@@ -919,6 +919,18 @@ func TestInsertLogmindSection_NoHeading(t *testing.T) {
 	if markerIdx > rulesIdx {
 		t.Errorf("logmind block must precede user content (markerIdx=%d > rulesIdx=%d)", markerIdx, rulesIdx)
 	}
+	// Guards the atomic-write fix: overwriting this EXISTING file must go
+	// through atomicio's temp-sibling-plus-rename, leaving no ".tmp-*"
+	// residue behind in dir.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file after InsertLogmindSection: %s", e.Name())
+		}
+	}
 	// Idempotency: second call must be a no-op (marker already present).
 	changed2, err := InsertLogmindSection(target)
 	if err != nil {

--- a/internal/timeline/canonical.go
+++ b/internal/timeline/canonical.go
@@ -163,11 +163,26 @@ func extractEntryBlocks(content string, stderr io.Writer) []entryBlock {
 			fmt.Fprintf(stderr, "logmind: skipping entry-block %q: unclosed at end of file\n", key)
 			i++
 		default:
-			out = append(out, entryBlock{Key: key, Body: strings.Join(lines[i+1:j], "\n")})
+			out = append(out, entryBlock{Key: key, Body: joinBodyLines(lines[i+1 : j])})
 			i = j + 1
 		}
 	}
 	return out
+}
+
+// joinBodyLines joins entry-block body lines with "\n", stripping any
+// trailing "\r" from each line first. A CRLF-line-ended source (e.g. a
+// Windows core.autocrlf=true checkout of docs/decisions-branches/*.md) would
+// otherwise leave a "\r" on every body line after the raw "\n" split, which
+// (a) writes a literal CR into docs/timeline.md — breaking this file's own
+// byte-determinism invariant (see the package doc comment) — and (b) can
+// defeat dedupeAndSuffix's same-body carve-out, since "body\r" != "body".
+func joinBodyLines(lines []string) string {
+	clean := make([]string, len(lines))
+	for i, l := range lines {
+		clean[i] = strings.TrimSuffix(l, "\r")
+	}
+	return strings.Join(clean, "\n")
 }
 
 // --- §1.6.4 main-canonical assembly ---------------------------------------

--- a/internal/timeline/canonical_assembly_test.go
+++ b/internal/timeline/canonical_assembly_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -191,6 +192,31 @@ func TestGenerateMainCanonical_SameEntryTwoSourcesCollapses(t *testing.T) {
 	blocks := extractEntryBlocks(out, &stderr)
 	if len(blocks) != 1 {
 		t.Errorf("got %d; want 1 (identical body collapses to one)\n%s", len(blocks), out)
+	}
+}
+
+// TestGenerateMainCanonical_CRLFAndLFSameEntryCollapses guards the CRLF
+// determinism fix end-to-end: a branch file checked out with CRLF line
+// endings (core.autocrlf=true on Windows) and one checked out with plain LF,
+// both carrying the SAME entry body, must still collapse to one row via the
+// same-entry carve-out — a stray "\r" surviving into the body would make
+// "body\r" != "body" and silently duplicate the entry.
+func TestGenerateMainCanonical_CRLFAndLFSameEntryCollapses(t *testing.T) {
+	docs := filepath.Join(t.TempDir(), "docs")
+	crlfBlock := strings.ReplaceAll(block("2026-06-29-dup", "- identical body"), "\n", "\r\n")
+	writeDoc(t, docs, "decisions-branches/feat__a.md", crlfBlock)
+	writeDoc(t, docs, "decisions-branches/feat__b.md", block("2026-06-29-dup", "- identical body"))
+	var stderr bytes.Buffer
+	out, err := Generate(docs, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := extractEntryBlocks(out, &stderr)
+	if len(blocks) != 1 {
+		t.Errorf("got %d; want 1 (CRLF- and LF-sourced identical bodies must collapse)\n%s", len(blocks), out)
+	}
+	if strings.Contains(out, "\r") {
+		t.Errorf("rendered timeline contains a stray \\r:\n%q", out)
 	}
 }
 

--- a/internal/timeline/canonical_test.go
+++ b/internal/timeline/canonical_test.go
@@ -159,4 +159,47 @@ func TestExtractEntryBlocks_TolerateCRLF(t *testing.T) {
 	if len(got) != 1 || got[0].Key != "2026-06-29-x" {
 		t.Errorf("got %+v (stderr=%s); want 1 block keyed 2026-06-29-x", got, stderr.String())
 	}
+	// The body itself must be clean — no trailing "\r" leaking in from the
+	// raw "\n" split, or renderCanonical would write a literal CR into
+	// docs/timeline.md (breaking its own byte-determinism invariant).
+	if strings.Contains(got[0].Body, "\r") {
+		t.Errorf("body = %q; contains a stray \\r (CRLF must be stripped from body lines)", got[0].Body)
+	}
+	if got[0].Body != "body" {
+		t.Errorf("body = %q; want %q", got[0].Body, "body")
+	}
+}
+
+func TestExtractEntryBlocks_CRLFMultiLineBodyIsClean(t *testing.T) {
+	// A multi-line body under CRLF must have EVERY line stripped of its
+	// trailing "\r", not just the last one.
+	content := entryStartPrefix + "2026-06-29-x" + entryStartSuffix + "\r\n" +
+		"line one\r\nline two\r\n" + entryEndMarker + "\r\n"
+	var stderr bytes.Buffer
+	got := extractEntryBlocks(content, &stderr)
+	if len(got) != 1 {
+		t.Fatalf("got %d blocks; want 1 (stderr=%s)", len(got), stderr.String())
+	}
+	if want := "line one\nline two"; got[0].Body != want {
+		t.Errorf("body = %q; want %q (no \\r on any line)", got[0].Body, want)
+	}
+}
+
+// TestExtractEntryBlocks_CRLFAndLFIdenticalBodiesDedup pins the interaction
+// with dedupeAndSuffix's same-body carve-out: a CRLF-sourced entry and an
+// LF-sourced entry with the otherwise-identical body must be recognized as
+// the SAME entry (one row), not two — "body\r" != "body" would otherwise
+// silently duplicate every entry that round-trips through a CRLF checkout.
+func TestExtractEntryBlocks_CRLFAndLFIdenticalBodiesDedup(t *testing.T) {
+	crlf := entryStartPrefix + "2026-06-29-dup" + entryStartSuffix + "\r\nsame body\r\n" + entryEndMarker + "\r\n"
+	lf := entryStartPrefix + "2026-06-29-dup" + entryStartSuffix + "\nsame body\n" + entryEndMarker + "\n"
+	var stderr bytes.Buffer
+	gotCRLF := extractEntryBlocks(crlf, &stderr)
+	gotLF := extractEntryBlocks(lf, &stderr)
+	if len(gotCRLF) != 1 || len(gotLF) != 1 {
+		t.Fatalf("got %d CRLF blocks, %d LF blocks; want 1 each", len(gotCRLF), len(gotLF))
+	}
+	if gotCRLF[0].Body != gotLF[0].Body {
+		t.Errorf("CRLF body %q != LF body %q; dedupeAndSuffix's same-body carve-out requires exact equality", gotCRLF[0].Body, gotLF[0].Body)
+	}
 }


### PR DESCRIPTION
## Summary

Six adversarially-confirmed defects fixed ahead of the v2.0.0 tag:

1. **MAJOR — CRLF `\r` leaks into the timeline body.** `extractEntryBlocks` (`internal/timeline/canonical.go`) split content on `"\n"` and captured body lines verbatim, so a CRLF-line-ended source left a trailing `\r` on every body line — writing a raw CR into `docs/timeline.md` (breaking its own byte-determinism invariant) and defeating `dedupeAndSuffix`'s same-body carve-out (`"body\r" != "body"`). Fixed by stripping a trailing `\r` from each body line via a new `joinBodyLines` helper.
2. **MAJOR — `gitcli.Push` has no timeout.** `Push` used plain `cmd.Run()` with no bound, on `logmind log`'s default hot path (`git.auto_push` defaults `true`). Now uses `context.WithTimeout` (45s) + `cmd.WaitDelay` (2s), mirroring `internal/doctor/doctor.go`'s existing pattern. Both are package-level vars so tests can shrink them for a fast, hermetic hang test.
3. **MAJOR — non-atomic overwrite of existing config/hook files.** `internal/claudehook/claudehook.go`, `internal/hooks/hooks.go`, and `internal/inserter/inserter.go` each overwrote an *existing* file with a bare `os.WriteFile` (O_TRUNC then write) — a crash mid-write could leave it empty/partial. Added a new shared `internal/atomicio` package (temp-sibling + rename, mode preserved) and routed all three sites through it.
4. **MAJOR — `--quiet` help text over-promises.** The persistent flag's help claimed "one ok line per verb," but only 9 of 22 subcommands (doctor, file-structure, guard-commit, headline, log, repomap, search, show, timeline) honor it. Reworded the help text to name the actual wired subset instead of wiring the remaining 13 verbs (out of scope).
5. **MINOR (SPEC §1.2.1) — missing default `ignore_patterns`.** `DefaultConfig()` omitted `.next`, `.turbo`, `.DS_Store`. Added (without the SPEC prose's trailing `/`, since `internal/tree`'s matcher does a literal component match and every sibling default already omits it).
6. **MINOR (SPEC §3.7) — self-update ignores `pinVersion`.** No `PinVersion` field existed at all. Added it to `Config`/`DefaultConfig` (default `""`, deliberately omitted from `DefaultMap` to preserve `config list` Python-parity, matching the existing `root_label`/`context.repomap`/`context.spec_file` precedent) and gated `runSelfUpdate` to print a clear "pinned to X, skipping" message and exit 0 when set.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./... -count=1` (all packages green)
- [x] New tests per fix: CRLF body/dedup tests in `internal/timeline`, a hermetic hanging-`git`-via-PATH test in `internal/gitcli`, atomic-write + rename-semantics tests in `internal/atomicio` plus per-call-site residue checks, a `--quiet` help-text scoping test, `DefaultConfig`/`DefaultMap` ignore-pattern consistency tests, and pinned/unpinned self-update tests.
- [x] No goldens required regeneration beyond the hand-maintained `config_test.go` pattern list (updated in place, not a `-update`-flag golden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)