### PR TITLE
docs: skdd-steward — rename to truth, bless all-repos scope, census duty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,12 @@ jobs:
           go-version: "1.22"
           cache: true
 
-      # Mint a 1-hour installation token for the `thrillmade-orchestrator[bot]`
-      # App, scoped to thrillmade/homebrew-tap only. The token replaces the
-      # personal HOMEBREW_TAP_PAT — see docs/orchestrator-app.md for the App
-      # spec and rotation procedure.
+      # Mint a 1-hour installation token for the `skdd-steward[bot]`
+      # App (renamed from thrillmade-orchestrator[bot]; org secrets keep
+      # their legacy THRILLMADE_ORCHESTRATOR_* names), scoped to
+      # thrillmade/homebrew-tap only. The token replaces the personal
+      # HOMEBREW_TAP_PAT — see docs/orchestrator-app.md for the App spec
+      # and rotation procedure.
       #
       # Allowlist constraint: this repo's `allowed_actions: selected` rule
       # only admits `actions/*`, `github/*`, verified-Marketplace creators,

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -181,8 +181,9 @@ homebrew_casks:
     binaries:
       - logmind
     # HOMEBREW_TAP_PAT is now an installation token for the
-    # `thrillmade-orchestrator[bot]` App (app_id 3951953), minted at
-    # workflow time by actions/create-github-app-token@v2 in release.yml.
+    # `skdd-steward[bot]` App (app_id 3951953, renamed from
+    # thrillmade-orchestrator), minted at workflow time by
+    # actions/create-github-app-token@v2 in release.yml.
     # The App is added as a bypass actor on the tap's ruleset 17128312,
     # so direct push to thrillmade/homebrew-tap/main goes through cleanly
     # with full audit trail under the App identity. No pull_request flow
@@ -202,8 +203,8 @@ homebrew_casks:
     # exact format ties each cask-bump commit to the App identity in
     # GitHub's UI rather than showing it as an anonymous bot.
     commit_author:
-      name: thrillmade-orchestrator[bot]
-      email: 3951953+thrillmade-orchestrator[bot]@users.noreply.github.com
+      name: skdd-steward[bot]
+      email: 3951953+skdd-steward[bot]@users.noreply.github.com
     commit_msg_template: "logmind {{ .Tag }}"
     # Post-install: strip macOS quarantine attr. logmind binaries are
     # codesigned + notarized in the release pipeline (so Gatekeeper will

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ This project uses [logmind](https://logmind.dev). What counts as a decision, bra
 
 Cross-repo writes from this project's workflows (Homebrew cask bumps today;
 future skill-catalog PRs and self-update fan-out) are signed by the
-`thrillmade-orchestrator[bot]` GitHub App, NOT a personal PAT. See
+`skdd-steward[bot]` GitHub App (renamed from `thrillmade-orchestrator[bot]`;
+same App ID, key, and installation), NOT a personal PAT. See
 [`docs/orchestrator-app.md`](docs/orchestrator-app.md) for the App spec,
 permissions, ruleset bypass details, and rotation procedure.
 

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -1,21 +1,54 @@
-# `thrillmade-orchestrator[bot]` GitHub App
+# `skdd-steward[bot]` GitHub App
+
+**Renamed from `thrillmade-orchestrator[bot]`.** This file documents
+**thrillmade's own installed instance** of the App (App ID 3951953) — the
+instance wired into `thrillmade/logmind`'s release pipeline and, since the
+weekly skill census shipped, into `thrillmade/agent-skills` too. It is not
+the registration guide for other organizations — see "Registering your own
+instance" under Purpose below.
 
 Reference manifest and click-by-click registration guide for the
-`thrillmade-orchestrator[bot]` GitHub App. Committed to logmind for
-reproducibility — if the App is ever rotated, deleted, or migrated to a
-different org, the steps below produce an identical replacement.
+`skdd-steward[bot]` GitHub App. Committed to logmind for reproducibility —
+if the App is ever rotated, deleted, or migrated to a different org, the
+steps below produce an identical replacement.
 
 Mirrors the schema of `/Users/ludlow/clud-bug-app/github-app-manifest.json`
 (thrillmade's first App). Permissions and event subscriptions differ — the
-orchestrator has a narrower surface than `clud-bug[bot]`.
+steward has a narrower surface than `clud-bug[bot]`.
 
 ## Purpose
 
-`thrillmade-orchestrator[bot]` is the App identity behind all cross-repo
-writes that originate from a thrillmade-owned workflow. In v1.0 it bumps the
-Homebrew cask formula on `thrillmade/homebrew-tap` after every `logmind`
-release (replacing the personal `HOMEBREW_TAP_PAT` that was a key-person
-single point of failure). Per the master plan at
+`skdd-steward[bot]` is the App identity behind all cross-repo writes that
+originate from a thrillmade-owned workflow.
+
+**Duties today:**
+
+- **Release cask bumps.** Since v1.0, bumps the Homebrew cask formula on
+  `thrillmade/homebrew-tap` after every `logmind` release (replacing the
+  personal `HOMEBREW_TAP_PAT` that was a key-person single point of
+  failure).
+- **Weekly skill census.** Powers `thrillmade/agent-skills`'
+  `.github/workflows/skill-census.yml`, which mints a per-run installation
+  token to read skill manifests across every repo in the org and file
+  census verdicts. See agent-skills'
+  [`docs/integrating-with-agent-skills.md`](https://github.com/thrillmade/agent-skills/blob/main/docs/integrating-with-agent-skills.md)
+  for the census's design and cadence — that doc is the operator's manual
+  for this duty, this file is the App spec.
+
+**Roadmap:**
+
+- **Catalog fan-out** — skill-catalog PRs to `thrillmade/agent-skills` via
+  `logmind skill push` (G7.n in the master plan).
+- **Chore loop** — org-wide maintenance PRs across consumer repos,
+  replacing today's per-repo `*-self-update.yml` crons with one watcher
+  under this identity.
+- **Steward service** — a standing service (not just workflow-minted
+  tokens) running under this App identity. Contract details are drafted in
+  [`thrillmade/protocol#39`](https://github.com/thrillmade/protocol/issues/39)
+  and SPEC §17 (draft — not yet merged into the canonical
+  `thrillmade/protocol` SPEC).
+
+Per the master plan at
 `/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md`,
 section "Architectural decisions in force — GitHub Apps are the primitive
 for release infrastructure", we register an App rather than mint a PAT or
@@ -25,18 +58,36 @@ add real-account-maintenance overhead with no narrower audit story than an
 App. Tokens are 1-hour installation tokens minted at workflow time by the
 official `actions/create-github-app-token@v2` action — the only App-token
 action compatible with the repo's `allowed_actions: selected` workflow
-allowlist. The App pre-positions the org for G7.n / D.10 (skill-catalog PRs
-to `thrillmade/agent-skills` via `logmind skill push`, and eventually the
-release-tag fan-out that consolidates per-repo `*-self-update.yml`
-workflows into a single org-wide watcher).
+allowlist.
+
+### Registering your own instance
+
+This file documents **thrillmade's own installed instance** only. Other
+organizations adopting the SkDD toolchain register a separate instance of
+the same App design under their own account — that consumer-facing,
+org-agnostic registration guide lives in `thrillmade/skdd`'s
+`docs/skdd-steward-app.md` (introduced in `skdd#2`). Use that guide for a
+fresh registration in a new org; use this file only to reproduce or reason
+about thrillmade's specific instance (App ID 3951953, secrets named
+`THRILLMADE_ORCHESTRATOR_*` — see "Secrets storage" below for why those
+legacy names stick around here specifically).
 
 ## App identity
 
-- **Name:** `thrillmade-orchestrator`
-- **Slug:** `thrillmade-orchestrator` (bot identity: `thrillmade-orchestrator[bot]`)
+- **Name:** `skdd-steward`
+- **Slug:** `skdd-steward` (bot identity: `skdd-steward[bot]`)
 - **Homepage URL:** `https://github.com/thrillmade` (org page — the App is internal infra, not a logmind feature)
 - **Owner:** `thrillmade` organization
 - **Public:** no (private to the thrillmade org)
+
+Formerly registered as `thrillmade-orchestrator` (slug
+`thrillmade-orchestrator`, bot identity `thrillmade-orchestrator[bot]`).
+The rename changed name, slug, and bot identity only — App ID (3951953),
+private key, and installation are all unchanged; no re-registration
+occurred. Anything recorded before the rename (commits, audit-log entries,
+decision-log history in this repo) still shows the old
+`thrillmade-orchestrator[bot]` identity — see "Audit log expectations"
+below.
 
 ## Permissions
 
@@ -46,40 +97,77 @@ Repository-level only. No user permissions. No organization permissions.
 |---|---|---|
 | Contents | Read and write | Direct push of `Casks/logmind.rb` bumps to `thrillmade/homebrew-tap/main`; future skill-catalog file writes. |
 | Pull requests | Read and write | v1.x expansion (G7.n) opens skill-catalog PRs on `thrillmade/agent-skills`; reserved now to avoid a re-registration when that lands. |
+| Issues | Read and write | Census verdict filing (`gap:` / `placement:` / `promotion-candidate:` / `demotion-candidate:` / `revise:` issues, plus the weekly digest) opened by the skill census under the steward identity. **Pending installation approval at the time of writing** — requested on the App's permissions page but not yet accepted by an org owner. |
 | Metadata | Read | Mandatory baseline for every App; grants read on repo name, default branch, topics. |
 
 ## Events
 
 None.
 
-The orchestrator is workflow-driven — it never subscribes to webhook events.
-Tokens are minted on demand inside `release.yml`; there is no Vercel
+The steward is workflow-driven — it never subscribes to webhook events.
+Tokens are minted on demand inside `release.yml` (and, for the census,
+inside `thrillmade/agent-skills`' `skill-census.yml`); there is no Vercel
 function and no event listener.
 
 ## Installation scope
 
-Selected repositories.
+`repository_selection: all` — the App is installed across every repository
+in the `thrillmade` org.
 
-- **v1.0:** `thrillmade/homebrew-tap` only.
-- **v1.x expansion** (per G7.n in the master plan
-  `/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md`):
-  add `thrillmade/agent-skills` when `logmind skill push` lands; later add
-  consumer repos in the self-update fan-out wave.
+This is a **CDO-blessed** decision, not the original design. Earlier
+revisions of this file documented "Selected repositories,
+`thrillmade/homebrew-tap` only," with expansion planned repo-by-repo as
+each new duty shipped. That plan was superseded once the weekly skill
+census needed org-wide manifest reads on day one — a `selected`-repos
+install would have silently blinded the census to any repo left off the
+list, and the planned catalog fan-out and chore loop need the same
+coverage.
 
-Expansion happens via the App's Installation settings page on the org —
-never re-register the App, never widen scope preemptively.
+Why the wider blast radius is acceptable:
+
+- **Branch rulesets force PRs on every repo.** Only
+  `thrillmade/homebrew-tap` carries the App as a ruleset bypass actor (see
+  "Ruleset bypass" below); every other repo in the org rejects a direct
+  push from the App's installation token and requires the write to land
+  through a reviewed PR like anyone else's. Installing on `all` repos does
+  not mean the App can direct-write to all of them.
+- **All-repos is what the census reads today, and what the catalog
+  fan-out / chore loop will require** — see "Purpose" above.
+
+**Residual risk, stated plainly:** a compromised App private key can mint
+an installation token scoped to every repository in the org, for that
+token's 1-hour lifetime. `homebrew-tap`'s bypass actor means that one repo
+is exposed to a direct, unreviewed push even under compromise; every other
+repo is limited by required PR review on merge — real exposure (an
+attacker could open PRs, comment, file issues, read contents across the
+org), but gated by human review rather than by installation scope.
+
+Expansion or contraction of the installed-repo list happens via the App's
+Installation settings page on the org — never re-register the App.
 
 ## Secrets storage
 
-Two org-level secrets on `thrillmade` with `selected` visibility. v1.0
-ships with only `thrillmade/logmind` in the visibility list. Expand the
-repo list as G7.n features ship.
+Two org-level secrets on `thrillmade`, now **org-wide visibility** (every
+repo in `thrillmade` can read them). v1.0 shipped with `selected`
+visibility limited to `thrillmade/logmind`; visibility widened to
+org-wide once `thrillmade/agent-skills` needed the same secrets for the
+weekly skill census — adding repos to a `selected` list one at a time
+stopped scaling once a second consumer showed up.
 
 - `THRILLMADE_ORCHESTRATOR_APP_ID` — the App's numeric ID (not a secret in
   the cryptographic sense, but stored as a secret to keep the wiring
   uniform across workflows).
 - `THRILLMADE_ORCHESTRATOR_PRIVATE_KEY` — the RSA PEM downloaded from the
   App's settings page.
+
+**Names predate the rename, and are kept on purpose.** Both secrets keep
+the legacy `THRILLMADE_ORCHESTRATOR_*` labels — renaming an org secret
+means touching every consuming workflow (`release.yml` here,
+`skill-census.yml` in agent-skills, and any future consumer) in lockstep,
+for a purely cosmetic win. New orgs registering their own instance use
+`SKDD_STEWARD_*` naming per the public guide (`thrillmade/skdd`
+`docs/skdd-steward-app.md`); this repo's secret names are a
+thrillmade-specific legacy exception, not the convention to copy.
 
 Exact commands (run after the user provides `APP_ID` and the `.pem` path
 via terminal — never paste private-key material into chat):
@@ -88,15 +176,13 @@ via terminal — never paste private-key material into chat):
 APP_ID=12345
 gh secret set THRILLMADE_ORCHESTRATOR_APP_ID \
   --org thrillmade \
-  --visibility selected \
-  --repos thrillmade/logmind \
+  --visibility all \
   --body "$APP_ID"
 
-cat ~/Downloads/thrillmade-orchestrator.YYYY-MM-DD.private-key.pem \
+cat ~/Downloads/skdd-steward.YYYY-MM-DD.private-key.pem \
   | gh secret set THRILLMADE_ORCHESTRATOR_PRIVATE_KEY \
       --org thrillmade \
-      --visibility selected \
-      --repos thrillmade/logmind
+      --visibility all
 ```
 
 The legacy `HOMEBREW_TAP_PAT` org secret is retired after G1.f passes.
@@ -105,10 +191,12 @@ The legacy `HOMEBREW_TAP_PAT` org secret is retired after G1.f passes.
 
 Ruleset 17128312 on `main` enforces deletion + non_fast_forward +
 required_linear_history + pull_request (0 reviews, squash only). The
-orchestrator App is added as a bypass actor so its direct pushes are
-exempt; human pushes still go through PR review. The bypass IS the audit
-trail — every direct push appears in the org audit log under the App
-identity.
+steward App is added as a bypass actor so its direct pushes are exempt;
+human pushes still go through PR review. The bypass IS the audit trail —
+every direct push appears in the org audit log under the App identity.
+`homebrew-tap` is the only repo in the org with a bypass entry — see
+"Installation scope" above for why that matters now that the App installs
+`all` repos rather than a selected list.
 
 The GitHub Rulesets API requires a full ruleset body on `PUT` — it does
 not accept a partial patch. Use a read-merge-PUT pattern: fetch the
@@ -140,6 +228,12 @@ only `name`, `target`, `enforcement`, `bypass_actors`, `conditions`, and
 USER ACTION. The agent cannot perform these steps — App creation requires
 an authenticated browser session as a thrillmade org owner.
 
+These steps describe registering **thrillmade's own instance** from
+scratch (e.g. if the App is ever deleted and must be recreated
+identically). If you're standing up a *different* organization's own
+instance of this App design, use the public guide instead —
+`thrillmade/skdd` `docs/skdd-steward-app.md`.
+
 ### Step 1 — Open the new-App page
 
 Navigate to:
@@ -155,9 +249,9 @@ their defaults.
 
 | Field | Value |
 |---|---|
-| GitHub App name | `thrillmade-orchestrator` |
+| GitHub App name | `skdd-steward` |
 | Homepage URL | `https://github.com/thrillmade` |
-| Description | `Org-level orchestrator for thrillmade release infrastructure — pushes cask bumps, skill-catalog updates, and self-update fan-out across thrillmade repos.` |
+| Description | `Org-level steward for thrillmade release infrastructure — pushes cask bumps, runs the weekly skill census, and (planned) skill-catalog updates and self-update fan-out across thrillmade repos.` |
 | Identifying and authorizing users → Callback URL | LEAVE BLANK |
 | Post installation → Setup URL | LEAVE BLANK |
 | Post installation → Redirect on update | unchecked |
@@ -171,6 +265,7 @@ their defaults.
 |---|---|
 | Contents | Read and write |
 | Pull requests | Read and write |
+| Issues | Read and write |
 | Metadata | Read-only (default; cannot be unset) |
 
 **Organization permissions:** all "No access".
@@ -186,27 +281,28 @@ their defaults.
 Click "Create GitHub App" at the bottom of the form. GitHub redirects to
 the App's settings page. Record the **App ID** displayed near the top of
 that page (also visible in the URL after a brief redirect:
-`https://github.com/organizations/thrillmade/settings/apps/thrillmade-orchestrator`).
+`https://github.com/organizations/thrillmade/settings/apps/skdd-steward`).
 
 ### Step 4 — Generate the private key
 
 On the App's settings page, scroll to the "Private keys" section. Click
 "Generate a private key". The browser downloads a `.pem` file named
-`thrillmade-orchestrator.YYYY-MM-DD.private-key.pem` to your default
-download directory.
+`skdd-steward.YYYY-MM-DD.private-key.pem` to your default download
+directory.
 
 Move the file somewhere outside the repo working tree — do not commit it,
 do not check it into any logmind clone. The `~/Downloads/` default
 location is fine until Step 6.
 
-### Step 5 — Install the App on `thrillmade/homebrew-tap`
+### Step 5 — Install the App on every repository in the org
 
 In the left sidebar of the App's settings page, click "Install App". Find
 the `thrillmade` row and click "Install" next to it. On the install page:
 
-1. Select "Only select repositories".
-2. Check `thrillmade/homebrew-tap`.
-3. Click "Install".
+1. Select "All repositories" (`repository_selection: all` — see
+   "Installation scope" above for why this is the blessed default now,
+   not `thrillmade/homebrew-tap` alone).
+2. Click "Install".
 
 GitHub records the installation and returns you to the App settings.
 
@@ -221,21 +317,19 @@ filename with the real download date):
 APP_ID=12345
 gh secret set THRILLMADE_ORCHESTRATOR_APP_ID \
   --org thrillmade \
-  --visibility selected \
-  --repos thrillmade/logmind \
+  --visibility all \
   --body "$APP_ID"
 
-cat ~/Downloads/thrillmade-orchestrator.2026-06-03.private-key.pem \
+cat ~/Downloads/skdd-steward.2026-06-03.private-key.pem \
   | gh secret set THRILLMADE_ORCHESTRATOR_PRIVATE_KEY \
       --org thrillmade \
-      --visibility selected \
-      --repos thrillmade/logmind
+      --visibility all
 ```
 
 Once both secrets are stored, securely delete the local `.pem`:
 
 ```sh
-rm ~/Downloads/thrillmade-orchestrator.2026-06-03.private-key.pem
+rm ~/Downloads/skdd-steward.2026-06-03.private-key.pem
 ```
 
 Note: `rm` is not a secure-erase on APFS/HFS+/most filesystems — the file
@@ -274,7 +368,7 @@ Then, on the release-path GoReleaser step:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Was secrets.HOMEBREW_TAP_PAT (personal PAT, retired post-G1.f).
-          # Now sourced from the orchestrator App's installation token.
+          # Now sourced from the steward App's installation token.
           HOMEBREW_TAP_PAT: ${{ steps.app_token.outputs.token }}
 ```
 
@@ -290,17 +384,16 @@ The `.goreleaser.yaml` `homebrew_casks` block needs three matching edits
 - Keep `repository.owner: thrillmade` and
   `repository.token: "{{ .Env.HOMEBREW_TAP_PAT }}"` (env-var name
   unchanged).
-- Update `commit_author.name` to `thrillmade-orchestrator[bot]` and
+- Update `commit_author.name` to `skdd-steward[bot]` and
   `commit_author.email` to
-  `<APP_ID>+thrillmade-orchestrator[bot]@users.noreply.github.com` —
+  `<APP_ID>+skdd-steward[bot]@users.noreply.github.com` —
   GitHub's canonical App-bot author format.
 
 ## Verification
 
 Before tagging `v1.0.0-rc3`, confirm the wiring with three checks.
 
-Verify both org secrets exist (visibility list should include
-`thrillmade/logmind`):
+Verify both org secrets exist (visibility should now be org-wide):
 
 ```sh
 gh api /orgs/thrillmade/actions/secrets | jq
@@ -333,7 +426,7 @@ rotation cycle, or after the lossy delete in Step 6 if you want a clean
 slate), follow these steps. Generate a new key first, then revoke the old
 one — never the reverse, or you'll lock out the workflow mid-rotation.
 Navigate to
-`https://github.com/organizations/thrillmade/settings/apps/thrillmade-orchestrator`,
+`https://github.com/organizations/thrillmade/settings/apps/skdd-steward`,
 scroll to "Private keys", click "Generate a private key" to download a
 new `.pem`, then re-run the `gh secret set THRILLMADE_ORCHESTRATOR_PRIVATE_KEY`
 command from Step 6 with the new file. Confirm a `workflow_dispatch`
@@ -345,13 +438,21 @@ to be updated.
 ## Audit log expectations
 
 Every direct push, PR comment, file write, or API call made under the
-orchestrator's installation token appears in the org audit log under the
+steward's installation token appears in the org audit log under the
 App's bot identity. Verify in the GitHub UI at
 `https://github.com/organizations/thrillmade/settings/audit-log` and
-filter with `actor:thrillmade-orchestrator[bot]`. Expect one entry per
-cask-bump direct push on `thrillmade/homebrew-tap` (`git.push` event,
-authored by `thrillmade-orchestrator[bot]`) for each `v*` tag release.
-The bypass entry on ruleset 17128312 is the policy expression of this
-audit trail — the ruleset itself records `rules.bypass` events when the
-App exercises its bypass, providing a second independent log of the
-same activity.
+filter with `actor:skdd-steward[bot]`. Expect one entry per cask-bump
+direct push on `thrillmade/homebrew-tap` (`git.push` event, authored by
+`skdd-steward[bot]`) for each `v*` tag release, plus, since the census
+shipped, periodic `issues.create` / `issues.comment` entries from the
+weekly `skill-census.yml` run. The bypass entry on ruleset 17128312 is the
+policy expression of the cask-bump audit trail — the ruleset itself
+records `rules.bypass` events when the App exercises its bypass, providing
+a second independent log of the same activity.
+
+**Events from before the rename** (the App was previously named
+`thrillmade-orchestrator`) still appear in the audit log and in this
+repo's own decision-log history under the old actor name,
+`thrillmade-orchestrator[bot]`. Filtering `actor:skdd-steward[bot]` will
+not surface those — filter `actor:thrillmade-orchestrator[bot]` instead
+for anything dated before the rename.


### PR DESCRIPTION
The App is renamed (live: `skdd-steward`, verified via org API) — this brings the docs and cosmetic strings to truth:

- `docs/orchestrator-app.md` (filename kept for inbound links): full rewrite for `skdd-steward[bot]` — **blesses `repository_selection: all`** (CDO ruling; rulesets force PRs everywhere except homebrew-tap's bypass, so write blast-radius is gated — residual 1-hour-token risk stated honestly), adds the Issues R/W permission row (now approved on the installation), documents the weekly skill-census duty, points consumer orgs at the public guide (skdd#2), keeps legacy `THRILLMADE_ORCHESTRATOR_*` secret names with the why.
- `.goreleaser.yaml` — `commit_author` → `skdd-steward[bot]` + matching noreply email (App ID preserved), so future cask bumps attribute to the live identity.
- `release.yml` comment block + `AGENTS.md` prose updated. Historical decision-log entries deliberately untouched (append-only record); functional secret names untouched everywhere; the `thrillmade/.github` reusable-workflow's `orchestrator-*` input names flagged as a separate coordinated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)