### PR TITLE
fix(spec-surface): list the two git.* config keys, scope the LOGMIND_QUIET claim in the full AGENTS template, re-base the contract framing on the SPEC

### DIFF
--- a/docs/decisions-branches/fix__spec-surface-docs.md
+++ b/docs/decisions-branches/fix__spec-surface-docs.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-28 00:31 - Close three SPEC-vs-docs gaps: list the two git.* config keys, scope the LOGMIND_QUIET claim in the full AGENTS template, and re-base the contract framing on the SPEC
+
+**Reasoning:** A 2026-07-27 feature-set audit against SPEC.md found the plan was complete on behavior and incomplete on surface. These are the three cheapest confirmed gaps, all verified against SPEC text rather than an agent report. (1) SPEC 1.2.1 documents git.enforce_commits (true) and git.commit_line_threshold (20) and places them after auto_rebase in its example config; both were parsed and honored by guard-commit but absent from config.DefaultMap(), so 'config get git.enforce_commits' answered 'not found' for a key with a documented default. (2) PR #247 fixed the LOGMIND_QUIET overclaim in skill/SKILL.md and the slim template but missed the sibling full AGENTS.md.template, which ships into every consumer repo claiming every verb honors the flag when only 9 of ~23 do. (3) docs/plan.md still named byte-identical output against frozen Python v0.6.16 as the hard contract, contradicting the ruling that the SPEC is the contract and Python is dead history.
+
+**Alternatives considered:** Scaffold the two config keys into config.yml.template instead of DefaultMap -- rejected: DefaultMap is only the merge base for LoadAsMap, so adding them fixes introspection without changing the bytes written into a new repo's config.yml. Reword the quiet claim from scratch -- rejected in favour of reusing #247's exact wording in skill/SKILL.md, so the two surfaces cannot drift apart again. Delete the Python sentence outright -- rejected: the port history is real and worth keeping, it just must not read as the live constraint.
+
+**Implications:**
+- 'logmind config get' now answers for both git.* keys with SPEC-documented defaults; verified before/after with a control key that already worked and a nonexistent key that must still exit 1. New repos scaffolded from the full AGENTS template no longer ship a false claim about quiet coverage. Separately: the plan's rule to run the suite under init.defaultBranch=master is now known to be wrong -- CI does not set it, and it manufactures two internal/cli failures that do not reproduce without it. A scratch-repo probe confirmed decision routing is correct either way, because gitcli.DefaultBranch resolves refs/heads/main at step 2 and never reaches init.defaultBranch at step 4.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -176,9 +176,12 @@ auto-fix in the `check-doc-links` workflow).
 - Single static binary — no runtime dependency for end users
 - Cross-platform distribution (brew, curl, `setup-logmind` action,
   `go install`)
-- Superseded the original Python implementation at v1.0.0; the port's
-  hard contract was byte-identical output against the frozen Python
-  v0.6.16 baseline
+- Superseded the original Python implementation at v1.0.0. Byte-identical
+  output against the frozen Python v0.6.16 baseline was the *migration*
+  check for that port; it is now dead history, not a live constraint
+- The contract is the SkDD SPEC (`thrillmade/protocol/SPEC.md`, declared by
+  `version.SpecVersion`). Conformance is judged against a cited SPEC
+  section — never against Python archaeology
 
 ### Storage: markdown, no database
 - `docs/decisions.md` (recent, default branch) + `docs/decisions-branches/`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -404,6 +404,15 @@ func DefaultMap() *OrderedMap {
 	git.Set("auto_push", true)
 	git.Set("commit_message_template", "logmind: {decision}")
 	git.Set("auto_rebase", false)
+	// SPEC §1.2.1 documents both keys with these defaults and places them
+	// here, after auto_rebase, in the section's example config. They are
+	// parsed and honored (guard_commit.go), but were missing from this map
+	// — so `config get git.enforce_commits` reported "not found" for a key
+	// with a documented default. §1.2.1's MAY-omit-from-listing carve-out
+	// covers context.repomap / file_structure.root_label / context.spec_file
+	// / skill_suggest.*; these two are not in it, so they belong here.
+	git.Set("enforce_commits", true)
+	git.Set("commit_line_threshold", 20)
 	root.Set("git", git)
 
 	decisions := NewOrderedMap()

--- a/internal/templates/AGENTS.md.template
+++ b/internal/templates/AGENTS.md.template
@@ -118,8 +118,11 @@ logmind show --all         # include archive
 logmind search "postgres"  # full-text across both files
 ```
 
-Working as an agent? Set `LOGMIND_QUIET=1` for terse, chainable machine output:
-each verb suppresses progress chatter and prints a single `ok <key=value>` line.
+Working as an agent? Set `LOGMIND_QUIET=1` for terse, chainable machine output
+on the read/emit verbs (`doctor`, `file-structure`, `guard-commit`, `headline`,
+`log`, `repomap`, `search`, `show`, `timeline`): each suppresses progress
+chatter and prints a single `ok <key=value>` line. Other verbs currently
+ignore this flag.
 
 Reading prior decisions first prevents you from re-litigating something
 the team already decided.


### PR DESCRIPTION
Three confirmed gaps from the 2026-07-27 feature-set audit against `SPEC.md`. Every one verified against SPEC text and `origin/main` directly, not taken from an agent report.

## 1. `config get git.enforce_commits` said "not found" for a key with a documented default

SPEC §1.2.1 documents `git.enforce_commits` (bool, `true`) and `git.commit_line_threshold` (int, `20`), and its example config places them immediately after `auto_rebase`. Both are parsed (`config.go:127,133`) and honored by `guard-commit` — but they were missing from `config.DefaultMap()`, which is the merge base `LoadAsMap` uses. So introspection denied the existence of keys the tool was actively obeying.

Reproduced before the fix, and re-checked after with two controls — a key that already worked (`git.auto_push`), and a genuinely absent key (`git.no_such_key`) that must still exit 1:

```
BEFORE  config get git.enforce_commits       → Key 'git.enforce_commits' not found   exit=1
AFTER   config get git.enforce_commits       → True                                  exit=0
AFTER   config get git.commit_line_threshold → 20                                    exit=0
AFTER   config get git.no_such_key           → Key 'git.no_such_key' not found       exit=1
```

`DefaultMap()` is *only* the merge base for `LoadAsMap` — it is not what writes a new repo's `config.yml`. So this changes `config list`/`get` output and nothing on disk. Placement matches the SPEC's own example ordering.

## 2. The full AGENTS template still shipped the `LOGMIND_QUIET` overclaim

#247 fixed this exact lie in `skill/SKILL.md` and `AGENTS.md.slim.template` — and missed the sibling full template, which is what `logmind init --agents codex` installs into a consumer repo. It claimed *every* verb prints a single `ok` line; **9 of ~23** do.

Reused #247's exact wording rather than inventing a variant, so the two surfaces can't drift apart again.

## 3. `docs/plan.md` still named Python as the hard contract

> the port's hard contract was byte-identical output against the frozen Python v0.6.16 baseline

Per the ruling that the SPEC is the contract and Python is dead history. The port history is kept — it just no longer reads as the live constraint.

## Verification

`go build ./...` clean. Both config controls above pass.

One process note worth recording: the plan's standing rule to run the suite under `GIT_CONFIG init.defaultBranch=master` is **wrong** and I've dropped it. CI does not set that variable, and it manufactures two `internal/cli` failures that reproduce nowhere real. A scratch-repo probe confirmed decision routing is correct with and without it — `gitcli.DefaultBranch` resolves `refs/heads/main` at step 2 and never reaches `init.defaultBranch` at step 4. The rule caught a genuine bug once in `hooks_test.go`; I over-generalized it into a standing mandate.