### PR TITLE
feat(derived-docs): clean timeline — zero-conflict derived docs (STEP 3, v2.0.0 headline)

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -1,94 +1,78 @@
 name: logmind / check-derived-docs
 
-# Self-healing derived-doc gate — build-from-source variant of the v5
-# consumer template (internal/templates/github/regen-timeline.yml.template).
-# This IS the logmind repo, so it regenerates with the binary built from
-# THIS PR's source (the change under review generates its own derived docs).
-#
-# Behaviour (identical to the template):
-#   * PAT path: same-repo PR + LOGMIND_AUTO_REGEN_PAT -> regenerate, commit
-#     ([skip-logmind]), push via the PAT (which re-triggers required checks).
-#   * Advisory path (default): regenerate, emit ::warning::, EXIT 0. Never
-#     blocks. The post-merge hook reconciles on the default branch.
-#
-# It NEVER pushes with GITHUB_TOKEN (such a push moves the PR head SHA
-# without re-triggering checks, stranding every required check). The token
-# is kept read-only; only the PAT pushes, only at push time.
-#
-# persist-credentials:false is load-bearing HERE: `make build` compiles
-# PR-authored code, so no git credential may be resident in .git during the
-# build. The PAT is injected only in the push command below.
+# v2.0.0 derived-docs-on-main. The two derived docs are regenerated ONLY here on
+# main. On a PR this gate is NON-mutating and BLOCKING: it fails if the branch
+# edited either derived doc (which would cause cross-PR merge conflicts). A
+# branch's real decisions live in docs/decisions-branches/<branch>.md; timeline
+# and file-structure regenerate on main after merge.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write        # regen-on-main commits + pushes the regen to main
+  pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
+  # NOTE: specifying ANY permission zeroes all others (GitHub default), so
+  # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
+  # the gate fails-closed on EVERY PR, not just violators.
 
 jobs:
   check-derived-docs:
     name: check-derived-docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the branch did not edit the derived docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
+          if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|file-structure)\.md'; then
+            echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md and/or docs/file-structure.md. These are DERIVED, main-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to main's version — run 'logmind warp', or 'git checkout origin/main -- docs/timeline.md docs/file-structure.md' — then commit. Their real content regenerates on main after merge."
+            exit 1
+          fi
+          echo "Branch did not edit the derived docs — the merge cannot conflict on them."
+
+  regen-on-main:
+    name: regen-on-main
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          # `repository:` is required so fork PRs check out (a fork's head_ref
-          # doesn't exist on the base repo); read-only, no persisted creds.
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
           persist-credentials: false
-
       - uses: actions/setup-go@v6
         with:
           go-version: "1.22"
           cache: true
-
       - name: Build logmind from source
         run: make build
-
       - name: Regenerate derived docs
         run: |
           set -euo pipefail
           ./bin/logmind timeline --write docs/timeline.md
           ./bin/logmind file-structure --write docs/file-structure.md
-
-      - name: Self-heal (PAT) or advise
+      - name: Commit + push if changed
         env:
           PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-
           if [ -z "$(git status --porcelain -- docs/timeline.md docs/file-structure.md)" ]; then
-            echo "docs/timeline.md + docs/file-structure.md are up to date."
+            echo "Derived docs already current on main."
             exit 0
           fi
-
-          echo "Derived docs were stale on this PR."
-
-          is_fork="false"
-          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            is_fork="true"
-          fi
-
-          if [ -n "${PAT:-}" ] && [ "$is_fork" = "false" ]; then
-            echo "::notice title=Auto-fixing derived docs::Regenerating and pushing to ${HEAD_REF}."
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/timeline.md docs/file-structure.md
-            git commit -m "[skip-logmind] chore: regen derived docs"
-            if ! git push "https://x-access-token:${PAT}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"; then
-              echo "::warning::Could not push the regen (push race or protected head ref); it reconciles on merge or the next run."
-            fi
-            echo "::notice::Derived docs regenerated."
+          if [ -z "${PAT:-}" ]; then
+            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap.)"
             exit 0
           fi
-
-          echo "::warning title=Derived docs stale (advisory — does not block)::docs/timeline.md or docs/file-structure.md is out of date on this PR. This is ADVISORY and does not fail the check; the post-merge hook reconciles it on the default branch. To update now, run \`./bin/logmind timeline --write docs/timeline.md && ./bin/logmind file-structure --write docs/file-structure.md\` locally and commit, or configure a LOGMIND_AUTO_REGEN_PAT secret for automatic push-back."
-          git add -N -- docs/timeline.md docs/file-structure.md 2>/dev/null || true
-          git --no-pager diff -- docs/timeline.md docs/file-structure.md | head -80 || true
-          exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/timeline.md docs/file-structure.md
+          git commit -m "[skip-logmind] chore: regen derived docs"
+          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -15,3 +15,12 @@
 
 ---
 
+## 2026-07-17 20:26 - Foundation: gitcli MergeBase/Fetch/ShowFile/RestorePathsToHead + shared derivedDocPaths/onNonDefaultBranch
+
+**Reasoning:** Thin git-wrapper helpers and the single definition of the two governed docs plus the non-default-branch predicate, consumed by L1 log, warp, the pulse probe, and context refresh
+
+**Implications:**
+- Fetch is the only network helper and is never called from the log hot path; onNonDefaultBranch is conservative-false so non-repo/detached/default paths keep pre-v2.0.0 behavior
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-17-adopt-derived-docs-on-main-plan-one-invariant-branch-derived -->
+- **2026-07-17** — Adopt derived-docs-on-main plan: one invariant (branch derived docs == merge-base) enforced by L0 hooks/L1 log/L3 CI gate, plus warp/context/pulse freshness
+<!-- logmind-entry-end -->
+
+## 2026-07-17 20:16 - Adopt derived-docs-on-main plan: one invariant (branch derived docs == merge-base) enforced by L0 hooks/L1 log/L3 CI gate, plus warp/context/pulse freshness
+
+**Reasoning:** The derived docs are pure functions of the decision files, so a branch never needs to edit them; keeping them byte-identical to the merge-base makes git 3-way merge conflict-free with no merge-driver dependency, which is the only thing that works on GitHub servers
+
+**Alternatives considered:** Merge-driver-only auto-resolution (rejected: GitHub cannot run logmind git merge-driver, so PRs still show conflicts), Detect-and-fix conflicts after they occur (rejected: conflicts burn agent tokens; the bar is structurally impossible not merely rare)
+
+**Implications:**
+- warp is the only network caller; logmind log hot path stays network-free; the CI check-derived-docs job becomes blocking and existing derived-doc-editing PRs must revert
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -57,3 +57,14 @@
 
 ---
 
+## 2026-07-17 21:19 - L3: check-derived-docs becomes a blocking PR gate; derived docs regenerate on main only (v7 to v8)
+
+**Reasoning:** The structural wall — a PR that edits a derived doc cannot merge (gh pr diff --name-only is the fork-correct branch-vs-merge-base delta), so even an unforeseen write path can never reintroduce a conflict. Adversarial review caught that permissions: contents:write alone zeroes pull-requests and would 403 gh pr diff on every PR — fixed by adding pull-requests: read in lockstep
+
+**Alternatives considered:** merge-base diff in shell (rejected: base.sha may be absent in a fork checkout; gh pr diff is simpler and fork-correct)
+
+**Implications:**
+- Regen moves to a main-only job that no-ops when current (no push loop); the main push needs a PAT with ruleset bypass and degrades to a freshness-only warning without it; a one-way rename of a derived doc evades --name-only but self-heals and causes no conflict (accepted); existing derived-doc-editing PRs now block until reverted; template bumped v7 to v8
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -46,3 +46,14 @@
 
 ---
 
+## 2026-07-17 21:04 - Freshness layer: logmind warp + main-decisions pulse probe + context origin-refresh
+
+**Reasoning:** A branch pins its derived docs to the merge-base (invariant), so it lags main; warp fetches origin and refreshes the working copy read-only, the 3rd pulse probe nudges warp when main advanced, and context renders the 2 derived docs from the last-fetched origin ref so cold-start reflects main without a network call
+
+**Alternatives considered:** warp merges origin/main into the branch (rejected: creates merge commits and can trip the invariant); a --refresh flag on context instead of a verb (rejected: the pulse needs a short verb to point at)
+
+**Implications:**
+- warp is the ONLY network caller (fetch); pulse+context read the local origin ref with no fetch, preserving the network-free hot path; context payload format is byte-unchanged, only the content source differs
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -77,3 +77,12 @@
 
 ---
 
+## 2026-07-25 14:58 - Document the derived-docs-on-main model in docs/plan.md and close the orphan-link gate
+
+**Reasoning:** docs/plan.md is required reading per AGENTS.md but never described the v2 invariant, and the implementation plan had zero inbound links which red-lit check-links on PR 236; documenting the model rather than adding a bare link fixes both and closes a Tier-1 cleanup item
+
+**Implications:**
+- check-links now reports all markdown links resolve and no orphans found
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -35,3 +35,14 @@
 
 ---
 
+## 2026-07-17 20:45 - L0: post-merge and post-rewrite hooks regenerate derived docs on the default branch only
+
+**Reasoning:** A rebase/amend/merge on a feature branch previously regenerated (post-rewrite even git-added) the derived docs, diverging the branch from its main merge-base; gating regen to the default branch keeps branches clean so merges never conflict. Adversarial panel confirmed no feature-branch regen path; test strengthened to pin the full guard against an operator-precedence bug
+
+**Alternatives considered:** Rely on the merge driver alone (rejected: GitHub cannot run it, so PRs still conflict)
+
+**Implications:**
+- Over-gating when origin/HEAD is unset and the default is not literally main is freshness-only never a conflict, and CI regen-on-main is the authority for main freshness; golden fixtures updated for the sanctioned v2.0.0 body change
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -24,3 +24,14 @@
 
 ---
 
+## 2026-07-17 20:32 - L1: logmind log restores derived docs to HEAD before staging on a non-default branch
+
+**Reasoning:** Primary defense of the zero-conflict invariant on the commit path — even if a hook or manual edit dirties timeline.md/file-structure.md, the branch commit never carries the divergent copy; applies in both stage=all and scoped so a dirty derived doc can never leak, and touches only the two derived docs, never the branch decision file or its marker
+
+**Alternatives considered:** Pathspec-exclude from git add (rejected: leaves a dirty working tree a later raw git add could sweep)
+
+**Implications:**
+- No-op on the default branch (main stays current) and lossless everywhere since the docs regenerate from the committed decision files
+
+---
+

--- a/docs/decisions-branches/feat__derived-docs-on-main.md
+++ b/docs/decisions-branches/feat__derived-docs-on-main.md
@@ -68,3 +68,12 @@
 
 ---
 
+## 2026-07-17 21:27 - Task 9: headline integration test — two concurrent branches merge with zero derived-doc conflict
+
+**Reasoning:** End-to-end regression guard for the whole invariant — each branch dirties timeline.md (simulating a stray hook regen), logs, and the commit still carries mains version (L1 restored it); both branches then merge into main with no conflict. Non-trivial: without L1 the per-branch assertion fails immediately and the second merge three-way conflicts
+
+**Implications:**
+- Proves the guarantee holds through the real logmind log path plus git merge, not just per-layer unit tests
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -193,6 +193,30 @@ auto-fix in the `check-doc-links` workflow).
   old dual-mode (branch-divergent vs. main-canonical) design — less
   config surface, no risk of the two renderers drifting apart
 
+### Derived docs: regenerated at the integration point (v2.0.0)
+- **The invariant:** on a non-default branch, `docs/timeline.md` and
+  `docs/file-structure.md` stay byte-identical to their merge-base with the
+  default branch. A branch never edits them; they are regenerated on the
+  default branch after a merge. Because the branch side of the file is
+  unchanged, git takes the default branch's copy silently — **a merge conflict
+  on a derived doc is impossible by construction**, without relying on the
+  merge driver (which is client-side and so cannot run on a server-side merge —
+  the reason PRs still showed conflicts before v2.0.0).
+- **Why reverting a branch-side edit is always safe:** both files are pure
+  functions of committed sources (`timeline.md` of the decision files,
+  `file-structure.md` of the tracked tree). Discarding a branch-local edit
+  cannot lose information, which is what licenses silent self-heal.
+- **Enforced in layers:** hooks regenerate on the default branch only ·
+  `logmind log` restores both files to HEAD before staging on a branch ·
+  a pre-commit restore covers raw `git commit` · CI `check-derived-docs`
+  blocks a PR that modified either file.
+- **Staying current on a branch:** `logmind warp` refreshes the working copy
+  from the default branch (read-only — it never commits, which would break the
+  pin), `logmind context` renders the last-fetched default-branch copy, and the
+  pulse nudges when the default branch has advanced.
+- Design record: [derived-docs-on-main implementation plan](superpowers/plans/2026-07-17-derived-docs-on-main.md).
+  Normative backing: SPEC §0.3.2 integration-point regeneration mode.
+
 ### Git as audit trail
 - Every decision is one commit; git history is the timeline's ground
   truth; diffs show what changed when

--- a/docs/superpowers/plans/2026-07-17-derived-docs-on-main.md
+++ b/docs/superpowers/plans/2026-07-17-derived-docs-on-main.md
@@ -1,0 +1,663 @@
+# Derived-Docs-on-Main / Clean Timeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a merge conflict on `docs/timeline.md` and `docs/file-structure.md` structurally impossible — a branch never edits them, so git's own 3-way merge is conflict-free — while keeping every agent's context fresh via `logmind warp`, a cold-start `context` refresh, and a pulse nudge.
+
+**Architecture:** The two derived docs are *purely* generated (`timeline.md` = f(decision files); `file-structure.md` = f(repo tree)), so a branch-side edit carries no unique information and can always be discarded losslessly. We enforce one invariant — **on any non-default branch, both derived docs stay byte-identical to their merge-base-with-main version** — with three layers: **L0** git hooks regenerate on the default branch only; **L1** `logmind log` restores the two docs to their committed (HEAD) content before staging on a non-default branch; **L3** the CI `check-derived-docs` gate BLOCKS any PR that modified a derived doc, and a new main-only job regenerates + commits them post-merge. Freshness rides on top: `logmind warp` (fetch + read-only refresh from main), `logmind context` prefers the last-fetched `origin/main` copy, and a third pulse probe nudges "run `logmind warp`".
+
+**Tech Stack:** Go 1.22, cobra CLI, `internal/gitcli` (thin `git` subprocess wrapper), GitHub Actions (`gh` CLI on the runner), the protocol SPEC (separate `thrillmade/protocol` repo).
+
+## Global Constraints
+
+- **Byte-parity with frozen Python v0.6.16** for `logmind log` stdout (the SPEC §3.1 three-line contract) and for derived-doc *generation* output. Do not alter `buildDecisionEntry`, `timeline.Generate`, or `tree.GenerateFileStructure` output bytes.
+- **`logmind log` hot path stays network-free.** No `git fetch`, no `gh`, no HTTP anywhere reachable from `runLog` / `emitPulse`. (Network lives only in `logmind warp`, an explicit command.)
+- **Hook bodies** are golden-fixture-pinned (`internal/hooks/hooks_test.go`). v2.0.0 is allowed to evolve them (the embedded `# logmind-hook-version:` line already differs from Python), but every body change MUST regenerate the golden fixture in the same task.
+- **The zero-conflict invariant is rule #1.** No task may introduce a code path that commits a branch-local edit to `docs/timeline.md` or `docs/file-structure.md`.
+- **Keep the CI job name `check-derived-docs`** exactly (branch-protection rulesets match on it).
+- **The two CI files change in lockstep:** `.github/workflows/regen-timeline.yml` (self-repo, `make build`) and `internal/templates/github/regen-timeline.yml.template` (fleet, `setup-logmind`). Bump the template marker `# logmind-template-version: v7` → `v8`.
+- **Commit via `logmind log`**, not raw git, for every substantive task. No backticks inside `logmind log` arguments.
+- **The two derived-doc paths are a single source of truth:** `docs/timeline.md`, `docs/file-structure.md`. Introduced once as `derivedDocPaths` (Task 2) and reused everywhere.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `internal/gitcli/gitcli.go` | New helpers: `MergeBase`, `Fetch`, `ShowFile`, `RestorePathsToHead` | 1 |
+| `internal/cli/derived.go` (new) | `derivedDocPaths` + `onNonDefaultBranch` — shared by log/warp/pulse/context | 2 |
+| `internal/cli/log.go` | L1: restore derived docs to HEAD before staging on a non-default branch | 3 |
+| `internal/hooks/hooks.go` (+ `hooks_test.go`) | L0: gate post-merge + post-rewrite regen to the default branch | 4 |
+| `internal/cli/warp.go` (new) + `internal/cli/root.go` | `logmind warp` command + registration | 5 |
+| `internal/cli/pulse.go` | 3rd probe: `mainDecisionsPulseLine` | 6 |
+| `internal/cli/context.go` | Cold-start: prefer last-fetched `origin/main` copy of derived docs | 7 |
+| `.github/workflows/regen-timeline.yml` + `internal/templates/github/regen-timeline.yml.template` | L3: blocking PR gate + main-only regen job | 8 |
+| `internal/cli/*_test.go`, a merge-cleanliness integration test | Headline zero-conflict proof + per-layer tests | 9 |
+| protocol `SPEC.md` §0.4 (cross-repo) | Sync-invariant reword | 10 |
+| agent-skills logmind skill (cross-repo) | "Staying current" note | 10 |
+
+---
+
+## Task 1: gitcli helpers (MergeBase, Fetch, ShowFile, RestorePathsToHead)
+
+**Files:**
+- Modify: `internal/gitcli/gitcli.go` (append near `RunCaptured` at :551)
+- Test: `internal/gitcli/gitcli_test.go`
+
+**Interfaces — Produces:**
+- `func MergeBase(repoRoot, ref string) (string, bool)` — `git merge-base <ref> HEAD`; `("",false)` on any error.
+- `func Fetch(repoRoot, remote, ref string) error` — `git fetch <remote> <ref>` (network; explicit-command use only).
+- `func ShowFile(repoRoot, ref, path string) (string, bool)` — `git show <ref>:<path>`; `("",false)` if absent.
+- `func RestorePathsToHead(repoRoot string, paths ...string) error` — `git checkout HEAD -- <path>` per path, best-effort.
+
+- [ ] **Step 1: Write the failing test** (`gitcli_test.go`) — build a temp repo with a committed `a.txt`, branch, edit `a.txt` on the branch, assert `RestorePathsToHead` reverts it and `ShowFile(main-sha, "a.txt")` returns the original bytes; assert `MergeBase(mainSha) != ""`.
+
+```go
+func TestRestorePathsToHead_RevertsBranchEdit(t *testing.T) {
+	repo := initTempRepo(t) // helper: git init + initial commit of a.txt="v1"
+	writeFile(t, repo, "a.txt", "v2-edited")
+	if err := RestorePathsToHead(repo, "a.txt"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := readFile(t, repo, "a.txt"); got != "v1" {
+		t.Fatalf("want restored v1, got %q", got)
+	}
+}
+
+func TestShowFile_ReadsRefContent(t *testing.T) {
+	repo := initTempRepo(t)
+	got, ok := ShowFile(repo, "HEAD", "a.txt")
+	if !ok || got != "v1" {
+		t.Fatalf("ShowFile HEAD:a.txt = %q,%v want v1,true", got, ok)
+	}
+	if _, ok := ShowFile(repo, "HEAD", "missing.txt"); ok {
+		t.Fatal("ShowFile of missing path should be false")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `go test ./internal/gitcli/ -run 'RestorePathsToHead|ShowFile' -v` → FAIL (undefined).
+- [ ] **Step 3: Implement** (append to `gitcli.go`):
+
+```go
+// MergeBase returns the merge-base commit SHA of ref and HEAD. Best-effort:
+// ("", false) on any error (ref missing, no common ancestor, not a repo).
+func MergeBase(repoRoot, ref string) (string, bool) {
+	out, _, err := RunCaptured(repoRoot, "merge-base", ref, "HEAD")
+	if err != nil {
+		return "", false
+	}
+	sha := strings.TrimSpace(out)
+	return sha, sha != ""
+}
+
+// Fetch runs `git fetch <remote> <ref>` (a NETWORK call). Used only by explicit
+// commands (logmind warp) — never the `logmind log` hot path.
+func Fetch(repoRoot, remote, ref string) error {
+	_, _, err := RunCaptured(repoRoot, "fetch", remote, ref)
+	return err
+}
+
+// ShowFile returns the content of path at ref (`git show <ref>:<path>`).
+// ("", false) if the path does not exist at ref or on any error.
+func ShowFile(repoRoot, ref, path string) (string, bool) {
+	out, _, err := RunCaptured(repoRoot, "show", ref+":"+path)
+	if err != nil {
+		return "", false
+	}
+	return out, true
+}
+
+// RestorePathsToHead restores each path to its committed (HEAD) content in BOTH
+// the index and the working tree (`git checkout HEAD -- <path>`), discarding any
+// staged or unstaged change. Per-path and best-effort: a path untracked at HEAD
+// errors for that path only and is skipped; the first error (if any) is returned
+// for logging but callers generally ignore it (the derived docs are purely
+// generated, so a failed restore just leaves the pre-existing state).
+func RestorePathsToHead(repoRoot string, paths ...string) error {
+	var firstErr error
+	for _, p := range paths {
+		if _, _, err := RunCaptured(repoRoot, "checkout", "HEAD", "--", p); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — `go test ./internal/gitcli/ -run 'RestorePathsToHead|ShowFile|MergeBase' -v` → PASS. Confirm `strings` already imported (it is).
+- [ ] **Step 5: Commit** — `logmind log "Add gitcli MergeBase/Fetch/ShowFile/RestorePathsToHead helpers" -r "Foundation for the derived-docs-on-main invariant: L1 restore, warp refresh, and the pulse main-compare all need merge-base, ref-file reads, and HEAD restore" -i "warp is the only network caller of Fetch; the hot path never touches it"`
+
+---
+
+## Task 2: shared derived-doc constants + branch predicate
+
+**Files:**
+- Create: `internal/cli/derived.go`
+- Test: `internal/cli/derived_test.go`
+
+**Interfaces — Produces:**
+- `var derivedDocPaths = []string{"docs/timeline.md", "docs/file-structure.md"}`
+- `func onNonDefaultBranch(cwd string) bool`
+
+- [ ] **Step 1: Write the failing test:**
+
+```go
+func TestOnNonDefaultBranch(t *testing.T) {
+	repo := initTempRepo(t) // on default branch "main" after initial commit
+	if onNonDefaultBranch(repo) {
+		t.Fatal("default branch should be false")
+	}
+	runGit(t, repo, "checkout", "-b", "feat/x")
+	if !onNonDefaultBranch(repo) {
+		t.Fatal("feature branch should be true")
+	}
+}
+```
+
+- [ ] **Step 2: Verify fails** — `go test ./internal/cli/ -run TestOnNonDefaultBranch -v` → FAIL.
+- [ ] **Step 3: Implement** (`derived.go`):
+
+```go
+package cli
+
+import "github.com/thrillmade/logmind/internal/gitcli"
+
+// derivedDocPaths are the two committed, purely-derived context docs governed by
+// the zero-conflict invariant: on any non-default branch they MUST stay
+// byte-identical to their merge-base-with-main version (the branch never edits
+// them), so git's 3-way merge is conflict-free. They are regenerated only at the
+// integration point (main). Repo-relative, forward-slash (git pathspec form).
+var derivedDocPaths = []string{"docs/timeline.md", "docs/file-structure.md"}
+
+// onNonDefaultBranch reports whether cwd is a git repo currently on a branch
+// other than the default branch. Best-effort: false on a non-repo, detached
+// HEAD, unborn branch, or unknown default — the conservative answer, since every
+// caller uses `true` to ENABLE the extra invariant guard and `false` preserves
+// pre-v2.0.0 behavior.
+func onNonDefaultBranch(cwd string) bool {
+	if !gitcli.IsRepo(cwd) {
+		return false
+	}
+	cur := gitcli.CurrentBranch(cwd)
+	if cur == "" {
+		return false
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		return false
+	}
+	return cur != def
+}
+```
+
+- [ ] **Step 4: Verify pass** — `go test ./internal/cli/ -run TestOnNonDefaultBranch -v` → PASS.
+- [ ] **Step 5: Commit** — `logmind log "Add shared derivedDocPaths + onNonDefaultBranch predicate" -r "Single source of truth for the two governed docs and the branch test, reused by L1 log/warp/pulse/context so the invariant boundary is defined in exactly one place"`
+
+---
+
+## Task 3: L1 — `logmind log` restores derived docs to HEAD on a non-default branch
+
+**Files:**
+- Modify: `internal/cli/log.go` — `commitDecision` (:877-898)
+- Test: `internal/cli/log_test.go`
+
+**Interfaces — Consumes:** `gitcli.RestorePathsToHead` (Task 1), `derivedDocPaths` + `onNonDefaultBranch` (Task 2).
+
+- [ ] **Step 1: Write the failing test** — on a feature branch, dirty `docs/timeline.md`, run `logmind log`, assert the resulting commit does NOT include a change to `docs/timeline.md` and the working tree copy matches HEAD.
+
+```go
+func TestLog_DoesNotCommitDirtiedDerivedDocOnBranch(t *testing.T) {
+	repo := initRepoWithLogmind(t)        // docs/ scaffolded, decisions.md committed, timeline.md committed
+	runGit(t, repo, "checkout", "-b", "feat/y")
+	writeFile(t, repo, "docs/timeline.md", "STALE BRANCH EDIT\n") // simulate a stray hook/manual regen
+	if err := runLog(repo, "Decide something", &logFlags{stage: "all"}, false, strings.NewReader(""), io.Discard, io.Discard); err != nil {
+		t.Fatalf("runLog: %v", err)
+	}
+	// The commit must not carry the derived-doc edit.
+	names, _, _ := gitcli.RunCaptured(repo, "show", "--name-only", "--format=", "HEAD")
+	if strings.Contains(names, "docs/timeline.md") {
+		t.Fatal("commit must NOT include docs/timeline.md on a branch (invariant)")
+	}
+	// And the working tree copy is back to committed content.
+	head, _ := gitcli.ShowFile(repo, "HEAD", "docs/timeline.md")
+	if readFile(t, repo, "docs/timeline.md") != head {
+		t.Fatal("working-tree derived doc must be restored to HEAD")
+	}
+}
+```
+
+- [ ] **Step 2: Verify fails** — `go test ./internal/cli/ -run TestLog_DoesNotCommitDirtiedDerivedDocOnBranch -v` → FAIL (the edit is currently swept by `git add -A`).
+- [ ] **Step 3: Implement** — at the TOP of `commitDecision`, before the stage switch (log.go:878):
+
+```go
+	// Zero-conflict invariant (v2.0.0): docs/timeline.md + docs/file-structure.md
+	// are purely-derived, main-only artifacts. On a non-default branch, restore
+	// them to their committed (HEAD) content BEFORE staging so neither a stray
+	// hook regen nor `git add -A` can sweep a branch-local edit into this commit —
+	// which would diverge the branch from main and cause a future merge conflict.
+	// Lossless: they regenerate deterministically from the decision files (which
+	// ARE committed, per-branch, and never conflict). On the default branch this
+	// is intentionally skipped — main is where the derived docs SHOULD be current.
+	if onNonDefaultBranch(cwd) {
+		_ = gitcli.RestorePathsToHead(cwd, derivedDocPaths...)
+	}
+```
+
+- [ ] **Step 4: Verify pass** — `go test ./internal/cli/ -run TestLog -v` → PASS (new test green, existing log tests unaffected — default-branch tests skip the restore). Then `go test ./internal/cli/` full-package green.
+- [ ] **Step 5: Confirm hot path unchanged** — grep `runLog`/`commitDecision` for any `Fetch`/network; there is none. `git checkout HEAD -- <path>` is local. Run `go test ./internal/cli/ -run Pulse -race` to confirm no race regressions.
+- [ ] **Step 6: Commit** — `logmind log "L1: logmind log restores derived docs to HEAD before staging on a non-default branch" -r "The primary defense of the zero-conflict invariant on the commit path: even if a hook or manual regen dirties timeline.md/file-structure.md, the branch commit never carries the divergent copy; auto-heal is lossless because the docs are pure functions of the committed decision files" -a "Exclude the two paths from git add via pathspec (rejected: leaves a dirty working tree a later raw git add could catch)" -i "On the default branch this is a no-op so main stays current; only branches are constrained"`
+
+---
+
+## Task 4: L0 — gate post-merge + post-rewrite hook regen to the default branch
+
+**Files:**
+- Modify: `internal/hooks/hooks.go` — `BuildPostMergeBody` (:102-178), `BuildPostRewriteBody` (:183-213)
+- Modify: `internal/hooks/hooks_test.go` — regenerate golden fixtures
+
+**Context:** post-merge already skips a fast-forward pull-up on the default branch but REGENERATES on feature branches; post-rewrite regenerates AND `git add`s unconditionally (hooks.go:210). Both leave (or stage) a branch-local derived-doc edit → invariant violation. Gate both to `current == default`.
+
+- [ ] **Step 1: Write the failing test** — assert the post-merge body contains an early `exit 0` when `current != default`, and the post-rewrite body regenerates only under a default-branch guard. (Behavioral fixture: install the hooks into a temp repo on a feature branch, run them, assert `docs/timeline.md` is NOT modified/staged.)
+
+```go
+func TestPostRewriteHook_NoRegenOnFeatureBranch(t *testing.T) {
+	repo := initRepoWithLogmind(t)
+	installHooks(t, repo) // writes .git/hooks/post-rewrite from BuildPostRewriteBody
+	runGit(t, repo, "checkout", "-b", "feat/z")
+	// Add a decision so a regen WOULD change timeline.md, then amend to fire post-rewrite.
+	appendFile(t, repo, "docs/decisions-branches/feat__z.md", "## 2026-07-17 10:00 - x\n\n---\n\n")
+	runGit(t, repo, "add", "-A"); runGit(t, repo, "commit", "-m", "wip")
+	runGit(t, repo, "commit", "--amend", "--no-edit") // fires post-rewrite
+	if isStagedOrDirty(t, repo, "docs/timeline.md") {
+		t.Fatal("post-rewrite must NOT regen/stage derived docs on a feature branch")
+	}
+}
+```
+
+- [ ] **Step 2: Verify fails** — `go test ./internal/hooks/ -run PostRewriteHook_NoRegen -v` → FAIL.
+- [ ] **Step 3: Implement** — in `BuildPostMergeBody`, after the `current`/`default` computation (hooks.go:160-165), replace the "skip only on fast-forward" block so a **non-default branch exits 0 outright**:
+
+```sh
+  if [ -n "$current" ] && [ "$current" != "$default" ]; then
+    # v2.0.0 derived-docs-on-main: never regenerate on a non-default branch —
+    # the branch must keep the derived docs byte-identical to its main
+    # merge-base (the zero-conflict invariant). main regenerates post-merge.
+    exit 0
+  fi
+  if [ -n "$current" ] && [ "$current" = "$default" ]; then
+    head_sha=$(git rev-parse HEAD 2>/dev/null || true)
+    origin_sha=$(git rev-parse "origin/$default" 2>/dev/null || true)
+    if [ -n "$origin_sha" ] && [ "$head_sha" = "$origin_sha" ]; then
+      exit 0
+    fi
+  fi
+```
+
+In `BuildPostRewriteBody`, wrap the regen+add in the same default-branch guard (add `current`/`default` detection mirroring post-merge, then only regen when `current = default`):
+
+```sh
+if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
+  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  default=${default#origin/}
+  [ -z "$default" ] && default=main
+  # v2.0.0: regenerate only on the default branch (invariant: branches never
+  # edit the derived docs). A rebase/amend on a feature branch leaves them as-is.
+  if [ -n "$current" ] && [ "$current" = "$default" ] && [ -d docs ]; then
+    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
+    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
+    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true
+  fi
+fi
+```
+
+- [ ] **Step 4: Regenerate golden fixtures** — update the golden strings/files in `hooks_test.go` (the fixture that pins the exact body). Run `go test ./internal/hooks/ -run Body -v`; if it diffs, update the golden to the new body (this is the sanctioned v2.0.0 body change — verify the diff is ONLY the new guard lines, nothing else).
+- [ ] **Step 5: Verify pass** — `go test ./internal/hooks/ -v` → PASS (behavioral + golden).
+- [ ] **Step 6: Commit** — `logmind log "L0: post-merge + post-rewrite hooks regenerate derived docs on the default branch only" -r "A rebase/amend/merge on a feature branch previously regenerated (post-rewrite even git-added) the derived docs, diverging the branch from main; gating regen to the default branch keeps branches clean so merges never conflict" -i "Golden hook-body fixtures updated — the sanctioned v2.0.0 body evolution; the embedded hook-version line already differs from Python v0.6.16"`
+
+---
+
+## Task 5: `logmind warp` command
+
+**Files:**
+- Create: `internal/cli/warp.go`
+- Modify: `internal/cli/root.go` (register near :83, after `newRebaseCmd`)
+- Test: `internal/cli/warp_test.go`
+
+**Interfaces — Consumes:** `gitcli.Fetch`, `gitcli.ShowFile` (Task 1), `derivedDocPaths` (Task 2), `writeAtomic` (existing). **Produces:** `newWarpCmd`, `runWarp`.
+
+**Behavior:** fetch `origin/<default>`, then overwrite the working-tree derived docs from `origin/<default>` for READING — **never staged, never committed** (committing main's newer blobs would set branch-blob ≠ merge-base-blob and trip the Task-8 gate). Report how many decision-touching commits main is ahead.
+
+- [ ] **Step 1: Write the failing test** — with `origin/<default>` ahead by a decision, `runWarp` overwrites `docs/timeline.md` with origin's content and leaves it UNstaged.
+
+```go
+func TestWarp_RefreshesFromOriginUncommitted(t *testing.T) {
+	origin, repo := initClonePair(t)                 // repo tracks origin/main
+	commitOn(t, origin, "docs/timeline.md", "MAIN-FRESH\n")
+	runGit(t, repo, "fetch", "origin", "main")       // pre-fetch so ShowFile sees it
+	runGit(t, repo, "checkout", "-b", "feat/w")
+	if err := runWarp(repo, io.Discard, io.Discard); err != nil {
+		t.Fatalf("warp: %v", err)
+	}
+	if readFile(t, repo, "docs/timeline.md") != "MAIN-FRESH\n" {
+		t.Fatal("warp must refresh the working copy from origin/main")
+	}
+	if isStaged(t, repo, "docs/timeline.md") {
+		t.Fatal("warp must NOT stage the refreshed docs")
+	}
+}
+```
+
+- [ ] **Step 2: Verify fails** — `go test ./internal/cli/ -run TestWarp -v` → FAIL.
+- [ ] **Step 3: Implement** (`warp.go`):
+
+```go
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+func newWarpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "warp",
+		Short: "Refresh docs/timeline.md + docs/file-structure.md from main (read-only catch-up)",
+		Long: `Fetch the latest default branch and refresh your working copy of the two
+DERIVED docs (docs/timeline.md, docs/file-structure.md) so your context reflects
+main's current decisions.
+
+Read-only: warp NEVER stages or commits these files. They are regenerated on
+main only; a branch must keep them byte-identical to its merge-base with main so
+that merges never conflict. Your branch's own decisions live in
+docs/decisions-branches/<branch>.md (committed, per-branch, conflict-free).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runWarp(cwd, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+}
+
+func runWarp(cwd string, stdout, stderr io.Writer) error {
+	if !gitcli.IsRepo(cwd) {
+		fmt.Fprintln(stdout, "Not a git repo — nothing to warp.")
+		return nil
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		def = "main"
+	}
+	if err := gitcli.Fetch(cwd, "origin", def); err != nil {
+		fmt.Fprintf(stderr, "warn: git fetch origin %s failed: %v (refreshing from last-known main)\n", def, err)
+	}
+	ref := "origin/" + def
+	refreshed := 0
+	for _, rel := range derivedDocPaths {
+		content, ok := gitcli.ShowFile(cwd, ref, rel)
+		if !ok {
+			continue
+		}
+		if err := writeAtomic(filepath.Join(cwd, rel), content); err != nil {
+			fmt.Fprintf(stderr, "warn: could not write %s: %v\n", rel, err)
+			continue
+		}
+		refreshed++
+	}
+	ahead := ""
+	if out, _, err := gitcli.RunCaptured(cwd, "rev-list", "--count", "HEAD.."+ref, "--",
+		"docs/decisions.md", "docs/decisions-branches", "docs/decisions-archive.md"); err == nil {
+		if n, e := strconv.Atoi(strings.TrimSpace(out)); e == nil && n > 0 {
+			ahead = fmt.Sprintf(" · main is +%d decision commit(s) ahead", n)
+		}
+	}
+	fmt.Fprintf(stdout, "ok warp: refreshed %d derived doc(s) from %s (read-only — not committed)%s\n", refreshed, ref, ahead)
+	return nil
+}
+```
+
+Register in `root.go` after line 83: `root.AddCommand(newWarpCmd())`.
+
+- [ ] **Step 4: Verify pass** — `go test ./internal/cli/ -run TestWarp -v` → PASS. `go build ./cmd/logmind && ./bin/logmind warp --help` shows the command.
+- [ ] **Step 5: Commit** — `logmind log "Add logmind warp: read-only refresh of derived docs from main" -r "The explicit catch-up verb — fetch origin/main and refresh the working copy of the two derived docs so an agent mid-branch sees main's current timeline, without committing them (committing would break the merge-base invariant and trip the CI gate)" -a "warp merges origin/main into the branch (rejected: creates merge commits / changes branch history for a pure context refresh)" -a "name it sync/refresh/rebase (rejected: sync and rebase are taken; warp is timeline-themed and carries no git-commit baggage)"`
+
+---
+
+## Task 6: 3rd pulse probe — `mainDecisionsPulseLine`
+
+**Files:**
+- Modify: `internal/cli/pulse.go` — add function + a third block in `emitPulse` (:88-93); add `strconv` import
+- Test: `internal/cli/pulse_test.go`, `internal/cli/pulse_hotpath_test.go`
+
+**Interfaces — Consumes:** `onNonDefaultBranch` (Task 2). **NETWORK-FREE** — reads the existing `origin/<default>` remote-tracking ref only (no fetch); the count reflects the last `logmind warp` / `git fetch`.
+
+- [ ] **Step 1: Write the failing test** — on a feature branch with `origin/main` ahead by a decision commit, `emitPulse` stderr contains `main has 1 new decision commit — run 'logmind warp'`; on the default branch it does NOT.
+
+- [ ] **Step 2: Verify fails** — `go test ./internal/cli/ -run Pulse -v` → FAIL.
+- [ ] **Step 3: Implement:**
+
+```go
+// mainDecisionsPulseLine reports the "main has advanced" freshness advisory:
+// on a NON-default branch, when the last-fetched origin/<default> carries
+// decision-touching commits the branch does not, nudge a catch-up. NETWORK-FREE:
+// reads the existing remote-tracking ref (no fetch), so the count is as of the
+// last warp/fetch. Best-effort: ("", false) on any error or missing origin ref —
+// this runs on every `logmind log`, so it must never fail or slow the hot path.
+func mainDecisionsPulseLine(cwd string) (string, bool) {
+	if !onNonDefaultBranch(cwd) {
+		return "", false
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		return "", false
+	}
+	out, _, err := gitcli.RunCaptured(cwd, "rev-list", "--count", "HEAD..origin/"+def, "--",
+		"docs/decisions.md", "docs/decisions-branches", "docs/decisions-archive.md")
+	if err != nil {
+		return "", false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil || n <= 0 {
+		return "", false
+	}
+	plural := "s"
+	if n == 1 {
+		plural = ""
+	}
+	return fmt.Sprintf("logmind: main has %d new decision commit%s — run 'logmind warp' to catch up", n, plural), true
+}
+```
+
+Add to `emitPulse` after the spec block (pulse.go:92):
+
+```go
+	if line, ok := mainDecisionsPulseLine(cwd); ok {
+		fmt.Fprintln(stderr, line)
+	}
+```
+
+Add `"strconv"` and confirm `"strings"` imports in pulse.go.
+
+- [ ] **Step 4: Verify pass** — `go test ./internal/cli/ -run Pulse -v` → PASS. Update the pulse hot-path test to allow the third probe. Confirm no network: the probe uses `rev-list` against the LOCAL `origin/<default>` ref only.
+- [ ] **Step 5: Verify hot-path budget** — `go test ./internal/cli/ -run Pulse -race`; confirm the new probe is guarded by `onNonDefaultBranch` (default-branch logs skip it entirely).
+- [ ] **Step 6: Commit** — `logmind log "Third pulse probe: nudge logmind warp when main has advanced" -r "Closes the freshness loop — after a log on a stale branch, stderr surfaces how far main has moved and points at logmind warp; network-free (reads the last-fetched origin ref) to preserve the hot-path budget" -i "The count is as of the last fetch/warp; warp itself does the network fetch"`
+
+---
+
+## Task 7: `logmind context` prefers the last-fetched main copy of derived docs
+
+**Files:**
+- Modify: `internal/cli/context.go` — the derived-doc read path in `contextPayload` (:164-194 / the `contextDocs` loop reading via `os.ReadFile` at :181)
+- Test: `internal/cli/context_test.go`
+
+**Interfaces — Consumes:** `gitcli.ShowFile` (Task 1), `onNonDefaultBranch` (Task 2), `derivedDocPaths` (Task 2). Non-network.
+
+**Behavior:** when on a non-default branch, render `docs/timeline.md` and `docs/file-structure.md` from `origin/<default>` (last-fetched, local — fresher than the branch's stale merge-base snapshot) if available, else the local file. The spec/repomap docs are unchanged. Never fetches (that is `warp`'s job).
+
+- [ ] **Step 1: Write the failing test** — on a feature branch with `origin/main`'s `timeline.md` = "MAIN", the branch's committed `timeline.md` = "BRANCH-STALE", assert `contextPayload` embeds "MAIN".
+- [ ] **Step 2: Verify fails** — `go test ./internal/cli/ -run Context -v` → FAIL.
+- [ ] **Step 3: Implement** — in the file-backed read for a doc whose `rel` is in `derivedDocPaths`, when `onNonDefaultBranch(cwd)`, try `gitcli.ShowFile(cwd, "origin/"+gitcli.DefaultBranch(cwd), rel)` first; fall back to the existing `os.ReadFile`. Keep the "absent" element behavior when neither source exists. Add a helper `readDerivedForContext(cwd, rel string) (string, bool)` to keep `contextPayload` readable.
+- [ ] **Step 4: Verify pass** — `go test ./internal/cli/ -run Context -v` → PASS; confirm the default-branch path still reads the local file (unchanged) and no network is invoked.
+- [ ] **Step 5: Commit** — `logmind log "logmind context renders derived docs from the last-fetched main on a branch" -r "Cold-start context reflects main's current decisions instead of the branch's stale merge-base snapshot, without a network call — origin/<default> is read locally; warp does the fetch" -i "The branch's committed derived docs stay at the merge-base (invariant); only the context RENDERING prefers the fresher local main copy"`
+
+---
+
+## Task 8: L3 — blocking PR gate + main-only regen (CI, lockstep)
+
+**Files:**
+- Rewrite: `.github/workflows/regen-timeline.yml`
+- Rewrite: `internal/templates/github/regen-timeline.yml.template` (bump `v7` → `v8`)
+
+**Contract:** keep job name `check-derived-docs`. The PR gate BLOCKS (exit 1) when the PR modified either derived doc — GitHub's 3-dot PR diff IS the branch-vs-merge-base delta, correct for forks, no checkout needed. A separate `push: [main]` job regenerates + commits the docs (the only writer to a tracked branch); no-op when current (no push loop).
+
+- [ ] **Step 1: Write the new `regen-timeline.yml`** (self-repo variant):
+
+```yaml
+name: logmind / check-derived-docs
+
+# v2.0.0 derived-docs-on-main. The two derived docs are regenerated ONLY here on
+# main. On a PR this gate is NON-mutating and BLOCKING: it fails if the branch
+# edited either derived doc (which would cause cross-PR merge conflicts). A
+# branch's real decisions live in docs/decisions-branches/<branch>.md; timeline
+# and file-structure regenerate on main after merge.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # PR gate uses read (gh pr diff); the main job commits regen
+
+jobs:
+  check-derived-docs:
+    name: check-derived-docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the branch did not edit the derived docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
+          if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|file-structure)\.md'; then
+            echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md and/or docs/file-structure.md. These are DERIVED, main-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to main's version — run 'logmind warp', or 'git checkout origin/main -- docs/timeline.md docs/file-structure.md' — then commit. Their real content regenerates on main after merge."
+            exit 1
+          fi
+          echo "Branch did not edit the derived docs — the merge cannot conflict on them."
+
+  regen-on-main:
+    name: regen-on-main
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.22"
+          cache: true
+      - name: Build logmind from source
+        run: make build
+      - name: Regenerate derived docs
+        run: |
+          set -euo pipefail
+          ./bin/logmind timeline --write docs/timeline.md
+          ./bin/logmind file-structure --write docs/file-structure.md
+      - name: Commit + push if changed
+        env:
+          PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain -- docs/timeline.md docs/file-structure.md)" ]; then
+            echo "Derived docs already current on main."
+            exit 0
+          fi
+          if [ -z "${PAT:-}" ]; then
+            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap.)"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/timeline.md docs/file-structure.md
+          git commit -m "[skip-logmind] chore: regen derived docs"
+          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"
+```
+
+- [ ] **Step 2: Write the lockstep template** `internal/templates/github/regen-timeline.yml.template` — identical jobs, with `# logmind-template-version: v8` as line 1, and the regen job using `thrillmade/setup-logmind@v1.0.0` (with `token: ${{ github.token }}`) + `logmind timeline --write ...` instead of `make build` + `./bin/logmind`.
+- [ ] **Step 3: Lint both** — `yamllint`/`actionlint` if available; otherwise `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" <file>` for both. Confirm the two files differ ONLY in the build/setup mechanism and the template-version line (diff them side by side).
+- [ ] **Step 4: Update the template-version test** — if a test pins the installed template's version marker, bump its expectation to `v8`. `go test ./internal/... -run Template -v`.
+- [ ] **Step 5: Commit** — `logmind log "L3: check-derived-docs becomes a blocking PR gate; derived docs regenerate on main only" -r "The structural wall: a PR that edits a derived doc cannot merge (gh pr diff is the branch-vs-merge-base delta, fork-correct), so even an unforeseen write path can never reintroduce a conflict; regen moves to a main-only job that no-ops when current (no push loop)" -a "merge-base diff in shell (rejected: base.sha may be absent in a fork checkout; gh pr diff is simpler and fork-correct)" -i "Existing PRs that modified derived docs (e.g. site #200) now block until reverted — the intended one-time migration; keeps job name check-derived-docs for ruleset matching; template bumped v7->v8"`
+
+---
+
+## Task 9: Headline zero-conflict integration test + layer regression tests
+
+**Files:**
+- Create: `internal/cli/derived_integration_test.go`
+
+- [ ] **Step 1: Two-concurrent-branches merge-clean test** — build a temp repo, scaffold logmind; on `main` commit timeline.md. Branch `A` and `B` from main; on each, `logmind log` a decision (writing only `docs/decisions-branches/<branch>.md`, derived docs restored by L1). Merge A into main, then B into main; assert BOTH merges succeed with **no conflict** on `docs/timeline.md`/`docs/file-structure.md` (check `git merge` exit 0 and no conflict markers).
+
+```go
+func TestConcurrentBranches_MergeWithoutDerivedDocConflict(t *testing.T) {
+	repo := initRepoWithLogmind(t)
+	for _, br := range []string{"feat/a", "feat/b"} {
+		runGit(t, repo, "checkout", "main")
+		runGit(t, repo, "checkout", "-b", br)
+		mustRunLog(t, repo, "decision on "+br)
+	}
+	runGit(t, repo, "checkout", "main")
+	for _, br := range []string{"feat/a", "feat/b"} {
+		out, _, err := gitcli.RunCaptured(repo, "merge", "--no-edit", br)
+		if err != nil || strings.Contains(out, "CONFLICT") {
+			t.Fatalf("merge %s conflicted: %v\n%s", br, err, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Verify** — `go test ./internal/cli/ -run TestConcurrentBranches -v` → PASS.
+- [ ] **Step 3: Full suite** — `go build ./... && go test ./... && go vet ./... && gofmt -l .` all clean.
+- [ ] **Step 4: Commit** — `logmind log "Integration test: concurrent branches merge with zero derived-doc conflict" -r "The headline proof of the feature — two branches each logging a decision merge into main cleanly because L1 keeps their derived docs at the merge-base; this is the regression guard for the whole invariant"`
+
+---
+
+## Task 10: SPEC §0.4 reword + agent-skill note (cross-repo, coordinate)
+
+**Files (separate repos — do NOT edit from this repo's worktree):**
+- `thrillmade/protocol` `SPEC.md` §0.4 — sync-invariant reword.
+- agent-skills logmind skill — "staying current" note.
+
+- [ ] **Step 1: Draft the §0.4 reword** as an additive `<!-- v1.6.0 addition (DRAFT ...) -->` comment (matching the house draft-then-tag flow; marker stays 1.5.1 until the CTO tags spec-v1.6.0): "Derived docs (`docs/timeline.md`, `docs/file-structure.md`) are regenerated at the integration point (the default branch); a non-default branch carries a byte-identical merge-base snapshot and never regenerates them, so concurrent branches never conflict on derived docs. Freshness is served by `logmind warp` / a cold-start `logmind context` refresh, both read-only." Additive per §8.3; co-tags with the 1.6.0 bump.
+- [ ] **Step 2: Draft the skill "staying current" note** — one paragraph: "Your branch's `docs/timeline.md` is a snapshot of main from when you branched. Run `logmind warp` (or re-run `logmind context`) to see decisions merged to main since. Never edit the derived docs — they regenerate on main; the CI gate blocks a PR that touches them."
+- [ ] **Step 3: Deliver both as orchestrator hand-off prompts** to the protocol co-author and the agent-skills owner (these land in their repos, co-tagging with spec-v1.6.0 / the skill wave). Do NOT commit cross-repo from here.
+
+---
+
+## Self-Review
+
+**Spec coverage:** L0 (Task 4) · L1 (Task 3) · L3 blocking gate + main regen (Task 8) · `warp` (Task 5) · 3rd pulse probe (Task 6) · context refresh (Task 7) · gitcli foundation (Task 1) · shared constants (Task 2) · headline conflict-free proof (Task 9) · SPEC §0.4 + skill (Task 10). L2 (dedicated pre-commit strip) is intentionally deferred — redundant with L3 (the wall) and L1 (the commit path); the only uncovered path is a raw `git commit --no-verify` of a hand-edited derived doc, which L3 blocks at PR time. Recorded here so the omission is explicit.
+
+**Type consistency:** `derivedDocPaths` / `onNonDefaultBranch` (Task 2) are the single definitions consumed by Tasks 3/5/6/7. `gitcli.{MergeBase,Fetch,ShowFile,RestorePathsToHead}` (Task 1) signatures match every call site. `RunCaptured(repoRoot, args...) (stdout, stderr string, err error)` used consistently.
+
+**Ordering / dependencies:** 1 → 2 → {3, 5, 6, 7} (all consume 1+2, file-isolated from each other) ; 4 (hooks, isolated) ; 8 (CI, isolated) ; 9 (integration, needs 3+4) ; 10 (cross-repo, last). Tasks 3/5/6/7 and 4 and 8 can run in parallel once 1+2 land.
+
+**Risk surface:** Task 8 (CI semantics — a wrong `if:`/permission strands a required check) and Task 4 (golden-fixture body change) are the highest-risk; both get opus-tier build + full dual review. Task 3 is load-bearing but small.

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/repomap"
 	"github.com/thrillmade/logmind/internal/tokens"
 )
@@ -178,8 +179,8 @@ func contextPayload(cwd string) string {
 			writeDoc(&b, d.typ, source, []byte(body))
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(cwd, d.rel))
-		if err != nil {
+		content, ok := readDerivedForContext(cwd, d.rel)
+		if !ok {
 			// A missing doc becomes a self-closing element carrying the
 			// regenerate command in an attribute — well-formed (an XML comment
 			// would hit the "--" double-hyphen rule via `--write`) and still
@@ -187,10 +188,54 @@ func contextPayload(cwd string) string {
 			fmt.Fprintf(&b, "<document type=%q source=%q status=\"absent\" regenerate=%q/>\n", d.typ, d.rel, d.regen)
 			continue
 		}
-		writeDoc(&b, d.typ, d.rel, data)
+		writeDoc(&b, d.typ, d.rel, []byte(content))
 	}
 	b.WriteString("</repo_context>\n")
 	return b.String()
+}
+
+// readDerivedForContext reads the content backing a file-backed contextDoc's
+// `rel` path. For the two governed derivedDocPaths (docs/timeline.md,
+// docs/file-structure.md) on a NON-default branch, it prefers the
+// last-fetched origin/<default> copy (gitcli.ShowFile) over the branch's own
+// working copy: the branch's committed copy is deliberately pinned to its
+// merge-base with main (the zero-conflict invariant, L1), so it can lag main
+// by however long the branch has existed, while origin/<default> — as of the
+// last `logmind warp` or `git fetch` — reflects what actually merged since.
+// NETWORK-FREE: reads the existing remote-tracking ref only, never fetches
+// (that is warp's job). Falls back to the local `os.ReadFile` when: rel is
+// not a governed derived doc, the branch IS the default branch, there's no
+// resolvable default branch, or the origin copy isn't available (no origin
+// remote, never fetched, path absent at that ref). Returns ("", false) only
+// when neither source has the doc — the caller renders the same "absent"
+// element it always has.
+func readDerivedForContext(cwd, rel string) (string, bool) {
+	if isDerivedDocPath(rel) && onNonDefaultBranch(cwd) {
+		if def := gitcli.DefaultBranch(cwd); def != "" {
+			if content, ok := gitcli.ShowFile(cwd, "origin/"+def, rel); ok {
+				return content, true
+			}
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(cwd, rel))
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// isDerivedDocPath reports whether rel is one of the two governed derived
+// docs (derivedDocPaths, derived.go) — the ONLY paths readDerivedForContext
+// treats specially. The spec doc and repomap are generated in-memory (d.gen)
+// and never reach this function; this guard keeps it that way even if a
+// future file-backed, non-derived contextDoc is added.
+func isDerivedDocPath(rel string) bool {
+	for _, p := range derivedDocPaths {
+		if p == rel {
+			return true
+		}
+	}
+	return false
 }
 
 // writeDoc emits one <document> envelope with a trailing-newline guarantee on

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -155,3 +155,92 @@ func TestContext_Repomap_Stats(t *testing.T) {
 		}
 	})
 }
+
+// --- v2.0.0 derived-docs-on-main: context prefers the last-fetched
+// origin/<default> copy of the two derived docs on a non-default branch ---
+//
+// initClonePair / commitOn / runGitIn are shared with warp_test.go (same
+// package).
+
+// TestContext_NonDefaultBranch_PrefersOriginOverStaleCommittedCopy: on a
+// feature branch, origin/<default> has moved past the branch's own committed
+// (merge-base-pinned) copy of docs/timeline.md. contextPayload must render
+// the fresher origin content, not the branch's stale local file — while the
+// <document>/<source> wrapping stays exactly the same shape as the
+// unset-source-independent case (only the byte SOURCE changes, never the
+// envelope).
+func TestContext_NonDefaultBranch_PrefersOriginOverStaleCommittedCopy(t *testing.T) {
+	origin, repo := initClonePair(t) // origin's docs/timeline.md = "ORIGIN-INITIAL\n"
+	commitOn(t, origin, "docs/timeline.md", "MAIN\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/ctx")
+	// The branch's own working copy is still the pre-advance content (nothing
+	// changed it locally) — this is the "stale merge-base snapshot" contextPayload
+	// must NOT prefer.
+	mustWriteUnder(t, repo, "docs/file-structure.md", "FS\n")
+
+	s := contextPayload(repo)
+	if !strings.Contains(s, "MAIN\n") {
+		t.Fatalf("expected the fresher origin/main copy (MAIN) to be rendered:\n%s", s)
+	}
+	if strings.Contains(s, "ORIGIN-INITIAL") {
+		t.Fatalf("branch's stale committed timeline.md leaked into the payload instead of origin/main's copy:\n%s", s)
+	}
+	// Wrapping format unchanged: same envelope, same <source> (the repo-relative
+	// path), regardless of which backing store the bytes came from.
+	if !strings.Contains(s, `<document type="decision-timeline">`) || !strings.Contains(s, "<source>docs/timeline.md</source>") {
+		t.Fatalf("document envelope/source changed for the origin-sourced doc:\n%s", s)
+	}
+}
+
+// TestContext_NonDefaultBranch_FallsBackToLocalWhenOriginLacksPath: when
+// origin/<default> does not have the doc at that path (e.g. it predates the
+// doc, or there is no origin ref at all), contextPayload falls back to the
+// existing local os.ReadFile behavior instead of rendering "absent".
+func TestContext_NonDefaultBranch_FallsBackToLocalWhenOriginLacksPath(t *testing.T) {
+	_, repo := initClonePair(t) // origin never committed docs/file-structure.md
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/ctx2")
+	mustWriteUnder(t, repo, "docs/file-structure.md", "LOCAL-ONLY-FS\n")
+
+	s := contextPayload(repo)
+	if !strings.Contains(s, "LOCAL-ONLY-FS") {
+		t.Fatalf("expected fallback to the local file-structure.md when origin/main lacks the path:\n%s", s)
+	}
+}
+
+// TestContext_NonDefaultBranch_AbsentWhenNeitherSourceHasIt: preserves the
+// pre-existing "absent" element behavior — when a derived doc exists at
+// NEITHER origin/<default> nor locally, the payload still emits the
+// self-closing absent element, not an error or a silently-dropped document.
+func TestContext_NonDefaultBranch_AbsentWhenNeitherSourceHasIt(t *testing.T) {
+	_, repo := initClonePair(t) // origin never committed docs/file-structure.md
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/ctx3")
+	// docs/file-structure.md intentionally absent both on origin/main and locally.
+
+	s := contextPayload(repo)
+	if !strings.Contains(s, `source="docs/file-structure.md" status="absent"`) || !strings.Contains(s, "regenerate=") {
+		t.Fatalf("absent derived doc not noted as a self-closing element on a non-default branch:\n%s", s)
+	}
+}
+
+// TestContext_DefaultBranch_NeverConsultsOrigin: on the default branch,
+// contextPayload must keep reading the local file even when origin/<default>
+// carries different content — origin-preference is scoped to non-default
+// branches only (Task 7's contract).
+func TestContext_DefaultBranch_NeverConsultsOrigin(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/timeline.md", "MAIN-SHOULD-NOT-APPEAR\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	// repo stays on its default branch ("main") — no checkout.
+	mustWriteUnder(t, repo, "docs/timeline.md", "LOCAL-MAIN-COPY\n")
+
+	s := contextPayload(repo)
+	if !strings.Contains(s, "LOCAL-MAIN-COPY") {
+		t.Fatalf("default branch must read the local file:\n%s", s)
+	}
+	if strings.Contains(s, "MAIN-SHOULD-NOT-APPEAR") {
+		t.Fatalf("default branch must never consult origin/main for the derived docs:\n%s", s)
+	}
+}

--- a/internal/cli/derived.go
+++ b/internal/cli/derived.go
@@ -1,0 +1,30 @@
+package cli
+
+import "github.com/thrillmade/logmind/internal/gitcli"
+
+// derivedDocPaths are the two committed, purely-derived context docs governed by
+// the zero-conflict invariant: on any non-default branch they MUST stay
+// byte-identical to their merge-base-with-main version (the branch never edits
+// them), so git's 3-way merge is conflict-free. They are regenerated only at the
+// integration point (main). Repo-relative, forward-slash (git pathspec form).
+var derivedDocPaths = []string{"docs/timeline.md", "docs/file-structure.md"}
+
+// onNonDefaultBranch reports whether cwd is a git repo currently on a branch
+// other than the default branch. Best-effort: false on a non-repo, detached
+// HEAD, unborn branch, or unknown default — the conservative answer, since every
+// caller uses `true` to ENABLE the extra invariant guard and `false` preserves
+// pre-v2.0.0 behavior.
+func onNonDefaultBranch(cwd string) bool {
+	if !gitcli.IsRepo(cwd) {
+		return false
+	}
+	cur := gitcli.CurrentBranch(cwd)
+	if cur == "" {
+		return false
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		return false
+	}
+	return cur != def
+}

--- a/internal/cli/derived_integration_test.go
+++ b/internal/cli/derived_integration_test.go
@@ -1,0 +1,104 @@
+// derived_integration_test.go — the headline zero-conflict integration proof
+// for the derived-docs-on-main feature (plan Task 9). Two concurrent
+// branches each log a decision — after first DIRTYING docs/timeline.md with
+// branch-specific content, simulating a stray post-merge/merge-driver regen
+// — and both merge into main with zero conflict on the two derived docs
+// (docs/timeline.md, docs/file-structure.md).
+//
+// This is deliberately NOT a naive "log then merge" test: `logmind log`
+// alone never rewrites docs/timeline.md, so a naive version (dirty nothing,
+// just log + merge) would pass even without L1. By dirtying the file first
+// and asserting the resulting HEAD commit's copy is byte-identical to
+// main's, L1 (commitDecision's onNonDefaultBranch restore, log.go:886-888)
+// is load-bearing for this test: remove the restore and the per-branch
+// assertion below fails immediately. It also makes the final merge
+// non-trivial — without L1, feat/a and feat/b would each carry their own
+// divergent docs/timeline.md content, and merging feat/b into a main
+// already fast-forwarded/merged to feat/a's tip would be a genuine
+// three-way conflict (both sides differ from the merge-base AND from each
+// other), not just a one-side-changed auto-merge.
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+func TestConcurrentBranches_MergeWithoutDerivedDocConflict(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		// Commit the scaffold (decisions.md, timeline.md, file-structure.md)
+		// on main so both branches share the same merge-base copy of the
+		// derived docs.
+		commitAll(t, d, "initial scaffold")
+
+		timelinePath := filepath.Join(d, "docs", "timeline.md")
+		mainTimeline := readFileStr(t, timelinePath)
+
+		branches := []string{"feat/a", "feat/b"}
+		for _, br := range branches {
+			runGitIn(t, d, "checkout", "main")
+			runGitIn(t, d, "checkout", "-b", br)
+
+			// Dirty docs/timeline.md with branch-specific content BEFORE
+			// logging — simulates a stray post-merge/merge-driver regen
+			// landing branch-local content in the derived doc. Confirm the
+			// dirty content actually differs from main's so the later
+			// byte-identical assertion is meaningful (not vacuously true).
+			dirty := "DIRTY ON " + br + " — simulated stray regen\n"
+			if dirty == mainTimeline {
+				t.Fatalf("dirty content for %s accidentally matches main's timeline.md; assertion would be meaningless", br)
+			}
+			if err := os.WriteFile(timelinePath, []byte(dirty), 0o644); err != nil {
+				t.Fatalf("dirty docs/timeline.md on %s: %v", br, err)
+			}
+
+			withFakeTTY(t, false, func() {
+				f := &logFlags{stage: "all"}
+				if err := runLog(d, "decision on "+br, f, true, strings.NewReader(""), io.Discard, io.Discard); err != nil {
+					t.Fatalf("runLog on %s: %v", br, err)
+				}
+			})
+
+			// L1 proof: the resulting HEAD commit's docs/timeline.md must be
+			// byte-identical to main's — NOT the dirtied branch content —
+			// proving commitDecision's onNonDefaultBranch restore ran before
+			// staging. Without L1 this would still read "DIRTY ON <br>...".
+			headTimeline, ok := gitcli.ShowFile(d, "HEAD", "docs/timeline.md")
+			if !ok {
+				t.Fatalf("git show HEAD:docs/timeline.md failed on %s", br)
+			}
+			if headTimeline != mainTimeline {
+				t.Fatalf("branch %s: HEAD docs/timeline.md diverged from main (L1 did not restore it)\nwant:\n%s\ngot:\n%s", br, mainTimeline, headTimeline)
+			}
+		}
+
+		// Merge both branches into main. Zero-conflict invariant: neither
+		// merge should touch docs/timeline.md or docs/file-structure.md —
+		// check the merge's exit code, the absence of "CONFLICT" in git's
+		// own output, AND the absence of literal conflict markers in both
+		// files on disk afterward.
+		runGitIn(t, d, "checkout", "main")
+		for _, br := range branches {
+			out, _, err := gitcli.RunCaptured(d, "merge", "--no-edit", br)
+			if err != nil {
+				t.Fatalf("merge %s failed: %v\n%s", br, err, out)
+			}
+			if strings.Contains(out, "CONFLICT") {
+				t.Fatalf("merge %s reported a conflict:\n%s", br, out)
+			}
+			for _, p := range derivedDocPaths {
+				content := readFileStr(t, filepath.Join(d, p))
+				if strings.Contains(content, "<<<<<<<") {
+					t.Fatalf("merge %s left conflict markers in %s:\n%s", br, p, content)
+				}
+			}
+		}
+	})
+}

--- a/internal/cli/derived_test.go
+++ b/internal/cli/derived_test.go
@@ -1,0 +1,29 @@
+// derived_test.go — exercises the shared derived-doc constants and the
+// non-default-branch predicate that the L1 log guard, warp, the pulse
+// probe, and context all key off of.
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOnNonDefaultBranch: false on the default branch (main), true once a
+// feature branch is checked out.
+func TestOnNonDefaultBranch(t *testing.T) {
+	dir := t.TempDir()
+	initLogTestGitRepo(t, dir) // git init --initial-branch=main + config
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	commitAll(t, dir, "init")
+
+	if onNonDefaultBranch(dir) {
+		t.Fatal("default branch should be false")
+	}
+	runGitIn(t, dir, "checkout", "-b", "feat/x")
+	if !onNonDefaultBranch(dir) {
+		t.Fatal("feature branch should be true")
+	}
+}

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -875,6 +875,18 @@ func nudgeBranchSummary(target string, forceNonInteractive, stdinOK bool, lines 
 // Commit message uses cfg.Git.CommitMessageTemplate with `{decision}`
 // substituted for the summary. Default is `logmind: <summary>`.
 func commitDecision(cwd, targetAbs, targetRel, stage, summary string, cfg config.Config) error {
+	// Zero-conflict invariant (v2.0.0): docs/timeline.md + docs/file-structure.md
+	// are purely-derived, main-only artifacts. On a non-default branch, restore
+	// them to their committed (HEAD) content BEFORE staging so neither a stray
+	// hook regen nor `git add -A` can sweep a branch-local edit into this commit —
+	// which would diverge the branch from main and cause a future merge conflict.
+	// Lossless: they regenerate deterministically from the decision files (which
+	// ARE committed, per-branch, and never conflict). On the default branch this
+	// is intentionally skipped — main is where the derived docs SHOULD be current.
+	if onNonDefaultBranch(cwd) {
+		_ = gitcli.RestorePathsToHead(cwd, derivedDocPaths...)
+	}
+
 	if stage == "all" {
 		if err := gitcli.AddAll(cwd); err != nil {
 			return err

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
 )
 
 // signalOnSubstr is a thread-safe io.Writer that closes `fired` the first time
@@ -1056,5 +1058,67 @@ func TestLog_SelfHeal_StderrTTY_StdinDeadPipe_DoesNotHang(t *testing.T) {
 				t.Fatalf("dead-pipe stdin must NOT enter the interactive prompt loop\nstdout:\n%s\nstderr:\n%s", out.String(), errBuf.String())
 			}
 		})
+	})
+}
+
+// TestLog_DoesNotCommitDirtiedDerivedDocOnBranch pins the L1 zero-conflict
+// guard (derived-docs-on-main plan, Task 3): docs/timeline.md and
+// docs/file-structure.md are purely-derived, main-only artifacts. On a
+// non-default branch, `commitDecision` restores them to HEAD before staging
+// so neither a stray hook regen nor `git add -A` can sweep a branch-local
+// edit into the decision commit — which would diverge the branch from main
+// and cause a future merge conflict. Here we simulate that stray edit by
+// hand-dirtying the already-committed docs/timeline.md, then assert the
+// resulting commit does NOT carry it and the working tree is restored to
+// HEAD's content.
+func TestLog_DoesNotCommitDirtiedDerivedDocOnBranch(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		// Commit the scaffold (including docs/timeline.md) on main FIRST so
+		// there is a HEAD copy for the branch to diverge from and later be
+		// restored to.
+		commitAll(t, d, "initial")
+		runGitIn(t, d, "checkout", "-b", "feat/y")
+
+		timelinePath := filepath.Join(d, "docs", "timeline.md")
+		headTimeline := readFileStr(t, timelinePath)
+
+		// Simulate a stray hook/manual regen dirtying the derived doc on the
+		// branch — this must never reach the commit.
+		if err := os.WriteFile(timelinePath, []byte("STALE BRANCH EDIT\n"), 0o644); err != nil {
+			t.Fatalf("dirty docs/timeline.md: %v", err)
+		}
+
+		withFakeTTY(t, false, func() {
+			f := &logFlags{stage: "all"}
+			var out, errBuf bytes.Buffer
+			if err := runLog(d, "Decide something", f, false, strings.NewReader(""), &out, &errBuf); err != nil {
+				t.Fatalf("runLog: %v\nstdout:\n%s\nstderr:\n%s", err, out.String(), errBuf.String())
+			}
+		})
+
+		// The commit must not carry the derived-doc edit.
+		names, _, err := gitcli.RunCaptured(d, "show", "--name-only", "--format=", "HEAD")
+		if err != nil {
+			t.Fatalf("git show --name-only HEAD: %v", err)
+		}
+		if strings.Contains(names, "docs/timeline.md") {
+			t.Fatalf("commit must NOT include docs/timeline.md on a branch (invariant); commit files:\n%s", names)
+		}
+
+		// And the working tree copy is back to committed (HEAD) content —
+		// which is also the pre-dirty content, since HEAD didn't move for
+		// this file.
+		head, ok := gitcli.ShowFile(d, "HEAD", "docs/timeline.md")
+		if !ok {
+			t.Fatalf("ShowFile HEAD:docs/timeline.md failed")
+		}
+		if head != headTimeline {
+			t.Fatalf("HEAD:docs/timeline.md changed unexpectedly; want original scaffold content")
+		}
+		if got := readFileStr(t, timelinePath); got != head {
+			t.Fatalf("working-tree docs/timeline.md must be restored to HEAD content; got %q want %q", got, head)
+		}
 	})
 }

--- a/internal/cli/pulse.go
+++ b/internal/cli/pulse.go
@@ -1,8 +1,8 @@
 // pulse.go — the v2.0.0 "pulse" feature: `logmind log` surfaces repo-health
 // advisories on STDERR after everything else has printed.
 //
-// Two independent, best-effort advisories, printed in this order (drift
-// before spec) when applicable:
+// Three independent, best-effort advisories, printed in this order (drift,
+// then spec, then main-decisions) when applicable:
 //
 //   - Drift pulse: any FILE-READ-ONLY doctor probe classified STALE (the
 //     drift class that flips doctor's Overall — stale hooks / stale
@@ -15,6 +15,13 @@
 //     uncommitted modifications, and at least specPulseThreshold decision
 //     entries postdate the spec's last git commit:
 //     `logmind: <spec-path> unchanged for <n> decisions — still accurate?`
+//
+//   - Main-decisions pulse (v2.0.0 derived-docs-on-main freshness layer): on a
+//     NON-default branch, the last-fetched origin/<default> remote-tracking
+//     ref carries one or more decision-touching commits (docs/decisions.md,
+//     docs/decisions-branches/, docs/decisions-archive.md) the branch does
+//     not yet have — see mainDecisionsPulseLine:
+//     `logmind: main has <n> new decision commit(s) — run 'logmind warp' to catch up`
 //
 // STDERR ONLY, unconditionally. This is deliberate and load-bearing:
 //
@@ -33,18 +40,25 @@
 // never writes there.
 //
 // HOT-PATH BUDGET: emitPulse runs on EVERY `logmind log`, so every probe it
-// calls transitively must be subprocess-free (file reads / stats only). The
-// drift pulse uses doctor.StaleCountFast specifically because doctor's full
-// probe set (doctor.StaleCount, used by `logmind doctor` itself) includes a
-// PATH lookup + a live `<binary> --version` subprocess — a hung or
-// daemonizing PATH binary can stall or hang that call outright. See
-// doctor.StaleCountFast's doc comment for the exact excluded-probe list.
+// calls transitively must stay fast and NETWORK-FREE. The drift and spec
+// pulses are subprocess-free (file reads / stats only). The drift pulse uses
+// doctor.StaleCountFast specifically because doctor's full probe set
+// (doctor.StaleCount, used by `logmind doctor` itself) includes a PATH
+// lookup + a live `<binary> --version` subprocess — a hung or daemonizing
+// PATH binary can stall or hang that call outright. See
+// doctor.StaleCountFast's doc comment for the exact excluded-probe list. The
+// main-decisions pulse is the one exception that shells out (`git
+// rev-list`), but ONLY against the local, already-fetched origin/<default>
+// ref — no `git fetch`, no `gh`, no HTTP anywhere in this file. Network
+// access is reserved for the explicit `logmind warp` command (warp.go).
 package cli
 
 import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/thrillmade/logmind/internal/config"
@@ -89,6 +103,9 @@ func emitPulse(cwd string, stderr io.Writer) {
 		fmt.Fprintln(stderr, line)
 	}
 	if line, ok := specPulseLine(cwd); ok {
+		fmt.Fprintln(stderr, line)
+	}
+	if line, ok := mainDecisionsPulseLine(cwd); ok {
 		fmt.Fprintln(stderr, line)
 	}
 }
@@ -201,6 +218,36 @@ func specPulseLine(cwd string) (string, bool) {
 		return "", false
 	}
 	return fmt.Sprintf("logmind: %s unchanged for %d decisions — still accurate?", relSpec, count), true
+}
+
+// mainDecisionsPulseLine reports the "main has advanced" freshness advisory:
+// on a NON-default branch, when the last-fetched origin/<default> carries
+// decision-touching commits the branch does not, nudge a catch-up. NETWORK-FREE:
+// reads the existing remote-tracking ref (no fetch), so the count is as of the
+// last warp/fetch. Best-effort: ("", false) on any error or missing origin ref —
+// this runs on every `logmind log`, so it must never fail or slow the hot path.
+func mainDecisionsPulseLine(cwd string) (string, bool) {
+	if !onNonDefaultBranch(cwd) {
+		return "", false
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		return "", false
+	}
+	out, _, err := gitcli.RunCaptured(cwd, "rev-list", "--count", "HEAD..origin/"+def, "--",
+		"docs/decisions.md", "docs/decisions-branches", "docs/decisions-archive.md")
+	if err != nil {
+		return "", false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil || n <= 0 {
+		return "", false
+	}
+	plural := "s"
+	if n == 1 {
+		plural = ""
+	}
+	return fmt.Sprintf("logmind: main has %d new decision commit%s — run 'logmind warp' to catch up", n, plural), true
 }
 
 // dateOnlyUTC reduces t to its calendar day (year/month/day) anchored at UTC

--- a/internal/cli/pulse_test.go
+++ b/internal/cli/pulse_test.go
@@ -1,5 +1,6 @@
 // pulse_test.go — exercises the v2.0.0 "pulse" feature: `logmind log`'s
-// stderr-only repo-health advisories (drift pulse + spec pulse, pulse.go).
+// stderr-only repo-health advisories (drift pulse + spec pulse + the
+// derived-docs-on-main main-decisions pulse, pulse.go).
 //
 // Coverage:
 //   - byte-exact §3.1 stdout contract holds even when a drift pulse fires
@@ -9,6 +10,10 @@
 //   - spec pulse: fires exactly at the specPulseThreshold boundary (19
 //     silent, 20 fires), with the correct count + path; stays silent when
 //     the spec is untracked or context.spec_file is unset
+//   - main-decisions pulse: fires with the correct singular/plural count on
+//     a stale feature branch, stays silent on the default branch, stays
+//     silent for a non-decision-touching origin advance, and is network-free
+//     (never auto-fetches — see the "no auto-fetch" case below)
 //   - ordering: drift pulse prints before spec pulse when both fire
 //   - --quiet: the single `ok ...` stdout contract holds; pulse still
 //     lands on stderr
@@ -530,5 +535,171 @@ func TestLog_Pulse_SpecLine_TimezoneStable(t *testing.T) {
 	// counted → below threshold → silent, in every zone.
 	t.Run("same_day_silent", func(t *testing.T) {
 		run(t, "2020-06-15", false, 0)
+	})
+}
+
+// --- v2.0.0 derived-docs-on-main: main-decisions pulse (mainDecisionsPulseLine) ---
+//
+// initClonePair / commitOn / runGitIn are shared with warp_test.go (same
+// package) — a real origin/repo clone pair is the natural fixture for
+// exercising a probe that compares HEAD against a remote-tracking ref.
+
+// TestMainDecisionsPulseLine_FiresOnStaleBranch: on a feature branch with a
+// pre-fetched origin/main carrying exactly one decision-touching commit the
+// branch lacks, the probe fires with the singular ("commit", not "commits")
+// exact message.
+func TestMainDecisionsPulseLine_FiresOnStaleBranch(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/decisions.md", "## decision one\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/p")
+
+	line, ok := mainDecisionsPulseLine(repo)
+	if !ok {
+		t.Fatal("expected the main-decisions pulse to fire")
+	}
+	want := "logmind: main has 1 new decision commit — run 'logmind warp' to catch up"
+	if line != want {
+		t.Fatalf("line = %q; want %q", line, want)
+	}
+}
+
+// TestMainDecisionsPulseLine_PluralCount: two decision-touching commits
+// ahead pluralizes ("commits").
+func TestMainDecisionsPulseLine_PluralCount(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/decisions.md", "## decision one\n")
+	commitOn(t, origin, "docs/decisions-branches/other.md", "## decision two\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/p2")
+
+	line, ok := mainDecisionsPulseLine(repo)
+	if !ok {
+		t.Fatal("expected the main-decisions pulse to fire")
+	}
+	want := "logmind: main has 2 new decision commits — run 'logmind warp' to catch up"
+	if line != want {
+		t.Fatalf("line = %q; want %q", line, want)
+	}
+}
+
+// TestMainDecisionsPulseLine_SilentOnDefaultBranch: the probe is gated by
+// onNonDefaultBranch — even with origin/main visibly ahead, staying on the
+// default branch (where L0/L1 don't apply and the docs regenerate locally)
+// must not fire.
+func TestMainDecisionsPulseLine_SilentOnDefaultBranch(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/decisions.md", "## decision one\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	// repo stays on its default branch ("main") — no checkout.
+
+	if _, ok := mainDecisionsPulseLine(repo); ok {
+		t.Fatal("main-decisions pulse must stay silent on the default branch")
+	}
+}
+
+// TestMainDecisionsPulseLine_NonDecisionCommit_Silent: origin advancing on an
+// unrelated path (not one of the three decision sources) must not fire —
+// the probe is scoped to decision-touching commits only, not "any commit".
+func TestMainDecisionsPulseLine_NonDecisionCommit_Silent(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "README.md", "unrelated change\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/p3")
+
+	if _, ok := mainDecisionsPulseLine(repo); ok {
+		t.Fatal("main-decisions pulse must stay silent when origin advanced on a non-decision path")
+	}
+}
+
+// TestMainDecisionsPulseLine_NetworkFree_NoAutoFetch: the probe must NEVER
+// fetch — it reads the local origin/<default> ref as of the last explicit
+// fetch/warp only. Advancing origin WITHOUT fetching in repo must leave the
+// probe silent (the stale local ref still matches HEAD).
+func TestMainDecisionsPulseLine_NetworkFree_NoAutoFetch(t *testing.T) {
+	origin, repo := initClonePair(t)
+	runGitIn(t, repo, "checkout", "-b", "feat/q")
+	// Advance origin AFTER the clone/checkout, WITHOUT ever fetching in repo.
+	commitOn(t, origin, "docs/decisions.md", "## decision one\n")
+
+	if _, ok := mainDecisionsPulseLine(repo); ok {
+		t.Fatal("main-decisions pulse must be network-free: it saw origin's new commit without an explicit fetch")
+	}
+}
+
+// initClonePairScaffolded builds a fully logmind-scaffolded origin
+// (docs/decisions.md, docs/timeline.md, .logmind/config.yml, ... via
+// `logmind init --no-git`) and a `git clone` of it. The plain initClonePair
+// (warp_test.go) only seeds docs/timeline.md, which is enough for warp but
+// not for a real `logmind log` invocation (TestLog_DocsMissingErrors shows
+// log refuses to run against an unscaffolded repo).
+func initClonePairScaffolded(t *testing.T) (origin, repo string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+	origin = t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	initLogTestGitRepo(t, origin)
+	if err := os.Chdir(origin); err != nil {
+		t.Fatalf("Chdir origin: %v", err)
+	}
+	scaffoldDocs(t)
+	if err := os.Chdir(origWD); err != nil {
+		t.Fatalf("Chdir back: %v", err)
+	}
+	commitAll(t, origin, "scaffold")
+
+	repo = filepath.Join(t.TempDir(), "repo")
+	cmd := exec.Command("git", "clone", "-q", origin, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %v\n%s", err, out)
+	}
+	runGitIn(t, repo, "config", "user.email", "test@example.com")
+	runGitIn(t, repo, "config", "user.name", "Test")
+	runGitIn(t, repo, "config", "commit.gpgsign", "false")
+	return origin, repo
+}
+
+// TestLog_Pulse_MainDecisionsLine_EndToEnd wires mainDecisionsPulseLine
+// through the real `logmind log` command on a stale feature branch: the
+// exact advisory string lands on stderr, positioned AFTER the drift/spec
+// pulses (none fire here, but the ordering is emitPulse's contract) and the
+// §3.1 stdout contract is untouched.
+func TestLog_Pulse_MainDecisionsLine_EndToEnd(t *testing.T) {
+	origin, repo := initClonePairScaffolded(t)
+	commitOn(t, origin, "docs/decisions.md", "## upstream decision\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/pulse-e2e")
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("Chdir repo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	withFakeTTY(t, false, func() {
+		root := NewRootCmd()
+		root.SetArgs([]string{"log", "branch decision", "-r", "why", "--no-push", "--no-interactive"})
+		var out, errBuf bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errBuf)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("log: %v\nstderr:\n%s", err, errBuf.String())
+		}
+		want := "logmind: main has 1 new decision commit — run 'logmind warp' to catch up"
+		if !strings.Contains(errBuf.String(), want) {
+			t.Fatalf("stderr missing the main-decisions pulse line; got %q", errBuf.String())
+		}
+		// The §3.1 stdout contract must stay untouched by the new probe.
+		if strings.Contains(out.String(), "logmind:") {
+			t.Fatalf("pulse output leaked onto stdout: %q", out.String())
+		}
 	})
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -81,6 +81,11 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newRepomapCmd())
 	root.AddCommand(newTreeCmd())
 	root.AddCommand(newRebaseCmd())
+	// v2.0.0 derived-docs-on-main: read-only refresh of docs/timeline.md +
+	// docs/file-structure.md from the default branch. Never stages/commits —
+	// committing main's newer blobs onto a branch would break the
+	// merge-base invariant the L1/L3 layers enforce.
+	root.AddCommand(newWarpCmd())
 	// B4: agent file templating subcommand tree.
 	root.AddCommand(newAgentsCmd())
 	// B5: skill authoring/validation/bench/audit/suggest tree.

--- a/internal/cli/warp.go
+++ b/internal/cli/warp.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
+
+func newWarpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "warp",
+		Short: "Refresh docs/timeline.md + docs/file-structure.md from main (read-only catch-up)",
+		Long: `Fetch the latest default branch and refresh your working copy of the two
+DERIVED docs (docs/timeline.md, docs/file-structure.md) so your context reflects
+main's current decisions.
+
+Read-only: warp NEVER stages or commits these files. They are regenerated on
+main only; a branch must keep them byte-identical to its merge-base with main so
+that merges never conflict. Your branch's own decisions live in
+docs/decisions-branches/<branch>.md (committed, per-branch, conflict-free).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runWarp(cwd, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+}
+
+func runWarp(cwd string, stdout, stderr io.Writer) error {
+	if !gitcli.IsRepo(cwd) {
+		fmt.Fprintln(stdout, "Not a git repo — nothing to warp.")
+		return nil
+	}
+	def := gitcli.DefaultBranch(cwd)
+	if def == "" {
+		def = "main"
+	}
+	if err := gitcli.Fetch(cwd, "origin", def); err != nil {
+		fmt.Fprintf(stderr, "warn: git fetch origin %s failed: %v (refreshing from last-known main)\n", def, err)
+	}
+	ref := "origin/" + def
+	refreshed := 0
+	for _, rel := range derivedDocPaths {
+		content, ok := gitcli.ShowFile(cwd, ref, rel)
+		if !ok {
+			continue
+		}
+		if err := writeAtomic(filepath.Join(cwd, rel), content); err != nil {
+			fmt.Fprintf(stderr, "warn: could not write %s: %v\n", rel, err)
+			continue
+		}
+		refreshed++
+	}
+	ahead := ""
+	if out, _, err := gitcli.RunCaptured(cwd, "rev-list", "--count", "HEAD.."+ref, "--",
+		"docs/decisions.md", "docs/decisions-branches", "docs/decisions-archive.md"); err == nil {
+		if n, e := strconv.Atoi(strings.TrimSpace(out)); e == nil && n > 0 {
+			ahead = fmt.Sprintf(" · main is +%d decision commit(s) ahead", n)
+		}
+	}
+	fmt.Fprintf(stdout, "ok warp: refreshed %d derived doc(s) from %s (read-only — not committed)%s\n", refreshed, ref, ahead)
+	return nil
+}

--- a/internal/cli/warp_test.go
+++ b/internal/cli/warp_test.go
@@ -1,0 +1,168 @@
+// warp_test.go — exercises `logmind warp`: the read-only refresh of the two
+// derived docs (docs/timeline.md, docs/file-structure.md) from the default
+// branch. Coverage:
+//
+//   - the refreshed working-tree copy matches origin/<default>'s content
+//   - the refresh is NEVER staged (git status stays clean for the path)
+//   - a non-repo cwd is a no-op, not an error
+package cli
+
+import (
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initClonePair builds a real origin/repo pair on the local filesystem: origin
+// is a normal (non-bare) working repo with an initial commit that seeds
+// docs/timeline.md, and repo is a `git clone` of it — so repo's "origin"
+// remote, tracking branch, and origin/HEAD symref are all set up exactly as
+// they would be for a real GitHub clone. A non-bare origin (rather than
+// gitcli_push_test.go's bareRemote) is deliberate: warp's test fixtures need
+// to commit new content directly onto origin's working tree between fetches.
+func initClonePair(t *testing.T) (origin, repo string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+
+	origin = t.TempDir()
+	initLogTestGitRepo(t, origin)
+	mustWriteUnder(t, origin, "docs/timeline.md", "ORIGIN-INITIAL\n")
+	commitAll(t, origin, "init")
+
+	repo = filepath.Join(t.TempDir(), "repo")
+	cmd := exec.Command("git", "clone", "-q", origin, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %v\n%s", err, out)
+	}
+	runGitIn(t, repo, "config", "user.email", "test@example.com")
+	runGitIn(t, repo, "config", "user.name", "Test")
+	runGitIn(t, repo, "config", "commit.gpgsign", "false")
+	return origin, repo
+}
+
+// commitOn writes content to relPath under dir and commits it — used to
+// simulate main advancing on origin between a repo's clone and its next warp.
+func commitOn(t *testing.T, dir, relPath, content string) {
+	t.Helper()
+	mustWriteUnder(t, dir, relPath, content)
+	commitAll(t, dir, "advance "+relPath)
+}
+
+// isStaged reports whether relPath has any staged (index vs HEAD) change —
+// used to assert warp never adds the refreshed docs to the index.
+func isStaged(t *testing.T, dir, relPath string) bool {
+	t.Helper()
+	out := runGitOut(t, dir, "diff", "--cached", "--name-only")
+	for _, line := range strings.Split(out, "\n") {
+		if line == relPath {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWarp_RefreshesFromOriginUncommitted(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/timeline.md", "MAIN-FRESH\n")
+	runGitIn(t, repo, "fetch", "origin", "main") // pre-fetch so ShowFile sees it
+	runGitIn(t, repo, "checkout", "-b", "feat/w")
+
+	if err := runWarp(repo, io.Discard, io.Discard); err != nil {
+		t.Fatalf("warp: %v", err)
+	}
+	if readFileStr(t, filepath.Join(repo, "docs", "timeline.md")) != "MAIN-FRESH\n" {
+		t.Fatal("warp must refresh the working copy from origin/main")
+	}
+	if isStaged(t, repo, "docs/timeline.md") {
+		t.Fatal("warp must NOT stage the refreshed docs")
+	}
+}
+
+// TestWarp_DoesNotCommit: beyond not staging, warp must leave HEAD untouched
+// — no new commit appears after a refresh.
+func TestWarp_DoesNotCommit(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/timeline.md", "MAIN-FRESH-2\n")
+	runGitIn(t, repo, "fetch", "origin", "main")
+	runGitIn(t, repo, "checkout", "-b", "feat/w2")
+
+	before := runGitOut(t, repo, "rev-parse", "HEAD")
+
+	if err := runWarp(repo, io.Discard, io.Discard); err != nil {
+		t.Fatalf("warp: %v", err)
+	}
+
+	after := runGitOut(t, repo, "rev-parse", "HEAD")
+	if before != after {
+		t.Fatalf("warp must not create a commit: HEAD moved from %q to %q", before, after)
+	}
+	// The working tree overall must still report the doc as modified
+	// (unstaged) relative to HEAD, since HEAD did not move.
+	status := runGitOut(t, repo, "status", "--porcelain", "--", "docs/timeline.md")
+	if !strings.HasPrefix(status, " M") {
+		t.Fatalf("expected docs/timeline.md to show as an unstaged modification; got %q", status)
+	}
+}
+
+// TestWarp_FetchesFromOrigin: unlike a pre-fetch-only refresh, runWarp itself
+// performs the `git fetch origin <default>` — so calling it WITHOUT a manual
+// fetch first still picks up content committed on origin after the clone.
+func TestWarp_FetchesFromOrigin(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/timeline.md", "MAIN-VIA-WARP-FETCH\n")
+	runGitIn(t, repo, "checkout", "-b", "feat/w3")
+	// Deliberately NOT fetching manually — runWarp must do it.
+
+	if err := runWarp(repo, io.Discard, io.Discard); err != nil {
+		t.Fatalf("warp: %v", err)
+	}
+	if readFileStr(t, filepath.Join(repo, "docs", "timeline.md")) != "MAIN-VIA-WARP-FETCH\n" {
+		t.Fatal("warp must fetch origin itself, not rely on a pre-existing fetch")
+	}
+}
+
+// TestWarp_NonRepo_NoOpNoError: running warp outside a git repo prints a
+// notice and returns nil rather than erroring.
+func TestWarp_NonRepo_NoOpNoError(t *testing.T) {
+	dir := t.TempDir()
+	var out strings.Builder
+	if err := runWarp(dir, &out, io.Discard); err != nil {
+		t.Fatalf("runWarp outside a repo should not error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Not a git repo") {
+		t.Fatalf("expected a not-a-repo notice; got %q", out.String())
+	}
+}
+
+// TestWarp_ReportsDecisionCommitsAhead: the stdout summary reports how many
+// decision-touching commits origin/<default> is ahead of HEAD.
+func TestWarp_ReportsDecisionCommitsAhead(t *testing.T) {
+	origin, repo := initClonePair(t)
+	commitOn(t, origin, "docs/decisions.md", "## decision\n")
+	runGitIn(t, repo, "checkout", "-b", "feat/w4")
+
+	var out strings.Builder
+	if err := runWarp(repo, &out, io.Discard); err != nil {
+		t.Fatalf("warp: %v", err)
+	}
+	if !strings.Contains(out.String(), "decision commit(s) ahead") {
+		t.Fatalf("expected the ahead-count summary in stdout; got %q", out.String())
+	}
+}
+
+// TestWarp_HelpRegistered smoke-tests that `logmind warp` is wired into the
+// root command tree.
+func TestWarp_HelpRegistered(t *testing.T) {
+	root := NewRootCmd()
+	cmd, _, err := root.Find([]string{"warp"})
+	if err != nil {
+		t.Fatalf("warp not registered on root: %v", err)
+	}
+	if cmd.Use != "warp" {
+		t.Fatalf("unexpected command found: %q", cmd.Use)
+	}
+}

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -558,6 +558,50 @@ func RunCaptured(repoRoot string, args ...string) (stdout, stderr string, err er
 	return so.String(), se.String(), err
 }
 
+// MergeBase returns the merge-base commit SHA of ref and HEAD. Best-effort:
+// ("", false) on any error (ref missing, no common ancestor, not a repo).
+func MergeBase(repoRoot, ref string) (string, bool) {
+	out, _, err := RunCaptured(repoRoot, "merge-base", ref, "HEAD")
+	if err != nil {
+		return "", false
+	}
+	sha := strings.TrimSpace(out)
+	return sha, sha != ""
+}
+
+// Fetch runs `git fetch <remote> <ref>` (a NETWORK call). Used only by explicit
+// commands (logmind warp) — never the `logmind log` hot path.
+func Fetch(repoRoot, remote, ref string) error {
+	_, _, err := RunCaptured(repoRoot, "fetch", remote, ref)
+	return err
+}
+
+// ShowFile returns the content of path at ref (`git show <ref>:<path>`).
+// ("", false) if the path does not exist at ref or on any error.
+func ShowFile(repoRoot, ref, path string) (string, bool) {
+	out, _, err := RunCaptured(repoRoot, "show", ref+":"+path)
+	if err != nil {
+		return "", false
+	}
+	return out, true
+}
+
+// RestorePathsToHead restores each path to its committed (HEAD) content in BOTH
+// the index and the working tree (`git checkout HEAD -- <path>`), discarding any
+// staged or unstaged change. Per-path and best-effort: a path untracked at HEAD
+// errors for that path only and is skipped; the first error (if any) is returned
+// for logging but callers generally ignore it (the derived docs are purely
+// generated, so a failed restore just leaves the pre-existing state).
+func RestorePathsToHead(repoRoot string, paths ...string) error {
+	var firstErr error
+	for _, p := range paths {
+		if _, _, err := RunCaptured(repoRoot, "checkout", "HEAD", "--", p); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // AddPaths runs `git add <path>...` against repoRoot. Returns a
 // non-nil error only when git itself fails — callers wrap it in
 // best-effort logic where appropriate (e.g., installer hooks).

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -357,5 +358,66 @@ func TestTopLevel_FalseOutsideRepo(t *testing.T) {
 	dir := t.TempDir()
 	if top, ok := TopLevel(dir); ok || top != "" {
 		t.Fatalf("TopLevel(%q) = (%q, %v); want (\"\", false)", dir, top, ok)
+	}
+}
+
+// TestRestorePathsToHead_RevertsBranchEdit: RestorePathsToHead discards an
+// unstaged edit and puts the working-tree copy back to HEAD's content — the
+// primitive the L1 zero-conflict guard relies on.
+func TestRestorePathsToHead_RevertsBranchEdit(t *testing.T) {
+	repo := initRepo(t) // git init + committed README.md
+	writeAndCommit(t, repo, "a.txt", "v1", "add a.txt")
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("v2-edited"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := RestorePathsToHead(repo, "a.txt"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(repo, "a.txt"))
+	if err != nil {
+		t.Fatalf("read a.txt: %v", err)
+	}
+	if string(got) != "v1" {
+		t.Fatalf("want restored v1, got %q", string(got))
+	}
+}
+
+// TestShowFile_ReadsRefContent: ShowFile reads a path's content at a ref
+// without touching the working tree, and reports ok=false for a path that
+// does not exist at that ref.
+func TestShowFile_ReadsRefContent(t *testing.T) {
+	repo := initRepo(t)
+	writeAndCommit(t, repo, "a.txt", "v1", "add a.txt")
+	got, ok := ShowFile(repo, "HEAD", "a.txt")
+	if !ok || got != "v1" {
+		t.Fatalf("ShowFile HEAD:a.txt = %q,%v want v1,true", got, ok)
+	}
+	if _, ok := ShowFile(repo, "HEAD", "missing.txt"); ok {
+		t.Fatal("ShowFile of missing path should be false")
+	}
+}
+
+// TestMergeBase_ReturnsCommonAncestor: MergeBase(repo, mainSha) resolves to a
+// non-empty SHA when ref and HEAD share history — the primitive `warp` and the
+// pulse main-compare probe both build on.
+func TestMergeBase_ReturnsCommonAncestor(t *testing.T) {
+	repo := initRepo(t)
+	mainSha := strings.TrimSpace(revParse(t, repo, "HEAD"))
+	writeAndCommit(t, repo, "a.txt", "v1", "add a.txt")
+	got, ok := MergeBase(repo, mainSha)
+	if !ok || got == "" {
+		t.Fatalf("MergeBase(repo, %q) = (%q, %v); want a non-empty SHA", mainSha, got, ok)
+	}
+	if got != mainSha {
+		t.Fatalf("MergeBase = %q; want %q (mainSha is an ancestor of HEAD)", got, mainSha)
+	}
+}
+
+// TestMergeBase_FalseOnUnknownRef: an unresolvable ref is best-effort
+// ("", false), not an error the caller must special-case.
+func TestMergeBase_FalseOnUnknownRef(t *testing.T) {
+	repo := initRepo(t)
+	if got, ok := MergeBase(repo, "does-not-exist"); ok || got != "" {
+		t.Fatalf("MergeBase(unknown ref) = (%q, %v); want (\"\", false)", got, ok)
 	}
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -163,6 +163,12 @@ func BuildPostMergeBody() string {
 		"  # in place; strip it so the bare-name comparison below works.\n" +
 		"  default=${default#origin/}\n" +
 		"  [ -z \"$default\" ] && default=main\n" +
+		"  if [ -n \"$current\" ] && [ \"$current\" != \"$default\" ]; then\n" +
+		"    # v2.0.0 derived-docs-on-main: never regenerate on a non-default branch —\n" +
+		"    # the branch must keep the derived docs byte-identical to its main\n" +
+		"    # merge-base (the zero-conflict invariant). main regenerates post-merge.\n" +
+		"    exit 0\n" +
+		"  fi\n" +
 		"  if [ -n \"$current\" ] && [ \"$current\" = \"$default\" ]; then\n" +
 		"    head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n" +
 		"    origin_sha=$(git rev-parse \"origin/$default\" 2>/dev/null || true)\n" +
@@ -202,11 +208,15 @@ func BuildPostRewriteBody() string {
 		"# v0.6.10: hook-version marker embedded above for doctor drift detection.\n" +
 		"\n" +
 		"if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then\n" +
-		"  if [ -d docs ]; then\n" +
+		"  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)\n" +
+		"  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)\n" +
+		"  default=${default#origin/}\n" +
+		"  [ -z \"$default\" ] && default=main\n" +
+		"  # v2.0.0: regenerate only on the default branch (invariant: branches never\n" +
+		"  # edit the derived docs). A rebase/amend on a feature branch leaves them as-is.\n" +
+		"  if [ -n \"$current\" ] && [ \"$current\" = \"$default\" ] && [ -d docs ]; then\n" +
 		"    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true\n" +
 		"    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true\n" +
-		"    # Stage the regens if they changed anything; user can `git commit --amend`\n" +
-		"    # or include in their next commit.\n" +
 		"    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true\n" +
 		"  fi\n" +
 		"fi\n"

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -110,6 +110,68 @@ func TestPostMergeBody_RollupInvariants(t *testing.T) {
 	}
 }
 
+// TestPostRewriteHook_NoRegenOnFeatureBranch pins the v2.0.0 derived-docs-on-main
+// invariant for the post-rewrite hook: a rebase/amend regenerates (and
+// `git add`s) docs/timeline.md + docs/file-structure.md ONLY on the default
+// branch. On a feature branch (current != default) the hook must leave the
+// derived docs untouched, so the branch stays byte-identical to its main
+// merge-base and merges never conflict.
+//
+// Approach: the hooks package has no in-test helper to install + fire a real
+// post-rewrite hook (the initRepoWithLogmind / installHooks / isStagedOrDirty
+// helpers the plan sketches live in internal/cli), and the task forbids
+// inventing duplicates — so this asserts on the BODY STRING instead. It proves
+// the gate structurally: the body detects current/default and every regen+add
+// action sits INSIDE the `[ "$current" = "$default" ]` guard (appears exactly
+// once, only after the guard opens), so a feature-branch rewrite can never
+// reach it.
+func TestPostRewriteHook_NoRegenOnFeatureBranch(t *testing.T) {
+	body := BuildPostRewriteBody()
+
+	// The branch-detection the default-branch guard depends on (mirrors
+	// post-merge).
+	for _, must := range []string{
+		`current=$(git rev-parse --abbrev-ref HEAD`,
+		`default=$(git symbolic-ref --short refs/remotes/origin/HEAD`,
+		`default=${default#origin/}`,
+	} {
+		if !strings.Contains(body, must) {
+			t.Errorf("post-rewrite body missing branch detection %q", must)
+		}
+	}
+
+	// The default-branch guard itself must be present — pinned in FULL,
+	// including the trailing `&& [ -d docs ]; then`. Pinning the whole guard
+	// line (not just the `= "$default"` prefix) is what catches an operator
+	// bug: `A && B || [ -d docs ]` parses as `(A && B) || [ -d docs ]`, which
+	// is true on ANY branch whenever docs/ exists — silently defeating the
+	// gate. That substitution breaks this substring match, so it can't pass.
+	const guard = `if [ -n "$current" ] && [ "$current" = "$default" ] && [ -d docs ]; then`
+	gi := strings.Index(body, guard)
+	if gi < 0 {
+		t.Fatalf("post-rewrite body missing the default-branch guard %q", guard)
+	}
+
+	// Every regen / stage action must appear EXACTLY ONCE and ONLY AFTER the
+	// guard opens — i.e. it is gated by `current == default`, so a
+	// feature-branch rewrite (current != default) never regenerates or stages
+	// the derived docs. An action appearing before the guard, or twice, would
+	// mean an ungated regen path — the invariant violation this pins against.
+	for _, action := range []string{
+		"logmind timeline --write docs/timeline.md",
+		"logmind file-structure --write docs/file-structure.md",
+		"git add docs/timeline.md docs/file-structure.md",
+	} {
+		if n := strings.Count(body, action); n != 1 {
+			t.Errorf("action %q appears %d time(s); want exactly 1 (only inside the guard)", action, n)
+			continue
+		}
+		if strings.Index(body, action) < gi {
+			t.Errorf("action %q appears BEFORE the default-branch guard — it would run on a feature branch (invariant violation)", action)
+		}
+	}
+}
+
 // TestPostMergeBody_ByteIdenticalToPython is THE parity contract for
 // wave B2. It shells to the Python interpreter (skipping the test if
 // Python or the src/logmind package isn't importable), captures

--- a/internal/hooks/testdata/post-merge.golden
+++ b/internal/hooks/testdata/post-merge.golden
@@ -61,6 +61,12 @@ if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
   # in place; strip it so the bare-name comparison below works.
   default=${default#origin/}
   [ -z "$default" ] && default=main
+  if [ -n "$current" ] && [ "$current" != "$default" ]; then
+    # v2.0.0 derived-docs-on-main: never regenerate on a non-default branch —
+    # the branch must keep the derived docs byte-identical to its main
+    # merge-base (the zero-conflict invariant). main regenerates post-merge.
+    exit 0
+  fi
   if [ -n "$current" ] && [ "$current" = "$default" ]; then
     head_sha=$(git rev-parse HEAD 2>/dev/null || true)
     origin_sha=$(git rev-parse "origin/$default" 2>/dev/null || true)

--- a/internal/hooks/testdata/post-rewrite.golden
+++ b/internal/hooks/testdata/post-rewrite.golden
@@ -19,11 +19,15 @@
 # v0.6.10: hook-version marker embedded above for doctor drift detection.
 
 if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
-  if [ -d docs ]; then
+  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  default=${default#origin/}
+  [ -z "$default" ] && default=main
+  # v2.0.0: regenerate only on the default branch (invariant: branches never
+  # edit the derived docs). A rebase/amend on a feature branch leaves them as-is.
+  if [ -n "$current" ] && [ "$current" = "$default" ] && [ -d docs ]; then
     logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
     logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
-    # Stage the regens if they changed anything; user can `git commit --amend`
-    # or include in their next commit.
     git add docs/timeline.md docs/file-structure.md 2>/dev/null || true
   fi
 fi

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,123 +1,76 @@
-# logmind-template-version: v7
+# logmind-template-version: v8
 name: logmind / check-derived-docs
 
-# Self-healing derived-doc gate (v5 — advisory model).
-#
-# docs/timeline.md + docs/file-structure.md are DERIVED artifacts,
-# deterministically regenerated from sources (per-branch decision logs +
-# decisions.md + archive for the timeline; the project tree for
-# file-structure). This gate keeps them current WITHOUT ever blocking a PR:
-#
-#   * PAT path (preferred). When `LOGMIND_AUTO_REGEN_PAT` is configured and
-#     the PR is from the same repo, stale docs are regenerated, committed
-#     (`[skip-logmind]`) and pushed back to the PR head. A PAT-pushed commit
-#     re-triggers required checks, so the merge gate stays healthy.
-#
-#   * Advisory path (default — no PAT, or a fork PR). Stale docs are
-#     regenerated in the job, a `::warning::` is emitted, and the job
-#     EXITS 0. It never red-lights the PR. Reconciliation happens on merge
-#     (the post-merge hook regenerates on the default branch).
-#
-# It NEVER pushes with the default GITHUB_TOKEN. A GITHUB_TOKEN-authored
-# push moves the PR head SHA but does NOT re-trigger workflows (GitHub's
-# anti-recursion rule), which would strand every required status check on
-# the new head ("Expected — Waiting for status to be reported…") and make
-# the PR permanently unmergeable. The workflow token is therefore kept at
-# `contents: read`; only the optional PAT pushes, and only at push time
-# (it is never persisted into .git, so it is not exposed to build steps).
-#
-# The job always runs (no actor filter). Filtering a required check out for
-# bot/fork PRs would itself strand it as "Expected — Waiting…"; bots and
-# forks simply take the advisory path.
-#
-# v7 — the `thrillmade/setup-logmind@…` step now passes `token:
-# ${{ github.token }}`. Composite actions can't default an input to
-# `github.token`; without it, setup-logmind's release-lookup call is
-# anonymous, and shared GitHub-hosted-runner IP ranges routinely blow
-# through the 60-req/hour unauthenticated api.github.com budget, 403ing
-# before logmind is even installed (setup-logmind#4).
-#
-# Setup for the PAT (auto-push) path:
-#   1. Create a fine-grained PAT scoped to THIS repo (not org-wide, to bound
-#      blast radius) with Contents: write.
-#   2. Add it as `LOGMIND_AUTO_REGEN_PAT` under
-#      Settings → Secrets and variables → Actions.
+# v2.0.0 derived-docs-on-main. The two derived docs are regenerated ONLY here on
+# main. On a PR this gate is NON-mutating and BLOCKING: it fails if the branch
+# edited either derived doc (which would cause cross-PR merge conflicts). A
+# branch's real decisions live in docs/decisions-branches/<branch>.md; timeline
+# and file-structure regenerate on main after merge.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 permissions:
-  contents: read        # GITHUB_TOKEN stays read-only; the optional PAT does any push
+  contents: write        # regen-on-main commits + pushes the regen to main
+  pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
+  # NOTE: specifying ANY permission zeroes all others (GitHub default), so
+  # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
+  # the gate fails-closed on EVERY PR, not just violators.
 
 jobs:
   check-derived-docs:
     name: check-derived-docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the branch did not edit the derived docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
+          if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|file-structure)\.md'; then
+            echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md and/or docs/file-structure.md. These are DERIVED, main-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to main's version — run 'logmind warp', or 'git checkout origin/main -- docs/timeline.md docs/file-structure.md' — then commit. Their real content regenerates on main after merge."
+            exit 1
+          fi
+          echo "Branch did not edit the derived docs — the merge cannot conflict on them."
+
+  regen-on-main:
+    name: regen-on-main
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          # Check out the PR head. `repository:` is REQUIRED so fork PRs work:
-          # a fork's head_ref does not exist on the base repo, so without it
-          # checkout fails and the gate would block every fork PR. Read-only;
-          # persist-credentials:false keeps any token out of .git during the
-          # regeneration step (the PAT is supplied only at push time below).
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
           persist-credentials: false
-
       - uses: thrillmade/setup-logmind@v1.0.0
         with:
           token: ${{ github.token }}
-
       - name: Regenerate derived docs
         run: |
           set -euo pipefail
           logmind timeline --write docs/timeline.md
           logmind file-structure --write docs/file-structure.md
-
-      - name: Self-heal (PAT) or advise
+      - name: Commit + push if changed
         env:
           PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-
-          # Stale = any change in the derived docs, INCLUDING an untracked or
-          # missing file (a plain `git diff` would miss those).
           if [ -z "$(git status --porcelain -- docs/timeline.md docs/file-structure.md)" ]; then
-            echo "docs/timeline.md + docs/file-structure.md are up to date."
+            echo "Derived docs already current on main."
             exit 0
           fi
-
-          echo "Derived docs were stale on this PR."
-
-          is_fork="false"
-          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            is_fork="true"
-          fi
-
-          # PAT auto-push path: same-repo PR + PAT configured. The PAT is used
-          # ONLY here (an explicit credentialed URL, never persisted), and a
-          # PAT push re-triggers downstream required checks.
-          if [ -n "${PAT:-}" ] && [ "$is_fork" = "false" ]; then
-            echo "::notice title=Auto-fixing derived docs::Regenerating and pushing to ${HEAD_REF}."
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/timeline.md docs/file-structure.md
-            git commit -m "[skip-logmind] chore: regen derived docs"
-            if ! git push "https://x-access-token:${PAT}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"; then
-              echo "::warning::Could not push the regen (push race or protected head ref); it reconciles on merge or the next run."
-            fi
-            echo "::notice::Derived docs regenerated."
+          if [ -z "${PAT:-}" ]; then
+            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap.)"
             exit 0
           fi
-
-          # Advisory path: no PAT, or a fork PR. Warn, never block.
-          echo "::warning title=Derived docs stale (advisory — does not block)::docs/timeline.md or docs/file-structure.md is out of date on this PR. This is ADVISORY and does not fail the check; the post-merge hook reconciles it on the default branch. To update now, run \`logmind timeline --write docs/timeline.md && logmind file-structure --write docs/file-structure.md\` locally and commit, or configure a LOGMIND_AUTO_REGEN_PAT secret for automatic push-back."
-          git add -N -- docs/timeline.md docs/file-structure.md 2>/dev/null || true
-          git --no-pager diff -- docs/timeline.md docs/file-structure.md | head -80 || true
-          exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/timeline.md docs/file-structure.md
+          git commit -m "[skip-logmind] chore: regen derived docs"
+          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -236,64 +236,70 @@ func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
 	}
 }
 
-// TestRegenTimelineTemplate_V7_Advisory pins the Slice-1 de-friction
-// contract: the derived-doc gate must NEVER hard-block a PR and must NEVER
-// push with the default GITHUB_TOKEN (a GITHUB_TOKEN push moves the PR head
-// SHA without re-triggering checks, stranding every required check). On
-// stale docs it either pushes via LOGMIND_AUTO_REGEN_PAT (which re-triggers
-// checks) or emits an advisory ::warning:: and exits 0.
-func TestRegenTimelineTemplate_V7_Advisory(t *testing.T) {
+// TestRegenTimelineTemplate_V8_BlockingGate pins the v2.0.0
+// derived-docs-on-main contract (replaces the Slice-1 advisory model): on a
+// PR the `check-derived-docs` job is NON-mutating and BLOCKING — it fails
+// (exit 1) if the branch edited docs/timeline.md or docs/file-structure.md,
+// because those are derived, main-only artifacts and a branch edit is exactly
+// what causes cross-PR merge conflicts. Regeneration moves to a SEPARATE
+// main-only `regen-on-main` job. The required-check NAME stays
+// `check-derived-docs` so branch-protection rulesets keep matching.
+func TestRegenTimelineTemplate_V8_BlockingGate(t *testing.T) {
 	body := Workflow("regen-timeline.yml.template")
 
-	// Marker bump v6 → v7 (setup-logmind#4: added `token: ${{ github.token }}`).
-	if !strings.Contains(body, "# logmind-template-version: v7") {
-		t.Errorf("regen-timeline template missing v7 marker")
+	// Marker bump v7 → v8 (advisory model → blocking gate + main-only regen).
+	if !strings.Contains(body, "# logmind-template-version: v8") {
+		t.Errorf("regen-timeline template missing v8 marker")
 	}
-	// Advisory, never fail-fast: no literal `exit 1`. Staleness must not
-	// red-light the PR (a real tool crash still fails the job via `set -e`).
-	if strings.Contains(body, "exit 1") {
-		t.Errorf("regen-timeline v7 must not `exit 1` — the gate is advisory and must never block a PR")
+	// The required-check name MUST stay check-derived-docs (ruleset matching),
+	// and the main regen is a distinct job.
+	if !strings.Contains(body, "check-derived-docs") {
+		t.Errorf("regen-timeline v8 must keep the check-derived-docs job name (ruleset matching)")
 	}
-	// The no-PAT / fork path must warn and pass.
-	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
-		t.Errorf("regen-timeline v7 missing the advisory warn + exit 0 path")
+	if !strings.Contains(body, "regen-on-main") {
+		t.Errorf("regen-timeline v8 missing the separate regen-on-main job")
 	}
-	// The PAT auto-push path is retained (the only path that pushes).
-	if !strings.Contains(body, "LOGMIND_AUTO_REGEN_PAT") {
-		t.Errorf("regen-timeline v7 missing the LOGMIND_AUTO_REGEN_PAT auto-push path")
+	// The PR gate BLOCKS: a branch edit to a derived doc must `exit 1`. This is
+	// the exact inversion of the old advisory contract and the structural
+	// guarantee that a derived-doc conflict can never merge.
+	if !strings.Contains(body, "exit 1") {
+		t.Errorf("regen-timeline v8 PR gate must `exit 1` on a derived-doc edit (blocking)")
 	}
-	// Regen commits carry the [skip-logmind] convention (SPEC §5.1/§5.2).
+	// The gate detects the edit via the PR's own file list (GitHub's 3-dot
+	// diff = branch-vs-merge-base, fork-correct) and matches ONLY the two
+	// derived docs as whole lines.
+	if !strings.Contains(body, "gh pr diff") || !strings.Contains(body, "--name-only") {
+		t.Errorf("regen-timeline v8 PR gate must use `gh pr diff --name-only`")
+	}
+	if !strings.Contains(body, `grep -qxE 'docs/(timeline|file-structure)\.md'`) {
+		t.Errorf("regen-timeline v8 PR gate must match exactly the two derived docs as whole lines")
+	}
+	// Event-gated jobs: gate runs only on pull_request, regen only on push.
+	if !strings.Contains(body, "github.event_name == 'pull_request'") ||
+		!strings.Contains(body, "github.event_name == 'push'") {
+		t.Errorf("regen-timeline v8 must event-gate the two jobs (pull_request gate / push regen)")
+	}
+	// The main regen commit carries the [skip-logmind] convention and pushes
+	// via the explicit PAT URL (never a persisted/GITHUB_TOKEN credential).
 	if !strings.Contains(body, "[skip-logmind]") {
-		t.Errorf("regen-timeline v7 PAT-push commit missing the [skip-logmind] prefix")
-	}
-	// The job must NOT filter itself out by actor: a filtered required check
-	// strands as "Expected — Waiting…". Bots/forks take the advisory path.
-	if strings.Contains(body, "github.actor != ") {
-		t.Errorf("regen-timeline v7 must not filter the job by actor (a filtered required check hangs forever)")
-	}
-	// Fork PRs must reach the advisory path, not die at checkout: the
-	// checkout MUST set `repository:` to the PR head repo (a fork's head_ref
-	// does not exist on the base repo, so checkout would otherwise fail red).
-	if !strings.Contains(body, "repository: ${{ github.event.pull_request.head.repo.full_name") {
-		t.Errorf("regen-timeline v7 checkout must set repository to the PR head repo (else fork PRs fail at checkout)")
-	}
-	// The advisory diff display MUST be SIGPIPE/pipefail-guarded: a large
-	// stale diff piped into `head` exits 141 under `set -euo pipefail` and
-	// would abort the job before `exit 0` — re-blocking on big diffs.
-	if !strings.Contains(body, "| head -80 || true") {
-		t.Errorf("regen-timeline v7 advisory diff must be `|| true`-guarded against SIGPIPE/pipefail")
-	}
-	// GITHUB_TOKEN must never push: the workflow token stays read-only and
-	// the push (if any) uses the explicit PAT-credentialed URL.
-	if !strings.Contains(body, "contents: read") {
-		t.Errorf("regen-timeline v7 must keep the workflow token read-only (contents: read)")
+		t.Errorf("regen-timeline v8 main regen commit missing the [skip-logmind] prefix")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("regen-timeline v7 PAT push must use the explicit PAT URL, not a persisted/GITHUB_TOKEN credential")
+		t.Errorf("regen-timeline v8 main push must use the explicit PAT URL")
 	}
-	// The PAT/token must not be persisted into .git during regeneration/build.
 	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("regen-timeline v7 checkout must set persist-credentials: false")
+		t.Errorf("regen-timeline v8 regen-on-main checkout must set persist-credentials: false")
+	}
+	// The PR gate reads the PR file list via `gh pr diff`, which needs
+	// pull-requests:read. Because specifying ANY permission zeroes the rest,
+	// this MUST be explicit or the gate 403s and fails-closed on every PR.
+	if !strings.Contains(body, "pull-requests: read") {
+		t.Errorf("regen-timeline v8 must grant pull-requests: read (else gh pr diff 403s and blocks every PR)")
+	}
+	// No-PAT is a freshness-only gap, not a failure: warn + exit 0 (never blocks
+	// the push event; the invariant guarantee lives in the PR gate, not here).
+	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
+		t.Errorf("regen-timeline v8 regen-on-main must warn + exit 0 when no PAT (freshness-only)")
 	}
 }
 


### PR DESCRIPTION
## The headline v2.0.0 feature: a derived-doc merge conflict becomes structurally impossible to merge.

`docs/timeline.md` and `docs/file-structure.md` are purely derived (functions of the decision files / repo tree). This PR enforces one invariant — **on any non-default branch those two docs stay byte-identical to their merge-base with main** — so git's own 3-way merge is conflict-free on them. No merge-driver dependency (GitHub can't run ours), no luck.

### The layers
- **L0** (`internal/hooks`): post-merge + post-rewrite hooks regenerate the derived docs on the **default branch only** — a rebase/amend on a feature branch no longer diverges them.
- **L1** (`internal/cli/log.go`): `logmind log` restores the two docs to HEAD before staging on a non-default branch — even a stray regen can't be swept into a branch commit. Lossless (they regenerate from the committed decision files).
- **L3** (`.github/workflows/regen-timeline.yml` + fleet template, v7→v8): `check-derived-docs` becomes a **blocking** PR gate (`gh pr diff --name-only` — the fork-correct branch-vs-merge-base delta — blocks any PR that edits a derived doc). Regeneration moves to a **main-only** job. Job name kept for ruleset matching.
- **Freshness (read-only, never commits):** new `logmind warp` (fetch + refresh the working copy from main), a 3rd pulse probe (`main has N new decision commit(s) — run 'logmind warp'`), and `logmind context` renders the last-fetched main copy.

### Proof
- Headline integration test: two concurrent branches each `logmind log` a decision + both merge into main with **zero conflict** on the derived docs (L1 verified load-bearing).
- Full `go test ./...` green; per-task adversarial panels + a capstone review.

### ⚠ Deploy requirement (the linchpin)
The structural guarantee holds at the merge boundary via L3 — which means **`check-derived-docs` must be a REQUIRED status check on a branch-protected `main`** in every repo. This is a hard line-item for the v2.0.0 migration rollout.

### Not in this PR (coordinated separately)
Protocol SPEC §0.4 sync-invariant reword and the agent-skills "staying current" note are drafted and co-tag with spec-v1.6.0 / the skill wave (draft-then-tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)