### PR TITLE
feat(show): implement SPEC §3.2 — --json (normative schema), --brief, and --all branch-file merge

### DIFF
--- a/docs/decisions-branches/worktree-agent-a6311ab45529db712.md
+++ b/docs/decisions-branches/worktree-agent-a6311ab45529db712.md
@@ -1,0 +1,14 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-07-28 00:57 - Implement SPEC §3.2's logmind show gaps: --all branch-file merge, --brief, --json
+
+**Reasoning:** SPEC §3.2 specified logmind show [--all] [--brief] [--json], but the Go binary only had --all, and --all's implementation only appended the archive, never docs/decisions-branches/*.md, contradicting its own doc comment ('include archive and every branch decisions file'). --brief and --json were entirely unimplemented despite --json having a NORMATIVE wire schema. Implemented all three: --all now walks every OTHER docs/decisions-branches/*.md file (excluding the current branch's own file, already the primary body) via a new listBranchSources/allExtraSources helper built on the existing decisions.ListBranchFiles primitive, appended under BRANCH DECISIONS banners before the existing archive banner. --brief prints title+timestamp only, grouped by [source] tag under --all. --json emits the SPEC's exact schema ({"decisions":[{title,timestamp,reasoning,alternatives,implications,source}]}) via a new showJSONEntry/showJSONOutput struct pair, reusing decisions.SplitRaw/SplitRawBytes (added by #249) to get per-entry raw byte ranges rather than writing a new file parser; a new parseDecisionBody line-scanner (no existing parser extracted reasoning/alternatives/implications, so this part is genuinely new) recovers those sub-fields from buildDecisionEntry's known markdown layout. --json is unconditionally machine-clean (JSON only, no ok trailer, ignores --quiet). --brief+--json keeps the full NORMATIVE key set but zeroes reasoning/alternatives/implications rather than parsing them, honoring --brief's contract without ever dropping a schema key.
+
+**Alternatives considered:** Export decisions.branchLabelFromFilename and reuse it directly instead of duplicating a 2-line reverse-sanitize helper in show.go — rejected to avoid growing internal/decisions' public API for one call site; the duplication is small, documented, and low-risk., Have --brief silently drop reasoning/alternatives/implications keys from the JSON when combined with --json — rejected because ruling #1 (SPEC schema is NORMATIVE) says never drop keys; zeroing content instead of omitting keys satisfies both --brief's contract and schema fidelity.
+
+**Implications:**
+- internal/cli/quiet_test.go needed a one-line positional-arg fix (runShow gained brief/json params) to keep the build green — no behavior change there, just call-site arity.
+- docs/decisions-branches/*.md files with commas embedded inside an alternative's own text will over-split on --json's alternatives array, since buildDecisionEntry itself joins alternatives with ', ' losslessly-in-appearance-only; this is a pre-existing storage-format limitation, not a bug introduced here — documented in parseDecisionBody's doc comment.
+
+---
+

--- a/internal/cli/quiet_test.go
+++ b/internal/cli/quiet_test.go
@@ -335,7 +335,7 @@ func TestQuiet_Log_ErrorToStderr(t *testing.T) {
 func TestQuiet_Show_ErrorToStderr(t *testing.T) {
 	cwd := t.TempDir() // no docs/ → error path
 	var out, errBuf bytes.Buffer
-	if err := runShow(cwd, false, true, &out, &errBuf); err == nil {
+	if err := runShow(cwd, false, false, false, true, &out, &errBuf); err == nil {
 		t.Fatal("expected ErrSilent when docs/ missing")
 	}
 	if out.Len() != 0 {

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -9,20 +9,48 @@
 // not a hardcoded docs/decisions.md — so `show` always reflects "this branch's
 // recent decisions", matching the documented contract.
 //
-// Output shape:
+// PROTOCOL SPEC §3.2 additionally specifies --all's "every branch decisions
+// file" half (not just the archive), --brief, and --json with a NORMATIVE
+// schema. This file now implements all three:
 //
-//   - default: streams the resolved decision file verbatim.
-//   - --all: appends docs/decisions-archive.md under an ARCHIVED DECISIONS
-//     banner, when the archive exists.
+//   - default: streams the resolved decision file verbatim (UNCHANGED byte
+//     for byte from the pre-§3.2 behavior — existing goldens still pin this).
+//   - --all: appends every OTHER docs/decisions-branches/*.md file (the base
+//     file, when on a feature branch, is already the primary body — never
+//     duplicated) under BRANCH DECISIONS banners, then
+//     docs/decisions-archive.md under an ARCHIVED DECISIONS banner, in that
+//     order, when each exists.
+//   - --brief: title + timestamp only, one line per decision. Under --all,
+//     lines are grouped under a "[source]" tag matching the --json source
+//     value exactly (main / archive / branch:<name>).
+//   - --json: the SPEC §3.2 NORMATIVE schema —
+//     {"decisions":[{"title","timestamp","reasoning","alternatives":[],
+//     "implications":[],"source":"main|archive|branch:<name>"}]}. Stdout
+//     carries ONLY the JSON document — no chatter, no ok trailer, regardless
+//     of --quiet, so it is always pipeable into `jq` unmodified.
+//   - --brief --json: the schema's keys never change (NORMATIVE — same key
+//     names, same nesting), but --brief's "title + timestamp only" contract
+//     wins for CONTENT: reasoning/alternatives/implications are present but
+//     zeroed ("" / [] / []) rather than parsed out of the entry body, since
+//     --brief's whole point is to skip exactly that.
+//
+// Entry parsing reuses internal/decisions.SplitRaw/SplitRawBytes (the
+// header-boundary byte-range splitter added for SPEC §1.3.2 rotation) rather
+// than writing a new decisions-file parser. Only the Reasoning /
+// Alternatives considered / Implications sub-field extraction (needed for
+// --json, unique to this command) is new — see parseDecisionBody.
 //
 // Quiet discipline (quiet.go): under --quiet/LOGMIND_QUIET the verbatim body
 // is suppressed — the deliverable a human wants (the markdown) isn't
 // "chatter", but an agent that opted into quiet mode wants a receipt, not the
 // payload, matching `logmind repomap`'s stdout-sink precedent. The single `ok`
 // line always carries the byte count so a script can tell empty from missing.
+// --json ignores --quiet entirely (see above) — the JSON output already IS
+// the machine-clean contract quiet mode exists to approximate elsewhere.
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -32,11 +60,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
+	"github.com/thrillmade/logmind/internal/gitcli"
 )
 
 // newShowCmd wires the `logmind show` subcommand.
 func newShowCmd() *cobra.Command {
-	var all bool
+	var all, brief, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show recent decisions on the current branch",
@@ -47,28 +77,279 @@ docs/decisions.md on the default branch, or
 docs/decisions-branches/<branch>.md on a feature branch (when
 decisions.branch_aware is on and this branch has entries).
 
-Pass --all to also print docs/decisions-archive.md, appended under an
-ARCHIVED DECISIONS banner.
+Pass --all to also include every OTHER docs/decisions-branches/<branch>.md
+file and docs/decisions-archive.md, each appended under its own banner.
+
+Pass --brief for title + timestamp only, one line per decision (under --all,
+lines are grouped by source).
+
+Pass --json for structured output matching PROTOCOL SPEC section sec-3-2's
+NORMATIVE schema:
+    {"decisions":[{"title","timestamp","reasoning","alternatives":[],
+    "implications":[],"source":"main|archive|branch:<name>"}]}
+--json is machine-clean: stdout carries ONLY the JSON document, safe to pipe
+into jq unmodified, regardless of --quiet.
+
+--brief --json together keep the full schema (all keys always present, per
+the NORMATIVE contract) but zero out reasoning/alternatives/implications
+("" / [] / []) rather than parsing them, honoring --brief's "title +
+timestamp only" contract for content while never dropping a schema key.
 
 Examples:
     logmind show
-    logmind show --all`,
+    logmind show --all
+    logmind show --brief
+    logmind show --all --json
+    logmind show --brief --json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
 			}
-			return runShow(cwd, all, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return runShow(cwd, all, brief, jsonOut, quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false,
-		"Also print docs/decisions-archive.md, appended under an ARCHIVED DECISIONS banner.")
+		"Also include every other docs/decisions-branches/*.md file and docs/decisions-archive.md, each under its own banner.")
+	cmd.Flags().BoolVar(&brief, "brief", false,
+		"Title + timestamp only, one line per decision. Combined with --json, zeroes reasoning/alternatives/implications instead of dropping them.")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"Structured output matching PROTOCOL SPEC section sec-3-2's NORMATIVE schema. Machine-clean: stdout is JSON only.")
 	return cmd
 }
 
+// showSource pairs a decisions file path with its NORMATIVE `source` label
+// (SPEC section sec-3-2's grammar: "main" | "archive" | "branch:<name>").
+type showSource struct {
+	path  string
+	label string
+}
+
+// branchLabelFromFilename reverses logmind log's branch-name sanitization
+// (sanitizeBranchName in log.go: "/" and "\\" -> "__", ":" -> "_") well
+// enough for display/source-tag purposes: strip ".md", turn "__" back into
+// "/". Mirrors decisions.branchLabelFromFilename (unexported in
+// internal/decisions, used there for timeline source labels) — duplicated
+// here rather than exported across a package boundary for one call site.
+func branchLabelFromFilename(name string) string {
+	stem := strings.TrimSuffix(name, ".md")
+	return strings.ReplaceAll(stem, "__", "/")
+}
+
+// listBranchSources returns every docs/decisions-branches/*.md file as a
+// showSource labeled "branch:<name>", excluding excludePath so a base file
+// already shown as the primary body is never duplicated. Order matches
+// decisions.ListBranchFiles (sorted by filename).
+func listBranchSources(docsPath, excludePath string) ([]showSource, error) {
+	dir := filepath.Join(docsPath, "decisions-branches")
+	files, err := decisions.ListBranchFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []showSource
+	for _, f := range files {
+		if f == excludePath {
+			continue
+		}
+		out = append(out, showSource{
+			path:  f,
+			label: "branch:" + branchLabelFromFilename(filepath.Base(f)),
+		})
+	}
+	return out, nil
+}
+
+// allExtraSources returns the ordered list of sources `--all` contributes
+// beyond the base file: every OTHER branch decisions file (see
+// listBranchSources), then docs/decisions-archive.md last, when present.
+// Shared by --brief and --json so both group sources identically; the
+// default raw-stream mode below reimplements this same ordering (branches
+// then archive) to keep its existing archive code path — and the goldens
+// pinned to it — untouched.
+func allExtraSources(docsPath, excludePath string) ([]showSource, error) {
+	out, err := listBranchSources(docsPath, excludePath)
+	if err != nil {
+		return nil, err
+	}
+	archivePath := filepath.Join(docsPath, "decisions-archive.md")
+	if pathExists(archivePath) {
+		out = append(out, showSource{path: archivePath, label: "archive"})
+	}
+	return out, nil
+}
+
+// showJSONEntry mirrors SPEC section sec-3-2's NORMATIVE --json schema
+// EXACTLY: same key names, same nesting, same source grammar. Do not add,
+// rename, or drop keys here — it is a wire contract, not an internal type.
+type showJSONEntry struct {
+	Title        string   `json:"title"`
+	Timestamp    string   `json:"timestamp"`
+	Reasoning    string   `json:"reasoning"`
+	Alternatives []string `json:"alternatives"`
+	Implications []string `json:"implications"`
+	Source       string   `json:"source"`
+}
+
+// showJSONOutput is the top-level --json document: {"decisions": [...]}.
+type showJSONOutput struct {
+	Decisions []showJSONEntry `json:"decisions"`
+}
+
+// collectShowEntries gathers every decision across basePath (labeled
+// baseLabel) plus, when all is true, allExtraSources(docsPath, basePath) —
+// the SPEC section sec-3-2 "--all: include archive and every branch
+// decisions file" set. withBody controls whether the Reasoning /
+// Alternatives / Implications sub-fields are parsed out of each entry's raw
+// text (skipped under --brief --json: those fields stay zeroed either way,
+// so parsing them would be wasted work).
+//
+// Entries within each source preserve on-disk (chronological, oldest-first)
+// order — decisions.md and decisions-archive.md are append-only — and
+// sources are concatenated in the order they're visited (base, then
+// branches, then archive).
+func collectShowEntries(docsPath, basePath, baseLabel string, all, withBody bool) ([]showJSONEntry, error) {
+	var out []showJSONEntry
+
+	appendFile := func(path, label string) error {
+		_, raws, err := decisions.SplitRaw(path)
+		if err != nil {
+			return err
+		}
+		for _, r := range raws {
+			e := showJSONEntry{
+				Title:        r.Title,
+				Timestamp:    r.Date.Format("2006-01-02 15:04"),
+				Alternatives: []string{},
+				Implications: []string{},
+				Source:       label,
+			}
+			if withBody {
+				reasoning, alts, impls := parseDecisionBody(r.Raw)
+				e.Reasoning = reasoning
+				if len(alts) > 0 {
+					e.Alternatives = alts
+				}
+				if len(impls) > 0 {
+					e.Implications = impls
+				}
+			}
+			out = append(out, e)
+		}
+		return nil
+	}
+
+	if err := appendFile(basePath, baseLabel); err != nil {
+		return nil, err
+	}
+	if all {
+		extra, err := allExtraSources(docsPath, basePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range extra {
+			if err := appendFile(s.path, s.label); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+
+// parseDecisionBody extracts the Reasoning / Alternatives considered /
+// Implications sections from one decision entry's raw text (a
+// decisions.RawEntry.Raw value), matching buildDecisionEntry's layout
+// (log.go) byte-for-byte:
+//
+//	## YYYY-MM-DD HH:MM - <summary>
+//
+//	**Reasoning:** <reasoning>
+//
+//	**Alternatives considered:** alt1, alt2, alt3
+//
+//	**Implications:**
+//	- impl1
+//	- impl2
+//
+//	---
+//
+// Sections are optional (an entry logged without -r/-a/-i, or a merge-commit
+// entry using the unrelated **PR:**/**Decisions:**/**Detail:** bullet shape,
+// has none of these lines) and line-oriented, so this is a small line-by-line
+// scan rather than a single regex — matching the "structural split, not
+// regex" style decisions.Iter/SplitRawBytes already use.
+//
+// KNOWN LOSSY EDGE CASE: buildDecisionEntry joins the alternatives slice with
+// ", " into a single stored string (log.go: strings.Join(alternatives, ", "))
+// — the original element boundaries are not preserved in the file if any
+// alternative's own text contains ", ". Splitting back on ", " here is the
+// best available reconstruction of that already-collapsed data; it is not a
+// bug introduced by this parser.
+func parseDecisionBody(raw string) (reasoning string, alternatives, implications []string) {
+	lines := strings.Split(raw, "\n")
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		switch {
+		case strings.HasPrefix(line, "**Reasoning:** "):
+			reasoning = strings.TrimPrefix(line, "**Reasoning:** ")
+			i++
+			for i < len(lines) && strings.TrimSpace(lines[i]) != "" {
+				reasoning += "\n" + lines[i]
+				i++
+			}
+		case strings.HasPrefix(line, "**Alternatives considered:** "):
+			joined := strings.TrimPrefix(line, "**Alternatives considered:** ")
+			i++
+			for i < len(lines) && strings.TrimSpace(lines[i]) != "" {
+				joined += "\n" + lines[i]
+				i++
+			}
+			for _, a := range strings.Split(joined, ", ") {
+				if a = strings.TrimSpace(a); a != "" {
+					alternatives = append(alternatives, a)
+				}
+			}
+		case strings.HasPrefix(line, "**Implications:**"):
+			i++
+			for i < len(lines) && strings.HasPrefix(lines[i], "- ") {
+				implications = append(implications, strings.TrimPrefix(lines[i], "- "))
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return reasoning, alternatives, implications
+}
+
+// writeBriefEntries prints entries in "--brief" text form: one
+// "TIMESTAMP - TITLE" line per decision. Under --all (grouped, more than the
+// base source), each new source starts a "[source]" tag line matching the
+// --json source value exactly (main / archive / branch:<name>), so brief
+// text output and --json output agree on source identity.
+func writeBriefEntries(stdout io.Writer, entries []showJSONEntry, all bool) {
+	if len(entries) == 0 {
+		fmt.Fprintln(stdout, "No decisions logged yet on this branch.")
+		return
+	}
+	currentSource := ""
+	first := true
+	for _, e := range entries {
+		if all && e.Source != currentSource {
+			currentSource = e.Source
+			if !first {
+				fmt.Fprintln(stdout)
+			}
+			fmt.Fprintf(stdout, "[%s]\n", currentSource)
+		}
+		fmt.Fprintf(stdout, "%s - %s\n", e.Timestamp, e.Title)
+		first = false
+	}
+}
+
 // runShow implements `logmind show`.
-func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
+func runShow(cwd string, all, brief, jsonOut, quiet bool, stdout, stderr io.Writer) error {
 	q := newQout(quiet, stdout, stderr)
 	docsPath := filepath.Join(cwd, "docs")
 	if !pathExists(docsPath) {
@@ -77,8 +358,60 @@ func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
 	}
 
 	cfg, _ := config.Load(cwd)
-	target, _ := resolveDecisionsPath(cwd, docsPath, cfg)
+	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
 	rel := relForOk(cwd, target)
+
+	baseLabel := "main"
+	if isBranchFile {
+		branch := gitcli.CurrentBranch(cwd)
+		if branch == "" {
+			// Detached HEAD / unborn repo shouldn't reach here (resolveDecisionsPath
+			// would have returned isBranchFile=false), but fall back to reversing
+			// the filename's sanitization rather than emitting an empty label.
+			branch = branchLabelFromFilename(filepath.Base(target))
+		}
+		baseLabel = "branch:" + branch
+	}
+
+	// --json: SPEC section sec-3-2's NORMATIVE schema. Always the full key
+	// set; --brief only zeroes reasoning/alternatives/implications (see
+	// collectShowEntries's withBody=!brief). No chatter, no ok trailer,
+	// --quiet has no additional effect — stdout is the JSON document, full
+	// stop.
+	if jsonOut {
+		entries, err := collectShowEntries(docsPath, target, baseLabel, all, !brief)
+		if err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(showJSONOutput{Decisions: entries}, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := stdout.Write(data); err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout)
+		return nil
+	}
+
+	// --brief (text, non-JSON): title + timestamp only.
+	if brief {
+		entries, err := collectShowEntries(docsPath, target, baseLabel, all, false)
+		if err != nil {
+			return err
+		}
+		if quiet {
+			q.ok("show brief=true all=%t decisions=%d", all, len(entries))
+			return nil
+		}
+		writeBriefEntries(stdout, entries, all)
+		suffix := ""
+		if all {
+			suffix = " (--all)"
+		}
+		fmt.Fprintf(stdout, "ok show: %d decision(s)%s\n", len(entries), suffix)
+		return nil
+	}
 
 	var body string
 	if pathExists(target) {
@@ -87,6 +420,29 @@ func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
 			return fmt.Errorf("read %s: %w", target, err)
 		}
 		body = string(data)
+	}
+
+	// --all's branch-file half of SPEC section sec-3-2 ("include archive and
+	// every branch decisions file"): every OTHER docs/decisions-branches/*.md
+	// file, appended verbatim under its own BRANCH DECISIONS banner, ordered
+	// before the archive section below (unchanged from before this feature).
+	type branchBlock struct {
+		label string
+		body  string
+	}
+	var branchBlocks []branchBlock
+	if all {
+		branchSrcs, err := listBranchSources(docsPath, target)
+		if err != nil {
+			return err
+		}
+		for _, s := range branchSrcs {
+			data, err := os.ReadFile(s.path)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", s.path, err)
+			}
+			branchBlocks = append(branchBlocks, branchBlock{label: s.label, body: string(data)})
+		}
 	}
 
 	var archiveBody string
@@ -104,7 +460,7 @@ func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
 	}
 
 	if quiet {
-		q.ok("show path=%s bytes=%d all=%t archive=%t", rel, len(body), all, archiveShown)
+		q.ok("show path=%s bytes=%d all=%t archive=%t branches=%d", rel, len(body), all, archiveShown, len(branchBlocks))
 		return nil
 	}
 
@@ -112,6 +468,15 @@ func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
 		fmt.Fprintln(stdout, "No decisions logged yet on this branch.")
 	} else {
 		fmt.Fprint(stdout, body)
+	}
+
+	for _, b := range branchBlocks {
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, strings.Repeat("=", 80))
+		fmt.Fprintf(stdout, "BRANCH DECISIONS: %s\n", strings.TrimPrefix(b.label, "branch:"))
+		fmt.Fprintln(stdout, strings.Repeat("=", 80))
+		fmt.Fprintln(stdout)
+		fmt.Fprint(stdout, b.body)
 	}
 
 	if archiveShown {
@@ -125,10 +490,17 @@ func runShow(cwd string, all, quiet bool, stdout, stderr io.Writer) error {
 
 	suffix := ""
 	if all {
+		var extras []string
+		if len(branchBlocks) > 0 {
+			extras = append(extras, fmt.Sprintf("%d branch file(s)", len(branchBlocks)))
+		}
 		if archiveShown {
-			suffix = " + archive"
-		} else {
+			extras = append(extras, "archive")
+		}
+		if len(extras) == 0 {
 			suffix = " (no archive)"
+		} else {
+			suffix = " + " + strings.Join(extras, " + ")
 		}
 	}
 	fmt.Fprintf(stdout, "ok show: %s (%d bytes%s)\n", rel, len(body), suffix)

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -8,12 +8,21 @@
 //   - no decisions logged yet on the current branch → friendly message
 //   - --all appends the archive under an ARCHIVED DECISIONS banner when the
 //     archive file exists, and a "(no archive)" ok-suffix when it doesn't
+//   - --all ALSO appends every other docs/decisions-branches/*.md file under
+//     a BRANCH DECISIONS banner (SPEC section sec-3-2's "every branch
+//     decisions file" half), without duplicating the current branch's own
+//     file
 //   - --quiet collapses stdout to exactly one `ok k=v` line
 //   - docs/ missing → friendly error + ErrSilent
+//   - --brief: title + timestamp only, grouped by "[source]" tag under --all
+//   - --json: SPEC section sec-3-2's NORMATIVE schema — exact key set, exact
+//     source grammar (main / archive / branch:<name>), machine-clean stdout
+//   - --brief --json: full schema keys always present, body fields zeroed
 package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,5 +187,282 @@ func TestShow_DocsMissingErrors(t *testing.T) {
 			t.Fatalf("expected ErrSilent when docs/ missing")
 		}
 		mustContain(t, out.String(), "docs/ directory not found")
+	})
+}
+
+// TestShow_All_IncludesBranchFiles: SPEC section sec-3-2's "--all: include
+// archive and EVERY branch decisions file" — the gap this build closes.
+// Before this change, --all only appended the archive; a repo with a branch
+// decisions file (from another in-flight branch) never surfaced it.
+func TestShow_All_IncludesBranchFiles(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs", "decisions-branches"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Main decision\n")
+		mustWrite(t, filepath.Join(d, "docs", "decisions-branches", "feat__other.md"),
+			"## 2026-06-02 11:00 - Other branch decision\n")
+
+		body := runShowCmd(t, "--all")
+		mustContain(t, body, "Main decision")
+		mustContain(t, body, "BRANCH DECISIONS: feat/other")
+		mustContain(t, body, "Other branch decision")
+		mustContain(t, body, "+ 1 branch file(s)")
+	})
+}
+
+// TestShow_All_ExcludesCurrentBranchFile: on a feature branch, the current
+// branch's own decisions-branches file is already the primary body — --all
+// must include every OTHER branch file without streaming the current one
+// twice.
+func TestShow_All_ExcludesCurrentBranchFile(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		initLogTestGitRepo(t, d)
+		scaffoldDocs(t)
+		checkoutBranch(t, d, "feat/login")
+		withFakeTTY(t, false, func() { logOnce(t, "Add JWT auth") })
+
+		// An unrelated in-flight branch's file, simulating another agent's work.
+		mustWrite(t, filepath.Join(d, "docs", "decisions-branches", "feat__other.md"),
+			"## 2026-06-02 11:00 - Other branch decision\n")
+
+		body := runShowCmd(t, "--all")
+		mustContain(t, body, "Add JWT auth")
+		mustContain(t, body, "BRANCH DECISIONS: feat/other")
+		mustContain(t, body, "Other branch decision")
+
+		// Exactly one BRANCH DECISIONS banner (feat/other) — the current
+		// branch's own file must not ALSO get a "BRANCH DECISIONS: feat/login"
+		// section (its content is already the primary body above).
+		if n := strings.Count(body, "BRANCH DECISIONS:"); n != 1 {
+			t.Errorf("want exactly 1 BRANCH DECISIONS banner, got %d:\n%s", n, body)
+		}
+		if strings.Contains(body, "BRANCH DECISIONS: feat/login") {
+			t.Errorf("current branch file re-shown under its own BRANCH DECISIONS banner:\n%s", body)
+		}
+	})
+}
+
+// TestShow_Brief_TitleAndTimestampOnly: --brief prints "TIMESTAMP - TITLE"
+// only — the reasoning/alternatives/implications body must not leak into the
+// text output.
+func TestShow_Brief_TitleAndTimestampOnly(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - First decision\n\n"+
+				"**Reasoning:** Because reasons\n\n"+
+				"**Alternatives considered:** Option A, Option B\n\n"+
+				"**Implications:**\n- Impact one\n\n---\n\n")
+
+		body := runShowCmd(t, "--brief")
+		mustContain(t, body, "2026-06-01 10:00 - First decision")
+		mustContain(t, body, "ok show: 1 decision(s)")
+		if strings.Contains(body, "Because reasons") {
+			t.Errorf("--brief leaked the reasoning body:\n%s", body)
+		}
+		if strings.Contains(body, "Option A") {
+			t.Errorf("--brief leaked the alternatives body:\n%s", body)
+		}
+	})
+}
+
+// TestShow_Brief_All_GroupsBySource: under --all, --brief groups lines under
+// a "[source]" tag per source, in main → branch → archive order, and the
+// tag text matches the --json "source" value exactly.
+func TestShow_Brief_All_GroupsBySource(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs", "decisions-branches"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Main decision\n")
+		mustWrite(t, filepath.Join(d, "docs", "decisions-branches", "feat__other.md"),
+			"## 2026-06-02 11:00 - Branch decision\n")
+		mustWrite(t, filepath.Join(d, "docs", "decisions-archive.md"),
+			"## 2025-01-01 09:00 - Archived decision\n")
+
+		body := runShowCmd(t, "--brief", "--all")
+		mustContain(t, body, "[main]")
+		mustContain(t, body, "[branch:feat/other]")
+		mustContain(t, body, "[archive]")
+		mustContain(t, body, "2026-06-01 10:00 - Main decision")
+		mustContain(t, body, "2026-06-02 11:00 - Branch decision")
+		mustContain(t, body, "2025-01-01 09:00 - Archived decision")
+
+		mainIdx := strings.Index(body, "[main]")
+		branchIdx := strings.Index(body, "[branch:feat/other]")
+		archiveIdx := strings.Index(body, "[archive]")
+		if !(mainIdx >= 0 && mainIdx < branchIdx && branchIdx < archiveIdx) {
+			t.Errorf("want [main] < [branch:feat/other] < [archive] ordering, got indices %d, %d, %d:\n%s",
+				mainIdx, branchIdx, archiveIdx, body)
+		}
+	})
+}
+
+// TestShow_JSON_SchemaKeysAndValues pins SPEC section sec-3-2's NORMATIVE
+// --json schema for a 2-decision fixture: exact key set (no more, no fewer —
+// a future rename/add/drop of a key breaks this test) and correct values,
+// including the alternatives/implications arrays parsed out of the
+// **Alternatives considered:**/**Implications:** markdown sections.
+func TestShow_JSON_SchemaKeysAndValues(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - First decision\n\n"+
+				"**Reasoning:** Because reasons\n\n"+
+				"**Alternatives considered:** Option A, Option B\n\n"+
+				"**Implications:**\n- Impact one\n- Impact two\n\n---\n\n"+
+				"## 2026-06-02 11:15 - Second decision\n\n"+
+				"**Reasoning:** Another reason\n\n---\n\n")
+
+		body := runShowCmd(t, "--json")
+
+		var doc struct {
+			Decisions []map[string]any `json:"decisions"`
+		}
+		if err := json.Unmarshal([]byte(body), &doc); err != nil {
+			t.Fatalf("--json output did not parse as JSON: %v\nbody:\n%s", err, body)
+		}
+		if len(doc.Decisions) != 2 {
+			t.Fatalf("want 2 decisions, got %d: %v", len(doc.Decisions), doc.Decisions)
+		}
+
+		wantKeys := []string{"title", "timestamp", "reasoning", "alternatives", "implications", "source"}
+		for _, entry := range doc.Decisions {
+			if len(entry) != len(wantKeys) {
+				t.Errorf("entry has %d keys, want %d (NORMATIVE schema): %v", len(entry), len(wantKeys), entry)
+			}
+			for _, k := range wantKeys {
+				if _, ok := entry[k]; !ok {
+					t.Errorf("entry missing NORMATIVE key %q: %v", k, entry)
+				}
+			}
+		}
+
+		first := doc.Decisions[0]
+		if first["title"] != "First decision" {
+			t.Errorf("title = %v, want %q", first["title"], "First decision")
+		}
+		if first["timestamp"] != "2026-06-01 10:00" {
+			t.Errorf("timestamp = %v, want %q", first["timestamp"], "2026-06-01 10:00")
+		}
+		if first["reasoning"] != "Because reasons" {
+			t.Errorf("reasoning = %v, want %q", first["reasoning"], "Because reasons")
+		}
+		if first["source"] != "main" {
+			t.Errorf("source = %v, want %q", first["source"], "main")
+		}
+		if alts, ok := first["alternatives"].([]any); !ok || len(alts) != 2 || alts[0] != "Option A" || alts[1] != "Option B" {
+			t.Errorf("alternatives = %v, want [Option A, Option B]", first["alternatives"])
+		}
+		if impls, ok := first["implications"].([]any); !ok || len(impls) != 2 || impls[0] != "Impact one" || impls[1] != "Impact two" {
+			t.Errorf("implications = %v, want [Impact one, Impact two]", first["implications"])
+		}
+
+		second := doc.Decisions[1]
+		if second["title"] != "Second decision" || second["reasoning"] != "Another reason" {
+			t.Errorf("second entry mismatch: %v", second)
+		}
+		if secondAlts, ok := second["alternatives"].([]any); !ok || len(secondAlts) != 0 {
+			t.Errorf("second.alternatives = %v, want empty array (present, not null, not omitted)", second["alternatives"])
+		}
+	})
+}
+
+// TestShow_JSON_MachineCleanOutput: --json's stdout must be the bare JSON
+// document and nothing else — no ok trailer, no banner — so it is pipeable
+// into `jq` unmodified.
+func TestShow_JSON_MachineCleanOutput(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - Only decision\n")
+
+		body := runShowCmd(t, "--json")
+		trimmed := strings.TrimSpace(body)
+		if !strings.HasPrefix(trimmed, "{") || !strings.HasSuffix(trimmed, "}") {
+			t.Fatalf("--json output is not a bare JSON document:\n%s", body)
+		}
+		if strings.Contains(body, "ok show") {
+			t.Errorf("--json output leaked the ok trailer:\n%s", body)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal([]byte(body), &doc); err != nil {
+			t.Fatalf("json.Unmarshal failed on the full body (must be pure JSON): %v", err)
+		}
+	})
+}
+
+// TestShow_JSON_All_SourceValues: under --all --json, every decision's
+// "source" value matches SPEC section sec-3-2's grammar exactly:
+// "main" | "archive" | "branch:<name>".
+func TestShow_JSON_All_SourceValues(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs", "decisions-branches"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-03 09:00 - Main decision\n")
+		mustWrite(t, filepath.Join(d, "docs", "decisions-branches", "feat__widget.md"),
+			"## 2026-06-02 08:00 - Branch decision\n")
+		mustWrite(t, filepath.Join(d, "docs", "decisions-archive.md"),
+			"## 2025-01-01 07:00 - Archived decision\n")
+
+		body := runShowCmd(t, "--all", "--json")
+		var doc struct {
+			Decisions []map[string]any `json:"decisions"`
+		}
+		if err := json.Unmarshal([]byte(body), &doc); err != nil {
+			t.Fatalf("--all --json output did not parse: %v\n%s", err, body)
+		}
+		got := map[string]bool{}
+		for _, e := range doc.Decisions {
+			got[e["source"].(string)] = true
+		}
+		for _, want := range []string{"main", "branch:feat/widget", "archive"} {
+			if !got[want] {
+				t.Errorf("missing source %q; got sources %v", want, got)
+			}
+		}
+	})
+}
+
+// TestShow_BriefJSON_ZeroesBodyFieldsKeepsSchema: --brief --json keeps the
+// FULL NORMATIVE key set (never drops a key) but zeroes
+// reasoning/alternatives/implications ("" / [] / []) rather than parsing
+// them out of the entry body — the documented --brief+--json precedence.
+func TestShow_BriefJSON_ZeroesBodyFieldsKeepsSchema(t *testing.T) {
+	withTempCwd(t, func(d string) {
+		mustMkdir(t, filepath.Join(d, "docs"))
+		mustWrite(t, filepath.Join(d, "docs", "decisions.md"),
+			"## 2026-06-01 10:00 - First decision\n\n"+
+				"**Reasoning:** Because reasons\n\n"+
+				"**Alternatives considered:** Option A, Option B\n\n"+
+				"**Implications:**\n- Impact one\n\n---\n\n")
+
+		body := runShowCmd(t, "--brief", "--json")
+		var doc struct {
+			Decisions []map[string]any `json:"decisions"`
+		}
+		if err := json.Unmarshal([]byte(body), &doc); err != nil {
+			t.Fatalf("--brief --json output did not parse: %v\n%s", err, body)
+		}
+		if len(doc.Decisions) != 1 {
+			t.Fatalf("want 1 decision, got %d", len(doc.Decisions))
+		}
+		e := doc.Decisions[0]
+		for _, k := range []string{"title", "timestamp", "reasoning", "alternatives", "implications", "source"} {
+			if _, ok := e[k]; !ok {
+				t.Errorf("--brief --json dropped NORMATIVE key %q: %v", k, e)
+			}
+		}
+		if e["title"] != "First decision" {
+			t.Errorf("title = %v, want %q (title/timestamp survive --brief)", e["title"], "First decision")
+		}
+		if e["reasoning"] != "" {
+			t.Errorf("reasoning = %v, want zeroed \"\" under --brief", e["reasoning"])
+		}
+		if alts, ok := e["alternatives"].([]any); !ok || len(alts) != 0 {
+			t.Errorf("alternatives = %v, want zeroed [] under --brief", e["alternatives"])
+		}
+		if impls, ok := e["implications"].([]any); !ok || len(impls) != 0 {
+			t.Errorf("implications = %v, want zeroed [] under --brief", e["implications"])
+		}
 	})
 }


### PR DESCRIPTION
Closes the three `logmind show` gaps found in the 2026-07-27 feature-set audit. SPEC §3.2 specifies a surface we only partly had.

## What was missing

`show` registered only `--all`, and that `--all` appended `docs/decisions-archive.md` alone — it never walked `docs/decisions-branches/*.md`, which §3.2 explicitly requires ("include archive **and every branch decisions file**").

## `--json` matches the NORMATIVE schema exactly

§3.2 gives the schema verbatim, so there was no design latitude here. Verified key-for-key against the SPEC text rather than against the implementation's own intent:

```
SPEC §3.2 keys:  alternatives decisions implications reasoning source timestamp title
binary emits:    alternatives decisions implications reasoning source timestamp title
```

The `source` grammar (`main | archive | branch:<name>`) verified across all three cases in a scratch repo:

```
main                  <- Initialize logmind decision tracking
main                  <- Main decision
branch:feat/my-thing  <- Branch decision here     # reverse-sanitized from feat__my-thing.md
archive               <- Ancient decision
```

`show --json` is machine-clean — stdout is pure JSON, confirmed by piping through `jq -e`.

`TestShow_JSON_SchemaKeysAndValues` pins the exact key set, so a future rename or added field breaks the build rather than silently emitting a non-conformant document.

## Reuse over reimplementation

- `decisions.SplitRaw`/`SplitRawBytes` (landed in #249) for per-entry byte ranges — no second parser.
- `decisions.ListBranchFiles` for the branch walk.
- `resolveDecisionsPath`'s `isBranchFile` + `gitcli.CurrentBranch` for source labelling.

One genuinely new helper, `parseDecisionBody`, extracts Reasoning / Alternatives / Implications from an entry body — `decisions.Iter` only yields title and date, so nothing existing covered it.

`--all` excludes the current branch's own file, since that is already the primary body; a test pins the dedup.

## Behavior preserved

Default `logmind show` output is unchanged — existing goldens pass untouched.

## Note on one out-of-scope edit

`internal/cli/quiet_test.go` has a **one-line** change: `runShow`'s signature grew two params, so its call site needed the arity fix to keep the build green. No behavior change.

## Verification

`go build`, `go vet`, `gofmt -l internal/ cmd/` clean; full `go test ./...` green. Eight new tests in `show_test.go`.

Schema and source-grammar claims above were re-verified by me against SPEC text and a built binary, not taken from the build report.