### PR TITLE
feat(derived-docs): make the invariant opt-in (derived_docs.mode + min_binary floor) and add the L2a/L2b pin layers

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -5,6 +5,12 @@ name: logmind / check-derived-docs
 # edited either derived doc (which would cause cross-PR merge conflicts). A
 # branch's real decisions live in docs/decisions-branches/<branch>.md; timeline
 # and file-structure regenerate on main after merge.
+#
+# v9 (B6 adoption gate): the blocking check only applies to a repo that
+# declared `derived_docs: {mode: integration-point}` in .logmind/config.yml.
+# A repo that hasn't adopted it (mode unset or "driver", the default) PASSES
+# with an explanatory message instead — this workflow must never block a PR
+# in a repo whose derived docs are still free to diverge per branch.
 
 on:
   pull_request:
@@ -25,12 +31,22 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          # B6 adoption gate: this repo must have explicitly opted into the
+          # zero-conflict invariant. Unadopted (mode unset or "driver", the
+          # default) → pass with an explanatory message; never block.
+          if ! grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
+            echo "This repo has not adopted derived_docs.mode: integration-point in .logmind/config.yml — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
+            exit 0
+          fi
           changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
           if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|file-structure)\.md'; then
             echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md and/or docs/file-structure.md. These are DERIVED, main-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to main's version — run 'logmind warp', or 'git checkout origin/main -- docs/timeline.md docs/file-structure.md' — then commit. Their real content regenerates on main after merge."

--- a/.logmind/config.yml
+++ b/.logmind/config.yml
@@ -3,6 +3,9 @@ git:
   auto_push: true
   commit_message_template: 'logmind: {decision}'
   auto_rebase: false
+derived_docs:
+  mode: integration-point
+  min_binary: "2.0.0"
 decisions:
   max_recent: 20
   branch_aware: true

--- a/README.md
+++ b/README.md
@@ -100,17 +100,53 @@ verification, and the legacy Python path).
 
 ## Recommended repo settings
 
-`logmind init` ships a GitHub Action (`regen-timeline.yml`) that keeps the
-derived docs (`docs/timeline.md` + `docs/file-structure.md`) current on
-every PR. It **self-heals rather than blocks**: when a derived doc is
-stale it regenerates it and emits an advisory warning — a stale derived
-doc never red-lights your PR. If you configure a `LOGMIND_AUTO_REGEN_PAT`
-secret (fine-grained, repo-scoped, Contents: write), the gate also commits
-and pushes the regenerated docs back to the PR automatically; otherwise
-the derived docs reconcile on merge via the post-merge hook.
+`docs/timeline.md` and `docs/file-structure.md` are **purely derived** —
+under `derived_docs: {mode: integration-point}` in `.logmind/config.yml`, a
+branch never edits them; they regenerate only on `main`. **This is opt-in**:
+`mode` defaults to `"driver"`, which reproduces the pre-v2.0.0 behavior
+(derived docs regenerate on every branch, nothing restores or blocks
+anything) — set `mode: integration-point` to turn the invariant on. Once
+adopted, it's enforced in layers, each closing a gap the previous one can't
+reach:
+
+- **L0** — the `post-merge`/`post-rewrite` git hooks regenerate on the
+  default branch only; a feature branch is never touched. (In driver mode
+  they regenerate on every branch instead.)
+- **L1** — `logmind log` restores both files to `HEAD` before staging, on
+  a non-default branch.
+- **L2 (pin-preservation)** — catches a raw `git commit` that L0/L1 can't
+  reach, e.g. after `logmind warp` deliberately pulls `main`'s newer copy
+  into your working tree for review. **L2a** is a `pre-commit` git hook
+  (pure git, no `logmind` binary required, never blocks a commit),
+  installed only in integration-point mode. **L2b** is the same restore run
+  inside the Claude Code harness's PreToolUse guard, before its allow/block
+  decision — this additionally catches `git commit --no-verify` (which
+  skips every git hook, including L2a) and works in a fresh clone (git
+  hooks aren't cloned; `.claude/settings.json` is).
+- **L3** — the `regen-timeline.yml` GitHub Action's `check-derived-docs`
+  job first checks whether *this repo* declared integration-point mode; an
+  unadopted (driver-mode) repo passes with an explanatory message instead
+  of blocking. An adopted repo's PR gate **blocks a PR** that modified
+  either derived doc, and on every push to `main` regenerates both files
+  and commits + pushes them back (needs a `LOGMIND_AUTO_REGEN_PAT` secret,
+  fine-grained, repo-scoped, Contents: write; without it, the workflow just
+  warns that `main` is momentarily stale — never a conflict risk, only a
+  freshness gap).
+
+Set `derived_docs.min_binary` (e.g. `"2.0.0"`) alongside `mode:
+integration-point` — `logmind doctor` warns when the running binary is
+older than that floor.
+
+L0-L2 are local guardrails, not guarantees — every one is bypassable
+(`--no-verify`, a deleted or disabled hook, hand-editing
+`.claude/settings.json`, or a tool that never goes through git or Claude
+Code). **L3 (CI) is the only non-bypassable enforcement**, since it runs
+server-side on every PR regardless of what did or didn't happen locally —
+and even it only applies once a repo has adopted integration-point mode.
 
 For the derived files to stay conflict-free across *concurrent* PRs, the
-following is **recommended** (no longer required just to avoid blocking):
+following is **recommended** (belt-and-suspenders — L0-L3 already make a
+derived-doc conflict impossible by construction on any single merge):
 
 - **Strict required status checks on `main`** —
   `Settings → Branches → Branch protection rule (or Ruleset)` →
@@ -119,10 +155,12 @@ following is **recommended** (no longer required just to avoid blocking):
   `docs/timeline.md` (and any other derived file) conflict-free across
   concurrent PRs.
 
-Without that toggle, two PRs in flight can both regenerate against
-different base commits; the regenerating `logmind-timeline` merge driver
-resolves the derived files automatically where it's installed, but a
-rebase is still cleaner.
+Without that toggle, the derived-doc invariant still holds per merge — a
+branch's copy is always byte-identical to its own merge-base, so git takes
+`main`'s (regenerated) side automatically, and the `logmind-timeline` merge
+driver is belt-and-suspenders for the rare case a branch diverges anyway.
+Being up to date mainly helps avoid unrelated conflicts elsewhere (e.g. two
+branches editing the same decision file) and keeps history linear.
 
 ### One-command setup via reporulez
 

--- a/docs/decisions-branches/feat__l2-pin-preservation.md
+++ b/docs/decisions-branches/feat__l2-pin-preservation.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-25-make-the-derived-docs-invariant-opt-in-via-derived-docs-mode -->
+- **2026-07-25** — Make the derived-docs invariant opt-in via derived_docs.mode plus a min_binary floor, and add the L2a/L2b pin-preservation layers
+<!-- logmind-entry-end -->
+
+## 2026-07-25 16:18 - Make the derived-docs invariant opt-in via derived_docs.mode plus a min_binary floor, and add the L2a/L2b pin-preservation layers
+
+**Reasoning:** The protocol owner reviewed the SPEC amendment and returned HOLD on two blocking findings: the compatibility argument rested on file_structure.auto_update which nothing reads (reproduced against released v1.2.0 — an old binary regenerates on a branch and the new blocking gate then fails a required check), and the SPEC called the behavior opt-in while L0 and L1 applied it unconditionally. Defaulting the new mode to driver makes a v2 binary in an unadopted repo behave exactly like v1, which closes both that break and its inverse
+
+**Alternatives considered:** Gate only on an adoption signal (rejected: an older tool cannot read the signal, so the old-tool break survives), Declare only a version floor (rejected: says who may adopt but not what a v2 binary does in a repo that never adopted, leaving the inverse break), Weaken the CI gate to advisory (rejected: trades away the structural guarantee to paper over an error in my own compatibility argument)
+
+**Implications:**
+- L0 reads the adoption signal from inside the shell hook body so one canonical body per hook keeps doctor byte-comparison working; the CI gate now passes with an explanation instead of blocking when a repo has not adopted; the binary lands before the SPEC reshape so the spec describes something that exists
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -193,27 +193,92 @@ auto-fix in the `check-doc-links` workflow).
   old dual-mode (branch-divergent vs. main-canonical) design — less
   config surface, no risk of the two renderers drifting apart
 
-### Derived docs: regenerated at the integration point (v2.0.0)
-- **The invariant:** on a non-default branch, `docs/timeline.md` and
-  `docs/file-structure.md` stay byte-identical to their merge-base with the
-  default branch. A branch never edits them; they are regenerated on the
-  default branch after a merge. Because the branch side of the file is
-  unchanged, git takes the default branch's copy silently — **a merge conflict
-  on a derived doc is impossible by construction**, without relying on the
-  merge driver (which is client-side and so cannot run on a server-side merge —
-  the reason PRs still showed conflicts before v2.0.0).
+### Derived docs: regenerated at the integration point (v2.0.0), opt-in via `derived_docs.mode` (B6)
+- **Opt-in, not default.** The protocol owner HOLD-blocked the first cut of
+  this feature on two findings: the SPEC's claimed compatibility story was
+  fiction (nothing read `file_structure.auto_update`), and the L0/L1 layers
+  applied UNCONDITIONALLY — keyed only on branch name, no per-repo signal —
+  which silently changed a repo's behavior the moment any contributor
+  upgraded to a v2 binary. The fix is `derived_docs.mode` in
+  `.logmind/config.yml`:
+  ```yaml
+  derived_docs:
+    mode: driver              # "driver" (DEFAULT) | "integration-point"
+    min_binary: ""            # e.g. "2.0.0" — SHOULD be set when integration-point
+  ```
+  `mode` **defaults to `driver`** — the exact pre-v2.0.0 behavior (derived
+  docs regenerate on every branch; nothing restores or blocks anything). Only
+  `mode: integration-point` turns on the invariant below. Tolerant parse: an
+  empty/unrecognised `mode` value resolves to `driver` — never an error.
+  Replaces the earlier `git.pin_derived_docs bool` (unreleased at the time;
+  no back-compat needed).
+- **The invariant (integration-point mode only):** on a non-default branch,
+  `docs/timeline.md` and `docs/file-structure.md` stay byte-identical to
+  their merge-base with the default branch. A branch never edits them; they
+  are regenerated on the default branch after a merge. Because the branch
+  side of the file is unchanged, git takes the default branch's copy
+  silently — **a merge conflict on a derived doc is impossible by
+  construction**, without relying on the merge driver (which is client-side
+  and so cannot run on a server-side merge — the reason PRs still showed
+  conflicts before v2.0.0). In **driver mode** (the default) neither the
+  invariant nor any of the layers below apply — a driver-mode repo's derived
+  docs are free to diverge per branch, exactly like a pre-v2.0.0 install.
 - **Why reverting a branch-side edit is always safe:** both files are pure
   functions of committed sources (`timeline.md` of the decision files,
   `file-structure.md` of the tracked tree). Discarding a branch-local edit
   cannot lose information, which is what licenses silent self-heal.
-- **Enforced in layers:** hooks regenerate on the default branch only ·
-  `logmind log` restores both files to HEAD before staging on a branch ·
-  a pre-commit restore covers raw `git commit` · CI `check-derived-docs`
-  blocks a PR that modified either file.
+- **Enforced in layers — ALL FOUR gated on `derived_docs.mode:
+  integration-point` (see `internal/cli/derived.go`'s `integrationPointMode`):**
+  - **L0** — the `post-merge`/`post-rewrite` git hooks. In integration-point
+    mode they regenerate on the default branch only, restoring nothing on a
+    non-default branch. In driver mode they regenerate on EVERY branch — the
+    pre-v2.0.0 behavior. Because the hook body is a standalone `sh` script
+    with no Go process to call `integrationPointMode` from, the check is
+    inlined as a `grep` against `.logmind/config.yml` — one canonical body
+    per hook either way, so `doctor`'s byte-comparison drift detection keeps
+    working unchanged.
+  - **L1** — `logmind log`'s `commitDecision` restores both files to HEAD
+    before staging, on a non-default branch — but only in integration-point
+    mode. Driver mode never restores here.
+  - **L2 (pin-preservation)** — closes the raw-`git commit` gap L0/L1 can't
+    reach (e.g. `logmind warp` deliberately writing the default branch's
+    newer copy into the working tree, then a plain `git commit -am` sweeping
+    it in). Two halves, both gated on integration-point mode: **L2a** is a
+    `pre-commit` git hook — pure git (`git checkout HEAD -- <path>`), no
+    `logmind` binary required, always exits 0 — INSTALLED only in
+    integration-point mode, that restores both files before the commit is
+    built. **L2b** is the SAME restore performed inside `logmind guard-commit
+    --layer harness` (the Claude Code PreToolUse guard), before its
+    allow/block decision — this is what additionally catches `git commit
+    --no-verify` (which skips every git hook, including L2a) and works in a
+    fresh clone (git hooks aren't cloned; `.claude/settings.json`, which
+    invokes guard-commit, is).
+  - **L3** — CI's `check-derived-docs` workflow. It first checks the repo's
+    own `.logmind/config.yml` for `mode: integration-point`; an unadopted
+    repo (driver, the default) PASSES with an explanatory message instead of
+    blocking. Only an adopted repo's PR gate blocks a branch that modified
+    either derived doc.
+  - **Honest caveat:** L0-L2 are local guardrails, not guarantees — every one
+    of them is bypassable (`--no-verify`, deleting or disabling a hook,
+    hand-editing `.claude/settings.json`, or simply using a tool that never
+    goes through git or Claude Code). **L3 (CI) is the only non-bypassable
+    enforcement** — it runs server-side on every PR regardless of what did
+    or didn't happen on the contributor's machine, and even it only applies
+    once a repo has declared integration-point mode.
+- **Version floor.** `min_binary` (e.g. `"2.0.0"`) SHOULD be set alongside
+  `mode: integration-point` — `logmind doctor` compares it against the
+  running binary (`internal/version.SatisfiesMin`, a small major.minor.patch
+  compare with no new dependency; a `X.Y.Z-dev` prerelease satisfies its own
+  `X.Y.Z` floor) and reports an advisory (never a hard failure) when the
+  binary is older, or when integration-point mode is declared without a
+  floor at all.
 - **Staying current on a branch:** `logmind warp` refreshes the working copy
   from the default branch (read-only — it never commits, which would break the
   pin), `logmind context` renders the last-fetched default-branch copy, and the
-  pulse nudges when the default branch has advanced.
+  pulse nudges when the default branch has advanced. These apply regardless of
+  mode.
+- **This repo's own adoption:** logmind dogfoods `derived_docs: {mode:
+  integration-point, min_binary: "2.0.0"}` in its own `.logmind/config.yml`.
 - Design record: [derived-docs-on-main implementation plan](superpowers/plans/2026-07-17-derived-docs-on-main.md).
   Normative backing: SPEC §0.3.2 integration-point regeneration mode.
 

--- a/internal/cli/derived.go
+++ b/internal/cli/derived.go
@@ -1,6 +1,9 @@
 package cli
 
-import "github.com/thrillmade/logmind/internal/gitcli"
+import (
+	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/gitcli"
+)
 
 // derivedDocPaths are the two committed, purely-derived context docs governed by
 // the zero-conflict invariant: on any non-default branch they MUST stay
@@ -27,4 +30,41 @@ func onNonDefaultBranch(cwd string) bool {
 		return false
 	}
 	return cur != def
+}
+
+// integrationPointMode resolves cwd's derived_docs.mode (default "driver")
+// from .logmind/config.yml and reports whether this repo has explicitly
+// opted into "integration-point" mode — the v2.0.0 B6 adoption-signal gate
+// that replaced the unconditional-by-default git.pin_derived_docs. Gates
+// ALL FOUR layers of the derived-docs pin-preservation design:
+//
+//   - L0 — the post-merge/post-rewrite hook BODIES (hooks.BuildPostMergeBody
+//     / BuildPostRewriteBody) regenerate on every branch in driver mode (the
+//     pre-v2.0.0 behavior) and skip non-default branches only in
+//     integration-point mode. Those hooks run as standalone `sh` scripts
+//     with no Go process to call this function from, so the equivalent
+//     check is inlined there as a `grep` against .logmind/config.yml — same
+//     contract, different runtime.
+//   - L1 — logmind log's commitDecision restore (log.go).
+//   - L2a — the pre-commit hook's installation (hooks.InstallPreCommit,
+//     wired in init.go/refresh.go).
+//   - L2b — the harness-layer restore (guard_commit.go's
+//     guardCommitHarness).
+//
+// Why the inversion: the protocol owner's HOLD found L0/L1 applying
+// UNCONDITIONALLY (keyed only on branch name, no per-repo signal) silently
+// broke a driver-mode repo's L0 branch regeneration the moment any
+// contributor upgraded to a v2 binary, and violated the SPEC's
+// backward-compatibility rule (an old tool + the new blocking CI gate
+// produced an unwinnable combination). "driver" is now the default —
+// adoption of the zero-conflict invariant must be explicit per repo.
+//
+// config.Load failure ⇒ "driver" (false) — the SAFE default now: a config
+// problem must never silently flip a repo's regen/restore behavior. An
+// empty or unrecognised Mode value ALSO resolves to "driver" (exact match
+// against "integration-point" only, nothing else) — config.Load never
+// errors or crashes over a bad Mode string; see DerivedDocsConfig.Mode.
+func integrationPointMode(cwd string) bool {
+	cfg, _ := config.Load(cwd)
+	return cfg.DerivedDocs.Mode == "integration-point"
 }

--- a/internal/cli/derived_integration_test.go
+++ b/internal/cli/derived_integration_test.go
@@ -17,6 +17,14 @@
 // already fast-forwarded/merged to feat/a's tip would be a genuine
 // three-way conflict (both sides differ from the merge-base AND from each
 // other), not just a one-side-changed auto-merge.
+//
+// v2.0.0 B6: the zero-conflict invariant this test proves is now opt-in
+// (`derived_docs: {mode: integration-point}`, the default is "driver" — see
+// internal/cli/derived.go's integrationPointMode). This test explicitly
+// declares integration-point mode via writeDerivedDocsMode (log_test.go) so
+// its headline scenario keeps proving what it always proved; it is NOT
+// testing the (now default) driver-mode behavior, which has its own
+// coverage in TestLog_DriverModeCommitsDirtiedDerivedDocOnBranch.
 package cli
 
 import (
@@ -33,6 +41,7 @@ func TestConcurrentBranches_MergeWithoutDerivedDocConflict(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		writeDerivedDocsMode(t, d, "integration-point")
 		// Commit the scaffold (decisions.md, timeline.md, file-structure.md)
 		// on main so both branches share the same merge-base copy of the
 		// derived docs.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -100,9 +100,10 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return err
 	}
 	res, refreshErr := applyRefresh(cwd, refreshOpts{
-		githubActions:      true,
-		git:                true,
-		claudeAgentEnabled: claudeAgentEnabledFromConfig(cwd),
+		githubActions:               true,
+		git:                         true,
+		claudeAgentEnabled:          claudeAgentEnabledFromConfig(cwd),
+		derivedDocsIntegrationPoint: integrationPointMode(cwd),
 	})
 	if refreshErr != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "error: doctor --fix:", refreshErr)
@@ -165,13 +166,13 @@ func driftCount(r doctor.StatusReport) int {
 }
 
 // residualProbes returns the names of probes still drifted after a fix pass:
-// PATH/version drift and foreign (markerless) hooks, which --fix
-// deliberately does not touch.
+// PATH/version drift and foreign (markerless, or — for the pre-commit hook
+// specifically — "foreign") hooks, which --fix deliberately does not touch.
 func residualProbes(r doctor.StatusReport) []string {
 	var out []string
 	for _, t := range r.Tools {
 		for _, wf := range t.Workflows {
-			if wf.Drift == "stale" || wf.Drift == "markerless" {
+			if wf.Drift == "stale" || wf.Drift == "markerless" || wf.Drift == "foreign" {
 				out = append(out, wf.Name)
 			}
 		}

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -297,6 +297,36 @@ func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, 
 
 	evalCwd := evalCwdOr(payload.Cwd, repoRootFlag)
 	repoRoot, enforce, threshold := resolveRepoAndConfig(evalCwd, thresholdFlag, thresholdExplicit)
+
+	// L2b — harness-layer restore (v2.0.0 derived-docs pin-preservation; see
+	// internal/cli/derived.go). ONLY runs when this repo has opted into
+	// `derived_docs: {mode: integration-point}` — see
+	// internal/cli/derived.go's integrationPointMode; "driver" (the
+	// default) never restores here. Deliberately runs BEFORE the
+	// enforce_commits off-ramp below and independent of its outcome:
+	// pin-preservation (derived_docs.mode) and commit enforcement
+	// (git.enforce_commits) are separate knobs, and a repo that opted OUT
+	// of enforcement may still want the zero-conflict invariant protected.
+	//
+	// Harness-layer ONLY — deliberately NOT added to guardCommitGitHook (the
+	// commit-msg layer): commit-msg fires AFTER git has already built the
+	// commit's tree from the index, so restoring files at that point can't
+	// change what's being committed — it would be a confusing no-op. This
+	// layer fires BEFORE git runs at all (Claude Code's PreToolUse guard
+	// intercepts the Bash tool call itself), so it catches two things L2a's
+	// pre-commit git hook can't: `git commit --no-verify` (which skips EVERY
+	// git hook, including pre-commit) and a fresh clone (git hooks aren't
+	// cloned — nothing under .git/ travels with `git clone` — but
+	// .claude/settings.json is regular repo content that IS cloned).
+	//
+	// Silent + best-effort, like every other restore call site: the docs
+	// regenerate deterministically from the committed decision files, so
+	// there's nothing to protect by surfacing a failure here, and doing so
+	// must never perturb the allow/block decision below.
+	if integrationPointMode(repoRoot) && onNonDefaultBranch(repoRoot) {
+		_ = gitcli.RestorePathsToHead(repoRoot, derivedDocPaths...)
+	}
+
 	if !enforce {
 		return 0 // the repo off-ramp: git.enforce_commits: false
 	}

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -58,6 +58,126 @@ func TestRunGuardCommit_Harness_AllowsSmallChange(t *testing.T) {
 	}
 }
 
+// TestRunGuardCommit_Harness_RestoresDerivedDocsOnNonDefaultBranch_IntegrationPointMode
+// is the L2b proof, UPDATED for the B6 adoption gate: with
+// `derived_docs: {mode: integration-point}` explicitly declared, the
+// harness layer restores docs/timeline.md to its committed (HEAD) content
+// on a non-default branch — BEFORE evaluating the allow/block decision —
+// the same restore L1 (`logmind log`) and L2a (the pre-commit git hook)
+// perform, but running BEFORE git itself. That's what lets this layer
+// catch `git commit --no-verify` (which skips every git hook, including
+// L2a) and work in a fresh clone (git hooks aren't cloned;
+// .claude/settings.json, which invokes this binary, is). See the
+// DriverMode sibling test below for the (now default) non-restoring case.
+func TestRunGuardCommit_Harness_RestoresDerivedDocsOnNonDefaultBranch_IntegrationPointMode(t *testing.T) {
+	repo := initRepo(t)
+	docsDir := filepath.Join(repo, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	timelinePath := filepath.Join(docsDir, "timeline.md")
+	original := "# Timeline\n\noriginal\n"
+	if err := os.WriteFile(timelinePath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write timeline.md: %v", err)
+	}
+	writeGuardCommitConfig(t, repo, "derived_docs:\n  mode: integration-point\n")
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", "add docs"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGitIn(t, repo, "checkout", "-b", "feat/restore-test")
+
+	// Dirty docs/timeline.md — simulates `logmind warp` (or any stray
+	// write) pulling in a different copy.
+	dirty := "# Timeline\n\nDIRTY\n"
+	if err := os.WriteFile(timelinePath, []byte(dirty), 0o644); err != nil {
+		t.Fatalf("dirty timeline.md: %v", err)
+	}
+
+	payload := harnessJSON(t, "Bash", `git commit -am x`, repo)
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(payload), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d; want 0 (restored file leaves nothing substantive to block)", exitCode)
+	}
+
+	got, err := os.ReadFile(timelinePath)
+	if err != nil {
+		t.Fatalf("read timeline.md: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("docs/timeline.md not restored by the harness layer\nwant %q\ngot %q", original, string(got))
+	}
+}
+
+// TestRunGuardCommit_Harness_DriverModeSkipsRestore: driver mode — both the
+// implicit default (no .logmind/config.yml at all) and an EXPLICIT
+// `derived_docs: {mode: driver}` — disables the harness-layer restore too,
+// not just L2a's pre-commit hook install (see the cli/init_test.go
+// counterpart for that half) — so a dirtied derived doc rides through
+// untouched. This is the v2.0.0 B6 inversion: pin-preservation used to be
+// unconditional-by-default (git.pin_derived_docs: true); now it's
+// opt-in-by-default (derived_docs.mode: driver).
+func TestRunGuardCommit_Harness_DriverModeSkipsRestore(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configBody string // "" == no .logmind/config.yml written at all
+	}{
+		{name: "implicit default (no config)", configBody: ""},
+		{name: "explicit driver mode", configBody: "derived_docs:\n  mode: driver\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := initRepo(t)
+			docsDir := filepath.Join(repo, "docs")
+			if err := os.MkdirAll(docsDir, 0o755); err != nil {
+				t.Fatalf("mkdir docs: %v", err)
+			}
+			timelinePath := filepath.Join(docsDir, "timeline.md")
+			if err := os.WriteFile(timelinePath, []byte("# Timeline\n\noriginal\n"), 0o644); err != nil {
+				t.Fatalf("write timeline.md: %v", err)
+			}
+			if tc.configBody != "" {
+				writeGuardCommitConfig(t, repo, tc.configBody)
+			}
+			for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", "add docs"}} {
+				cmd := exec.Command("git", args...)
+				cmd.Dir = repo
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v\n%s", args, err, out)
+				}
+			}
+			runGitIn(t, repo, "checkout", "-b", "feat/restore-test")
+
+			dirty := "# Timeline\n\nDIRTY\n"
+			if err := os.WriteFile(timelinePath, []byte(dirty), 0o644); err != nil {
+				t.Fatalf("dirty timeline.md: %v", err)
+			}
+
+			payload := harnessJSON(t, "Bash", `git commit -am x`, repo)
+			var stdout, stderr bytes.Buffer
+			if _, err := runGuardCommit(repo, "harness", "", 20, true, false,
+				strings.NewReader(payload), &stdout, &stderr); err != nil {
+				t.Fatalf("runGuardCommit: %v", err)
+			}
+
+			got, err := os.ReadFile(timelinePath)
+			if err != nil {
+				t.Fatalf("read timeline.md: %v", err)
+			}
+			if string(got) != dirty {
+				t.Fatalf("docs/timeline.md was restored despite driver mode\nwant %q (untouched)\ngot %q", dirty, string(got))
+			}
+		})
+	}
+}
+
 func TestRunGuardCommit_Harness_BlocksOverThresholdUnstagedChange(t *testing.T) {
 	repo := initRepo(t)
 	// Unstaged (not `git add`ed) — this is the WorkingTreeUnion regression:

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -259,6 +259,16 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		if _, err := hooks.InstallCommitMsg(cwd); err != nil {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: commit-msg hook install failed:", err)
 		}
+		// L2a of the derived-docs pin-preservation design (see
+		// internal/cli/derived.go). Gated on derived_docs.mode ==
+		// "integration-point" (default "driver" — install ONLY on explicit
+		// opt-in) — the config.yml written just above already has the
+		// key, so this reads the real, just-scaffolded value.
+		if integrationPointMode(cwd) {
+			if _, err := hooks.InstallPreCommit(cwd); err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Warning: pre-commit hook install failed:", err)
+			}
+		}
 	}
 
 	// Layer 1 of commit enforcement: the Claude Code harness's PreToolUse
@@ -378,7 +388,12 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 		applyInitSpec(cmd, cwd)
 	}
 
-	res, err := applyRefresh(cwd, refreshOpts{githubActions: f.githubActions, git: true, claudeAgentEnabled: claudeAgentEnabled})
+	res, err := applyRefresh(cwd, refreshOpts{
+		githubActions:               f.githubActions,
+		git:                         true,
+		claudeAgentEnabled:          claudeAgentEnabled,
+		derivedDocsIntegrationPoint: integrationPointMode(cwd),
+	})
 	if err != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: refresh failed:", err)
 	}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -376,6 +376,98 @@ func TestInit_RefreshMode_InstallsMissingClaudeHook(t *testing.T) {
 	}
 }
 
+// TestInit_RefreshMode_DriverModeSkipsPreCommitHookInstall: driver mode —
+// both the IMPLICIT default (config.yml as `logmind init` scaffolds it,
+// with no `derived_docs:` section at all) and an EXPLICIT
+// `derived_docs: {mode: driver}` — must NOT install L2a's pre-commit hook.
+// This is the v2.0.0 B6 inversion (see internal/cli/derived.go's
+// integrationPointMode): pin-preservation used to be unconditional-by-
+// default (git.pin_derived_docs: true, now removed); adoption is now
+// opt-in, so a repo that never declares `derived_docs.mode` gets the
+// pre-v2.0.0 behavior. The other three git hooks (post-merge/
+// post-rewrite/commit-msg), which are NOT gated on this key, still get
+// installed — proving the gate is scoped to pre-commit only, not a
+// wholesale `opts.git` failure. See
+// TestInit_RefreshMode_IntegrationPointModeInstallsPreCommitHook below for
+// the opt-in case.
+func TestInit_RefreshMode_DriverModeSkipsPreCommitHookInstall(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		derivedDocsCfg string // "" leaves the config.yml `logmind init` scaffolds untouched
+	}{
+		{name: "implicit default (config.yml as scaffolded)"},
+		{name: "explicit driver mode", derivedDocsCfg: "derived_docs:\n  mode: driver\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := withTempCwd(t, func(d string) {
+				initLogTestGitRepo(t, d)
+				// --no-git here scaffolds docs/ + .logmind/config.yml without
+				// touching git hooks at all (this test is purely about the
+				// refresh-mode gate, exercised by the SECOND init call below).
+				runQuiet(t, []string{"init", "--no-git"})
+
+				if tc.derivedDocsCfg != "" {
+					cfgPath := filepath.Join(d, ".logmind", "config.yml")
+					if err := os.WriteFile(cfgPath, []byte(tc.derivedDocsCfg), 0o644); err != nil {
+						t.Fatalf("write config.yml: %v", err)
+					}
+				}
+
+				// Second call: already-initialized → refresh mode. No --no-git
+				// this time, so applyRefresh's opts.git branch runs for real.
+				root := NewRootCmd()
+				root.SetArgs([]string{"init"})
+				var out, errOut bytes.Buffer
+				root.SetOut(&out)
+				root.SetErr(&errOut)
+				if err := root.Execute(); err != nil {
+					t.Fatalf("refresh init: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+				}
+				if strings.Contains(out.String(), "pre-commit") {
+					t.Errorf("did NOT expect a pre-commit hook line in driver mode:\n%s", out.String())
+				}
+			})
+			if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "pre-commit")); err == nil {
+				t.Errorf("did NOT expect .git/hooks/pre-commit in driver mode")
+			}
+			if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "post-merge")); err != nil {
+				t.Errorf("expected .git/hooks/post-merge to still be installed (derived_docs.mode only gates pre-commit): %v", err)
+			}
+		})
+	}
+}
+
+// TestInit_RefreshMode_IntegrationPointModeInstallsPreCommitHook is the
+// opt-in companion to the driver-mode test above: with
+// `derived_docs: {mode: integration-point}` declared, a refresh-mode
+// `logmind init` DOES install L2a's pre-commit hook.
+func TestInit_RefreshMode_IntegrationPointModeInstallsPreCommitHook(t *testing.T) {
+	dir := withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		runQuiet(t, []string{"init", "--no-git"})
+
+		cfgPath := filepath.Join(d, ".logmind", "config.yml")
+		if err := os.WriteFile(cfgPath, []byte("derived_docs:\n  mode: integration-point\n"), 0o644); err != nil {
+			t.Fatalf("write config.yml: %v", err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"init"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("refresh init: %v\nstdout=%s\nstderr=%s", err, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "pre-commit") {
+			t.Errorf("expected a pre-commit hook line with derived_docs.mode: integration-point:\n%s", out.String())
+		}
+	})
+	if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "pre-commit")); err != nil {
+		t.Errorf("expected .git/hooks/pre-commit with derived_docs.mode: integration-point: %v", err)
+	}
+}
+
 // runQuiet runs a root command silencing stdout/stderr; used to drive
 // setup steps in multi-stage tests without polluting test logs.
 func runQuiet(t *testing.T, args []string) {

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -875,15 +875,21 @@ func nudgeBranchSummary(target string, forceNonInteractive, stdinOK bool, lines 
 // Commit message uses cfg.Git.CommitMessageTemplate with `{decision}`
 // substituted for the summary. Default is `logmind: <summary>`.
 func commitDecision(cwd, targetAbs, targetRel, stage, summary string, cfg config.Config) error {
-	// Zero-conflict invariant (v2.0.0): docs/timeline.md + docs/file-structure.md
-	// are purely-derived, main-only artifacts. On a non-default branch, restore
-	// them to their committed (HEAD) content BEFORE staging so neither a stray
-	// hook regen nor `git add -A` can sweep a branch-local edit into this commit —
-	// which would diverge the branch from main and cause a future merge conflict.
-	// Lossless: they regenerate deterministically from the decision files (which
-	// ARE committed, per-branch, and never conflict). On the default branch this
-	// is intentionally skipped — main is where the derived docs SHOULD be current.
-	if onNonDefaultBranch(cwd) {
+	// Zero-conflict invariant (v2.0.0) — INTEGRATION-POINT MODE ONLY (v2.0.0
+	// B6): docs/timeline.md + docs/file-structure.md are purely-derived,
+	// main-only artifacts under `derived_docs: {mode: integration-point}`.
+	// On a non-default branch, restore them to their committed (HEAD)
+	// content BEFORE staging so neither a stray hook regen nor `git add -A`
+	// can sweep a branch-local edit into this commit — which would diverge
+	// the branch from main and cause a future merge conflict. Lossless:
+	// they regenerate deterministically from the decision files (which ARE
+	// committed, per-branch, and never conflict). On the default branch
+	// this is intentionally skipped — main is where the derived docs SHOULD
+	// be current. In "driver" mode (the default) this restore never fires
+	// at all — a driver-mode repo's derived docs are free to regenerate on
+	// every branch, matching the pre-v2.0.0 behavior; see
+	// internal/cli/derived.go's integrationPointMode.
+	if onNonDefaultBranch(cwd) && integrationPointMode(cwd) {
 		_ = gitcli.RestorePathsToHead(cwd, derivedDocPaths...)
 	}
 

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -1062,19 +1062,23 @@ func TestLog_SelfHeal_StderrTTY_StdinDeadPipe_DoesNotHang(t *testing.T) {
 }
 
 // TestLog_DoesNotCommitDirtiedDerivedDocOnBranch pins the L1 zero-conflict
-// guard (derived-docs-on-main plan, Task 3): docs/timeline.md and
-// docs/file-structure.md are purely-derived, main-only artifacts. On a
-// non-default branch, `commitDecision` restores them to HEAD before staging
-// so neither a stray hook regen nor `git add -A` can sweep a branch-local
-// edit into the decision commit — which would diverge the branch from main
-// and cause a future merge conflict. Here we simulate that stray edit by
-// hand-dirtying the already-committed docs/timeline.md, then assert the
-// resulting commit does NOT carry it and the working tree is restored to
-// HEAD's content.
+// guard (derived-docs-on-main plan, Task 3), UPDATED for the v2.0.0 B6
+// adoption gate: docs/timeline.md and docs/file-structure.md are
+// purely-derived, main-only artifacts ONLY under
+// `derived_docs: {mode: integration-point}`. With that declared,
+// `commitDecision` restores them to HEAD before staging so neither a stray
+// hook regen nor `git add -A` can sweep a branch-local edit into the
+// decision commit — which would diverge the branch from main and cause a
+// future merge conflict. Here we simulate that stray edit by hand-dirtying
+// the already-committed docs/timeline.md, then assert the resulting commit
+// does NOT carry it and the working tree is restored to HEAD's content. See
+// TestLog_DriverModeCommitsDirtiedDerivedDocOnBranch below for the (now
+// default) driver-mode case where the dirtied doc rides through.
 func TestLog_DoesNotCommitDirtiedDerivedDocOnBranch(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		writeDerivedDocsMode(t, d, "integration-point")
 		// Commit the scaffold (including docs/timeline.md) on main FIRST so
 		// there is a HEAD copy for the branch to diverge from and later be
 		// restored to.
@@ -1121,4 +1125,75 @@ func TestLog_DoesNotCommitDirtiedDerivedDocOnBranch(t *testing.T) {
 			t.Fatalf("working-tree docs/timeline.md must be restored to HEAD content; got %q want %q", got, head)
 		}
 	})
+}
+
+// TestLog_DriverModeCommitsDirtiedDerivedDocOnBranch is the inversion
+// companion: in "driver" mode — BOTH the implicit default (the config.yml
+// `logmind init` scaffolds, with no `derived_docs:` section at all) and an
+// EXPLICIT `derived_docs: {mode: driver}` — `logmind log` must NOT restore
+// docs/timeline.md on a non-default branch. A branch-local edit rides into
+// the decision commit unmodified, matching the pre-v2.0.0 behavior: a
+// driver-mode repo's derived docs are free to diverge per branch.
+func TestLog_DriverModeCommitsDirtiedDerivedDocOnBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode string // "" leaves the config.yml `logmind init` scaffolds untouched
+	}{
+		{name: "implicit default (config.yml as scaffolded)"},
+		{name: "explicit driver mode", mode: "driver"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempCwd(t, func(d string) {
+				initLogTestGitRepo(t, d)
+				scaffoldDocs(t)
+				if tc.mode != "" {
+					writeDerivedDocsMode(t, d, tc.mode)
+				}
+				commitAll(t, d, "initial")
+				runGitIn(t, d, "checkout", "-b", "feat/y")
+
+				timelinePath := filepath.Join(d, "docs", "timeline.md")
+				dirty := "STALE BRANCH EDIT\n"
+				if err := os.WriteFile(timelinePath, []byte(dirty), 0o644); err != nil {
+					t.Fatalf("dirty docs/timeline.md: %v", err)
+				}
+
+				withFakeTTY(t, false, func() {
+					f := &logFlags{stage: "all"}
+					var out, errBuf bytes.Buffer
+					if err := runLog(d, "Decide something", f, false, strings.NewReader(""), &out, &errBuf); err != nil {
+						t.Fatalf("runLog: %v\nstdout:\n%s\nstderr:\n%s", err, out.String(), errBuf.String())
+					}
+				})
+
+				// Driver mode: the commit DOES carry the dirtied derived doc —
+				// nothing restores it.
+				names, _, err := gitcli.RunCaptured(d, "show", "--name-only", "--format=", "HEAD")
+				if err != nil {
+					t.Fatalf("git show --name-only HEAD: %v", err)
+				}
+				if !strings.Contains(names, "docs/timeline.md") {
+					t.Fatalf("expected docs/timeline.md in the commit (driver mode never restores); commit files:\n%s", names)
+				}
+				head, ok := gitcli.ShowFile(d, "HEAD", "docs/timeline.md")
+				if !ok {
+					t.Fatalf("ShowFile HEAD:docs/timeline.md failed")
+				}
+				if head != dirty {
+					t.Fatalf("HEAD:docs/timeline.md = %q; want the dirtied content %q (driver mode never restores)", head, dirty)
+				}
+			})
+		})
+	}
+}
+
+// writeDerivedDocsMode overwrites .logmind/config.yml under d with a
+// `derived_docs: {mode: <mode>}` section — the v2.0.0 B6 adoption signal.
+func writeDerivedDocsMode(t *testing.T, d, mode string) {
+	t.Helper()
+	cfgPath := filepath.Join(d, ".logmind", "config.yml")
+	body := "derived_docs:\n  mode: " + mode + "\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config.yml: %v", err)
+	}
 }

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -59,6 +59,12 @@ type refreshOpts struct {
 	githubActions      bool // install/refresh .github/workflows/*
 	git                bool // configure merge drivers + install git hooks (no-op outside a git repo)
 	claudeAgentEnabled bool // install/refresh .claude/settings.json PreToolUse guard (Layer 1)
+	// derivedDocsIntegrationPoint gates installing/refreshing L2a's
+	// pre-commit hook (hooks.InstallPreCommit) — resolved from
+	// derived_docs.mode == "integration-point" (default "driver"; see
+	// internal/cli/derived.go's integrationPointMode). Only meaningful when
+	// git is also true (same as the other 3 hooks).
+	derivedDocsIntegrationPoint bool
 }
 
 // applyRefresh runs every idempotent installer that brings a drifted repo
@@ -111,6 +117,16 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 		}
 		if c, _ := hooks.InstallCommitMsg(cwd); c {
 			res.HooksRefreshed = append(res.HooksRefreshed, "commit-msg")
+		}
+		// L2a (pin-preservation) — install ONLY on explicit opt-in
+		// (derived_docs.mode: integration-point). Unlike the three hooks
+		// above, this one is config-gated: a driver-mode repo (the default)
+		// shouldn't have the hook silently installed/reinstalled on the
+		// next `doctor --fix` / `init` refresh.
+		if opts.derivedDocsIntegrationPoint {
+			if c, _ := hooks.InstallPreCommit(cwd); c {
+				res.HooksRefreshed = append(res.HooksRefreshed, "pre-commit")
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,17 @@ import (
 // merged in. Only the subsections B3 actually reads are typed —
 // extending this struct for B4+B5+B6 is purely additive.
 type Config struct {
-	Git           GitConfig           `yaml:"git"`
+	Git GitConfig `yaml:"git"`
+	// DerivedDocs is the v2.0.0 B6 adoption-signal gate for the
+	// derived-docs pin-preservation feature (see DerivedDocsConfig). A
+	// top-level section — not nested under `git:` — because it spans well
+	// beyond git-hook config: it governs L0 (the post-merge/post-rewrite
+	// hook bodies), L1 (logmind log's commitDecision restore), L2a/L2b (the
+	// pre-commit hook + Claude Code harness restore), and L3 (the CI
+	// blocking gate). Replaces the removed `git.pin_derived_docs` key
+	// (unreleased; no back-compat needed) — see DerivedDocsConfig's doc
+	// comment for why.
+	DerivedDocs   DerivedDocsConfig   `yaml:"derived_docs"`
 	Decisions     DecisionsConfig     `yaml:"decisions"`
 	FileStructure FileStructureConfig `yaml:"file_structure"`
 	// Context gates what `logmind context` folds into the cold-start payload
@@ -118,6 +128,57 @@ type GitConfig struct {
 	// `logmind guard-commit` wins over this; this value wins over the
 	// hardcoded fallback of 20.
 	CommitLineThreshold int `yaml:"commit_line_threshold"`
+}
+
+// DerivedDocsConfig mirrors the `derived_docs:` section — the v2.0.0 B6
+// adoption-signal gate for the derived-docs pin-preservation feature (SPEC
+// §0.3.2's integration-point regeneration mode).
+//
+// Replaces the removed `git.pin_derived_docs bool` (unreleased; no
+// back-compat needed). The protocol owner reviewed the SPEC amendment
+// describing pin-preservation and returned HOLD with two blocking findings:
+// (1) the SPEC's compatibility story was fiction — it claimed an old tool
+// would defer via `file_structure.auto_update`, but nothing reads that
+// flag; reproduced against a released binary, an old tool regenerating on
+// a branch, followed by `logmind log --stage all` sweeping the regen in,
+// diverges the branch from its merge-base and fails the new blocking CI
+// gate — violating the SPEC's "older minor version MUST continue to work"
+// rule. (2) "opt-in" wasn't true of the implementation: L0/L1 applied
+// UNCONDITIONALLY, keyed only on branch name, with no per-repo adoption
+// signal — which ALSO silently switched off a driver-mode repo's L0 branch
+// regeneration the moment any contributor upgraded to a v2 binary. This
+// section is the fix: an explicit, per-repo adoption signal that every
+// layer (L0-L3) gates on, defaulting to the pre-v2.0.0 behavior.
+type DerivedDocsConfig struct {
+	// Mode is "driver" (DEFAULT) or "integration-point". Adoption must be
+	// explicit — Mode defaults to "driver", which reproduces logmind's
+	// exact pre-v2.0.0 behavior: derived docs regenerate on every branch,
+	// and no layer in the L0-L3 stack restores or blocks anything. Setting
+	// Mode to "integration-point" opts this repo into the zero-conflict
+	// invariant (see internal/cli/derived.go): docs/timeline.md and
+	// docs/file-structure.md regenerate ONLY on the default branch, a
+	// non-default branch has them restored to HEAD before a commit can
+	// carry a branch-local edit (the pre-commit hook + the Claude Code
+	// harness restore), and a blocking CI gate rejects a PR that edited
+	// them anyway.
+	//
+	// Tolerant parse: an empty or unrecognised value — a typo, a value
+	// written by some future logmind version, whatever — resolves to
+	// "driver". The resolver (internal/cli.integrationPointMode) does an
+	// exact match against "integration-point" and nothing else; config.Load
+	// never errors or crashes over a bad Mode string.
+	Mode string `yaml:"mode"`
+
+	// MinBinary declares the minimum logmind binary version this repo's
+	// integration-point adoption expects contributors to run — e.g.
+	// "2.0.0". SHOULD be set whenever Mode is "integration-point" (a repo
+	// that opts in without declaring a floor gets no version-drift
+	// warning). `logmind doctor` compares this against the running
+	// binary (internal/version.Version, via internal/version.SatisfiesMin)
+	// and reports an advisory — never a hard failure — when the binary is
+	// older. Ignored entirely when Mode is "driver". Default "" (no floor
+	// declared).
+	MinBinary string `yaml:"min_binary"`
 }
 
 // DecisionsConfig mirrors the `decisions:` section.
@@ -203,6 +264,14 @@ func DefaultConfig() Config {
 			CommitMessageTemplate: "logmind: {decision}",
 			EnforceCommits:        true,
 			CommitLineThreshold:   20,
+		},
+		// DerivedDocs.Mode defaults to "driver" — the SAFE, pre-v2.0.0
+		// behavior. Adoption of the zero-conflict invariant
+		// ("integration-point") must be explicit per-repo; see
+		// DerivedDocsConfig's doc comment for the HOLD finding this fixes.
+		DerivedDocs: DerivedDocsConfig{
+			Mode:      "driver",
+			MinBinary: "",
 		},
 		Decisions: DecisionsConfig{
 			MaxRecent:   20,

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -95,6 +95,19 @@ func TestDefaultMap_OmitsNewKeys_PreservesConfigListByteParity(t *testing.T) {
 	if _, ok := GetPath(m, "context.spec_file"); ok {
 		t.Errorf("DefaultMap exposes `context.spec_file` — breaks `config list` byte-parity")
 	}
+	// derived_docs.mode / derived_docs.min_binary (v2.0.0 B6 adoption-signal
+	// gate, replacing the removed git.pin_derived_docs) have no Python
+	// ancestor either — same rule as enforce_commits / commit_line_threshold
+	// in GitConfig.
+	if _, ok := m.Get("derived_docs"); ok {
+		t.Errorf("DefaultMap contains `derived_docs` — breaks `config list` byte-parity")
+	}
+	if _, ok := GetPath(m, "derived_docs.mode"); ok {
+		t.Errorf("DefaultMap exposes `derived_docs.mode` — breaks `config list` byte-parity")
+	}
+	if _, ok := GetPath(m, "derived_docs.min_binary"); ok {
+		t.Errorf("DefaultMap exposes `derived_docs.min_binary` — breaks `config list` byte-parity")
+	}
 	fs, ok := m.Get("file_structure")
 	if !ok {
 		t.Fatal("file_structure missing from DefaultMap")

--- a/internal/doctor/derived_docs_advisory_test.go
+++ b/internal/doctor/derived_docs_advisory_test.go
@@ -1,0 +1,143 @@
+// derived_docs_advisory_test.go — exercises collectDerivedDocsAdvisories /
+// the CollectStatus.DerivedDocsAdvisories field (v2.0.0 B6, the
+// derived-docs adoption gate's version floor). Every case is ADVISORY
+// ONLY — Overall must stay OK regardless of what fires.
+package doctor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/version"
+)
+
+func TestDerivedDocsAdvisories_DriverMode_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	// No .logmind/config.yml at all — default "driver" mode.
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 0 {
+		t.Errorf("DerivedDocsAdvisories = %v; want none (driver mode, the default)", r.DerivedDocsAdvisories)
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the derived-docs floor advisory must never be drift")
+	}
+}
+
+func TestDerivedDocsAdvisories_DriverModeExplicit_MinBinarySet_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	// Explicit "driver" with a min_binary set anyway — min_binary is
+	// documented as ignored entirely outside integration-point mode.
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: driver\n  min_binary: \"99.0.0\"\n")
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 0 {
+		t.Errorf("DerivedDocsAdvisories = %v; want none (min_binary ignored in driver mode)", r.DerivedDocsAdvisories)
+	}
+}
+
+func TestDerivedDocsAdvisories_IntegrationPoint_NoFloorDeclared_Advisory(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n")
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 1 {
+		t.Fatalf("DerivedDocsAdvisories = %v; want 1 (integration-point without a declared floor)", r.DerivedDocsAdvisories)
+	}
+	mustContainSubstr(t, r.DerivedDocsAdvisories[0], "min_binary")
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the derived-docs floor advisory must never be drift")
+	}
+}
+
+func TestDerivedDocsAdvisories_IntegrationPoint_FloorSatisfied_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	// A trivially-satisfied floor: the running test binary's version.Version
+	// must be >= "0.0.1" (true for every real Version this repo ships).
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n  min_binary: \"0.0.1\"\n")
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 0 {
+		t.Errorf("DerivedDocsAdvisories = %v; want none (floor satisfied)", r.DerivedDocsAdvisories)
+	}
+}
+
+// TestDerivedDocsAdvisories_IntegrationPoint_DevPrereleaseSatisfiesOwnFloor
+// pins the exact self-adoption case (ruling 6): this repo's own dogfood
+// binary reports "X.Y.Z-dev"; declaring min_binary at the CORE of that same
+// version (stripping the prerelease suffix) must NOT warn about itself —
+// see internal/version.SatisfiesMin's doc comment for why the suffix is
+// stripped before comparing.
+func TestDerivedDocsAdvisories_IntegrationPoint_DevPrereleaseSatisfiesOwnFloor(t *testing.T) {
+	core, ok := coreVersionForTest(version.Version)
+	if !ok {
+		t.Skipf("version.Version %q isn't in a testable X.Y.Z(-suffix) shape", version.Version)
+	}
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n  min_binary: \""+core+"\"\n")
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 0 {
+		t.Errorf("DerivedDocsAdvisories = %v; want none (running %q must satisfy its own core version %q as a floor)", r.DerivedDocsAdvisories, version.Version, core)
+	}
+}
+
+func TestDerivedDocsAdvisories_IntegrationPoint_FloorViolated_Advisory(t *testing.T) {
+	dir := freshRepo(t)
+	// A floor no real released Version will ever satisfy.
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n  min_binary: \"9999.0.0\"\n")
+	r := CollectStatus(dir, true)
+	if len(r.DerivedDocsAdvisories) != 1 {
+		t.Fatalf("DerivedDocsAdvisories = %v; want 1 (running binary older than the declared floor)", r.DerivedDocsAdvisories)
+	}
+	mustContainSubstr(t, r.DerivedDocsAdvisories[0], "9999.0.0")
+	mustContainSubstr(t, r.DerivedDocsAdvisories[0], "older")
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the derived-docs floor advisory must never be drift")
+	}
+}
+
+func TestDerivedDocsAdvisories_JSONFieldPresent(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n")
+	r := CollectStatus(dir, true)
+	js, err := r.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	mustContainSubstr(t, js, `"derived_docs_advisories"`)
+	mustContainSubstr(t, js, "min_binary")
+}
+
+func TestDerivedDocsAdvisories_RenderStatus_HumanTable(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"), "derived_docs:\n  mode: integration-point\n  min_binary: \"9999.0.0\"\n")
+	r := CollectStatus(dir, true)
+	body := RenderStatus(r)
+	mustContainSubstr(t, body, "Derived-docs version floor")
+	mustContainSubstr(t, body, "9999.0.0")
+	mustContainSubstr(t, body, "Stack status: OK")
+}
+
+// coreVersionForTest strips a "-prerelease"/"+build" suffix (and a leading
+// "v") from a version string, returning ok=false if what's left isn't
+// exactly three dot-separated integers — mirrors internal/version's
+// unexported parseVersionCore closely enough for this test's purposes
+// without reaching into that package's internals.
+func coreVersionForTest(v string) (string, bool) {
+	s := v
+	if len(s) > 0 && s[0] == 'v' {
+		s = s[1:]
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' || s[i] == '+' {
+			s = s[:i]
+			break
+		}
+	}
+	parts := 1
+	for _, c := range s {
+		if c == '.' {
+			parts++
+		}
+	}
+	if parts != 3 {
+		return "", false
+	}
+	return s, true
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -138,6 +138,16 @@ type StatusReport struct {
 	// spec_file is unset. Like SummariesNeeded, this NEVER affects Overall —
 	// the spec fold-in is a nice-to-have, not a gate.
 	SpecAdvisories []string `json:"spec_advisories"`
+
+	// DerivedDocsAdvisories is an ADVISORY list (v2.0.0 B6, the derived-docs
+	// adoption gate's version floor) reporting: a repo that declared
+	// `derived_docs: {mode: integration-point}` without a `min_binary`
+	// floor, or one whose declared floor the RUNNING binary doesn't
+	// satisfy (internal/version.SatisfiesMin). Empty for a "driver"-mode
+	// repo (the default) — there's nothing to warn about until a repo
+	// opts in. Like SpecAdvisories, this NEVER affects Overall: the floor
+	// is a nudge for contributors to upgrade, not a hard gate.
+	DerivedDocsAdvisories []string `json:"derived_docs_advisories"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -203,13 +213,14 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 	}
 
 	return StatusReport{
-		ProjectRoot:     projectRoot,
-		Tools:           tools,
-		Overall:         overall,
-		NetworkUsed:     false,
-		Suggestions:     suggestions,
-		SummariesNeeded: collectSummariesNeeded(projectRoot),
-		SpecAdvisories:  collectSpecAdvisories(projectRoot),
+		ProjectRoot:           projectRoot,
+		Tools:                 tools,
+		Overall:               overall,
+		NetworkUsed:           false,
+		Suggestions:           suggestions,
+		SummariesNeeded:       collectSummariesNeeded(projectRoot),
+		SpecAdvisories:        collectSpecAdvisories(projectRoot),
+		DerivedDocsAdvisories: collectDerivedDocsAdvisories(projectRoot),
 	}
 }
 
@@ -316,6 +327,44 @@ func collectSpecAdvisories(projectRoot string) []string {
 	return nil
 }
 
+// collectDerivedDocsAdvisories returns the ADVISORY list (v2.0.0 B6) for
+// the derived-docs adoption gate's version floor. Nil for a "driver"-mode
+// repo (the default) — there's nothing to check until a repo declares
+// `derived_docs: {mode: integration-point}`. Two conditions, checked in
+// order (at most one fires — MinBinary is either set or it isn't):
+//
+//   - integration-point mode declared WITHOUT a min_binary floor — a repo
+//     that opted in gets no version-drift warning until it sets one.
+//   - a declared floor the RUNNING binary doesn't satisfy
+//     (internal/version.SatisfiesMin) — the repo expects contributors on
+//     at least this version.
+//
+// Like SpecAdvisories/SummariesNeeded, this NEVER affects Overall: it's a
+// nudge for contributors to upgrade, not a hard gate — doctor makes no
+// network calls and has no way to KNOW a contributor is stuck; it can only
+// compare the binary actually running it against the repo's own
+// declaration.
+func collectDerivedDocsAdvisories(projectRoot string) []string {
+	cfg, err := config.Load(projectRoot)
+	if err != nil {
+		return nil
+	}
+	if cfg.DerivedDocs.Mode != "integration-point" {
+		return nil
+	}
+	if cfg.DerivedDocs.MinBinary == "" {
+		return []string{
+			`derived_docs.mode is "integration-point" but derived_docs.min_binary is unset — set it (e.g. "2.0.0") in .logmind/config.yml so ` + "`logmind doctor`" + ` can warn contributors running an older binary.`,
+		}
+	}
+	if !version.SatisfiesMin(version.Version, cfg.DerivedDocs.MinBinary) {
+		return []string{
+			fmt.Sprintf("running logmind %s is older than this repo's declared derived_docs.min_binary (%s) — upgrade before relying on integration-point mode's guarantees.", version.Version, cfg.DerivedDocs.MinBinary),
+		}
+	}
+	return nil
+}
+
 var prSuffixRe = regexp.MustCompile(` \(#\d+\)$`)
 
 // stripPRSuffix removes a trailing " (#NN)" PR suffix so a placeholder headline
@@ -342,6 +391,11 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 	workflows = append(workflows, probePostMergeHook(projectRoot))
 	workflows = append(workflows, probePostRewriteHook(projectRoot))
 	workflows = append(workflows, probeCommitMsgHook(projectRoot))
+	// v2.0.0 L2a probe — the pin-preservation pre-commit hook. Sits right
+	// after commit-msg (the other commit-time git hook) and right before
+	// the Claude Code harness guard (L2b uses the same restore, different
+	// layer) since all three are part of the same enforcement/pin story.
+	workflows = append(workflows, probePreCommitHook(projectRoot))
 	// v2.0.0 Layer 1 probe — the Claude Code harness's PreToolUse guard
 	// entry in .claude/settings.json. Sits right after the commit-msg row
 	// (Layer 2) since the two are the enforcement feature's matched pair.
@@ -421,6 +475,7 @@ func collectLogmindStatusFast(projectRoot string) []WorkflowStatus {
 	workflows = append(workflows, probePostMergeHook(projectRoot))
 	workflows = append(workflows, probePostRewriteHook(projectRoot))
 	workflows = append(workflows, probeCommitMsgHook(projectRoot))
+	workflows = append(workflows, probePreCommitHook(projectRoot))
 	workflows = append(workflows, probeClaudePreToolUseHook(projectRoot))
 	return workflows
 }
@@ -682,6 +737,72 @@ func probeCommitMsgHook(projectRoot string) WorkflowStatus {
 	return probeHook(projectRoot, "commit-msg hook", "commit-msg", hooks.BuildCommitMsgBody())
 }
 
+// probePreCommitHook reports drift for L2a of the v2.0.0 derived-docs
+// pin-preservation design — the `pre-commit` git hook installed by
+// hooks.InstallPreCommit (see hooks.BuildPreCommitBody). Unlike the three
+// probeHook-based probes above, a pre-commit hook file MAY ALREADY be owned
+// by a totally different, older, opt-in logmind feature: `logmind
+// install-hook`'s `check-decisions` body (internal/cli/install_hook.go),
+// which carries no hooks.PreCommitMarker of its own. Neither that body nor
+// a hand-written hook is drift — both are reported "foreign" (Installed:
+// true) rather than "stale"/"markerless", which classifyLogmindDrift falls
+// through to "ok" for, exactly like a missing hook: `logmind init` and
+// `doctor --fix` both deliberately leave a foreign pre-commit hook alone
+// (see hooks.installHook), so there is nothing to auto-fix here either.
+//
+// File-read only (stat + read, no subprocess) — safe for the fast path;
+// see StaleCountFast's doc comment for why that matters.
+func probePreCommitHook(projectRoot string) WorkflowStatus {
+	const displayName = "pre-commit hook (derived-docs pin)"
+	current := version.Version
+	if _, err := os.Stat(filepath.Join(projectRoot, ".git")); err != nil {
+		return WorkflowStatus{
+			Name: displayName, Installed: false,
+			Marker: nil, BundledMarker: nil, Drift: "missing",
+		}
+	}
+	path := filepath.Join(projectRoot, ".git", "hooks", "pre-commit")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return WorkflowStatus{
+			Name: displayName, Installed: false,
+			Marker: nil, BundledMarker: &current, Drift: "missing",
+		}
+	}
+	if !strings.Contains(string(data), hooks.PreCommitMarker) {
+		marker := "foreign pre-commit hook present — left alone"
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &marker, BundledMarker: &current, Drift: "foreign",
+		}
+	}
+	hookVer, ok := hookInstalledVersion(path)
+	if !ok {
+		marker := "markerless"
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &marker, BundledMarker: &current, Drift: "markerless",
+		}
+	}
+	if hookVer != current {
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &hookVer, BundledMarker: &current, Drift: "stale",
+		}
+	}
+	if string(data) != hooks.BuildPreCommitBody() {
+		marker := hookVer + " (content drift)"
+		return WorkflowStatus{
+			Name: displayName, Installed: true,
+			Marker: &marker, BundledMarker: &current, Drift: "stale",
+		}
+	}
+	return WorkflowStatus{
+		Name: displayName, Installed: true,
+		Marker: &hookVer, BundledMarker: &current, Drift: "current",
+	}
+}
+
 // probeClaudePreToolUseHook reports drift for Layer 1 of the v2.0.0
 // commit-enforcement design — the Claude Code harness's PreToolUse guard
 // entry in .claude/settings.json (installed/refreshed by
@@ -822,6 +943,8 @@ func formatDrift(drift string) string {
 		return "markerless"
 	case "missing":
 		return "—"
+	case "foreign":
+		return "foreign (left alone)"
 	}
 	return drift
 }
@@ -900,6 +1023,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Canonical spec file (%d):", len(r.SpecAdvisories)))
 		for _, s := range r.SpecAdvisories {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
+		}
+	}
+	if len(r.DerivedDocsAdvisories) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Derived-docs version floor (%d):", len(r.DerivedDocsAdvisories)))
+		for _, s := range r.DerivedDocsAdvisories {
 			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -93,6 +94,7 @@ func TestCollectStatus_FreshRepoListsAllProbes(t *testing.T) {
 		"AGENTS.md", ".gitattributes (merge driver)",
 		"git config (merge driver)", "post-merge hook",
 		"post-rewrite hook", "commit-msg hook",
+		"pre-commit hook (derived-docs pin)",
 		"Claude Code PreToolUse guard",
 		"logmind on PATH",
 	} {
@@ -197,6 +199,7 @@ func TestCollectLogmindStatusFast_ExcludesSubprocessProbes(t *testing.T) {
 		"regen-timeline.yml", "check-doc-links.yml", "logmind-self-update.yml", "check-decisions.yml",
 		"AGENTS.md", ".gitattributes (merge driver)",
 		"post-merge hook", "post-rewrite hook", "commit-msg hook",
+		"pre-commit hook (derived-docs pin)",
 		"Claude Code PreToolUse guard",
 	} {
 		if !contains(names, want) {
@@ -653,5 +656,98 @@ func revertClaudeHookMarker(t *testing.T, dir string) {
 	reverted := strings.ReplaceAll(string(data), version.Version, "0.1.0-FAKE")
 	if err := os.WriteFile(path, []byte(reverted), 0o644); err != nil {
 		t.Fatalf("write reverted settings.json: %v", err)
+	}
+}
+
+// --- probePreCommitHook (L2a / v2.0.0 derived-docs pin-preservation) -----
+
+// fakeGitDir plants a bare `.git/hooks/` directory under dir — enough for
+// probePreCommitHook's (and probeHook's) `.git`-presence check, without
+// needing a real `git init`. File-read-only probes only ever stat/read
+// paths, so this is a faithful, hermetic fixture.
+func fakeGitDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/hooks: %v", err)
+	}
+}
+
+func TestProbePreCommitHook_MissingOnFreshRepo(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	row := probePreCommitHook(dir)
+	if row.Drift != "missing" {
+		t.Errorf("Drift = %q; want missing", row.Drift)
+	}
+	if row.Installed {
+		t.Errorf("Installed = true; want false (no pre-commit hook on disk)")
+	}
+}
+
+// TestProbePreCommitHook_ForeignHookLeftAlone pins the "foreign, not
+// markerless/stale" classification (ruling 5): a pre-commit hook that
+// predates PreCommitMarker — here, the legacy `logmind install-hook`
+// check-decisions body — is reported as Installed=true, Drift="foreign", so
+// classifyLogmindDrift treats it exactly like a missing hook (benign, never
+// flips Overall to DRIFT) instead of "stale" (which WOULD flip it).
+func TestProbePreCommitHook_ForeignHookLeftAlone(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	foreign := "#!/bin/sh\n# logmind check-decisions — hang-guarded (issue #213)\nlogmind check-decisions\n"
+	mustWrite(t, filepath.Join(dir, ".git", "hooks", "pre-commit"), foreign)
+
+	row := probePreCommitHook(dir)
+	if row.Drift != "foreign" {
+		t.Errorf("Drift = %q; want foreign", row.Drift)
+	}
+	if !row.Installed {
+		t.Errorf("Installed = false; want true (a foreign hook IS present on disk)")
+	}
+
+	r := CollectStatus(dir, true)
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK — a foreign pre-commit hook must not flip Overall to DRIFT", r.Overall)
+	}
+}
+
+func TestProbePreCommitHook_CurrentAfterInstall(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	if _, err := hooks.InstallPreCommit(dir); err != nil {
+		t.Fatalf("InstallPreCommit: %v", err)
+	}
+	row := probePreCommitHook(dir)
+	if row.Drift != "current" {
+		t.Errorf("Drift = %q; want current", row.Drift)
+	}
+	if row.Marker == nil || *row.Marker != version.Version {
+		t.Errorf("Marker = %v; want %v", row.Marker, version.Version)
+	}
+}
+
+func TestProbePreCommitHook_StaleOnRevertedMarker(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	if _, err := hooks.InstallPreCommit(dir); err != nil {
+		t.Fatalf("InstallPreCommit: %v", err)
+	}
+	path := filepath.Join(dir, ".git", "hooks", "pre-commit")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pre-commit: %v", err)
+	}
+	reverted := strings.ReplaceAll(string(data), version.Version, "0.1.0-FAKE")
+	if err := os.WriteFile(path, []byte(reverted), 0o755); err != nil {
+		t.Fatalf("write reverted pre-commit: %v", err)
+	}
+
+	row := probePreCommitHook(dir)
+	if row.Drift != "stale" {
+		t.Errorf("Drift = %q; want stale", row.Drift)
+	}
+
+	r := CollectStatus(dir, true)
+	if r.Overall != "DRIFT" {
+		t.Errorf("Overall = %q; want DRIFT with stale pre-commit marker", r.Overall)
 	}
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -64,6 +64,19 @@ const PostRewriteMarker = "# logmind post-rewrite hook"
 // to Layer 2 of the commit-enforcement design (see BuildCommitMsgBody).
 const CommitMsgMarker = "# logmind commit-msg hook"
 
+// PreCommitMarker identifies a logmind-installed pre-commit hook — L2a of
+// the v2.0.0 derived-docs pin-preservation design (see BuildPreCommitBody).
+// Distinct from `install-hook`'s OWN, separate, opt-in pre-commit body
+// (internal/cli/install_hook.go's preCommitMarker == "logmind
+// check-decisions"): that body predates this one, serves a different
+// purpose (blocking undocumented commits), and is intentionally left alone
+// by installHook's marker check below — a repo running the legacy
+// check-decisions hook is "foreign" from THIS marker's point of view, and
+// vice versa. Both markers can coexist in principle, but installHook never
+// merges two hook bodies into one file; see BuildPreCommitBody's doc
+// comment for the conservative-interop rule this implies.
+const PreCommitMarker = "# logmind pre-commit hook"
+
 // hookVersion returns the version string embedded in each hook body.
 // Reads from internal/version.Version — kept as a function (not a
 // package-level var) so tests can override it via a build-tagged
@@ -71,6 +84,19 @@ const CommitMsgMarker = "# logmind commit-msg hook"
 func hookVersion() string {
 	return version.Version
 }
+
+// derivedDocsIntegrationPointGrep is the shell fragment every L0 hook body
+// (BuildPostMergeBody / BuildPostRewriteBody) uses to detect this repo's
+// derived-docs adoption signal (v2.0.0 B6) WITHOUT a `logmind` subprocess —
+// git hooks already gate their whole body on `command -v logmind`, but the
+// mode check itself has to work even when that binary can't be trusted to
+// answer (or is momentarily absent) mid-hook, and reading one line out of a
+// YAML file is cheap enough to inline directly. Matches `mode:
+// integration-point`, optionally quoted, allowing leading indentation and
+// trailing whitespace — the exact shape DerivedDocsConfig.Mode's YAML tag
+// renders as. Kept as ONE shared Go constant so both hook bodies (and any
+// future one) never drift from each other on this string.
+const derivedDocsIntegrationPointGrep = `grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null`
 
 // BuildPostMergeBody returns the canonical post-merge hook body for
 // the currently-running logmind binary. Byte-identical to the Python
@@ -99,6 +125,13 @@ func hookVersion() string {
 // reintroduce the GITHUB_TOKEN-stranding + self-trigger loop the advisory
 // model exists to avoid. The TestPostMergeBody_RollupInvariants guard pins
 // "regenerates the timeline, never pushes" even across a golden regen.
+//
+// v2.0.0 B6 adoption gate: the non-default-branch skip below fires ONLY when
+// THIS repo has opted into `derived_docs: {mode: integration-point}` (see
+// derivedDocsIntegrationPointGrep). "driver" (the default — including a repo
+// with no `derived_docs:` section at all) regenerates on every branch, the
+// exact pre-v2.0.0 behavior; that's the whole point of the adoption gate — a
+// v2 binary must never silently change a driver-mode repo's behavior.
 func BuildPostMergeBody() string {
 	return "#!/bin/sh\n" +
 		"# logmind post-merge hook\n" +
@@ -164,10 +197,15 @@ func BuildPostMergeBody() string {
 		"  default=${default#origin/}\n" +
 		"  [ -z \"$default\" ] && default=main\n" +
 		"  if [ -n \"$current\" ] && [ \"$current\" != \"$default\" ]; then\n" +
-		"    # v2.0.0 derived-docs-on-main: never regenerate on a non-default branch —\n" +
-		"    # the branch must keep the derived docs byte-identical to its main\n" +
-		"    # merge-base (the zero-conflict invariant). main regenerates post-merge.\n" +
-		"    exit 0\n" +
+		"    # v2.0.0 B6: only skip regen here when THIS repo declared\n" +
+		"    # derived_docs.mode: integration-point — the branch must then keep\n" +
+		"    # the derived docs byte-identical to its main merge-base (the\n" +
+		"    # zero-conflict invariant); main regenerates post-merge. A repo\n" +
+		"    # that hasn't adopted (mode unset or \"driver\", the default) falls\n" +
+		"    # through and regenerates on every branch — the pre-v2.0.0 behavior.\n" +
+		"    if " + derivedDocsIntegrationPointGrep + "; then\n" +
+		"      exit 0\n" +
+		"    fi\n" +
 		"  fi\n" +
 		"  if [ -n \"$current\" ] && [ \"$current\" = \"$default\" ]; then\n" +
 		"    head_sha=$(git rev-parse HEAD 2>/dev/null || true)\n" +
@@ -186,6 +224,12 @@ func BuildPostMergeBody() string {
 // BuildPostRewriteBody returns the canonical post-rewrite hook body
 // for the currently-running logmind binary. See BuildPostMergeBody
 // for the byte-identical-vs-Python contract.
+//
+// v2.0.0 B6 adoption gate: same contract as BuildPostMergeBody — the
+// non-default-branch skip fires ONLY when THIS repo declared
+// `derived_docs: {mode: integration-point}` (see
+// derivedDocsIntegrationPointGrep). "driver" (the default) regenerates
+// after every rebase/amend regardless of branch, the pre-v2.0.0 behavior.
 func BuildPostRewriteBody() string {
 	return "#!/bin/sh\n" +
 		"# logmind post-rewrite hook\n" +
@@ -212,9 +256,17 @@ func BuildPostRewriteBody() string {
 		"  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)\n" +
 		"  default=${default#origin/}\n" +
 		"  [ -z \"$default\" ] && default=main\n" +
-		"  # v2.0.0: regenerate only on the default branch (invariant: branches never\n" +
-		"  # edit the derived docs). A rebase/amend on a feature branch leaves them as-is.\n" +
-		"  if [ -n \"$current\" ] && [ \"$current\" = \"$default\" ] && [ -d docs ]; then\n" +
+		"  # v2.0.0 B6: only skip regen on a non-default branch when THIS repo\n" +
+		"  # declared derived_docs.mode: integration-point (invariant: branches\n" +
+		"  # never edit the derived docs under that mode). A repo that hasn't\n" +
+		"  # adopted (mode unset or \"driver\", the default) falls through to the\n" +
+		"  # regen below regardless of branch — the pre-v2.0.0 behavior.\n" +
+		"  if [ -n \"$current\" ] && [ \"$current\" != \"$default\" ]; then\n" +
+		"    if " + derivedDocsIntegrationPointGrep + "; then\n" +
+		"      exit 0\n" +
+		"    fi\n" +
+		"  fi\n" +
+		"  if [ -n \"$current\" ] && [ -d docs ]; then\n" +
 		"    logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true\n" +
 		"    logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true\n" +
 		"    git add docs/timeline.md docs/file-structure.md 2>/dev/null || true\n" +
@@ -333,6 +385,82 @@ func BuildCommitMsgBody() string {
 		"exit 0\n"
 }
 
+// BuildPreCommitBody returns the canonical pre-commit hook body — L2a of
+// the v2.0.0 derived-docs pin-preservation design (see internal/cli/derived.go
+// for the invariant, and internal/cli/log.go's commitDecision for L1, the
+// same restore already run by `logmind log` itself).
+//
+// The gap L2a closes: L1 only fires inside `logmind log`. A raw `git commit
+// -am ...` (or any commit that skips `logmind log` entirely) stages
+// whatever docs/timeline.md / docs/file-structure.md currently look like in
+// the working tree — including a stale/dirty copy left behind by something
+// like `logmind warp` deliberately writing the default branch's newer copy
+// into the working tree for review. `guard-commit`'s CarveOutUnderThreshold
+// lets such a commit through (a derived-doc-only change is small), so
+// nothing else in the enforcement stack catches it. This hook does: on a
+// non-default branch, it restores both files to their committed (HEAD)
+// content — in both the index and the working tree — before the commit is
+// built, so the raw commit can never carry a derived-doc change off the
+// zero-conflict invariant.
+//
+// MUST NEVER block a commit. Unlike the commit-msg hook (Layer 2 of commit
+// enforcement, which can legitimately reject a commit), this hook exists
+// solely to keep two files pinned — a purely mechanical, lossless operation
+// (the docs regenerate deterministically from the committed decision files,
+// which travel with the branch and never conflict). It always exits 0,
+// whether or not `.logmind/config.yml` is present, whether or not the
+// restore itself succeeds, and regardless of branch-detection failures.
+//
+// Deliberately pure git — NO `logmind` binary required on PATH, unlike the
+// commit-msg hook's delegation to `logmind guard-commit`. The restore is
+// simple enough (`git checkout HEAD -- <path>`) to inline directly, which
+// keeps this guardrail working in the two places it matters most: a fresh
+// clone or CI runner where logmind might not be installed yet, and a repo
+// where the on-PATH logmind is stale or broken.
+//
+// Branch detection mirrors BuildPostMergeBody / BuildPostRewriteBody
+// exactly: `git rev-parse --abbrev-ref HEAD` for the current branch,
+// `git symbolic-ref --short refs/remotes/origin/HEAD` (stripped of its
+// `origin/` prefix) for the default branch, falling back to "main" when the
+// remote symbolic ref can't be resolved (no origin, detached HEAD, etc.).
+func BuildPreCommitBody() string {
+	return "#!/bin/sh\n" +
+		"# logmind pre-commit hook\n" +
+		HookVersionPrefix + hookVersion() + "\n" +
+		"# Installed by `logmind init` (v2.0.0+). L2a of the derived-docs-on-main\n" +
+		"# pin-preservation design: docs/timeline.md and docs/file-structure.md are\n" +
+		"# purely-derived, main-only artifacts (see internal/cli/derived.go). A raw\n" +
+		"# `git commit` — bypassing `logmind log`, whose own commitDecision restore\n" +
+		"# is Layer 1 — could otherwise sweep a dirtied copy of either file into the\n" +
+		"# commit on a non-default branch, e.g. after `logmind warp` pulls in the\n" +
+		"# default branch's newer copy for review. This hook restores both to their\n" +
+		"# committed (HEAD) content, in both the index and the working tree, right\n" +
+		"# before the commit is built.\n" +
+		"#\n" +
+		"# This hook MUST NEVER block a commit — it always exits 0. The restore is\n" +
+		"# lossless (the docs regenerate deterministically from the committed\n" +
+		"# decision files) so there is nothing to protect by failing closed.\n" +
+		"#\n" +
+		"# Deliberately pure git — no `logmind` binary required on PATH. Unlike the\n" +
+		"# commit-msg hook (which delegates the enforce/allow decision to `logmind\n" +
+		"# guard-commit`), this restore is simple enough to inline directly, which\n" +
+		"# keeps it working in a fresh clone or CI runner before logmind is\n" +
+		"# installed, or when the on-PATH binary is stale or broken.\n" +
+		"\n" +
+		"if [ -f .logmind/config.yml ]; then\n" +
+		"  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)\n" +
+		"  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)\n" +
+		"  # --short on a remote symbolic-ref leaves the `origin/` prefix\n" +
+		"  # in place; strip it so the bare-name comparison below works.\n" +
+		"  default=${default#origin/}\n" +
+		"  [ -z \"$default\" ] && default=main\n" +
+		"  if [ -n \"$current\" ] && [ \"$current\" != \"$default\" ]; then\n" +
+		"    git checkout HEAD -- docs/timeline.md docs/file-structure.md >/dev/null 2>&1 || true\n" +
+		"  fi\n" +
+		"fi\n" +
+		"exit 0\n"
+}
+
 // InstallPostMerge writes `.git/hooks/post-merge` to the current
 // binary's canonical body. Returns (true, nil) if the file was
 // created or rewritten, (false, nil) if a logmind-marked hook was
@@ -366,6 +494,20 @@ func InstallCommitMsg(repoRoot string) (bool, error) {
 		filepath.Join(repoRoot, ".git", "hooks", "commit-msg"),
 		BuildCommitMsgBody(),
 		CommitMsgMarker,
+	)
+}
+
+// InstallPreCommit writes `.git/hooks/pre-commit`. See InstallPostMerge for
+// the shared contract — including the conservative-interop behavior that
+// matters most here: a pre-commit hook that already exists WITHOUT
+// PreCommitMarker (a hand-written hook, OR the separate, opt-in
+// `logmind check-decisions` body `logmind install-hook` writes — see
+// PreCommitMarker's doc comment) is left completely alone. v2.0.0+.
+func InstallPreCommit(repoRoot string) (bool, error) {
+	return installHook(
+		filepath.Join(repoRoot, ".git", "hooks", "pre-commit"),
+		BuildPreCommitBody(),
+		PreCommitMarker,
 	)
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -83,6 +83,65 @@ func TestCommitMsgBody_DelegatesToGuardCommit(t *testing.T) {
 	}
 }
 
+// TestPreCommitBody_MatchesGolden pins the L2a pre-commit hook body — the
+// derived-docs pin-preservation guardrail. No Python ancestor (this hook is
+// v2.0.0+/Go-only), same as commit-msg's golden: exists purely so a future
+// refactor that reflows the shell script trips CI loudly instead of
+// silently drifting every consumer's next `doctor --fix`/`init` upgrade.
+func TestPreCommitBody_MatchesGolden(t *testing.T) {
+	checkGolden(t, "pre-commit.golden", BuildPreCommitBody())
+}
+
+// TestPreCommitBody_GatesRestoreAndAlwaysExitsZero pins the L2a contract as
+// INTENT, distinct from the byte-golden above: the restore only runs on a
+// NON-default branch, and the hook exits 0 unconditionally — it must NEVER
+// block a commit. The full guard line (with `!=`, not accidentally
+// flippable to `==`/`||`) is pinned so an operator-bug regression trips
+// this test instead of silently defeating the gate.
+func TestPreCommitBody_GatesRestoreAndAlwaysExitsZero(t *testing.T) {
+	body := BuildPreCommitBody()
+
+	for _, must := range []string{
+		`current=$(git rev-parse --abbrev-ref HEAD`,
+		`default=$(git symbolic-ref --short refs/remotes/origin/HEAD`,
+		`default=${default#origin/}`,
+	} {
+		if !strings.Contains(body, must) {
+			t.Errorf("pre-commit body missing branch detection %q", must)
+		}
+	}
+
+	// The non-default-branch guard itself, pinned in FULL (not just the
+	// `!=` prefix) — the same operator-bug protection
+	// TestPostRewriteHook_NoRegenOnFeatureBranch applies to the post-rewrite
+	// hook's guard: a substitution like `A && B || true` would silently
+	// widen when the restore fires.
+	const guard = `if [ -n "$current" ] && [ "$current" != "$default" ]; then`
+	gi := strings.Index(body, guard)
+	if gi < 0 {
+		t.Fatalf("pre-commit body missing the non-default-branch guard %q", guard)
+	}
+
+	const restore = "git checkout HEAD -- docs/timeline.md docs/file-structure.md"
+	ri := strings.Index(body, restore)
+	if ri < 0 {
+		t.Fatalf("pre-commit body missing the restore command %q", restore)
+	}
+	if n := strings.Count(body, restore); n != 1 {
+		t.Errorf("restore command appears %d time(s); want exactly 1", n)
+	}
+	if ri < gi {
+		t.Errorf("restore command appears BEFORE the non-default-branch guard — it would also run on the default branch")
+	}
+
+	// MUST NEVER block a commit: a top-level (unindented) `exit 0` outside
+	// any conditional guarantees this regardless of the restore's outcome,
+	// missing `.logmind/config.yml`, or a branch-detection failure.
+	if !regexp.MustCompile(`(?m)^exit 0\s*(#.*)?$`).MatchString(body) {
+		t.Errorf("pre-commit body has no top-level `exit 0` — it must NEVER block a commit")
+	}
+}
+
 // TestPostMergeBody_RollupInvariants pins the Slice 2 roll-up contract as
 // INTENT (distinct from the byte-golden): the post-merge hook MUST regenerate
 // the timeline + file-structure (so a main-canonical repo rebuilds its §1.6.4
@@ -110,25 +169,122 @@ func TestPostMergeBody_RollupInvariants(t *testing.T) {
 	}
 }
 
-// TestPostRewriteHook_NoRegenOnFeatureBranch pins the v2.0.0 derived-docs-on-main
-// invariant for the post-rewrite hook: a rebase/amend regenerates (and
-// `git add`s) docs/timeline.md + docs/file-structure.md ONLY on the default
-// branch. On a feature branch (current != default) the hook must leave the
-// derived docs untouched, so the branch stays byte-identical to its main
-// merge-base and merges never conflict.
+// TestPostMergeBody_IntegrationPointModeSkipsFeatureBranchRegen pins the
+// v2.0.0 B6 adoption gate for the post-merge hook: on a non-default branch,
+// the hook exits BEFORE the roll-up regen ONLY when THIS repo declared
+// `derived_docs: {mode: integration-point}` (detected via
+// derivedDocsIntegrationPointGrep against .logmind/config.yml). "driver"
+// (the default) falls through and regenerates regardless of branch — see
+// TestPostMergeBody_DriverModeNoLongerUnconditionallySkipsNonDefaultBranch
+// for the companion proof that the old unconditional skip is gone.
+//
+// Approach: same as the post-rewrite sibling test — no in-package helper
+// fires a real post-merge hook against a live .logmind/config.yml, so this
+// asserts on the BODY STRING. It proves the gate structurally: the
+// mode-check's `exit 0` sits INSIDE the non-default-branch guard, strictly
+// BEFORE the roll-up regen block (itself guarded only by `[ -d docs ]`, no
+// branch condition — see the sibling test below).
+func TestPostMergeBody_IntegrationPointModeSkipsFeatureBranchRegen(t *testing.T) {
+	body := BuildPostMergeBody()
+
+	const branchGuard = `if [ -n "$current" ] && [ "$current" != "$default" ]; then`
+	bgi := strings.Index(body, branchGuard)
+	if bgi < 0 {
+		t.Fatalf("post-merge body missing the non-default-branch guard %q", branchGuard)
+	}
+
+	modeCheck := "if " + derivedDocsIntegrationPointGrep + "; then"
+	mci := strings.Index(body, modeCheck)
+	if mci < 0 {
+		t.Fatalf("post-merge body missing the integration-point mode check %q", modeCheck)
+	}
+	if mci < bgi {
+		t.Errorf("mode check appears BEFORE the non-default-branch guard %q — it must be nested inside it", branchGuard)
+	}
+	// No bare `exit 0` between the guard opening and the mode check — that
+	// would be the OLD unconditional skip lingering alongside the new gate.
+	between := body[bgi:mci]
+	if strings.Contains(between, "exit 0") {
+		t.Errorf("post-merge body has an exit 0 between the branch guard and the mode check — the old unconditional skip must be fully replaced, not just supplemented")
+	}
+
+	exitRel := strings.Index(body[mci:], "exit 0")
+	if exitRel < 0 {
+		t.Fatalf("post-merge body's mode check has no exit 0")
+	}
+	exitIdx := mci + exitRel
+
+	for _, action := range []string{
+		"logmind timeline --write docs/timeline.md",
+		"logmind file-structure --write docs/file-structure.md",
+	} {
+		if n := strings.Count(body, action); n != 1 {
+			t.Errorf("action %q appears %d time(s); want exactly 1", action, n)
+			continue
+		}
+		if strings.Index(body, action) < exitIdx {
+			t.Errorf("action %q appears BEFORE the integration-point mode's exit 0", action)
+		}
+	}
+}
+
+// TestPostMergeBody_DriverModeNoLongerUnconditionallySkipsNonDefaultBranch
+// pins the inversion ruling 3 requires: the roll-up regen actions
+// (BuildPostMergeBody's final `[ -d docs ]` block) must NOT be nested
+// inside any `current != default` OR `current == default` branch
+// condition — driver mode (the default) regenerates after every local
+// merge regardless of branch, matching the pre-v2.0.0 behavior. Only the
+// integration-point mode check (pinned above) may skip it, and only via
+// its own explicit `exit 0`.
+func TestPostMergeBody_DriverModeNoLongerUnconditionallySkipsNonDefaultBranch(t *testing.T) {
+	body := BuildPostMergeBody()
+	const finalGuard = `if [ -d docs ]; then`
+	fgi := strings.LastIndex(body, finalGuard)
+	if fgi < 0 {
+		t.Fatalf("post-merge body missing the final regen guard %q", finalGuard)
+	}
+	// The two roll-up regen calls must sit inside THIS `[ -d docs ]` guard —
+	// not additionally re-gated on a branch-equality condition. We already
+	// proved (in the sibling test) that reaching this point at all requires
+	// falling through both the non-default-branch mode check AND the
+	// default-branch fast-forward check without hitting either `exit 0`; the
+	// only condition left immediately guarding the actions is `-d docs`.
+	for _, action := range []string{
+		"logmind timeline --write docs/timeline.md",
+		"logmind file-structure --write docs/file-structure.md",
+	} {
+		idx := strings.LastIndex(body, action)
+		if idx < fgi {
+			t.Errorf("action %q does not appear after the final `[ -d docs ]` guard %q", action, finalGuard)
+		}
+	}
+}
+
+// TestPostRewriteHook_IntegrationPointModeSkipsFeatureBranchRegen pins the
+// v2.0.0 derived-docs-on-main invariant for the post-rewrite hook, UPDATED
+// for the B6 adoption gate: a rebase/amend on a non-default branch skips
+// the regen (and `git add`) of docs/timeline.md + docs/file-structure.md
+// ONLY when THIS repo declared `derived_docs: {mode: integration-point}`
+// (detected via derivedDocsIntegrationPointGrep against
+// .logmind/config.yml). "driver" (the default) regenerates regardless of
+// branch — the exact pre-v2.0.0 behavior; see
+// TestPostRewriteHook_DriverModeNoLongerGatesOnBranch for the companion
+// proof that the OLD unconditional branch guard is gone.
 //
 // Approach: the hooks package has no in-test helper to install + fire a real
-// post-rewrite hook (the initRepoWithLogmind / installHooks / isStagedOrDirty
-// helpers the plan sketches live in internal/cli), and the task forbids
-// inventing duplicates — so this asserts on the BODY STRING instead. It proves
-// the gate structurally: the body detects current/default and every regen+add
-// action sits INSIDE the `[ "$current" = "$default" ]` guard (appears exactly
-// once, only after the guard opens), so a feature-branch rewrite can never
-// reach it.
-func TestPostRewriteHook_NoRegenOnFeatureBranch(t *testing.T) {
+// post-rewrite hook against a live .logmind/config.yml (the
+// initRepoWithLogmind / installHooks / isStagedOrDirty helpers the plan
+// sketches live in internal/cli), and the task forbids inventing
+// duplicates — so this asserts on the BODY STRING instead. It proves the
+// gate structurally: the mode-check's `exit 0` sits INSIDE the
+// non-default-branch guard, and strictly BEFORE the (now
+// branch-unconditional) regen/add actions — so an interpreter reading
+// top-to-bottom exits before ever reaching those actions when (current !=
+// default) AND the repo's config matches integration-point mode.
+func TestPostRewriteHook_IntegrationPointModeSkipsFeatureBranchRegen(t *testing.T) {
 	body := BuildPostRewriteBody()
 
-	// The branch-detection the default-branch guard depends on (mirrors
+	// The branch-detection the non-default-branch guard depends on (mirrors
 	// post-merge).
 	for _, must := range []string{
 		`current=$(git rev-parse --abbrev-ref HEAD`,
@@ -140,35 +296,58 @@ func TestPostRewriteHook_NoRegenOnFeatureBranch(t *testing.T) {
 		}
 	}
 
-	// The default-branch guard itself must be present — pinned in FULL,
-	// including the trailing `&& [ -d docs ]; then`. Pinning the whole guard
-	// line (not just the `= "$default"` prefix) is what catches an operator
-	// bug: `A && B || [ -d docs ]` parses as `(A && B) || [ -d docs ]`, which
-	// is true on ANY branch whenever docs/ exists — silently defeating the
-	// gate. That substitution breaks this substring match, so it can't pass.
-	const guard = `if [ -n "$current" ] && [ "$current" = "$default" ] && [ -d docs ]; then`
-	gi := strings.Index(body, guard)
-	if gi < 0 {
-		t.Fatalf("post-rewrite body missing the default-branch guard %q", guard)
+	const branchGuard = `if [ -n "$current" ] && [ "$current" != "$default" ]; then`
+	bgi := strings.Index(body, branchGuard)
+	if bgi < 0 {
+		t.Fatalf("post-rewrite body missing the non-default-branch guard %q", branchGuard)
 	}
 
+	modeCheck := "if " + derivedDocsIntegrationPointGrep + "; then"
+	mci := strings.Index(body, modeCheck)
+	if mci < 0 {
+		t.Fatalf("post-rewrite body missing the integration-point mode check %q", modeCheck)
+	}
+	if mci < bgi {
+		t.Errorf("mode check appears BEFORE the non-default-branch guard %q — it must be nested inside it", branchGuard)
+	}
+
+	exitRel := strings.Index(body[mci:], "exit 0")
+	if exitRel < 0 {
+		t.Fatalf("post-rewrite body's mode check has no exit 0")
+	}
+	exitIdx := mci + exitRel
+
 	// Every regen / stage action must appear EXACTLY ONCE and ONLY AFTER the
-	// guard opens — i.e. it is gated by `current == default`, so a
-	// feature-branch rewrite (current != default) never regenerates or stages
-	// the derived docs. An action appearing before the guard, or twice, would
-	// mean an ungated regen path — the invariant violation this pins against.
+	// mode check's exit 0 — so a non-default branch in integration-point
+	// mode exits before ever reaching these actions, while driver mode (no
+	// grep match) falls through to them regardless of branch.
 	for _, action := range []string{
 		"logmind timeline --write docs/timeline.md",
 		"logmind file-structure --write docs/file-structure.md",
 		"git add docs/timeline.md docs/file-structure.md",
 	} {
 		if n := strings.Count(body, action); n != 1 {
-			t.Errorf("action %q appears %d time(s); want exactly 1 (only inside the guard)", action, n)
+			t.Errorf("action %q appears %d time(s); want exactly 1", action, n)
 			continue
 		}
-		if strings.Index(body, action) < gi {
-			t.Errorf("action %q appears BEFORE the default-branch guard — it would run on a feature branch (invariant violation)", action)
+		if strings.Index(body, action) < exitIdx {
+			t.Errorf("action %q appears BEFORE the integration-point mode's exit 0", action)
 		}
+	}
+}
+
+// TestPostRewriteHook_DriverModeNoLongerGatesOnBranch pins the inversion
+// ruling 3 requires: the OLD unconditional `current == default` guard
+// around the regen/add actions must be GONE. Driver mode (the default —
+// including a repo with no `derived_docs:` section at all) must regenerate
+// on every branch after a rebase/amend, matching the pre-v2.0.0 behavior;
+// only an explicit integration-point-mode grep match (pinned by
+// TestPostRewriteHook_IntegrationPointModeSkipsFeatureBranchRegen above)
+// may skip it.
+func TestPostRewriteHook_DriverModeNoLongerGatesOnBranch(t *testing.T) {
+	body := BuildPostRewriteBody()
+	if strings.Contains(body, `[ "$current" = "$default" ]`) {
+		t.Errorf("post-rewrite body still gates the regen on current==default — driver mode must regenerate on every branch regardless of default-branch equality")
 	}
 }
 
@@ -388,6 +567,159 @@ func TestInstallCommitMsg_LeavesForeignHook(t *testing.T) {
 	}
 }
 
+func TestInstallPreCommit_FreshInstall(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	changed, err := InstallPreCommit(repo)
+	if err != nil {
+		t.Fatalf("InstallPreCommit: %v", err)
+	}
+	if !changed {
+		t.Fatalf("InstallPreCommit returned changed=false on a fresh repo; want true")
+	}
+	body, err := os.ReadFile(filepath.Join(repo, ".git", "hooks", "pre-commit"))
+	if err != nil {
+		t.Fatalf("read pre-commit: %v", err)
+	}
+	if string(body) != BuildPreCommitBody() {
+		t.Fatalf("installed body drifts from BuildPreCommitBody()")
+	}
+}
+
+func TestInstallPreCommit_Idempotent(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	if _, err := InstallPreCommit(repo); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	changed, err := InstallPreCommit(repo)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if changed {
+		t.Fatalf("InstallPreCommit changed=true on identical second install; want false")
+	}
+}
+
+// TestInstallPreCommit_LeavesForeignHook pins the conservative-interop rule
+// (ruling 2): a pre-commit hook that already exists WITHOUT PreCommitMarker
+// is left completely untouched — no clobber, no append. Two distinct
+// foreign shapes are exercised: a hand-written hook, and the legacy
+// `logmind install-hook`-installed `check-decisions` body (a DIFFERENT
+// logmind-owned hook that predates this feature and carries no
+// PreCommitMarker of its own — see PreCommitMarker's doc comment).
+func TestInstallPreCommit_LeavesForeignHook(t *testing.T) {
+	cases := map[string]string{
+		"hand-written": "#!/bin/sh\n# user's custom pre-commit hook\necho hi\n",
+		"legacy check-decisions": "#!/bin/sh\n" +
+			"# logmind check-decisions — hang-guarded (issue #213): run under a\n" +
+			"# deadline so a wedged logmind binary can never stall `git commit`.\n" +
+			"if command -v logmind >/dev/null 2>&1; then\n" +
+			"    logmind check-decisions &\n" +
+			"    __lm_pid=$!\n" +
+			"    wait \"$__lm_pid\" 2>/dev/null\n" +
+			"    __lm_rc=$?\n" +
+			"    exit \"$__lm_rc\"\n" +
+			"fi\n",
+	}
+	for name, custom := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := tempRepoWithHooks(t)
+			hookPath := filepath.Join(repo, ".git", "hooks", "pre-commit")
+			if err := os.WriteFile(hookPath, []byte(custom), 0o755); err != nil {
+				t.Fatalf("seed foreign hook: %v", err)
+			}
+			changed, err := InstallPreCommit(repo)
+			if err != nil {
+				t.Fatalf("InstallPreCommit: %v", err)
+			}
+			if changed {
+				t.Fatalf("InstallPreCommit changed=true on foreign hook; want false (leave alone)")
+			}
+			got, err := os.ReadFile(hookPath)
+			if err != nil {
+				t.Fatalf("re-read hook: %v", err)
+			}
+			if string(got) != custom {
+				t.Fatalf("foreign hook was modified:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestPreCommitHook_EndToEnd_RawGitCommitDoesNotCarryDirtyDerivedDoc is the
+// L2a proof (ruling task 3b): with the pre-commit hook installed, a raw
+// `git commit -am` (bypassing `logmind log` and its own L1 restore) on a
+// feature branch must NOT let a dirtied docs/timeline.md ride into the
+// commit. This is the exact gap L2a exists to close — the named trigger
+// scenario is `logmind warp` writing the default branch's newer copy into
+// the working tree, but any raw commit reaches the same hook.
+//
+// Needs a REAL git repository (not just the `.git/hooks/` shell
+// tempRepoWithHooks builds) so `git commit` actually invokes the installed
+// hook — see initRealGitRepo.
+func TestPreCommitHook_EndToEnd_RawGitCommitDoesNotCarryDirtyDerivedDoc(t *testing.T) {
+	repo := initRealGitRepo(t)
+
+	docsDir := filepath.Join(repo, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	timelinePath := filepath.Join(docsDir, "timeline.md")
+	original := "# Timeline\n\noriginal content\n"
+	if err := os.WriteFile(timelinePath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write timeline.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "file-structure.md"), []byte("# File structure\n"), 0o644); err != nil {
+		t.Fatalf("write file-structure.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, ".logmind"), 0o755); err != nil {
+		t.Fatalf("mkdir .logmind: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".logmind", "config.yml"), []byte("git: {}\n"), 0o644); err != nil {
+		t.Fatalf("write config.yml: %v", err)
+	}
+	gitCommitAll(t, repo, "initial scaffold")
+
+	// Install the pre-commit hook — mirrors the init/doctor --fix wiring.
+	if _, err := InstallPreCommit(repo); err != nil {
+		t.Fatalf("InstallPreCommit: %v", err)
+	}
+
+	// Move to a feature branch — the restore only fires when current !=
+	// default, and DefaultBranch resolves to whatever local branch `git
+	// init` created (main or master), so any freshly-created branch name
+	// differs from it.
+	gitIn(t, repo, "checkout", "-b", "feat/dirty-timeline")
+
+	// Dirty docs/timeline.md — simulates `logmind warp` (or any stray
+	// write) pulling in a different copy.
+	dirty := "# Timeline\n\nDIRTY simulated warp content\n"
+	if err := os.WriteFile(timelinePath, []byte(dirty), 0o644); err != nil {
+		t.Fatalf("dirty timeline.md: %v", err)
+	}
+
+	// Raw `git commit -am` — NOT `logmind log`. The pre-commit hook must
+	// fire and restore docs/timeline.md to HEAD before the commit is built.
+	gitIn(t, repo, "commit", "-am", "raw commit bypassing logmind log")
+
+	committed, ok := gitShowFile(repo, "HEAD", "docs/timeline.md")
+	if !ok {
+		t.Fatalf("git show HEAD:docs/timeline.md failed")
+	}
+	if committed != original {
+		t.Fatalf("commit carried the dirtied docs/timeline.md; L2a pre-commit hook did not restore it\nwant:\n%s\ngot:\n%s", original, committed)
+	}
+
+	// `git checkout HEAD --` restores both the index AND the working tree —
+	// confirm the on-disk copy was restored too, not just what got committed.
+	onDisk, err := os.ReadFile(timelinePath)
+	if err != nil {
+		t.Fatalf("read timeline.md: %v", err)
+	}
+	if string(onDisk) != original {
+		t.Fatalf("working tree docs/timeline.md not restored either\nwant:\n%s\ngot:\n%s", original, onDisk)
+	}
+}
+
 func TestExtractVersion_FromInstalledHook(t *testing.T) {
 	repo := tempRepoWithHooks(t)
 	if _, err := InstallPostMerge(repo); err != nil {
@@ -503,6 +835,55 @@ func tempRepoWithHooks(t *testing.T) string {
 		t.Fatalf("mkdir .git/hooks: %v", err)
 	}
 	return dir
+}
+
+// initRealGitRepo creates a fresh, REAL git working repo (not just the
+// `.git/hooks/` shell tempRepoWithHooks builds) rooted at t.TempDir(),
+// configured with a deterministic identity and gpg signing disabled.
+// Needed by TestPreCommitHook_EndToEnd_* — those tests run an actual
+// `git commit` so the installed pre-commit hook fires for real. Deliberately
+// uses plain `os/exec` rather than importing internal/gitcli, keeping this
+// package's import graph small (see the package doc comment).
+func initRealGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q")
+	gitIn(t, dir, "config", "user.email", "test@example.com")
+	gitIn(t, dir, "config", "user.name", "Test")
+	gitIn(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+// gitIn runs `git <args>` against dir, failing the test on a non-zero exit.
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// gitCommitAll stages everything and commits it in dir.
+func gitCommitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-q", "-m", msg)
+}
+
+// gitShowFile returns the content of path at ref (`git show <ref>:<path>`)
+// within dir. ("", false) on any failure.
+func gitShowFile(dir, ref, path string) (string, bool) {
+	cmd := exec.Command("git", "show", ref+":"+path)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
 }
 
 func checkGolden(t *testing.T, name, body string) {

--- a/internal/hooks/testdata/post-merge.golden
+++ b/internal/hooks/testdata/post-merge.golden
@@ -62,10 +62,15 @@ if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
   default=${default#origin/}
   [ -z "$default" ] && default=main
   if [ -n "$current" ] && [ "$current" != "$default" ]; then
-    # v2.0.0 derived-docs-on-main: never regenerate on a non-default branch —
-    # the branch must keep the derived docs byte-identical to its main
-    # merge-base (the zero-conflict invariant). main regenerates post-merge.
-    exit 0
+    # v2.0.0 B6: only skip regen here when THIS repo declared
+    # derived_docs.mode: integration-point — the branch must then keep
+    # the derived docs byte-identical to its main merge-base (the
+    # zero-conflict invariant); main regenerates post-merge. A repo
+    # that hasn't adopted (mode unset or "driver", the default) falls
+    # through and regenerates on every branch — the pre-v2.0.0 behavior.
+    if grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
+      exit 0
+    fi
   fi
   if [ -n "$current" ] && [ "$current" = "$default" ]; then
     head_sha=$(git rev-parse HEAD 2>/dev/null || true)

--- a/internal/hooks/testdata/post-rewrite.golden
+++ b/internal/hooks/testdata/post-rewrite.golden
@@ -23,9 +23,17 @@ if command -v logmind >/dev/null 2>&1 && [ -f .logmind/config.yml ]; then
   default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
   default=${default#origin/}
   [ -z "$default" ] && default=main
-  # v2.0.0: regenerate only on the default branch (invariant: branches never
-  # edit the derived docs). A rebase/amend on a feature branch leaves them as-is.
-  if [ -n "$current" ] && [ "$current" = "$default" ] && [ -d docs ]; then
+  # v2.0.0 B6: only skip regen on a non-default branch when THIS repo
+  # declared derived_docs.mode: integration-point (invariant: branches
+  # never edit the derived docs under that mode). A repo that hasn't
+  # adopted (mode unset or "driver", the default) falls through to the
+  # regen below regardless of branch — the pre-v2.0.0 behavior.
+  if [ -n "$current" ] && [ "$current" != "$default" ]; then
+    if grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
+      exit 0
+    fi
+  fi
+  if [ -n "$current" ] && [ -d docs ]; then
     logmind timeline --write docs/timeline.md >/dev/null 2>&1 || true
     logmind file-structure --write docs/file-structure.md >/dev/null 2>&1 || true
     git add docs/timeline.md docs/file-structure.md 2>/dev/null || true

--- a/internal/hooks/testdata/pre-commit.golden
+++ b/internal/hooks/testdata/pre-commit.golden
@@ -1,0 +1,35 @@
+#!/bin/sh
+# logmind pre-commit hook
+# logmind-hook-version: 2.0.0-dev
+# Installed by `logmind init` (v2.0.0+). L2a of the derived-docs-on-main
+# pin-preservation design: docs/timeline.md and docs/file-structure.md are
+# purely-derived, main-only artifacts (see internal/cli/derived.go). A raw
+# `git commit` — bypassing `logmind log`, whose own commitDecision restore
+# is Layer 1 — could otherwise sweep a dirtied copy of either file into the
+# commit on a non-default branch, e.g. after `logmind warp` pulls in the
+# default branch's newer copy for review. This hook restores both to their
+# committed (HEAD) content, in both the index and the working tree, right
+# before the commit is built.
+#
+# This hook MUST NEVER block a commit — it always exits 0. The restore is
+# lossless (the docs regenerate deterministically from the committed
+# decision files) so there is nothing to protect by failing closed.
+#
+# Deliberately pure git — no `logmind` binary required on PATH. Unlike the
+# commit-msg hook (which delegates the enforce/allow decision to `logmind
+# guard-commit`), this restore is simple enough to inline directly, which
+# keeps it working in a fresh clone or CI runner before logmind is
+# installed, or when the on-PATH binary is stale or broken.
+
+if [ -f .logmind/config.yml ]; then
+  current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  # --short on a remote symbolic-ref leaves the `origin/` prefix
+  # in place; strip it so the bare-name comparison below works.
+  default=${default#origin/}
+  [ -z "$default" ] && default=main
+  if [ -n "$current" ] && [ "$current" != "$default" ]; then
+    git checkout HEAD -- docs/timeline.md docs/file-structure.md >/dev/null 2>&1 || true
+  fi
+fi
+exit 0

--- a/internal/templates/config.yml.template
+++ b/internal/templates/config.yml.template
@@ -29,6 +29,25 @@ git:
   # Lines-changed threshold shared with `logmind check-decisions --threshold`.
   commit_line_threshold: 20
 
+# Derived-docs pin-preservation adoption (v2.0.0). See docs/plan.md's
+# "Derived docs" section for the full L0-L3 design.
+derived_docs:
+  # "driver" (default) reproduces logmind's pre-v2.0.0 behavior:
+  # docs/timeline.md + docs/file-structure.md regenerate on every branch,
+  # and nothing restores or blocks a branch-local edit to them.
+  #
+  # "integration-point" opts INTO the zero-conflict invariant: those two
+  # files regenerate ONLY on the default branch; on any other branch they
+  # are restored to their committed (HEAD) content before a commit can
+  # carry a change to them (pre-commit hook + Claude Code harness), and a
+  # blocking CI gate rejects a PR that edited them anyway.
+  mode: driver
+
+  # SHOULD be set (e.g. "2.0.0") when mode is integration-point — `logmind
+  # doctor` warns when the running binary is older than this floor. Ignored
+  # when mode is driver.
+  min_binary: ""
+
 # Decision management
 decisions:
   # Maximum number of recent decisions to keep in decisions.md

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v8
+# logmind-template-version: v9
 name: logmind / check-derived-docs
 
 # v2.0.0 derived-docs-on-main. The two derived docs are regenerated ONLY here on
@@ -6,6 +6,12 @@ name: logmind / check-derived-docs
 # edited either derived doc (which would cause cross-PR merge conflicts). A
 # branch's real decisions live in docs/decisions-branches/<branch>.md; timeline
 # and file-structure regenerate on main after merge.
+#
+# v9 (B6 adoption gate): the blocking check only applies to a repo that
+# declared `derived_docs: {mode: integration-point}` in .logmind/config.yml.
+# A repo that hasn't adopted it (mode unset or "driver", the default) PASSES
+# with an explanatory message instead — this workflow must never block a PR
+# in a repo whose derived docs are still free to diverge per branch.
 
 on:
   pull_request:
@@ -26,12 +32,22 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          # B6 adoption gate: this repo must have explicitly opted into the
+          # zero-conflict invariant. Unadopted (mode unset or "driver", the
+          # default) → pass with an explanatory message; never block.
+          if ! grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
+            echo "This repo has not adopted derived_docs.mode: integration-point in .logmind/config.yml — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
+            exit 0
+          fi
           changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
           if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|file-structure)\.md'; then
             echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md and/or docs/file-structure.md. These are DERIVED, main-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to main's version — run 'logmind warp', or 'git checkout origin/main -- docs/timeline.md docs/file-structure.md' — then commit. Their real content regenerates on main after merge."

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -236,7 +236,7 @@ func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
 	}
 }
 
-// TestRegenTimelineTemplate_V8_BlockingGate pins the v2.0.0
+// TestRegenTimelineTemplate_V9_BlockingGate pins the v2.0.0
 // derived-docs-on-main contract (replaces the Slice-1 advisory model): on a
 // PR the `check-derived-docs` job is NON-mutating and BLOCKING — it fails
 // (exit 1) if the branch edited docs/timeline.md or docs/file-structure.md,
@@ -244,62 +244,86 @@ func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
 // what causes cross-PR merge conflicts. Regeneration moves to a SEPARATE
 // main-only `regen-on-main` job. The required-check NAME stays
 // `check-derived-docs` so branch-protection rulesets keep matching.
-func TestRegenTimelineTemplate_V8_BlockingGate(t *testing.T) {
+//
+// v9 (B6 adoption gate): the blocking behavior is itself conditioned on this
+// repo having declared `derived_docs: {mode: integration-point}` — a repo
+// that hasn't adopted it (mode unset or "driver", the default) must PASS
+// with an explanatory message instead of ever blocking.
+func TestRegenTimelineTemplate_V9_BlockingGate(t *testing.T) {
 	body := Workflow("regen-timeline.yml.template")
 
-	// Marker bump v7 → v8 (advisory model → blocking gate + main-only regen).
-	if !strings.Contains(body, "# logmind-template-version: v8") {
-		t.Errorf("regen-timeline template missing v8 marker")
+	// Marker bump v8 → v9 (blocking gate now conditioned on repo adoption).
+	if !strings.Contains(body, "# logmind-template-version: v9") {
+		t.Errorf("regen-timeline template missing v9 marker")
 	}
 	// The required-check name MUST stay check-derived-docs (ruleset matching),
 	// and the main regen is a distinct job.
 	if !strings.Contains(body, "check-derived-docs") {
-		t.Errorf("regen-timeline v8 must keep the check-derived-docs job name (ruleset matching)")
+		t.Errorf("regen-timeline v9 must keep the check-derived-docs job name (ruleset matching)")
 	}
 	if !strings.Contains(body, "regen-on-main") {
-		t.Errorf("regen-timeline v8 missing the separate regen-on-main job")
+		t.Errorf("regen-timeline v9 missing the separate regen-on-main job")
 	}
-	// The PR gate BLOCKS: a branch edit to a derived doc must `exit 1`. This is
-	// the exact inversion of the old advisory contract and the structural
-	// guarantee that a derived-doc conflict can never merge.
+	// The PR gate BLOCKS (for an adopted repo): a branch edit to a derived doc
+	// must `exit 1`. This is the exact inversion of the old advisory contract
+	// and the structural guarantee that a derived-doc conflict can never merge.
 	if !strings.Contains(body, "exit 1") {
-		t.Errorf("regen-timeline v8 PR gate must `exit 1` on a derived-doc edit (blocking)")
+		t.Errorf("regen-timeline v9 PR gate must `exit 1` on a derived-doc edit (blocking)")
 	}
 	// The gate detects the edit via the PR's own file list (GitHub's 3-dot
 	// diff = branch-vs-merge-base, fork-correct) and matches ONLY the two
 	// derived docs as whole lines.
 	if !strings.Contains(body, "gh pr diff") || !strings.Contains(body, "--name-only") {
-		t.Errorf("regen-timeline v8 PR gate must use `gh pr diff --name-only`")
+		t.Errorf("regen-timeline v9 PR gate must use `gh pr diff --name-only`")
 	}
 	if !strings.Contains(body, `grep -qxE 'docs/(timeline|file-structure)\.md'`) {
-		t.Errorf("regen-timeline v8 PR gate must match exactly the two derived docs as whole lines")
+		t.Errorf("regen-timeline v9 PR gate must match exactly the two derived docs as whole lines")
 	}
 	// Event-gated jobs: gate runs only on pull_request, regen only on push.
 	if !strings.Contains(body, "github.event_name == 'pull_request'") ||
 		!strings.Contains(body, "github.event_name == 'push'") {
-		t.Errorf("regen-timeline v8 must event-gate the two jobs (pull_request gate / push regen)")
+		t.Errorf("regen-timeline v9 must event-gate the two jobs (pull_request gate / push regen)")
 	}
 	// The main regen commit carries the [skip-logmind] convention and pushes
 	// via the explicit PAT URL (never a persisted/GITHUB_TOKEN credential).
 	if !strings.Contains(body, "[skip-logmind]") {
-		t.Errorf("regen-timeline v8 main regen commit missing the [skip-logmind] prefix")
+		t.Errorf("regen-timeline v9 main regen commit missing the [skip-logmind] prefix")
 	}
 	if !strings.Contains(body, "x-access-token:${PAT}") {
-		t.Errorf("regen-timeline v8 main push must use the explicit PAT URL")
+		t.Errorf("regen-timeline v9 main push must use the explicit PAT URL")
 	}
-	if !strings.Contains(body, "persist-credentials: false") {
-		t.Errorf("regen-timeline v8 regen-on-main checkout must set persist-credentials: false")
+	if strings.Count(body, "persist-credentials: false") < 2 {
+		t.Errorf("regen-timeline v9 must set persist-credentials: false on BOTH checkouts (the new check-derived-docs one + regen-on-main's)")
 	}
 	// The PR gate reads the PR file list via `gh pr diff`, which needs
 	// pull-requests:read. Because specifying ANY permission zeroes the rest,
 	// this MUST be explicit or the gate 403s and fails-closed on every PR.
 	if !strings.Contains(body, "pull-requests: read") {
-		t.Errorf("regen-timeline v8 must grant pull-requests: read (else gh pr diff 403s and blocks every PR)")
+		t.Errorf("regen-timeline v9 must grant pull-requests: read (else gh pr diff 403s and blocks every PR)")
 	}
 	// No-PAT is a freshness-only gap, not a failure: warn + exit 0 (never blocks
 	// the push event; the invariant guarantee lives in the PR gate, not here).
 	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
-		t.Errorf("regen-timeline v8 regen-on-main must warn + exit 0 when no PAT (freshness-only)")
+		t.Errorf("regen-timeline v9 regen-on-main must warn + exit 0 when no PAT (freshness-only)")
+	}
+
+	// v9 adoption gate: the PR gate must check THIS repo's own
+	// .logmind/config.yml for integration-point mode before ever
+	// considering blocking, and pass with an explanatory message when
+	// unadopted.
+	if !strings.Contains(body, ".logmind/config.yml") {
+		t.Errorf("regen-timeline v9 PR gate must check .logmind/config.yml for adoption")
+	}
+	if !strings.Contains(body, `mode:[[:space:]]*"?integration-point"?`) {
+		t.Errorf("regen-timeline v9 PR gate must grep for the integration-point mode line")
+	}
+	if !strings.Contains(body, "has not adopted derived_docs.mode: integration-point") {
+		t.Errorf("regen-timeline v9 PR gate must explain WHY it passed on an unadopted repo")
+	}
+	// The PR gate now needs a checkout to read .logmind/config.yml — it had
+	// none in v8 (gh pr diff alone was enough).
+	if !strings.Contains(body, "actions/checkout@v7") {
+		t.Errorf("regen-timeline v9 PR gate must add a checkout step to read .logmind/config.yml")
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,6 +16,11 @@
 // §3.1.1 the pulse — see docs/spec.md).
 package version
 
+import (
+	"strconv"
+	"strings"
+)
+
 // Version is the logmind binary's semantic version. Bumped at release.
 // Overridable via -ldflags at build time; see package docstring.
 //
@@ -59,3 +64,69 @@ var Version = "2.0.0-dev"
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
 var SpecVersion = "1.5.0"
+
+// SatisfiesMin reports whether v is at least min, using a simple
+// major.minor.patch integer compare — NOT full semver precedence. v2.0.0 B6
+// (the derived-docs adoption gate's version floor, `derived_docs.min_binary`)
+// is the only caller today: `logmind doctor` compares the running Version
+// against a repo-declared floor and warns (never errors) when it's older.
+//
+// Deliberately no semver dependency (per the B6 build ruling: "do NOT add a
+// dependency") — go.mod carries none today, and the compare this needs is
+// small enough not to justify one.
+//
+// Both v and min tolerate a leading "v" and a trailing prerelease/build
+// suffix (anything from the first '-' or '+' onward) — the suffix is
+// stripped BEFORE comparing, a deliberate departure from strict semver
+// precedence (where "2.0.0-dev" < "2.0.0"): this repo's own dogfood binary
+// reports "2.0.0-dev" (see Version above), and it must satisfy its own
+// repo's `min_binary: "2.0.0"` floor rather than perpetually warning about
+// itself. A caller that needs strict prerelease ordering isn't served by
+// this helper — there is no such caller today.
+//
+// A version string that isn't parseable as three dot-separated integers
+// (missing a component, non-numeric, empty) makes SatisfiesMin return true
+// for BOTH v and min — fail open. A floor check is an advisory-only nudge
+// (see internal/doctor), never a gate; reporting a false warning off a
+// version string this helper can't even parse would be worse than staying
+// silent.
+func SatisfiesMin(v, min string) bool {
+	vp, ok := parseVersionCore(v)
+	if !ok {
+		return true
+	}
+	mp, ok := parseVersionCore(min)
+	if !ok {
+		return true
+	}
+	for i := 0; i < 3; i++ {
+		if vp[i] != mp[i] {
+			return vp[i] > mp[i]
+		}
+	}
+	return true // equal
+}
+
+// parseVersionCore extracts the [major, minor, patch] integer triple from a
+// version string, stripping a leading "v" and any trailing
+// prerelease/build suffix (from the first '-' or '+' onward) first. Returns
+// ok=false when the (suffix-stripped) remainder isn't exactly three
+// dot-separated non-negative integers.
+func parseVersionCore(s string) (core [3]int, ok bool) {
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return core, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return core, false
+		}
+		core[i] = n
+	}
+	return core, true
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,65 @@
+package version
+
+import "testing"
+
+// TestSatisfiesMin_DevPrereleaseSatisfiesItsOwnFloor pins the deliberate
+// departure from strict semver precedence (see SatisfiesMin's doc comment):
+// this repo's own dogfood binary reports "2.0.0-dev" and adopts
+// `derived_docs: {mode: integration-point, min_binary: "2.0.0"}" — the
+// prerelease suffix must be stripped before comparing, or logmind's own
+// local builds would perpetually warn about themselves.
+func TestSatisfiesMin_DevPrereleaseSatisfiesItsOwnFloor(t *testing.T) {
+	if !SatisfiesMin("2.0.0-dev", "2.0.0") {
+		t.Errorf("SatisfiesMin(%q, %q) = false; want true (prerelease suffix stripped before compare)", "2.0.0-dev", "2.0.0")
+	}
+}
+
+func TestSatisfiesMin_OlderVersionFails(t *testing.T) {
+	cases := []struct{ v, min string }{
+		{"1.9.9", "2.0.0"},
+		{"2.0.0-dev", "2.0.1"},
+		{"1.2.3", "1.2.4"},
+		{"0.9.0", "1.0.0"},
+	}
+	for _, c := range cases {
+		if SatisfiesMin(c.v, c.min) {
+			t.Errorf("SatisfiesMin(%q, %q) = true; want false", c.v, c.min)
+		}
+	}
+}
+
+func TestSatisfiesMin_NewerOrEqualSucceeds(t *testing.T) {
+	cases := []struct{ v, min string }{
+		{"2.0.0", "2.0.0"},
+		{"2.0.1", "2.0.0"},
+		{"3.0.0", "2.9.9"},
+		{"v2.0.0", "2.0.0"}, // leading "v" tolerated on either side
+		{"2.0.0", "v2.0.0"},
+	}
+	for _, c := range cases {
+		if !SatisfiesMin(c.v, c.min) {
+			t.Errorf("SatisfiesMin(%q, %q) = false; want true", c.v, c.min)
+		}
+	}
+}
+
+// TestSatisfiesMin_UnparseableFailsOpen: a floor check is advisory-only —
+// an unparseable version string (either side) must never manufacture a
+// bogus warning, so SatisfiesMin returns true (satisfied) rather than
+// erroring or panicking.
+func TestSatisfiesMin_UnparseableFailsOpen(t *testing.T) {
+	cases := []struct{ v, min string }{
+		{"", "2.0.0"},
+		{"2.0.0", ""},
+		{"not-a-version", "2.0.0"},
+		{"2.0.0", "not-a-version"},
+		{"2.0", "2.0.0"},     // only two components
+		{"2.0.0.1", "2.0.0"}, // four components
+		{"2.x.0", "2.0.0"},   // non-numeric component
+	}
+	for _, c := range cases {
+		if !SatisfiesMin(c.v, c.min) {
+			t.Errorf("SatisfiesMin(%q, %q) = false; want true (fail open on unparseable input)", c.v, c.min)
+		}
+	}
+}


### PR DESCRIPTION
Unblocks **protocol#47**, which came back **HOLD** with two blocking findings. Both were correct; one I should have caught myself.

## The findings

**1. The compatibility argument was fiction.** The SPEC claimed older tools would defer via `file_structure.auto_update`. **Nothing reads that flag** — and my own dead-code sweep had flagged it as unwired two days earlier, in the plan of record, before I built the argument on top of it. The protocol owner reproduced the break against released **v1.2.0**: old binary → post-merge hook regenerates derived docs on a branch → its next `logmind log --stage all` sweeps them in → branch diverges from the merge base → the new **blocking** gate fails a required check. That is the SPEC's "older tools MUST continue to work against newer repos" rule, violated.

**2. "Opt-in" wasn't true.** L0 and L1 applied the restriction unconditionally, keyed only on branch name. Same root cause produced an *inverse* break: a repo that never opted in had its Layer-1 branch regeneration silently switched off the moment any contributor upgraded to a v2 binary.

## The fix — both halves, because neither alone suffices

An adoption signal alone doesn't help an *older* tool (it can't read the signal). A version floor alone says who may adopt but not how a v2 binary behaves in a repo that never adopted. So:

```yaml
derived_docs:
  mode: driver            # DEFAULT — exactly the pre-v2.0.0 behavior
  min_binary: ""          # e.g. "2.0.0" when adopting
```

**`driver` is the default**, so **a v2 binary in an unadopted repo behaves exactly like v1.** All four layers are now gated on `mode: integration-point`:

| Layer | Gate |
|---|---|
| **L0** post-merge / post-rewrite | `grep` for the adoption signal *inside the shell body* — keeps ONE canonical body per hook, so `doctor`'s byte-comparison drift detection is untouched |
| **L1** `commitDecision` | `onNonDefaultBranch(cwd) && integrationPointMode(cwd)` |
| **L2a** pre-commit hook (new) | installed only in integration-point mode |
| **L2b** Claude `PreToolUse` restore (new) | same gate |

**The CI gate now passes with an explanation instead of blocking** when a repo hasn't adopted — that's what makes §8.3 hold. Template marker `v8` → `v9`.

I explicitly did **not** take the third option offered (weaken the gate to advisory). That would trade away the structural guarantee to paper over a mistake in my own argument.

## The new L2 layers

Closing the last local hole: `logmind warp` deliberately writes main's copy into your tree, and a raw `git commit -am` would sweep it in (`guard-commit` waves it through as under-threshold). **L2a** (git pre-commit) covers humans and non-Claude tools; **L2b** (harness) covers what a git hook structurally cannot — `git commit --no-verify` skips every git hook, and **git hooks aren't cloned** while `.claude/settings.json` is. Both restore silently and **never block a commit**.

Documented honestly in `docs/plan.md`: these are guardrails, not walls. CI is the only non-bypassable enforcement.

## Verification

Full suite green (20 packages), `vet`/`gofmt` clean. Verified by hand beyond the tests: the L0 shell `grep` correctly rejects `driver`, a commented-out line, an `integration-point-foo` suffix, and a missing file; `mode:` appears exactly once in the schema so the non-section-aware grep can't collide; **no tests were deleted** (hooks 19→28, cli log 24→25 — renames kept their assertion strength); and the post-rewrite golden restructure is behaviorally equivalent in both modes. This repo dogfoods the mode on itself.

Next: reshape protocol#47 to describe what now exists, fold in #48's pin-preservation clause, and promote the `GH013` ruleset-bypass note into §5.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)