### PR TITLE
fix(ci): regen-on-main pushes as the steward App and degrades instead of failing

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -58,21 +58,46 @@ jobs:
           set -euo pipefail
           ./bin/logmind timeline --write docs/timeline.md
           ./bin/logmind file-structure --write docs/file-structure.md
+      # Mint a 1-hour installation token for the `skdd-steward[bot]` App
+      # (org secrets keep their legacy THRILLMADE_ORCHESTRATOR_* names). This
+      # identity — NOT a PAT — is the one carrying ruleset bypass, which the
+      # push below REQUIRES: `main` is governed by a "changes must be made
+      # through a pull request" rule, so a plain credentialed push is rejected
+      # with GH013 no matter how much repo scope the token has.
+      # See docs/orchestrator-app.md for the App spec + rotation.
+      - name: Mint steward App installation token
+        id: app_token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
+          private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}
+          owner: thrillmade
+          repositories: logmind
+
       - name: Commit + push if changed
         env:
-          PAT: ${{ secrets.LOGMIND_AUTO_REGEN_PAT }}
+          STEWARD_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -z "$(git status --porcelain -- docs/timeline.md docs/file-structure.md)" ]; then
             echo "Derived docs already current on main."
             exit 0
           fi
-          if [ -z "${PAT:-}" ]; then
-            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap.)"
+          if [ -z "${STEWARD_TOKEN:-}" ]; then
+            echo "::warning title=Derived docs stale on main::Could not mint a steward token; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap: branches never modify the derived docs, so nothing can conflict on them.)"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "skdd-steward[bot]"
+          git config user.email "skdd-steward[bot]@users.noreply.github.com"
           git add docs/timeline.md docs/file-structure.md
           git commit -m "[skip-logmind] chore: regen derived docs"
-          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"
+          # Degrade, never fail: a rejected push (missing ruleset bypass, or a
+          # race with another push to main) leaves main's derived docs stale for
+          # one cycle — a freshness gap, never a conflict risk — and the next
+          # merge regenerates them. Failing the job here would red-light main
+          # for something that is by construction harmless.
+          if ! git push "https://x-access-token:${STEWARD_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"; then
+            echo "::warning title=Derived-doc regen could not be pushed to main::The push was rejected (most likely the steward App lacks a ruleset bypass for 'changes must be made through a pull request', or another push won a race). main's derived docs are stale by one cycle and will be regenerated on the next merge. No conflict risk."
+            exit 0
+          fi

--- a/docs/decisions-branches/fix__regen-on-main-steward-token.md
+++ b/docs/decisions-branches/fix__regen-on-main-steward-token.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-25-fix-regen-on-main-push-as-the-steward-app-and-degrade-instea -->
+- **2026-07-25** — Fix regen-on-main: push as the steward App and degrade instead of failing when the push is rejected
+<!-- logmind-entry-end -->
+
+## 2026-07-25 15:12 - Fix regen-on-main: push as the steward App and degrade instead of failing when the push is rejected
+
+**Reasoning:** The first real run of regen-on-main went red: main is governed by a changes-must-be-made-through-a-pull-request rule, so the credentialed push was rejected with GH013 regardless of token scope. The pushing identity must carry a ruleset bypass, which is the skdd-steward App (already used by release.yml), not a PAT. A rejected push is also now a warning rather than a job failure, matching what SPEC 5.1.3 already specifies: on the default branch a stale derived doc is a freshness gap, never a conflict risk, so it must not red-light main
+
+**Alternatives considered:** Have the job open a PR with the regen instead of pushing (rejected: PR churn on every merge, and that PR would itself need review), Drop main regeneration entirely (rejected: main is the only place the derived docs are allowed to be current, so the freshness half of the feature would be gone)
+
+**Implications:**
+- The consumer template keeps the PAT path since consumers have no steward App, but gains the same degrade-never-fail behavior plus a note that the pushing identity needs a ruleset bypass; ORG ACTION still required to make the push actually land — the steward App must be added to the main ruleset bypass list
+
+---
+

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -66,11 +66,21 @@ jobs:
             exit 0
           fi
           if [ -z "${PAT:-}" ]; then
-            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap.)"
+            echo "::warning title=Derived docs stale on main::No LOGMIND_AUTO_REGEN_PAT configured; cannot push the regen. main is momentarily stale until the next push or a manual regen. (No conflict risk — this is a freshness-only gap: branches never modify the derived docs, so nothing can conflict on them.)"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/timeline.md docs/file-structure.md
           git commit -m "[skip-logmind] chore: regen derived docs"
-          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"
+          # Degrade, never fail. If your default branch is protected by a
+          # "changes must be made through a pull request" rule, a plain
+          # credentialed push is rejected (GH013) no matter how much scope the
+          # token has — the pushing identity must be on the ruleset BYPASS list.
+          # Until it is, main's derived docs go stale by one cycle and the next
+          # merge regenerates them: a freshness gap, never a conflict risk.
+          # Failing here would red-light main for something harmless.
+          if ! git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"; then
+            echo "::warning title=Derived-doc regen could not be pushed to main::The push was rejected — most likely the token's identity lacks a ruleset bypass for 'changes must be made through a pull request', or another push won a race. main's derived docs are stale by one cycle and will be regenerated on the next merge. No conflict risk."
+            exit 0
+          fi


### PR DESCRIPTION
**main is red.** The first real run of `regen-on-main` (introduced by #236) failed. Two independent problems, both fixed here.

## 1. The push was rejected — wrong identity, not wrong scope

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

`main` is governed by a *"changes must be made through a pull request"* rule, so **no amount of token scope helps** — the pushing identity has to be on the ruleset **bypass** list. That identity already exists in this org: the **`skdd-steward[bot]` App**, which `release.yml` already mints a token for and which `docs/orchestrator-app.md` documents as carrying ruleset bypass. This switches the job from `LOGMIND_AUTO_REGEN_PAT` to a minted steward installation token, following release.yml's existing pattern (and staying inside the `allowed_actions` allowlist, since `actions/create-github-app-token` is under `actions/*`).

## 2. A rejected push should never red-light main

Even with the right identity, a push can lose a race with another merge. Failing the job in that case is wrong, and **the SPEC already says so** — §5.1.3 (filed in protocol#47) specifies that where the regen can't be pushed the job "MUST degrade to a `::warning::` and exit 0: on the default branch this is a freshness gap only, never a conflict risk."

That's the key property worth being explicit about: **a stale derived doc on main cannot cause a conflict.** Branches never modify these files, so there is nothing to conflict *with*; the next merge regenerates them. The old code only handled "PAT absent" and treated "push rejected" as fatal. Now both degrade.

## ⚠️ Org action still required

This makes the job **stop failing**, but the regen still won't *land* until the **`skdd-steward[bot]` App is added to the `main` ruleset's bypass list**. Until then main's derived docs simply lag — visible as a `::warning::`, harmless by construction. That's an org-admin action (CEO).

## Lockstep

Both halves updated together: the self-repo workflow uses the steward App; the fleet template keeps the PAT (consumers have no steward App) but gains the identical degrade-never-fail behavior plus a comment explaining the bypass requirement. `TestRegenTimelineTemplate_V8_BlockingGate` passes; YAML + `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)