### PR TITLE
fix(security): derived-docs gate must read its adoption signal from the base ref, not the PR it judges

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -31,20 +31,34 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
+      # NO checkout, deliberately. This job reads ONLY the base ref (via the
+      # API) and the PR's file list — never the PR's own content. See below.
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           # B6 adoption gate: this repo must have explicitly opted into the
           # zero-conflict invariant. Unadopted (mode unset or "driver", the
           # default) → pass with an explanatory message; never block.
-          if ! grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
-            echo "This repo has not adopted derived_docs.mode: integration-point in .logmind/config.yml — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
+          #
+          # SECURITY — the adoption signal MUST be read from the BASE ref, never
+          # from the pull request under judgement. `actions/checkout` on a
+          # pull_request event checks out refs/pull/N/merge (i.e. the PR's own
+          # content), so reading .logmind/config.yml from the workspace let a PR
+          # DISABLE THIS GATE FOR ITSELF just by setting `mode: driver` — or
+          # deleting the key — in the same PR that edits a derived doc. That is
+          # the self-referential-authority failure the SPEC's base-ref MUSTs
+          # (§1.12.1, §10.3.3) exist to prevent. Reading at base.sha makes the
+          # signal unforgeable by the PR: only a commit already ON the base
+          # branch can turn this gate on or off.
+          base_cfg=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/.logmind/config.yml?ref=${BASE_SHA}" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+          if ! printf '%s\n' "$base_cfg" | grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$'; then
+            echo "This repo has not adopted derived_docs.mode: integration-point on the BASE branch — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
             exit 0
           fi
           changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")

--- a/docs/decisions-branches/fix__gate-adoption-from-base-ref.md
+++ b/docs/decisions-branches/fix__gate-adoption-from-base-ref.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-26-security-read-the-derived-docs-gate-adoption-signal-from-the -->
+- **2026-07-26** — Security: read the derived-docs gate adoption signal from the base ref, never from the PR under judgement
+<!-- logmind-entry-end -->
+
+## 2026-07-26 22:03 - Security: read the derived-docs gate adoption signal from the base ref, never from the PR under judgement
+
+**Reasoning:** actions/checkout on a pull_request event lands refs/pull/N/merge — the PR own content — so grepping .logmind/config.yml from the workspace let a pull request DISABLE THE GATE FOR ITSELF by setting mode driver in the same PR that edited a derived doc. That is the self-referential-authority failure the SPEC base-ref MUSTs in 1.12.1 and 10.3.3 exist to prevent, and it was live on main
+
+**Alternatives considered:** Keep the checkout but compare against origin/main in the workspace (rejected: the workspace is still PR-controlled; the fix has to be a ref the PR cannot influence)
+
+**Implications:**
+- The PR job now performs NO checkout at all and reads the config at pull_request.base.sha via the API, so only a commit already on the base branch can turn the gate on or off; the template test pins both the base-ref read and the ABSENCE of a checkout, proven non-vacuous by mutation
+
+---
+

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -32,20 +32,34 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
+      # NO checkout, deliberately. This job reads ONLY the base ref (via the
+      # API) and the PR's file list — never the PR's own content. See below.
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           # B6 adoption gate: this repo must have explicitly opted into the
           # zero-conflict invariant. Unadopted (mode unset or "driver", the
           # default) → pass with an explanatory message; never block.
-          if ! grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$' .logmind/config.yml 2>/dev/null; then
-            echo "This repo has not adopted derived_docs.mode: integration-point in .logmind/config.yml — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
+          #
+          # SECURITY — the adoption signal MUST be read from the BASE ref, never
+          # from the pull request under judgement. `actions/checkout` on a
+          # pull_request event checks out refs/pull/N/merge (i.e. the PR's own
+          # content), so reading .logmind/config.yml from the workspace let a PR
+          # DISABLE THIS GATE FOR ITSELF just by setting `mode: driver` — or
+          # deleting the key — in the same PR that edits a derived doc. That is
+          # the self-referential-authority failure the SPEC's base-ref MUSTs
+          # (§1.12.1, §10.3.3) exist to prevent. Reading at base.sha makes the
+          # signal unforgeable by the PR: only a commit already ON the base
+          # branch can turn this gate on or off.
+          base_cfg=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/.logmind/config.yml?ref=${BASE_SHA}" \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+          if ! printf '%s\n' "$base_cfg" | grep -Eq '^[[:space:]]*mode:[[:space:]]*"?integration-point"?[[:space:]]*$'; then
+            echo "This repo has not adopted derived_docs.mode: integration-point on the BASE branch — the derived-docs invariant isn't enforced here. Passing (see docs/plan.md's 'Derived docs' section to opt in)."
             exit 0
           fi
           changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -253,8 +253,8 @@ func TestRegenTimelineTemplate_V9_BlockingGate(t *testing.T) {
 	if !strings.Contains(body, "x-access-token:${PAT}") {
 		t.Errorf("regen-timeline v9 main push must use the explicit PAT URL")
 	}
-	if strings.Count(body, "persist-credentials: false") < 2 {
-		t.Errorf("regen-timeline v9 must set persist-credentials: false on BOTH checkouts (the new check-derived-docs one + regen-on-main's)")
+	if !strings.Contains(body, "persist-credentials: false") {
+		t.Errorf("regen-timeline v9 must set persist-credentials: false on regen-on-main's checkout")
 	}
 	// The PR gate reads the PR file list via `gh pr diff`, which needs
 	// pull-requests:read. Because specifying ANY permission zeroes the rest,
@@ -281,10 +281,33 @@ func TestRegenTimelineTemplate_V9_BlockingGate(t *testing.T) {
 	if !strings.Contains(body, "has not adopted derived_docs.mode: integration-point") {
 		t.Errorf("regen-timeline v9 PR gate must explain WHY it passed on an unadopted repo")
 	}
-	// The PR gate now needs a checkout to read .logmind/config.yml — it had
-	// none in v8 (gh pr diff alone was enough).
-	if !strings.Contains(body, "actions/checkout@v7") {
-		t.Errorf("regen-timeline v9 PR gate must add a checkout step to read .logmind/config.yml")
+
+	// SECURITY — this is the load-bearing part of this test. The adoption
+	// signal MUST be read from the BASE ref, never from the pull request under
+	// judgement. The first v9 draft checked out the PR and grepped the
+	// workspace copy of .logmind/config.yml, which let a PR DISABLE THIS GATE
+	// FOR ITSELF by setting `mode: driver` in the very PR that edited a derived
+	// doc — the self-referential-authority failure the SPEC's base-ref MUSTs
+	// (§1.12.1, §10.3.3) exist to prevent. Pin BOTH the base-ref read AND the
+	// absence of any checkout in the PR job, so reintroducing the hole fails CI.
+	if !strings.Contains(body, "pull_request.base.sha") {
+		t.Errorf("regen-timeline v9 PR gate must read the adoption signal at the BASE sha, not from the PR itself")
+	}
+	if !strings.Contains(body, "contents/.logmind/config.yml?ref=") {
+		t.Errorf("regen-timeline v9 PR gate must fetch .logmind/config.yml pinned to a ref, not read a workspace copy")
+	}
+	if !strings.Contains(body, "on the BASE branch") {
+		t.Errorf("regen-timeline v9 PR gate's pass message must state the signal came from the BASE branch")
+	}
+	prJob, _, found := strings.Cut(body, "  regen-on-main:")
+	if !found {
+		t.Fatalf("regen-timeline v9: could not locate the regen-on-main job boundary")
+	}
+	// Match the STEP INVOCATION, not the bare action name — the security
+	// comment in the job body legitimately mentions `actions/checkout` while
+	// explaining why there isn't one.
+	if strings.Contains(prJob, "uses: actions/checkout") {
+		t.Errorf("regen-timeline v9 PR gate must NOT check out the PR — a checkout on a pull_request event lands refs/pull/N/merge (the PR's own content) and reintroduces the adoption-signal bypass")
 	}
 }
 


### PR DESCRIPTION
**A pull request could switch this gate off for itself.** Live on `main` since #246. Found by the protocol owner reviewing protocol#47; I verified it against source before fixing.

## The hole

```yaml
- uses: actions/checkout@v7          # pull_request → checks out refs/pull/N/merge
  ...
  grep ... .logmind/config.yml       # ← the PR's OWN copy
```

`actions/checkout` with no `ref:` on a `pull_request` event checks out **the PR's content**. The gate then read its adoption signal — `derived_docs.mode` — from that workspace copy.

So a PR that sets `mode: driver`, or simply deletes the key, **disables the gate for itself** and is then free to edit `docs/timeline.md` in the same PR. The check that exists to make derived-doc conflicts impossible could be turned off by the thing it was checking.

This is the self-referential-authority failure the SPEC's base-ref MUSTs (§1.12.1, §10.3.3) exist to prevent — the same principle as reviewer==notary, which I co-authored and then violated one section over.

## The fix

The PR job now performs **no checkout at all** and reads the config at `pull_request.base.sha`:

```yaml
BASE_SHA: ${{ github.event.pull_request.base.sha }}
...
base_cfg=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.logmind/config.yml?ref=${BASE_SHA}" \
  --jq '.content' | base64 -d || true)
```

Only a commit **already on the base branch** can turn the gate on or off. Dropping the checkout entirely is deliberate: with no PR content in the workspace, there's nothing PR-controlled left to accidentally trust.

Applied in lockstep to `.github/workflows/regen-timeline.yml` and the fleet template.

## Pinned, and proven non-vacuous

`TestRegenTimelineTemplate_V9_BlockingGate` now asserts the base-ref read **and the absence of any checkout in the PR job**. Verified by mutation — reintroducing the checkout fails both it and the lockstep test:

```
--- FAIL: TestRegenTimelineTemplate_V9_BlockingGate
    regen-timeline v9 PR gate must NOT check out the PR — a checkout on a
    pull_request event lands refs/pull/N/merge (the PR's own content) and
    reintroduces the adoption-signal bypass
--- FAIL: TestRegenTimelineWorkflow_LockstepWithTemplate
```

That mutation run also caught a bug in the new test itself: it matched `actions/checkout` inside the explanatory comment, so it would have failed for the wrong reason. Tightened to match the step invocation (`uses: actions/checkout`).

Two prior assertions pinned the *vulnerable* shape (requiring the checkout, and requiring 2× `persist-credentials: false`); both rewritten to pin the secure one.

## Verification

20/20 packages green, `go vet` clean, `gofmt` clean, both workflow YAMLs parse, `actionlint` clean.

**No behavior change for an unadopted repo** — it still passes with an explanatory message; the message now says the signal came from the BASE branch, which is the honest description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)