### PR TITLE
feat(sync): implement SPEC §3.9 — --since, --update-provenance, --write-drafts

### DIFF
--- a/docs/decisions-branches/worktree-agent-adac3eed4a7ed2e4a.md
+++ b/docs/decisions-branches/worktree-agent-adac3eed4a7ed2e4a.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-07-28-implement-spec-3-9-s-since-update-provenance-write-drafts-fl -->
+- **2026-07-28** — Implement SPEC §3.9's --since/--update-provenance/--write-drafts flags for logmind sync
+<!-- logmind-entry-end -->
+
+## 2026-07-28 01:04 - Implement SPEC §3.9's --since/--update-provenance/--write-drafts flags for logmind sync
+
+**Reasoning:** SPEC §3.9 names three flags 'logmind sync' didn't have; the code comment called them 'tracked for later waves' and the ruling was that a flag which doesn't do what it says is worse than a missing one (PR #247 deleted five for exactly that). --since is a genuine Go-duration-plus-day-shorthand parser (time.ParseDuration has no 'd' unit) with a hard-error path on malformed input, wired into the existing docs/reviews/PR-*.md mtime scan. --update-provenance is a new, separate reconciliation path (skill.UpdateProvenance) that writes the actual SPEC §1.11.1 NORMATIVE PROVENANCE.md template (the '<!-- maintained-by: logmind sync -->' marker, Source/Last refined/Cited by clud-bug/Derived from decisions/Refinement history) sourced from .claude/skills/.clud-bug.json usage[<slug>].citations and docs/decisions*.md heading matches -- the pre-existing Sync() path writes a different, non-SPEC '<!-- logmind:provenance v1 -->' skeleton from docs/reviews/PR-*.md, which is left untouched as the flag-less default per the no-behavior-change ruling. --write-drafts (skill.WriteSkillDrafts) reuses SuggestFromDecisions's heuristic but renders fresh SPEC §1.9/§1.10.1-conformant frontmatter (source: logmind-derived, status: candidate) rather than reusing suggest_llm.go's GH-issue-body WriteDrafts, which has no frontmatter at all and would violate the same 1.9 contract at the new call site.
+
+**Alternatives considered:** Considered gating the legacy citation-fold path behind --update-provenance so there'd be only one PROVENANCE.md writer; rejected because the task's ruling #5 requires bare 'logmind sync' behavior to stay byte-identical with no new flags passed, and the legacy path already runs unconditionally today. Considered reusing suggest_llm.go's WriteDrafts/FormatIssueDraft directly for --write-drafts; rejected because that renderer has no YAML frontmatter at all, so it would put a correctly-named file at docs/skills-derived/ with SPEC-noncompliant contents -- the same 'flag lies about what it did' failure mode, just relocated. Considered sourcing PROVENANCE.md's Source field from .clud-bug.json installed[].source; rejected because that enum (baseline|remote|custom) doesn't match SKILL.md's own source enum (manual|logmind-derived|skills-sh|clud-bug-baseline) that section 1.10.1 defines -- reading the skill's own frontmatter is the more authoritative, honest source.
+
+**Implications:**
+- Two PROVENANCE.md writers now coexist in internal/skill/sync.go: the legacy provenance.go-skeleton writer (default, unconditional) and the new SPEC-conformant writer (--update-provenance only). A follow-up wave should retire the legacy skeleton format once consumers migrate, at which point --update-provenance's gating can likely become the default.
+- docs/reviews/PR-*.md citations are deliberately NOT re-read by --update-provenance -- .clud-bug.json's usage[<slug>].citations is the SPEC's own primary citation source for PROVENANCE.md; folding both in would produce two disagreeing counters for the same field.
+- The 'Derived from decisions' matching heuristic (case-insensitive skill-name substring match against decision titles) is a best-effort implementation choice -- SPEC §1.11.1 only says the list is 'computed from docs/decisions*.md heading anchors' without specifying a match rule.
+
+---
+

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -11,39 +11,63 @@ import (
 	"github.com/thrillmade/logmind/internal/skill"
 )
 
-// newSyncCmd wires `logmind sync [--dry-run]`. Per SPEC §3.9, sync is
-// the loop-closer that turns clud-bug-review output (
-// `docs/reviews/PR-<n>.md`) into incremental updates of each cited
-// skill's `PROVENANCE.md`.
+// newSyncCmd wires `logmind sync [--dry-run] [--since <duration>]
+// [--update-provenance] [--write-drafts]` per SPEC §3.9.
 //
-// The Python v0.6.x line never shipped a `sync` command — the loop
-// was closed by `clud-bug` itself writing the `.clud-bug.json` usage
-// counters. The Go port (B5b / G4.a) routes the same signal through
-// the more durable `docs/reviews/PR-*.md` files so it survives
-// `.clud-bug.json` schema migrations, works for the GitHub-App
-// variant of clud-bug (no on-disk JSON edit), and stays grep-friendly
-// for humans reading their own repo. See SPEC §6.5 — sync MUST read
-// from local files; no GitHub API call.
+// The Python v0.6.x line never shipped a `sync` command — the loop was
+// closed by `clud-bug` itself writing the `.clud-bug.json` usage
+// counters. The Go port (B5b / G4.a) routes the same signal through the
+// more durable `docs/reviews/PR-*.md` files for its default (no-flag)
+// behaviour, which stays exactly as it always has: fold review
+// citations into each cited skill's (pre-existing, non-SPEC)
+// PROVENANCE.md skeleton. That default is left untouched by this
+// change — see runSync below.
 //
-// SPEC §3.9 also lists `--since`, `--update-provenance`, and
-// `--write-drafts`. This Go port ships `--dry-run` first; the other
-// three are tracked for later waves (see PR description). Provenance
-// update is the default (and currently only) behaviour, so an
-// `--update-provenance` flag here would be vacuous until the
-// `--write-drafts` path lands.
+// The three flags §3.9 lists beyond --dry-run are additive, opt-in code
+// paths (internal/skill/sync.go's ParseSinceDuration / UpdateProvenance
+// / WriteSkillDrafts):
+//
+//   - --since restricts the review-file scan (and, when combined with
+//     the two flags below, the decision + usage-counter scans) to
+//     entries newer than the given duration.
+//   - --update-provenance refreshes each installed skill's
+//     PROVENANCE.md into the SPEC §1.11.1 NORMATIVE format, sourced
+//     from `.claude/skills/.clud-bug.json` usage counters and
+//     docs/decisions*.md — genuinely new behaviour, not a rename of
+//     the legacy path (see the doc comment on skill.UpdateProvenance
+//     for why the two provenance surfaces stay separate).
+//   - --write-drafts writes skill-candidate drafts to
+//     docs/skills-derived/ per SPEC §1.9, reusing the same
+//     decision-pattern heuristic `logmind skill suggest` uses.
 func newSyncCmd() *cobra.Command {
 	var dryRun bool
+	var since string
+	var updateProvenance bool
+	var writeDrafts bool
 	cmd := &cobra.Command{
 		Use:   "sync",
-		Short: "Fold clud-bug review citations into each cited skill's PROVENANCE.md",
+		Short: "Reconcile clud-bug usage, decisions, and reviews into PROVENANCE.md / skill drafts",
 		Long: `Walk docs/reviews/PR-*.md and update each cited skill's PROVENANCE.md.
 
 For every PR review file (NORMATIVE format defined in SPEC §1.8.1), sync
 parses the **Skills cited:** block and increments cited-by-clud-bug for
 each skill listed, sets last-refined to today's date, and records the
 review SHA in applied-review-shas so subsequent runs are idempotent.
+This default behaviour never changes based on the flags below — it is
+identical whether or not --since / --update-provenance / --write-drafts
+are passed.
 
-Re-running with no new review files is a no-op — sync is safe to wire
+--since <duration> (e.g. "7d", "30d") limits the scan(s) to entries
+newer than the given window.
+
+--update-provenance additionally refreshes each installed skill's
+PROVENANCE.md into the SPEC §1.11.1 format, reconciling
+.claude/skills/.clud-bug.json usage counters with docs/decisions*.md.
+
+--write-drafts additionally writes skill-candidate drafts under
+docs/skills-derived/ (SPEC §1.9) from recent decision-log patterns.
+
+Re-running with nothing new to fold in is a no-op — sync is safe to wire
 into post-merge hooks or scheduled jobs.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -51,25 +75,62 @@ into post-merge hooks or scheduled jobs.`,
 			if err != nil {
 				return err
 			}
-			return runSync(cwd, dryRun, time.Time{}, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			opts := SyncCLIOptions{
+				DryRun:           dryRun,
+				Since:            since,
+				UpdateProvenance: updateProvenance,
+				WriteDrafts:      writeDrafts,
+			}
+			return runSync(cwd, opts, time.Time{}, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
-		"Parse + aggregate citations but skip the PROVENANCE.md writes.")
+		"Compute what sync would do but skip every write (composes with the other flags).")
+	cmd.Flags().StringVar(&since, "since", "",
+		`Limit the scan to entries newer than this duration (e.g. "7d", "30d"). Unset means unrestricted.`)
+	cmd.Flags().BoolVar(&updateProvenance, "update-provenance", false,
+		"Refresh each installed skill's PROVENANCE.md (SPEC §1.11.1) from clud-bug usage + docs/decisions*.md.")
+	cmd.Flags().BoolVar(&writeDrafts, "write-drafts", false,
+		"Write skill-candidate drafts to docs/skills-derived/ (SPEC §1.9) from recent decision patterns.")
 	return cmd
 }
 
+// SyncCLIOptions bundles the flag values `logmind sync` was invoked
+// with. Exists (rather than four positional bools/strings) so runSync's
+// signature stays stable as flags are added.
+type SyncCLIOptions struct {
+	DryRun           bool
+	Since            string
+	UpdateProvenance bool
+	WriteDrafts      bool
+}
+
 // runSync is the testable core of `logmind sync`. The `now` arg lets
-// unit tests pin `last-refined` to a fixed instant; production callers
-// pass time.Time{} so skill.Sync defaults to time.Now().
-func runSync(cwd string, dryRun bool, now time.Time, stdout, stderr io.Writer) error {
+// unit tests pin timestamps to a fixed instant; production callers pass
+// time.Time{} so the skill package defaults to time.Now().
+func runSync(cwd string, opts SyncCLIOptions, now time.Time, stdout, stderr io.Writer) error {
 	warn := func(msg string) {
 		fmt.Fprintln(stderr, "warn:", msg)
 	}
+
+	var since time.Duration
+	if opts.Since != "" {
+		d, err := skill.ParseSinceDuration(opts.Since)
+		if err != nil {
+			// Malformed --since is a hard error, not a silent
+			// fall-through to "scan everything" — see
+			// skill.ParseSinceDuration's doc comment.
+			fmt.Fprintf(stdout, "Error: %v\n", err)
+			return ErrSilent
+		}
+		since = d
+	}
+
 	summary, err := skill.Sync(cwd, skill.SyncOptions{
-		DryRun: dryRun,
+		DryRun: opts.DryRun,
 		Now:    now,
 		Warn:   warn,
+		Since:  since,
 	})
 	if err != nil {
 		// Filesystem-level failures (e.g., docs/reviews/ readable but
@@ -80,18 +141,47 @@ func runSync(cwd string, dryRun bool, now time.Time, stdout, stderr io.Writer) e
 		return ErrSilent
 	}
 
-	skill.FormatSummary(stdout, summary, dryRun)
+	skill.FormatSummary(stdout, summary, opts.DryRun)
 	// Prefix the machine-parseable `ok sync:` line with `(dry-run) ` so
 	// consumers (e.g., post-merge hooks scraping stdout, CI summaries)
 	// can distinguish a real run's counters from a dry-run preview's.
 	// FormatSummary already carries the marker; this line gates it on
 	// the same dryRun flag so the two surfaces agree. (Review #135 / Bug 2.)
 	prefix := ""
-	if dryRun {
+	if opts.DryRun {
 		prefix = "(dry-run) "
 	}
 	fmt.Fprintf(stdout, "ok sync: %s%d skill(s) updated · %d citation(s) added · %d/%d review(s) applied\n",
 		prefix, summary.SkillsUpdated, summary.CitationsAdded,
 		summary.ReviewsApplied, summary.ReviewsScanned)
+
+	if opts.UpdateProvenance {
+		provSummary, err := skill.UpdateProvenance(cwd, skill.ProvenanceOptions{
+			DryRun: opts.DryRun,
+			Now:    now,
+			Since:  since,
+			Warn:   warn,
+		})
+		if err != nil {
+			fmt.Fprintf(stdout, "Error: %v\n", err)
+			return ErrSilent
+		}
+		skill.FormatProvenanceSummary(stdout, provSummary, opts.DryRun)
+	}
+
+	if opts.WriteDrafts {
+		draftSummary, err := skill.WriteSkillDrafts(cwd, skill.DraftOptions{
+			DryRun: opts.DryRun,
+			Now:    now,
+			Since:  since,
+			Warn:   warn,
+		})
+		if err != nil {
+			fmt.Fprintf(stdout, "Error: %v\n", err)
+			return ErrSilent
+		}
+		skill.FormatDraftSummary(stdout, draftSummary, opts.DryRun)
+	}
+
 	return nil
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3,11 +3,15 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/skill"
 )
@@ -60,7 +64,7 @@ func writeReviewForSync(t *testing.T, root, filename, sha string, citations []st
 func TestRunSync_NoReviewsDir(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	if err := runSync(dir, false, fixedNow, &stdout, &stderr); err != nil {
+	if err := runSync(dir, SyncCLIOptions{}, fixedNow, &stdout, &stderr); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
 	got := stdout.String()
@@ -82,7 +86,7 @@ func TestRunSync_AppliesCitations(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	if err := runSync(dir, false, fixedNow, &stdout, &stderr); err != nil {
+	if err := runSync(dir, SyncCLIOptions{}, fixedNow, &stdout, &stderr); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
 	got := stdout.String()
@@ -115,7 +119,7 @@ func TestRunSync_DryRun(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	if err := runSync(dir, true, fixedNow, &stdout, &stderr); err != nil {
+	if err := runSync(dir, SyncCLIOptions{DryRun: true}, fixedNow, &stdout, &stderr); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
 	got := stdout.String()
@@ -150,7 +154,7 @@ func TestRunSync_UnknownSkillWarning(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	if err := runSync(dir, false, fixedNow, &stdout, &stderr); err != nil {
+	if err := runSync(dir, SyncCLIOptions{}, fixedNow, &stdout, &stderr); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
 	if !strings.Contains(stderr.String(), "missing-skill") {
@@ -188,7 +192,7 @@ func TestRunSync_DocsButNoReviewsDir(t *testing.T) {
 		t.Fatalf("mkdir docs: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	if err := runSync(dir, false, fixedNow, &stdout, &stderr); err != nil {
+	if err := runSync(dir, SyncCLIOptions{}, fixedNow, &stdout, &stderr); err != nil {
 		t.Fatalf("runSync: %v", err)
 	}
 	if !strings.Contains(stdout.String(), "no skills updated") {
@@ -216,11 +220,179 @@ func TestRunSync_FilesystemError(t *testing.T) {
 	defer os.Chmod(reviewsDir, 0o755) // restore so t.TempDir cleanup works
 
 	var stdout, stderr bytes.Buffer
-	err := runSync(dir, false, fixedNow, &stdout, &stderr)
+	err := runSync(dir, SyncCLIOptions{}, fixedNow, &stdout, &stderr)
 	if !errors.Is(err, ErrSilent) {
 		t.Fatalf("expected ErrSilent on read failure; got %v", err)
 	}
 	if !strings.Contains(stdout.String(), "Error:") {
 		t.Errorf("expected Error: line on stdout; got:\n%s", stdout.String())
 	}
+}
+
+// TestRunSync_MalformedSince: a garbage --since value is a hard error —
+// runSync must not silently fall back to "scan everything" (which is
+// what a zero-valued/ignored duration would produce).
+func TestRunSync_MalformedSince(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	err := runSync(dir, SyncCLIOptions{Since: "not-a-duration"}, fixedNow, &stdout, &stderr)
+	if !errors.Is(err, ErrSilent) {
+		t.Fatalf("expected ErrSilent for malformed --since; got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Error:") {
+		t.Errorf("expected Error: line on stdout; got:\n%s", stdout.String())
+	}
+}
+
+// TestNewSyncCmd_RegistersNewFlags: --since, --update-provenance, and
+// --write-drafts are all reachable on the cobra command tree (not just
+// wired internally) — a regression guard against a flag silently
+// dropping off `newSyncCmd`.
+func TestNewSyncCmd_RegistersNewFlags(t *testing.T) {
+	root := NewRootCmd()
+	var syncCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Use == "sync" {
+			syncCmd = c
+			break
+		}
+	}
+	if syncCmd == nil {
+		t.Fatal("sync subcommand not found")
+	}
+	for _, name := range []string{"dry-run", "since", "update-provenance", "write-drafts"} {
+		if syncCmd.Flags().Lookup(name) == nil {
+			t.Errorf("--%s not registered on `logmind sync`", name)
+		}
+	}
+}
+
+// TestRunSync_UpdateProvenance_WritesSpecFormat: --update-provenance
+// composes with the legacy default path — both run in the same
+// invocation, and the new PROVENANCE.md carries the SPEC §1.11.1
+// marker.
+func TestRunSync_UpdateProvenance_WritesSpecFormat(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldSkillForSync(t, dir, "prov-cli-skill")
+
+	var stdout, stderr bytes.Buffer
+	opts := SyncCLIOptions{UpdateProvenance: true}
+	if err := runSync(dir, opts, fixedNow, &stdout, &stderr); err != nil {
+		t.Fatalf("runSync: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "ok sync-provenance:") {
+		t.Errorf("missing ok sync-provenance line; stdout:\n%s", got)
+	}
+	body, err := os.ReadFile(filepath.Join(skill.SkillDir(dir, "prov-cli-skill"), "PROVENANCE.md"))
+	if err != nil {
+		t.Fatalf("read PROVENANCE.md: %v", err)
+	}
+	if !strings.Contains(string(body), "<!-- maintained-by: logmind sync -->") {
+		t.Errorf("PROVENANCE.md missing SPEC marker after --update-provenance; body:\n%s", body)
+	}
+}
+
+// TestRunSync_WriteDrafts_WritesSkillsDerived: --write-drafts writes
+// docs/skills-derived/<slug>.md from decision-log patterns, alongside
+// the (unconditional) legacy sync pass.
+func TestRunSync_WriteDrafts_WritesSkillsDerived(t *testing.T) {
+	dir := t.TempDir()
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	body := "# Decisions\n\n" +
+		"## 2026-05-15 - first\n\n**Date**: 2026-05-15\n\nadopt rate-limiting everywhere.\n\n" +
+		"## 2026-05-20 - second\n\n**Date**: 2026-05-20\n\nmore rate-limiting work.\n\n" +
+		"## 2026-05-25 - third\n\n**Date**: 2026-05-25\n\nrate-limiting again.\n"
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	var stdout, stderr bytes.Buffer
+	opts := SyncCLIOptions{WriteDrafts: true}
+	if err := runSync(dir, opts, now, &stdout, &stderr); err != nil {
+		t.Fatalf("runSync: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "ok sync-drafts:") {
+		t.Errorf("missing ok sync-drafts line; stdout:\n%s", got)
+	}
+	draftBody, err := os.ReadFile(filepath.Join(dir, "docs", "skills-derived", "rate-limiting.md"))
+	if err != nil {
+		t.Fatalf("read draft: %v", err)
+	}
+	if !strings.Contains(string(draftBody), "status: candidate") {
+		t.Errorf("draft missing status: candidate; body:\n%s", draftBody)
+	}
+}
+
+// TestRunSync_DryRun_ComposesWithNewFlags: --dry-run together with
+// --update-provenance and --write-drafts previews everything but writes
+// nothing — neither a new PROVENANCE.md nor a new docs/skills-derived/
+// file appears on disk.
+func TestRunSync_DryRun_ComposesWithNewFlags(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldSkillForSync(t, dir, "dry-compose-skill")
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	body := "# Decisions\n\n" +
+		"## 2026-05-15 - first\n\n**Date**: 2026-05-15\n\nadopt cache-warming everywhere.\n\n" +
+		"## 2026-05-20 - second\n\n**Date**: 2026-05-20\n\nmore cache-warming work.\n\n" +
+		"## 2026-05-25 - third\n\n**Date**: 2026-05-25\n\ncache-warming again.\n"
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	// Snapshot the entire tree before the dry-run so we can assert
+	// nothing changed, rather than checking only the paths we expect
+	// might change (which would miss an unexpected write elsewhere).
+	before := snapshotTree(t, dir)
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	var stdout, stderr bytes.Buffer
+	opts := SyncCLIOptions{DryRun: true, UpdateProvenance: true, WriteDrafts: true}
+	if err := runSync(dir, opts, now, &stdout, &stderr); err != nil {
+		t.Fatalf("runSync: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "(dry-run)") {
+		t.Errorf("expected (dry-run) marker somewhere in output; stdout:\n%s", got)
+	}
+
+	after := snapshotTree(t, dir)
+	if before != after {
+		t.Errorf("dry-run must not touch disk.\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// snapshotTree returns a stable, sorted "path\tsize\tmtime" listing for
+// every regular file under root, used to assert a dry-run left the tree
+// byte-for-byte (and file-for-file) untouched.
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+	var lines []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		lines = append(lines, fmt.Sprintf("%s\t%d\t%s", rel, info.Size(), info.ModTime()))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
 }

--- a/internal/skill/sync.go
+++ b/internal/skill/sync.go
@@ -28,11 +28,22 @@ package skill
 // `.claude/skills/<name>/` are skipped with a warning rather than
 // erroring out — the review file is the source of truth and may cite
 // skills installed elsewhere (or removed since the review was written).
+//
+// This file also implements the three SPEC §3.9 flags the above loop
+// shipped without: --since (ParseSinceDuration, plus the `Since` field
+// on SyncOptions), --update-provenance (UpdateProvenance), and
+// --write-drafts (WriteSkillDrafts). Each is a separate, additive
+// entry point — none of them replace or gate the default Sync() path
+// above, which is why a bare `logmind sync` (no flags) is untouched by
+// their presence. See each function's doc comment for why it's a
+// distinct code path rather than a rename/extension of Sync().
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -42,6 +53,8 @@ import (
 	"time"
 
 	"github.com/thrillmade/logmind/internal/atomicio"
+	"github.com/thrillmade/logmind/internal/decisions"
+	"github.com/thrillmade/logmind/internal/timeline"
 )
 
 // reviewSHARE matches the `<!-- review-sha: <40 hex chars> -->` comment
@@ -209,6 +222,13 @@ type SyncOptions struct {
 	// or skills we couldn't update. Nil silences warnings — useful
 	// for tests that pin success cases and don't want stderr noise.
 	Warn func(string)
+	// Since, when non-zero, restricts the docs/reviews/PR-*.md scan to
+	// files whose mtime falls within [Now-Since, Now] — SPEC §3.9's
+	// "limit scan to entries newer than <duration>". Zero (the
+	// SyncOptions default) means "no filtering", which is exactly
+	// today's unbounded-scan behaviour — so callers that never set
+	// Since see byte-identical output to before this field existed.
+	Since time.Duration
 }
 
 // SyncSummary captures what Sync did so the CLI layer can render a
@@ -271,6 +291,7 @@ func Sync(repoRoot string, opts SyncOptions) (SyncSummary, error) {
 		now = time.Now()
 	}
 	today := now.UTC().Format("2006-01-02")
+	cutoff := sinceCutoff(now, opts.Since)
 
 	reviewsDir := filepath.Join(repoRoot, "docs", "reviews")
 	entries, err := os.ReadDir(reviewsDir)
@@ -306,6 +327,24 @@ func Sync(repoRoot string, opts SyncOptions) (SyncSummary, error) {
 		if !prFilenameRE.MatchString(name) {
 			// Quiet: docs/reviews/README.md or similar is allowed.
 			continue
+		}
+		if !cutoff.IsZero() {
+			// --since: a file outside the window is outside the SCAN,
+			// per SPEC §3.9 — it's not merely excluded from the result,
+			// it's never opened. mtime is the only recency signal a
+			// PR-<n>.md file carries (§1.8.1's template has no embedded
+			// date field), so we use it as-is. A stat failure here is
+			// surprising enough (the entry just came from ReadDir) that
+			// we warn and skip rather than silently including it, which
+			// would quietly widen the window the caller asked for.
+			info, ierr := e.Info()
+			if ierr != nil {
+				warn(fmt.Sprintf("skipping %s: stat: %v", name, ierr))
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				continue
+			}
 		}
 		summary.ReviewsScanned++
 		path := filepath.Join(reviewsDir, name)
@@ -685,4 +724,667 @@ func FormatSummary(w io.Writer, s SyncSummary, dryRun bool) {
 		fmt.Fprintf(w, "  - %s: %d → %d%s\n",
 			u.Name, u.PreviousCount, u.NewCount, shasPart)
 	}
+}
+
+// --- --since ---------------------------------------------------------
+//
+// SPEC §3.9: `logmind sync [--since <duration>] ...` — "limit scan to
+// entries newer than <duration> (e.g. 7d, 30d)". Go's time.ParseDuration
+// has no "d" (day) unit, so the shorthand SPEC actually uses (`7d`,
+// `30d`) isn't a valid Go duration string on its own. We handle the
+// day-count form explicitly and fall back to time.ParseDuration for
+// everything else (`24h`, `90m`, `1h30m`, ...) so a caller who happens
+// to already think in Go-duration syntax isn't punished for it.
+//
+// sinceDurationRE deliberately does NOT accept w/m/y suffixes the way
+// `logmind skill suggest --since` does (internal/cli/skill.go's
+// sinceRE): "m" would collide with Go's own duration unit for minutes,
+// and the SPEC text for `sync` only specifies day-shorthand examples.
+// Silently guessing "m" means "month" here — when time.ParseDuration
+// would otherwise have parsed "5m" as five minutes — is exactly the
+// kind of ambiguity that produces a flag which lies about what it did.
+var sinceDurationRE = regexp.MustCompile(`^(\d+)d$`)
+
+// ParseSinceDuration parses a `--since` value per SPEC §3.9. Malformed
+// input (empty string, non-positive count, unrecognized unit, garbage)
+// is a hard error — never silently normalized to zero. A `--since`
+// value that's silently ignored would make `logmind sync --since 7d`
+// quietly scan the entire history while claiming to have honored the
+// 7-day window; that's the lying-flag failure mode this build must
+// avoid (see PR #247, which deleted five flags for exactly this
+// reason).
+func ParseSinceDuration(s string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, fmt.Errorf("--since: empty duration (want e.g. \"7d\", \"30d\", \"24h\")")
+	}
+	if m := sinceDurationRE.FindStringSubmatch(trimmed); m != nil {
+		days, err := strconv.Atoi(m[1])
+		if err != nil || days <= 0 {
+			return 0, fmt.Errorf("--since %q: day count must be a positive integer", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("--since %q: not a valid duration (want e.g. \"7d\", \"30d\", \"24h\"): %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("--since %q: duration must be positive", s)
+	}
+	return d, nil
+}
+
+// sinceCutoff turns a (now, since) pair into the absolute instant a
+// scan should stop at. Zero Duration means "no filtering", represented
+// by the zero time.Time so callers can test cutoff.IsZero() rather than
+// re-deriving the "was Since even set" question.
+func sinceCutoff(now time.Time, since time.Duration) time.Time {
+	if since <= 0 {
+		return time.Time{}
+	}
+	return now.Add(-since)
+}
+
+// --- --update-provenance ----------------------------------------------
+//
+// UpdateProvenance implements the SPEC §3.9 / §1.11 "refreshed
+// PROVENANCE.md" surface. Unlike the legacy Sync() above (which folds
+// docs/reviews/PR-*.md citations into a pre-existing, non-SPEC
+// `<!-- logmind:provenance v1 -->` skeleton — see provenance.go — this
+// writes the NORMATIVE §1.11.1 template byte-for-byte, sourced from all
+// three surfaces §3.9 names:
+//
+//   - `.claude/skills/.clud-bug.json` `usage[<slug>].citations` (§1.12)
+//   - `docs/decisions.md` + `docs/decisions-branches/*.md` (§1.3/§1.4),
+//     matched against each skill's slug to build "Derived from
+//     decisions"
+//   - docs/reviews/PR-*.md is deliberately NOT re-read here: its
+//     citation signal is already the legacy Sync() path above, and
+//     folding it into a *second*, differently-shaped counter here would
+//     just create two disagreeing numbers for the same thing. The
+//     `.clud-bug.json` usage counters are the SPEC's own primary
+//     citation source for PROVENANCE.md (§1.11.1 sources `usage[<slug>]
+//     .citations` explicitly); docs/reviews/PR-*.md is the legacy
+//     bridge Sync() was built around before that JSON surface existed.
+//
+// This is a genuinely additive code path, gated entirely behind
+// --update-provenance: bare `logmind sync` never calls this function,
+// so its default-no-flags behaviour (the legacy skeleton format) is
+// untouched.
+type ProvenanceOptions struct {
+	// DryRun: compute the refresh but don't write PROVENANCE.md.
+	DryRun bool
+	// Now is the clock used for "Last refined" and --since. Zero means
+	// time.Now().
+	Now time.Time
+	// Since restricts which decision entries count toward "Derived
+	// from decisions" (by entry date) and which `.clud-bug.json` usage
+	// counters count toward "Cited by clud-bug" (by last_cited) to the
+	// [Now-Since, Now] window. Zero means unrestricted — the full
+	// history.
+	Since time.Duration
+	// Warn receives one-line diagnostics. Nil silences them.
+	Warn func(string)
+}
+
+// ProvenanceUpdate is the per-skill result of a refresh, for CLI
+// reporting.
+type ProvenanceUpdate struct {
+	Name          string
+	PrevCitations int
+	NewCitations  int
+	DecisionRefs  int
+	// Migrated is true when the skill had no prior SPEC §1.11.1
+	// PROVENANCE.md (either none at all, or the pre-existing
+	// non-SPEC `<!-- logmind:provenance v1 -->` skeleton) and this run
+	// wrote the first conformant one.
+	Migrated bool
+}
+
+// ProvenanceSummary captures what UpdateProvenance did.
+type ProvenanceSummary struct {
+	SkillsScanned   int
+	SkillsRefreshed int
+	Updates         []ProvenanceUpdate
+}
+
+// cludBugUsageEntry mirrors the `usage[<slug>]` object in SPEC §1.12.1.
+// We only need the two fields PROVENANCE.md's template surfaces;
+// unknown/absent fields (this repo's own `.claude/skills/.clud-bug.json`
+// is schema v1 and has no `usage` block at all) round-trip as zero
+// values rather than erroring, since a manifest that predates a field
+// is not malformed — it's just older.
+type cludBugUsageEntry struct {
+	Citations int    `json:"citations"`
+	LastCited string `json:"last_cited"`
+}
+
+// cludBugManifest is the subset of SPEC §1.12.1's `.clud-bug.json`
+// schema UpdateProvenance reads.
+type cludBugManifest struct {
+	Usage map[string]cludBugUsageEntry `json:"usage"`
+}
+
+// loadCludBugManifest reads `.claude/skills/.clud-bug.json`. A missing
+// file is not an error — a repo that hasn't run clud-bug yet simply has
+// zero citations for every skill.
+func loadCludBugManifest(repoRoot string) (cludBugManifest, error) {
+	path := filepath.Join(repoRoot, ".claude", "skills", ".clud-bug.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cludBugManifest{}, nil
+		}
+		return cludBugManifest{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m cludBugManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return cludBugManifest{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// listSkillDirs returns the sorted names of every directory under
+// SkillsDir(repoRoot) that has a SKILL.md — i.e., every installed
+// skill, regardless of whether `.clud-bug.json` also lists it in
+// `installed[]` (a repo's clud-bug manifest can drift from the skills
+// actually on disk; PROVENANCE.md is a per-skill file, so we drive off
+// the filesystem, the same source loadExistingSkillNames in suggest.go
+// uses).
+func listSkillDirs(repoRoot string) []string {
+	skillsDir := SkillsDir(repoRoot)
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if st, err := os.Stat(filepath.Join(skillsDir, e.Name(), "SKILL.md")); err == nil && st.Mode().IsRegular() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// skillFrontmatterSourceRE matches the `source:` key inside a SKILL.md
+// frontmatter block (SPEC §1.10.1).
+var skillFrontmatterSourceRE = regexp.MustCompile(`(?m)^source:\s*(\S+)\s*$`)
+
+// readSkillSource returns the skill's own `source:` frontmatter value
+// (SPEC §1.10.1: manual | logmind-derived | skills-sh | clud-bug-baseline)
+// for use as PROVENANCE.md's `**Source:**` field. Falls back to
+// "manual" when the SKILL.md is unreadable or doesn't declare one —
+// every real SKILL.md in this repo predates the `source:` key (the
+// v0.4.0 basicTemplate in scaffold.go doesn't emit it either), so
+// "manual" (the most common real-world case: a human wrote it) is a
+// more honest default than leaving the field blank.
+func readSkillSource(repoRoot, name string) string {
+	data, err := os.ReadFile(MDPath(repoRoot, name))
+	if err != nil {
+		return "manual"
+	}
+	fm := extractFrontmatter(string(data))
+	if m := skillFrontmatterSourceRE.FindStringSubmatch(fm); m != nil {
+		return m[1]
+	}
+	return "manual"
+}
+
+// extractFrontmatter returns the content between the opening and
+// closing `---` fences of a SKILL.md, or "" when the file doesn't open
+// with a frontmatter block. Scoping the source-field regex to just this
+// slice (rather than the whole file) avoids a false match on the word
+// "source" appearing in prose below the fence.
+func extractFrontmatter(body string) string {
+	if !strings.HasPrefix(body, "---\n") {
+		return ""
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// warnWriter adapts a `func(string)` warn callback to io.Writer so it
+// can be handed to APIs (like internal/decisions.Collect) that want a
+// writer for diagnostics.
+type warnWriter struct {
+	warn func(string)
+}
+
+func (w warnWriter) Write(p []byte) (int, error) {
+	if w.warn != nil {
+		if s := strings.TrimRight(string(p), "\n"); s != "" {
+			w.warn(s)
+		}
+	}
+	return len(p), nil
+}
+
+// decisionRefsForSkill scans docs/decisions.md + docs/decisions-branches/
+// *.md + docs/decisions-archive.md (via internal/decisions.Collect, the
+// same multi-source reader `logmind timeline` uses) for entries whose
+// title mentions the skill by name, and returns SPEC §1.11.1 "Derived
+// from decisions" anchor lines (`docs/<file>#<title-slug>`), sorted for
+// stable output.
+//
+// Matching heuristic: case-insensitive substring match of the skill's
+// slug (`avoid-naked-fetch`) OR its space-separated form
+// (`avoid naked fetch`) against the decision's title. This is a
+// best-effort heuristic — the SPEC only says the list is "computed from
+// docs/decisions*.md heading anchors" without specifying a match rule —
+// but it directly matches how a human would title a decision that
+// introduced or refined a named skill ("Add avoid-naked-fetch skill",
+// "Refine the avoid naked fetch guidance", ...), and it errs toward
+// under-matching (an honest empty list) rather than over-matching
+// (fabricating provenance).
+//
+// The anchor slug uses internal/timeline.Slugify on the title alone
+// (not the full "YYYY-MM-DD HH:MM - title" heading line) to match the
+// SPEC template's literal `<title-slug>` placeholder name.
+func decisionRefsForSkill(repoRoot, skillName string, cutoff time.Time, warn func(string)) []string {
+	entries, err := decisions.Collect(filepath.Join(repoRoot, "docs"), warnWriter{warn})
+	if err != nil {
+		if warn != nil {
+			warn(fmt.Sprintf("derived-from-decisions: %v", err))
+		}
+		return nil
+	}
+	needleHyphen := strings.ToLower(skillName)
+	needleSpaced := strings.ToLower(strings.ReplaceAll(skillName, "-", " "))
+
+	seen := map[string]struct{}{}
+	var refs []string
+	for _, e := range entries {
+		if !cutoff.IsZero() && e.Date.Before(cutoff) {
+			continue
+		}
+		titleLower := strings.ToLower(e.Title)
+		if !strings.Contains(titleLower, needleHyphen) && !strings.Contains(titleLower, needleSpaced) {
+			continue
+		}
+		anchor := fmt.Sprintf("docs/%s#%s", e.SourcePath, timeline.Slugify(e.Title))
+		if _, dup := seen[anchor]; dup {
+			continue
+		}
+		seen[anchor] = struct{}{}
+		refs = append(refs, anchor)
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// provenanceSpecState is what parseSpecProvenance extracts from an
+// existing PROVENANCE.md that's already in the SPEC §1.11.1 format.
+type provenanceSpecState struct {
+	IsSpecFormat bool
+	Source       string
+	Citations    int
+	DecisionRefs []string
+	History      []string
+}
+
+var (
+	specMarkerRE     = regexp.MustCompile(`<!--\s*maintained-by:\s*logmind sync\s*-->`)
+	specSourceRE     = regexp.MustCompile(`^\*\*Source:\*\*\s*(.*)$`)
+	specCitationsRE  = regexp.MustCompile(`^\*\*Cited by clud-bug:\*\*\s*(\d+)\s+times?\s*$`)
+	specDerivedHdrRE = regexp.MustCompile(`^\*\*Derived from decisions:\*\*\s*$`)
+	specHistoryHdrRE = regexp.MustCompile(`^\*\*Refinement history:\*\*\s*$`)
+	specBulletRE     = regexp.MustCompile(`^-\s+(.*)$`)
+)
+
+// parseSpecProvenance reads an existing PROVENANCE.md body. Files that
+// don't carry the `<!-- maintained-by: logmind sync -->` marker —
+// because they're the pre-existing `<!-- logmind:provenance v1 -->`
+// skeleton (provenance.go), or because no file exists yet — report
+// IsSpecFormat=false and every other field at its zero value, which
+// UpdateProvenance treats as "first SPEC-conformant refresh" (a
+// migration, not an update).
+func parseSpecProvenance(body string) provenanceSpecState {
+	st := provenanceSpecState{}
+	if !specMarkerRE.MatchString(body) {
+		return st
+	}
+	st.IsSpecFormat = true
+	section := ""
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		switch {
+		case specSourceRE.MatchString(line):
+			st.Source = specSourceRE.FindStringSubmatch(line)[1]
+			section = ""
+		case specCitationsRE.MatchString(line):
+			n, _ := strconv.Atoi(specCitationsRE.FindStringSubmatch(line)[1])
+			st.Citations = n
+			section = ""
+		case specDerivedHdrRE.MatchString(line):
+			section = "derived"
+		case specHistoryHdrRE.MatchString(line):
+			section = "history"
+		case section == "derived" && specBulletRE.MatchString(line):
+			st.DecisionRefs = append(st.DecisionRefs, specBulletRE.FindStringSubmatch(line)[1])
+		case section == "history" && specBulletRE.MatchString(line):
+			st.History = append(st.History, specBulletRE.FindStringSubmatch(line)[1])
+		}
+	}
+	return st
+}
+
+// equalStringSlices reports whether a and b hold the same elements in
+// the same order. Both DecisionRefs inputs to this comparison are
+// always sorted before being written, so order-sensitivity here doesn't
+// cause spurious "changed" diffs across re-runs.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// diffProvenance decides whether a refresh actually changes anything
+// worth writing, and if so, the one-line refinement-history summary to
+// append. Re-running UpdateProvenance with no new citations, no new
+// matching decisions, and no source change is a no-op — same
+// idempotency discipline as the legacy Sync() above.
+func diffProvenance(prev provenanceSpecState, citations int, refs []string, source string) (changed bool, summary string) {
+	if !prev.IsSpecFormat {
+		return true, "Migrated to SPEC §1.11.1 provenance format via `logmind sync --update-provenance`"
+	}
+	var parts []string
+	if prev.Citations != citations {
+		parts = append(parts, fmt.Sprintf("cited-by-clud-bug %d → %d", prev.Citations, citations))
+	}
+	if !equalStringSlices(prev.DecisionRefs, refs) {
+		parts = append(parts, fmt.Sprintf("derived-from-decisions %d → %d entries", len(prev.DecisionRefs), len(refs)))
+	}
+	if prev.Source != source {
+		parts = append(parts, fmt.Sprintf("source %q → %q", prev.Source, source))
+	}
+	if len(parts) == 0 {
+		return false, ""
+	}
+	return true, strings.Join(parts, "; ")
+}
+
+// renderProvenanceMD renders the SPEC §1.11.1 NORMATIVE template
+// byte-for-byte.
+func renderProvenanceMD(name, source string, citations int, lastRefined string, refs, history []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Provenance for %s\n", name)
+	b.WriteString("<!-- maintained-by: logmind sync -->\n\n")
+	fmt.Fprintf(&b, "**Source:** %s\n", source)
+	fmt.Fprintf(&b, "**Last refined:** %s\n", lastRefined)
+	fmt.Fprintf(&b, "**Cited by clud-bug:** %d times\n\n", citations)
+	b.WriteString("**Derived from decisions:**\n")
+	for _, r := range refs {
+		fmt.Fprintf(&b, "- %s\n", r)
+	}
+	b.WriteString("\n**Refinement history:**\n")
+	for _, h := range history {
+		fmt.Fprintf(&b, "- %s\n", h)
+	}
+	return b.String()
+}
+
+// UpdateProvenance refreshes every installed skill's PROVENANCE.md into
+// the SPEC §1.11.1 format. See the package doc comment above this type
+// block for the source-reconciliation design.
+func UpdateProvenance(repoRoot string, opts ProvenanceOptions) (ProvenanceSummary, error) {
+	warn := opts.Warn
+	if warn == nil {
+		warn = func(string) {}
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	today := now.UTC().Format("2006-01-02")
+	cutoff := sinceCutoff(now, opts.Since)
+
+	manifest, err := loadCludBugManifest(repoRoot)
+	if err != nil {
+		return ProvenanceSummary{}, err
+	}
+
+	names := listSkillDirs(repoRoot)
+	summary := ProvenanceSummary{}
+	for _, name := range names {
+		summary.SkillsScanned++
+
+		citations := 0
+		if u, ok := manifest.Usage[name]; ok {
+			switch {
+			case cutoff.IsZero():
+				citations = u.Citations
+			case u.LastCited != "":
+				if lc, perr := time.Parse(time.RFC3339, u.LastCited); perr == nil && !lc.Before(cutoff) {
+					citations = u.Citations
+				}
+				// Parseable-but-stale, or unparseable, both fall through
+				// to citations staying 0: --since asked us to limit the
+				// scan, and we can't honestly claim a citation count is
+				// "newer than <duration>" without a usable timestamp.
+			}
+		}
+
+		refs := decisionRefsForSkill(repoRoot, name, cutoff, warn)
+		source := readSkillSource(repoRoot, name)
+
+		provPath := filepath.Join(SkillDir(repoRoot, name), "PROVENANCE.md")
+		existing, readErr := os.ReadFile(provPath)
+		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+			warn(fmt.Sprintf("skill %q: read %s: %v", name, provPath, readErr))
+			continue
+		}
+		prev := parseSpecProvenance(string(existing))
+
+		changed, historyNote := diffProvenance(prev, citations, refs, source)
+		if !changed {
+			continue
+		}
+		history := append(append([]string{}, prev.History...), fmt.Sprintf("%s: %s", today, historyNote))
+		rendered := renderProvenanceMD(name, source, citations, today, refs, history)
+
+		if !opts.DryRun {
+			if err := atomicWriteFile(provPath, []byte(rendered), 0o644); err != nil {
+				warn(fmt.Sprintf("skill %q: write %s: %v", name, provPath, err))
+				continue
+			}
+		}
+
+		summary.SkillsRefreshed++
+		summary.Updates = append(summary.Updates, ProvenanceUpdate{
+			Name:          name,
+			PrevCitations: prev.Citations,
+			NewCitations:  citations,
+			DecisionRefs:  len(refs),
+			Migrated:      !prev.IsSpecFormat,
+		})
+	}
+	return summary, nil
+}
+
+// FormatProvenanceSummary renders a human-readable report of an
+// UpdateProvenance run.
+func FormatProvenanceSummary(w io.Writer, s ProvenanceSummary, dryRun bool) {
+	prefix := ""
+	if dryRun {
+		prefix = "(dry-run) "
+	}
+	fmt.Fprintf(w, "%s%d skill(s) refreshed (%d scanned)\n", prefix, s.SkillsRefreshed, s.SkillsScanned)
+	for _, u := range s.Updates {
+		tag := ""
+		if u.Migrated {
+			tag = " [migrated to SPEC §1.11.1]"
+		}
+		fmt.Fprintf(w, "  - %s: cited-by-clud-bug %d → %d, %d decision ref(s)%s\n",
+			u.Name, u.PrevCitations, u.NewCitations, u.DecisionRefs, tag)
+	}
+	fmt.Fprintf(w, "ok sync-provenance: %s%d skill(s) refreshed/%d scanned\n",
+		prefix, s.SkillsRefreshed, s.SkillsScanned)
+}
+
+// --- --write-drafts ----------------------------------------------------
+//
+// WriteSkillDrafts implements the SPEC §3.9 / §1.9 "skill candidate
+// drafts under docs/skills-derived/" surface. It reuses
+// SuggestFromDecisions (suggest.go) — the same decision-pattern
+// heuristic `logmind skill suggest` uses — rather than re-implementing
+// pattern detection, since §1.9 already names both `logmind skill
+// suggest --write-drafts` and `logmind sync --write-drafts` as
+// producers of the same file shape and the SPEC gives no reason to
+// expect them to disagree on WHICH patterns are skill-worthy.
+//
+// It does NOT reuse suggest_llm.go's WriteDrafts/FormatIssueDraft: those
+// render a GH-issue-body (no frontmatter at all) into an
+// arbitrary caller-chosen directory — the shape `logmind skill suggest
+// --write-drafts <dir>` promises. SPEC §1.9 requires a different, fixed
+// shape: Markdown with YAML frontmatter setting `source: logmind-derived`
+// and `status: candidate`, at the fixed path
+// docs/skills-derived/<name>.md. Reusing the issue-body renderer here
+// would produce a file at the right path with the wrong contents — the
+// same "flag that doesn't do what it says" failure this build is
+// required to avoid, just relocated from "doesn't write" to "writes the
+// wrong thing".
+const (
+	// syncDraftsDefaultSinceDays mirrors `logmind skill suggest`'s own
+	// --since default (internal/cli/skill.go newSkillSuggestCmd) so the
+	// two producers of docs/skills-derived/*.md agree on "recent"
+	// absent an explicit --since override.
+	syncDraftsDefaultSinceDays = 30
+	// syncDraftsMinDecisions mirrors `logmind skill suggest`'s
+	// --min-decisions default.
+	syncDraftsMinDecisions = 3
+	// syncDraftsTopN mirrors `logmind skill suggest`'s --top default.
+	syncDraftsTopN = 5
+)
+
+// DraftOptions controls WriteSkillDrafts.
+type DraftOptions struct {
+	// DryRun: compute the candidate list but don't write files.
+	DryRun bool
+	// Now is the clock used for --since. Zero means time.Now().
+	Now time.Time
+	// Since restricts the decision-log lookback window. Zero means the
+	// syncDraftsDefaultSinceDays fallback (30d), matching `logmind
+	// skill suggest`'s own default.
+	Since time.Duration
+	// Warn receives one-line diagnostics. Nil silences them.
+	Warn func(string)
+}
+
+// DraftSummary captures what WriteSkillDrafts did.
+type DraftSummary struct {
+	CandidatesConsidered int
+	DraftsWritten        []string // skill slugs, in the order suggested
+}
+
+// draftsDir is the SPEC §1.9 canonical location for skill-candidate
+// drafts.
+func draftsDir(repoRoot string) string {
+	return filepath.Join(repoRoot, "docs", "skills-derived")
+}
+
+// renderSkillDraftMD renders a SPEC §1.9/§1.10.1-conformant draft: YAML
+// frontmatter (source: logmind-derived, status: candidate — the two
+// keys §1.9 says a draft's frontmatter MUST set) followed by a
+// human-readable body carrying the same evidence
+// `logmind skill suggest` shows on stdout.
+func renderSkillDraftMD(s Suggestion) string {
+	// Frontmatter values are single-line YAML scalars; draft_description
+	// is generated text (not user input) but collapsing defensively
+	// costs nothing and avoids ever emitting frontmatter that doesn't
+	// parse.
+	desc := strings.ReplaceAll(strings.TrimSpace(s.DraftDescription), "\n", " ")
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "name: %s\n", s.Slug)
+	fmt.Fprintf(&b, "description: %s\n", desc)
+	b.WriteString("source: logmind-derived\n")
+	b.WriteString("status: candidate\n")
+	b.WriteString("---\n\n")
+	fmt.Fprintf(&b, "# %s\n\n", s.Slug)
+	fmt.Fprintf(&b, "Trigger: when working on `%s` — pattern emerged in %d recent decisions.\n\n",
+		s.Phrase, s.DecisionCount)
+	b.WriteString("## Evidence (auto-extracted from decision log)\n\n")
+	for _, e := range s.Evidence {
+		fmt.Fprintf(&b, "- `%s`: %s\n", e.File, e.Snippet)
+	}
+	b.WriteString("\n_Generated by `logmind sync --write-drafts` (SPEC §1.9). This is a " +
+		"candidate awaiting human review — promote it into `.claude/skills/<name>/` " +
+		"only after editing the trigger and body; tools MUST NOT load draft skills " +
+		"as active skills._\n")
+	return b.String()
+}
+
+// WriteSkillDrafts scans recent decisions for skill-worthy patterns and
+// writes one docs/skills-derived/<slug>.md per candidate.
+func WriteSkillDrafts(repoRoot string, opts DraftOptions) (DraftSummary, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	sinceDays := syncDraftsDefaultSinceDays
+	if opts.Since > 0 {
+		sinceDays = int(math.Ceil(opts.Since.Hours() / 24))
+		if sinceDays < 1 {
+			sinceDays = 1
+		}
+	}
+
+	suggestions := SuggestFromDecisions(repoRoot, sinceDays, syncDraftsMinDecisions, syncDraftsTopN, now)
+	summary := DraftSummary{CandidatesConsidered: len(suggestions)}
+	if len(suggestions) == 0 {
+		return summary, nil
+	}
+
+	if !opts.DryRun {
+		if err := os.MkdirAll(draftsDir(repoRoot), 0o755); err != nil {
+			return summary, fmt.Errorf("mkdir %s: %w", draftsDir(repoRoot), err)
+		}
+	}
+
+	for _, s := range suggestions {
+		path := filepath.Join(draftsDir(repoRoot), s.Slug+".md")
+		body := renderSkillDraftMD(s)
+		if !opts.DryRun {
+			if err := atomicWriteFile(path, []byte(body), 0o644); err != nil {
+				if opts.Warn != nil {
+					opts.Warn(fmt.Sprintf("draft %q: write %s: %v", s.Slug, path, err))
+				}
+				continue
+			}
+		}
+		summary.DraftsWritten = append(summary.DraftsWritten, s.Slug)
+	}
+	return summary, nil
+}
+
+// FormatDraftSummary renders a human-readable report of a
+// WriteSkillDrafts run.
+func FormatDraftSummary(w io.Writer, s DraftSummary, dryRun bool) {
+	prefix := ""
+	if dryRun {
+		prefix = "(dry-run) "
+	}
+	fmt.Fprintf(w, "%s%d draft(s) written (%d candidate(s) considered)\n",
+		prefix, len(s.DraftsWritten), s.CandidatesConsidered)
+	for _, slug := range s.DraftsWritten {
+		fmt.Fprintf(w, "  - docs/skills-derived/%s.md\n", slug)
+	}
+	fmt.Fprintf(w, "ok sync-drafts: %s%d draft(s) written/%d candidate(s)\n",
+		prefix, len(s.DraftsWritten), s.CandidatesConsidered)
 }

--- a/internal/skill/sync_test.go
+++ b/internal/skill/sync_test.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -697,5 +698,459 @@ func TestSync_SHAcase_Canonicalised(t *testing.T) {
 	body, _ := os.ReadFile(provPath)
 	if !strings.Contains(string(body), "cited-by-clud-bug: 2") {
 		t.Errorf("counter should still be 2; body:\n%s", body)
+	}
+}
+
+// --- ParseSinceDuration --------------------------------------------------
+
+// TestParseSinceDuration_Valid pins the accepted shapes: SPEC §3.9's own
+// `<N>d` shorthand, plus a fallback to time.ParseDuration for ordinary
+// Go duration strings.
+func TestParseSinceDuration_Valid(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"7d", 7 * 24 * time.Hour},
+		{"30d", 30 * 24 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"365d", 365 * 24 * time.Hour},
+		{"24h", 24 * time.Hour},
+		{"90m", 90 * time.Minute},
+		{"1h30m", 90 * time.Minute},
+	}
+	for _, c := range cases {
+		got, err := ParseSinceDuration(c.in)
+		if err != nil {
+			t.Errorf("ParseSinceDuration(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseSinceDuration(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestParseSinceDuration_Malformed pins the rejection path. A malformed
+// --since MUST error rather than silently resolve to zero (which would
+// mean "scan everything" while claiming to have honored the window —
+// the exact lying-flag failure mode this build must avoid).
+func TestParseSinceDuration_Malformed(t *testing.T) {
+	cases := []string{
+		"", "   ", "0d", "-5d", "7dd", "7 d", "7days", "garbage",
+		"d7", "-24h", "0h", "7w", "1y", "d",
+	}
+	for _, in := range cases {
+		if _, err := ParseSinceDuration(in); err == nil {
+			t.Errorf("ParseSinceDuration(%q): expected error, got nil", in)
+		}
+	}
+}
+
+// --- Sync: --since --------------------------------------------------------
+
+// TestSync_Since_ExcludesOldReviews: a review file backdated outside the
+// --since window is excluded from the scan entirely — it doesn't count
+// toward ReviewsScanned and its citations never reach PROVENANCE.md.
+func TestSync_Since_ExcludesOldReviews(t *testing.T) {
+	dir := t.TempDir()
+	provPath := scaffoldSkillWithProvenance(t, dir, "since-skill")
+
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	writeReview(t, dir, "PR-1.md", reviewWith(oldSHA, []string{"since-skill (2 findings)"}))
+	writeReview(t, dir, "PR-2.md", reviewWith(newSHA, []string{"since-skill (5 findings)"}))
+
+	oldTime := fixedNow.Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "docs", "reviews", "PR-1.md"), oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes PR-1: %v", err)
+	}
+	if err := os.Chtimes(filepath.Join(dir, "docs", "reviews", "PR-2.md"), fixedNow, fixedNow); err != nil {
+		t.Fatalf("chtimes PR-2: %v", err)
+	}
+
+	got, err := Sync(dir, SyncOptions{Now: fixedNow, Since: 7 * 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got.ReviewsScanned != 1 {
+		t.Errorf("ReviewsScanned = %d; want 1 (old review excluded by --since)", got.ReviewsScanned)
+	}
+	if got.CitationsAdded != 5 {
+		t.Errorf("CitationsAdded = %d; want 5 (only PR-2's citations)", got.CitationsAdded)
+	}
+
+	body, _ := os.ReadFile(provPath)
+	if strings.Contains(string(body), oldSHA) {
+		t.Errorf("old SHA must not be recorded when excluded by --since; body:\n%s", body)
+	}
+	if !strings.Contains(string(body), newSHA) {
+		t.Errorf("new SHA missing; body:\n%s", body)
+	}
+}
+
+// TestSync_Since_Zero_IsUnbounded: the zero value of Since (what every
+// pre-existing caller passes) must behave exactly like the pre-flag
+// code path — a backdated review is still picked up.
+func TestSync_Since_Zero_IsUnbounded(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldSkillWithProvenance(t, dir, "unbounded-skill")
+	sha := strings.Repeat("c", 40)
+	writeReview(t, dir, "PR-1.md", reviewWith(sha, []string{"unbounded-skill (1 findings)"}))
+	oldTime := fixedNow.Add(-3650 * 24 * time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "docs", "reviews", "PR-1.md"), oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	got, err := Sync(dir, SyncOptions{Now: fixedNow})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got.ReviewsScanned != 1 || got.CitationsAdded != 1 {
+		t.Errorf("Since=0 must not filter anything; got %+v", got)
+	}
+}
+
+// --- UpdateProvenance -------------------------------------------------
+
+// writeCludBugManifest drops a minimal SPEC §1.12.1-shaped
+// .claude/skills/.clud-bug.json under root.
+func writeCludBugManifest(t *testing.T, root string, usage map[string]cludBugUsageEntry) {
+	t.Helper()
+	dir := filepath.Join(root, ".claude", "skills")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .claude/skills: %v", err)
+	}
+	m := cludBugManifest{Usage: usage}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".clud-bug.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// scaffoldPlainSkill creates just .claude/skills/<name>/SKILL.md — no
+// PROVENANCE.md at all — the "brand new skill" starting state for
+// UpdateProvenance tests.
+func scaffoldPlainSkill(t *testing.T, root, name string) {
+	t.Helper()
+	if _, err := ScaffoldBasic(root, name, "desc"); err != nil {
+		t.Fatalf("scaffold %s: %v", name, err)
+	}
+}
+
+// TestUpdateProvenance_FreshSkill_NoPriorFile: a skill with no
+// PROVENANCE.md at all gets the SPEC §1.11.1 template written from
+// scratch, reported as Migrated.
+func TestUpdateProvenance_FreshSkill_NoPriorFile(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "fresh-skill")
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.SkillsScanned != 1 || got.SkillsRefreshed != 1 {
+		t.Fatalf("unexpected summary: %+v", got)
+	}
+	if !got.Updates[0].Migrated {
+		t.Errorf("expected Migrated=true for a brand-new file; got %+v", got.Updates[0])
+	}
+
+	body, err := os.ReadFile(filepath.Join(SkillDir(dir, "fresh-skill"), "PROVENANCE.md"))
+	if err != nil {
+		t.Fatalf("read PROVENANCE.md: %v", err)
+	}
+	got0 := string(body)
+	for _, want := range []string{
+		"# Provenance for fresh-skill\n",
+		"<!-- maintained-by: logmind sync -->\n",
+		"**Source:** manual\n",
+		"**Last refined:** 2026-06-03\n",
+		"**Cited by clud-bug:** 0 times\n",
+		"**Derived from decisions:**\n",
+		"**Refinement history:**\n",
+	} {
+		if !strings.Contains(got0, want) {
+			t.Errorf("PROVENANCE.md missing %q; body:\n%s", want, got0)
+		}
+	}
+}
+
+// TestUpdateProvenance_MigratesLegacySkeleton: a skill that already has
+// the pre-existing non-SPEC `<!-- logmind:provenance v1 -->` skeleton
+// (provenance.go) gets replaced with the SPEC §1.11.1 format, not
+// merged with it — the two formats share no fields worth carrying over
+// (the legacy skeleton's cited-by-clud-bug counter is sourced from
+// docs/reviews/PR-*.md, a different source than this function reads).
+func TestUpdateProvenance_MigratesLegacySkeleton(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldSkillWithProvenance(t, dir, "legacy-skill")
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.SkillsRefreshed != 1 || !got.Updates[0].Migrated {
+		t.Fatalf("expected one migrated refresh; got %+v", got)
+	}
+	body, _ := os.ReadFile(filepath.Join(SkillDir(dir, "legacy-skill"), "PROVENANCE.md"))
+	if strings.Contains(string(body), "logmind:provenance v1") {
+		t.Errorf("legacy marker should be gone after migration; body:\n%s", body)
+	}
+	if !strings.Contains(string(body), "<!-- maintained-by: logmind sync -->") {
+		t.Errorf("missing SPEC marker after migration; body:\n%s", body)
+	}
+}
+
+// TestUpdateProvenance_ReadsCludBugUsage: the citation count comes from
+// .claude/skills/.clud-bug.json's usage[<slug>].citations field, per
+// SPEC §1.11.1 / §1.12.
+func TestUpdateProvenance_ReadsCludBugUsage(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "cited-skill")
+	writeCludBugManifest(t, dir, map[string]cludBugUsageEntry{
+		"cited-skill": {Citations: 7, LastCited: "2026-06-01T00:00:00Z"},
+	})
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.Updates[0].NewCitations != 7 {
+		t.Fatalf("NewCitations = %d; want 7", got.Updates[0].NewCitations)
+	}
+	body, _ := os.ReadFile(filepath.Join(SkillDir(dir, "cited-skill"), "PROVENANCE.md"))
+	if !strings.Contains(string(body), "**Cited by clud-bug:** 7 times") {
+		t.Errorf("citation count missing from body:\n%s", body)
+	}
+}
+
+// TestUpdateProvenance_DerivedFromDecisions: a decision entry whose
+// title mentions the skill by name (hyphenated slug form) surfaces as a
+// SPEC §1.11.1 "Derived from decisions" anchor line.
+func TestUpdateProvenance_DerivedFromDecisions(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "avoid-naked-fetch")
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	body := "# Decisions\n\n" +
+		"## 2026-05-15 10:00 - Add avoid-naked-fetch skill\n\n" +
+		"**Reasoning:** codify the timeout convention.\n\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.Updates[0].DecisionRefs != 1 {
+		t.Fatalf("DecisionRefs = %d; want 1; got %+v", got.Updates[0].DecisionRefs, got.Updates[0])
+	}
+	provBody, _ := os.ReadFile(filepath.Join(SkillDir(dir, "avoid-naked-fetch"), "PROVENANCE.md"))
+	if !strings.Contains(string(provBody), "docs/decisions.md#add-avoid-naked-fetch-skill") {
+		t.Errorf("expected decision anchor line; body:\n%s", provBody)
+	}
+}
+
+// TestUpdateProvenance_Idempotent: re-running with no new signal is a
+// no-op — SkillsRefreshed is 0 on the second pass and the file is
+// byte-identical.
+func TestUpdateProvenance_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "steady-skill")
+	writeCludBugManifest(t, dir, map[string]cludBugUsageEntry{
+		"steady-skill": {Citations: 2, LastCited: "2026-06-01T00:00:00Z"},
+	})
+
+	if _, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow}); err != nil {
+		t.Fatalf("first UpdateProvenance: %v", err)
+	}
+	provPath := filepath.Join(SkillDir(dir, "steady-skill"), "PROVENANCE.md")
+	before, err := os.ReadFile(provPath)
+	if err != nil {
+		t.Fatalf("read after first run: %v", err)
+	}
+
+	later := fixedNow.Add(24 * time.Hour)
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: later})
+	if err != nil {
+		t.Fatalf("second UpdateProvenance: %v", err)
+	}
+	if got.SkillsRefreshed != 0 {
+		t.Errorf("re-run with no new signal must be a no-op; got %+v", got)
+	}
+	after, err := os.ReadFile(provPath)
+	if err != nil {
+		t.Fatalf("read after second run: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("unchanged re-run must leave the file byte-identical.\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// TestUpdateProvenance_DryRun_WritesNothing: --dry-run reports what
+// would change but never touches disk.
+func TestUpdateProvenance_DryRun_WritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "dry-prov-skill")
+	provPath := filepath.Join(SkillDir(dir, "dry-prov-skill"), "PROVENANCE.md")
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow, DryRun: true})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.SkillsRefreshed != 1 {
+		t.Errorf("dry-run summary should still report the would-be refresh; got %+v", got)
+	}
+	if _, err := os.Stat(provPath); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create PROVENANCE.md; stat err = %v", err)
+	}
+}
+
+// TestUpdateProvenance_Since_ExcludesStaleUsageAndOldDecisions: --since
+// filters BOTH the usage-counter recency check (usage[<slug>].last_cited)
+// and the decision-entry date filter. A skill whose only citation
+// evidence is outside the window shows 0 citations for this run, and a
+// decision entry outside the window doesn't appear in "Derived from
+// decisions".
+func TestUpdateProvenance_Since_ExcludesStaleUsageAndOldDecisions(t *testing.T) {
+	dir := t.TempDir()
+	scaffoldPlainSkill(t, dir, "stale-skill")
+	writeCludBugManifest(t, dir, map[string]cludBugUsageEntry{
+		"stale-skill": {Citations: 9, LastCited: "2025-01-01T00:00:00Z"}, // ancient
+	})
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	body := "# Decisions\n\n" +
+		"## 2025-01-02 10:00 - Old note about stale-skill\n\n" +
+		"**Reasoning:** ancient.\n\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	got, err := UpdateProvenance(dir, ProvenanceOptions{Now: fixedNow, Since: 30 * 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("UpdateProvenance: %v", err)
+	}
+	if got.SkillsRefreshed != 1 {
+		// Even "nothing recent" is a meaningful first-write (Migrated),
+		// so a refresh still happens — it should just show zeros.
+		t.Fatalf("expected one refresh (fresh file, zeroed by --since); got %+v", got)
+	}
+	if got.Updates[0].NewCitations != 0 {
+		t.Errorf("NewCitations = %d; want 0 (stale last_cited excluded by --since)", got.Updates[0].NewCitations)
+	}
+	if got.Updates[0].DecisionRefs != 0 {
+		t.Errorf("DecisionRefs = %d; want 0 (old decision excluded by --since)", got.Updates[0].DecisionRefs)
+	}
+}
+
+// --- WriteSkillDrafts ---------------------------------------------------
+
+// decisionsBodyForDrafts builds three dated entries citing the same
+// kebab-case token, matching the fixture shape
+// TestSuggestFromDecisions_FindsPattern already pins in suggest_test.go
+// — WriteSkillDrafts is a thin wrapper around SuggestFromDecisions, so
+// reusing that fixture shape keeps the two tests honest about testing
+// the same underlying heuristic.
+func decisionsBodyForDrafts() string {
+	return "# Decisions\n\n" +
+		"## 2026-05-15 - first\n\n**Date**: 2026-05-15\n\n" +
+		"We standardized on cache-invalidation everywhere.\n\n" +
+		"## 2026-05-20 - second\n\n**Date**: 2026-05-20\n\n" +
+		"More cache-invalidation work landed.\n\n" +
+		"## 2026-05-25 - third\n\n**Date**: 2026-05-25\n\n" +
+		"cache-invalidation again, third time.\n"
+}
+
+// TestWriteSkillDrafts_WritesConformantFrontmatter: the SPEC §1.9
+// frontmatter contract (`source: logmind-derived`, `status: candidate`)
+// is honored, and the file lands at the SPEC path
+// docs/skills-derived/<name>.md.
+func TestWriteSkillDrafts_WritesConformantFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(decisionsBodyForDrafts()), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	summary, err := WriteSkillDrafts(dir, DraftOptions{Now: now})
+	if err != nil {
+		t.Fatalf("WriteSkillDrafts: %v", err)
+	}
+	if summary.CandidatesConsidered != 1 {
+		t.Fatalf("CandidatesConsidered = %d; want 1; summary=%+v", summary.CandidatesConsidered, summary)
+	}
+	if len(summary.DraftsWritten) != 1 || summary.DraftsWritten[0] != "cache-invalidation" {
+		t.Fatalf("DraftsWritten = %v; want [cache-invalidation]", summary.DraftsWritten)
+	}
+
+	path := filepath.Join(dir, "docs", "skills-derived", "cache-invalidation.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read draft: %v", err)
+	}
+	got := string(body)
+	if !strings.HasPrefix(got, "---\nname: cache-invalidation\n") {
+		t.Errorf("frontmatter doesn't open as expected; body starts:\n%s", got[:80])
+	}
+	if !strings.Contains(got, "\nsource: logmind-derived\n") {
+		t.Errorf("missing source: logmind-derived; body:\n%s", got)
+	}
+	if !strings.Contains(got, "\nstatus: candidate\n") {
+		t.Errorf("missing status: candidate; body:\n%s", got)
+	}
+}
+
+// TestWriteSkillDrafts_DryRun_WritesNothing: --dry-run must not create
+// docs/skills-derived/ at all, even though the summary still reports
+// what would have been written.
+func TestWriteSkillDrafts_DryRun_WritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	docsDir := filepath.Join(dir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(docsDir, "decisions.md"), []byte(decisionsBodyForDrafts()), 0o644); err != nil {
+		t.Fatalf("write decisions.md: %v", err)
+	}
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	summary, err := WriteSkillDrafts(dir, DraftOptions{Now: now, DryRun: true})
+	if err != nil {
+		t.Fatalf("WriteSkillDrafts: %v", err)
+	}
+	if len(summary.DraftsWritten) != 1 {
+		t.Fatalf("DraftsWritten = %v; want 1 entry reported even in dry-run", summary.DraftsWritten)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "docs", "skills-derived")); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create docs/skills-derived/; stat err = %v", err)
+	}
+}
+
+// TestWriteSkillDrafts_NoCandidates: an empty/absent decision log is a
+// clean zero-work summary, not an error.
+func TestWriteSkillDrafts_NoCandidates(t *testing.T) {
+	dir := t.TempDir()
+	summary, err := WriteSkillDrafts(dir, DraftOptions{Now: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteSkillDrafts: %v", err)
+	}
+	if summary.CandidatesConsidered != 0 || len(summary.DraftsWritten) != 0 {
+		t.Errorf("expected zero-work summary; got %+v", summary)
 	}
 }


### PR DESCRIPTION
Closes the `logmind sync` gap from the feature-set audit. §3.9 specifies three flags; `sync` had only `--dry-run`, with a source comment conceding the rest were "tracked for later waves."

## The lying-flag hazard, and how it was avoided

This repo deleted five flags in #247 for silently doing nothing, so the standing rule was: **if a flag can't be made to genuinely work, don't register it.**

`--since` was the live risk. Go's `time.ParseDuration` has no day unit, so `7d` doesn't parse natively — and a careless fallback makes `--since 7d` silently mean *scan everything*, which is precisely the failure mode #247 existed to kill. Verified against a built binary:

```
--since '7dd'      exit=1  Error: --since "7dd": not a valid duration (want e.g. "7d")
--since 'garbage'  exit=1  Error: --since "garbage": not a valid duration
--since '-5d'      exit=1  Error: --since "-5d": not a valid duration
--since '0d'       exit=1  Error: --since "0d": day count must be a positive integer
--since 7d/24h/90m exit=0  accepted   # control — valid forms still work
```

Malformed input is a hard error, never coerced to unbounded.

## `--dry-run` composition, proven with a control

```
--dry-run --update-provenance --write-drafts  → tree byte-identical, wrote nothing ✓
real --update-provenance                      → tree changed ✓  (proves the probe detects writes)
```

The control is the point — without showing the probe *can* see a write, "nothing changed" proves nothing.

## `--update-provenance`

Emits §1.11.1's NORMATIVE template, including the `<!-- maintained-by: logmind sync -->` marker:

```markdown
# Provenance for my-skill
<!-- maintained-by: logmind sync -->

**Source:** manual
**Last refined:** 2026-07-28
**Cited by clud-bug:** 0 times
```

A pre-existing `provenance.go` already wrote a **different, non-SPEC** `<!-- logmind:provenance v1 -->` skeleton. Per "don't change default behavior," that legacy path is untouched; the new flag is an additive writer producing real §1.11.1 bytes, and migrates a legacy file when it encounters one.

Deliberately does **not** re-fold `docs/reviews/PR-*.md` citations — `.clud-bug.json`'s `usage[<slug>].citations` is the SPEC's primary source for that field, and summing both would yield two disagreeing counters. Documented in the function's doc comment.

## `--write-drafts`

Writes `docs/skills-derived/<slug>.md` with the frontmatter §1.9 **MUSTs**: `source: logmind-derived` and `status: candidate`. (`status` is genuinely mandated here by §1.9 — it is not a misuse of §17's RESERVED key of the same name.) Avoids `suggest_llm.go`'s `WriteDrafts`, which emits GitHub-issue bodies with no frontmatter at all.

**Known limitation, stated plainly:** the draft body is a fixed template — heading, one trigger line, and an evidence dump from the decision log. It contains no actual *rule*, so it is a **lead**, not a finished skill. That is a consequence of `sync` being offline and deterministic (no model access on this path), and it is consistent with §1.9 calling these "candidates awaiting human review" and §17.1's nomination-≠-publication gate. A follow-up should point the draft footer at the house skill-authoring standard so a human landing on a lead doesn't invent their own format.

## Verification

`go build`, `go vet`, `gofmt -l internal/ cmd/` clean; full `go test ./...` green. Tests cover duration parsing (valid + malformed), `--since` filtering, provenance freshness/migration/idempotency, and a full-tree snapshot diff asserting zero writes under `--dry-run`.

Flag behavior and provenance bytes above re-verified by me against a built binary, not taken from the build report.

Files: `internal/cli/sync.go`, `internal/cli/sync_test.go`, `internal/skill/sync.go`, `internal/skill/sync_test.go`.