### PR TITLE
fix(regen): a refused push is a failure, not a warning — closes #262(a)

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -10,6 +10,13 @@ name: logmind / check-derived-docs
 # this workflow — v9's per-repo `derived_docs.mode: integration-point`
 # adoption gate (and its "hasn't opted in → pass" escape) is removed. The
 # blocking check always applies; there is no way to opt out from within a PR.
+#
+# v11: regen-on-main's push step no longer treats "no credential" and "push
+# refused" alike (SPEC-2 §3.3, logmind#262). No credential still degrades —
+# warn + exit 0. A push that was attempted and refused now fails the job
+# (::error + exit 1): it is the job not doing its job, and reporting it as
+# success is how a regenerator stays broken for weeks while every run is
+# green.
 
 on:
   pull_request:
@@ -105,14 +112,21 @@ jobs:
           git config user.email "skdd-steward[bot]@users.noreply.github.com"
           git add docs/timeline.md docs/file-structure.md
           git commit -m "[skip-logmind] chore: regen derived docs"
-          # Degrade, never fail: a rejected push leaves main's derived docs
-          # stale — a freshness gap, never a conflict risk — rather than
-          # red-lighting main for something that is by construction harmless.
-          # When the cause is a missing ruleset bypass (GH013, a policy
-          # refusal), this is NOT transient: every future push hits the same
-          # refusal until a human adds the identity to the bypass list — see
-          # the warning message below and docs/orchestrator-app.md.
+          # SPEC-2 §3.3: "Three outcomes, and they MUST NOT look alike."
+          # No credential (above) degrades — a warning and a successful
+          # exit, because a merge that was otherwise fine should not fail
+          # over it. A push that was attempted and refused is different:
+          # "a refused write is the job not doing its job", so unlike the
+          # no-credential case this one MUST fail the job, loudly — a
+          # rejected push here is not conflict risk (branches never modify
+          # the derived docs) but it IS main's derived docs going stale,
+          # and reporting it as success is how that stayed invisible for
+          # eleven days straight (#262). When the cause is a missing
+          # ruleset bypass (GH013, a policy refusal), this is NOT
+          # transient: every future push hits the same refusal until a
+          # human adds the identity to the bypass list — see the error
+          # message below and docs/orchestrator-app.md.
           if ! git push "https://x-access-token:${STEWARD_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"; then
-            echo "::warning title=Derived-doc regen could not be pushed to main::The push was rejected — most likely GH013: the skdd-steward[bot] identity is missing from the 'main' ruleset's bypass list for 'changes must be made through a pull request'. This is a POLICY refusal, not a token-scope problem, so it will NOT self-heal on the next merge — every future push hits the same refusal until the identity is added to the bypass list (see docs/orchestrator-app.md). No conflict risk — branches never modify the derived docs, so nothing can conflict on them."
-            exit 0
+            echo "::error title=Derived-doc regen push refused::The push was rejected — most likely GH013: the skdd-steward[bot] identity is missing from the 'main' ruleset's bypass list for 'changes must be made through a pull request'. This is a POLICY refusal, not a token-scope problem, so it will NOT self-heal on the next merge — every future push hits the same refusal until the identity is added to the bypass list (see docs/orchestrator-app.md). No conflict risk — branches never modify the derived docs, so nothing can conflict on them — but main's derived docs are now stale and this run failed to fix that."
+            exit 1
           fi

--- a/docs/decisions-branches/worktree-agent-a87c775331a53711d.md
+++ b/docs/decisions-branches/worktree-agent-a87c775331a53711d.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-01-regen-timeline-a-refused-push-must-fail-the-job-not-report-s -->
+- **2026-08-01** — regen-timeline: a refused push must fail the job, not report success (logmind#262a)
+<!-- logmind-entry-end -->
+
+## 2026-08-01 01:22 - regen-timeline: a refused push must fail the job, not report success (logmind#262a)
+
+**Reasoning:** SPEC-2 §3.3 requires three push outcomes that MUST NOT look alike: nothing-to-push (success), no credential (warning + exit 0, since a merge that was otherwise fine should not fail over a missing secret), and a push attempted and refused (a failure, MUST be reported as one). regen-on-main's push step conflated the last two — both used ::warning + exit 0 — so a refused push (GH013, main's ruleset rejecting a non-bypassed identity) reported success identically to a run with nothing to do. Real evidence: the job ran green for 11 days while 14 branch decision files never reached docs/timeline.md. §6.5 generalizes this beyond gates: any producer writing something another party depends on must report a write it attempted and could not complete.
+
+**Alternatives considered:** Considered leaving the refusal path at exit 0 with only a stronger warning message. Rejected: §3.3 is explicit that a refused write MUST be reported as a failure, and a warning that still exits 0 is indistinguishable from success to a reader scanning job status or a dashboard that only checks conclusion — which is exactly the failure mode #262 documents.
+
+**Implications:**
+- regen-on-main (a push-to-main job, not a required PR check) now fails its own run when the steward token mints but the push is rejected — this surfaces the staleness in the Actions tab/commit status without blocking any merge, since nothing merge-time depends on this job. The no-credential path is untouched: still ::warning + exit 0. .github/workflows/regen-timeline.yml and internal/templates/github/regen-timeline.yml.template were changed in lockstep (marker bumped v10 -> v11); TestRegenTimelineWorkflow_LockstepWithTemplate gained a trailing anchor pinning 'exit 1' as shared structure in the previously-unconstrained credential gap, and TestRegenTimelineTemplate_V10_UnconditionalBlockingGate gained assertions scoping ::warning+exit0 to the no-credential branch and ::error+exit1 to the push-refusal branch specifically. Does not touch part (b) (making the push land) — no credential, secret, or push-mechanism change.
+
+---
+

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v10
+# logmind-template-version: v11
 name: logmind / check-derived-docs
 
 # v2.0.0 derived-docs-on-main. The two derived docs are regenerated ONLY here on
@@ -11,6 +11,13 @@ name: logmind / check-derived-docs
 # this workflow — v9's per-repo `derived_docs.mode: integration-point`
 # adoption gate (and its "hasn't opted in → pass" escape) is removed. The
 # blocking check always applies; there is no way to opt out from within a PR.
+#
+# v11: regen-on-main's push step no longer treats "no credential" and "push
+# refused" alike (SPEC-2 §3.3, logmind#262). No credential still degrades —
+# warn + exit 0. A push that was attempted and refused now fails the job
+# (::error + exit 1): it is the job not doing its job, and reporting it as
+# success is how a regenerator stays broken for weeks while every run is
+# green.
 
 on:
   pull_request:
@@ -83,16 +90,19 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/timeline.md docs/file-structure.md
           git commit -m "[skip-logmind] chore: regen derived docs"
-          # Degrade, never fail: a rejected push leaves main's derived docs
-          # stale — a freshness gap, never a conflict risk — rather than
-          # red-lighting main for something that is by construction harmless.
-          # If your default branch is protected by a "changes must be made
-          # through a pull request" rule, a plain credentialed push is
-          # rejected (GH013) no matter how much scope the token has — the
-          # pushing identity must be on the ruleset BYPASS list. That's a
-          # policy refusal, NOT transient: every future push hits the same
+          # SPEC-2 §3.3: "Three outcomes, and they MUST NOT look alike."
+          # No credential (above) degrades — a warning and a successful
+          # exit, because a merge that was otherwise fine should not fail
+          # over it. A push that was attempted and refused is different:
+          # "a refused write is the job not doing its job", so unlike the
+          # no-credential case this one MUST fail the job, loudly. If your
+          # default branch is protected by a "changes must be made through
+          # a pull request" rule, a plain credentialed push is rejected
+          # (GH013) no matter how much scope the token has — the pushing
+          # identity must be on the ruleset BYPASS list. That's a policy
+          # refusal, NOT transient: every future push hits the same
           # refusal until a human adds the identity to the bypass list.
           if ! git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"; then
-            echo "::warning title=Derived-doc regen could not be pushed to main::The push was rejected — most likely GH013: the PAT's identity is missing from the 'main' ruleset's bypass list for 'changes must be made through a pull request'. This is a POLICY refusal, not a token-scope problem, so it will NOT self-heal on the next merge — every future push hits the same refusal until the identity is added to the bypass list. No conflict risk — branches never modify the derived docs, so nothing can conflict on them."
-            exit 0
+            echo "::error title=Derived-doc regen push refused::The push was rejected — most likely GH013: the PAT's identity is missing from the 'main' ruleset's bypass list for 'changes must be made through a pull request'. This is a POLICY refusal, not a token-scope problem, so it will NOT self-heal on the next merge — every future push hits the same refusal until the identity is added to the bypass list. No conflict risk — branches never modify the derived docs, so nothing can conflict on them — but main's derived docs are now stale and this run failed to fix that."
+            exit 1
           fi

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -210,13 +210,22 @@ func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
 // v10: removes v9's `derived_docs.mode: integration-point` opt-in — the
 // invariant is now unconditional, with no per-repo escape hatch and no
 // adoption signal left to read from anywhere, PR or base ref.
+//
+// v11 (logmind#262): regen-on-main's push step stops conflating "no
+// credential" with "push refused". SPEC-2 §3.3 requires three outcomes
+// that MUST NOT look alike — nothing-to-push and no-credential still exit
+// 0 (the latter with a `::warning`, since a merge that was otherwise fine
+// should not fail over a missing secret), but a push that was attempted
+// and refused now fails the job (`::error` + `exit 1`): "a refused write
+// is the job not doing its job", and reporting it as success is how a
+// regenerator stayed green for eleven days while doing nothing.
 func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	body := Workflow("regen-timeline.yml.template")
 
-	// Marker bump v9 → v10 (adoption gate removed; the invariant is now
-	// unconditional).
-	if !strings.Contains(body, "# logmind-template-version: v10") {
-		t.Errorf("regen-timeline template missing v10 marker")
+	// Marker bump v10 → v11 (push-refusal now fails the job; see v11 note
+	// above).
+	if !strings.Contains(body, "# logmind-template-version: v11") {
+		t.Errorf("regen-timeline template missing v11 marker")
 	}
 	// The required-check name MUST stay check-derived-docs (ruleset matching),
 	// and the main regen is a distinct job.
@@ -264,17 +273,48 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	}
 	// No-PAT is a freshness-only gap, not a failure: warn + exit 0 (never blocks
 	// the push event; the invariant guarantee lives in the PR gate, not here).
-	if !strings.Contains(body, "::warning") || !strings.Contains(body, "exit 0") {
-		t.Errorf("regen-timeline v10 regen-on-main must warn + exit 0 when no PAT (freshness-only)")
+	// Scoped to the no-credential branch specifically — SPEC-2 §3.3 requires
+	// the push-refusal branch below to look visibly different, not merely
+	// for "::warning" to appear somewhere in the file.
+	_, noPATBlock, found := strings.Cut(body, `if [ -z "${PAT:-}" ]; then`)
+	if !found {
+		t.Fatalf("regen-timeline v11 missing the no-PAT credential check")
 	}
-	// The push-rejection warning must not promise self-healing — a missing
+	noPATBlock, _, found = strings.Cut(noPATBlock, "fi\n")
+	if !found {
+		t.Fatalf("regen-timeline v11: could not find the end of the no-PAT block")
+	}
+	if !strings.Contains(noPATBlock, "::warning") || !strings.Contains(noPATBlock, "exit 0") {
+		t.Errorf("regen-timeline v11 regen-on-main must warn + exit 0 when no PAT (freshness-only)")
+	}
+
+	// SPEC-2 §3.3 (logmind#262): "A push that was attempted and refused is
+	// a failure, and MUST be reported as one." This is a DIFFERENT outcome
+	// from the no-credential case above and must fail the job loudly
+	// (::error + exit 1), never degrade quietly (::warning + exit 0) —
+	// that conflation is exactly what let the regen job stay green for
+	// eleven days while doing nothing.
+	_, pushBlock, found := strings.Cut(body, `if ! git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:main"; then`)
+	if !found {
+		t.Fatalf("regen-timeline v11 missing the push-refusal check")
+	}
+	if !strings.Contains(pushBlock, "::error") {
+		t.Errorf("regen-timeline v11 push-refusal must be reported with ::error — it MUST NOT look like the no-credential ::warning case")
+	}
+	if !strings.Contains(pushBlock, "exit 1") {
+		t.Errorf("regen-timeline v11 push-refusal must fail the job (exit 1), not degrade (exit 0)")
+	}
+	if strings.Contains(pushBlock, "::warning") {
+		t.Errorf("regen-timeline v11 push-refusal must not also emit a ::warning — the two outcomes must be visibly distinct")
+	}
+	// The push-rejection error must not promise self-healing — a missing
 	// ruleset bypass (GH013) is a POLICY refusal that repeats every cycle,
 	// not a transient one-off; see docs/orchestrator-app.md.
 	if !strings.Contains(body, "GH013") {
-		t.Errorf("regen-timeline v10 push-rejection warning must name GH013 as the likely cause")
+		t.Errorf("regen-timeline v11 push-rejection error must name GH013 as the likely cause")
 	}
 	if !strings.Contains(body, "NOT self-heal") {
-		t.Errorf("regen-timeline v10 warnings must not promise the staleness resolves itself on the next merge")
+		t.Errorf("regen-timeline v11 messaging must not promise the staleness resolves itself on the next merge")
 	}
 
 	// v10 removes the entire adoption gate: no per-repo config read, no
@@ -554,8 +594,11 @@ func repoRootFromCaller(t *testing.T) string {
 //  3. The credential block: a consumer repo configures a
 //     LOGMIND_AUTO_REGEN_PAT secret directly; this repo mints a
 //     short-lived `skdd-steward[bot]` GitHub App installation token
-//     instead (see docs/orchestrator-app.md) — a different identity,
-//     the same "degrade, never fail" push contract.
+//     instead (see docs/orchestrator-app.md) — a different identity, the
+//     same push-outcome contract (SPEC-2 §3.3, logmind#262): no
+//     credential still degrades (warn + exit 0), but a push that was
+//     attempted and refused now fails the job (error + exit 1) — those
+//     two outcomes MUST NOT look alike, on either side of this pair.
 //
 // Everything else — MOST IMPORTANTLY the check-derived-docs job, which
 // is the actual PR-blocking enforcement logic — must be byte-identical,
@@ -633,10 +676,18 @@ func TestRegenTimelineWorkflow_LockstepWithTemplate(t *testing.T) {
 			"            echo \"Derived docs already current on main.\"\n" +
 			"            exit 0\n" +
 			"          fi\n",
-		// gap 3 (unanchored, runs to EOF): the credential-missing check,
-		// the git identity, the push-failure comment prose, and the
-		// push URL's token variable — all keyed on which identity this
-		// repo vs. a consumer repo pushes as.
+		// gap 3: the credential-missing check, the git identity, the
+		// push-failure comment prose, and the push URL's token variable —
+		// all keyed on which identity this repo vs. a consumer repo
+		// pushes as.
+		"            exit 1\n" +
+			"          fi\n",
+		// The trailing anchor above pins the one thing gap 3 must NOT be
+		// free to diverge on: a push that was attempted and refused MUST
+		// fail the job (exit 1) on both sides of this pair, per SPEC-2
+		// §3.3 (logmind#262) — a fix landed on only one side would leave
+		// that repo's own CI exercising the old silent-success behavior
+		// while claiming to match its template.
 	}
 	requireAnchorsInOrder(t, "template", tmplBody[tmplGateEnd:], anchors)
 	requireAnchorsInOrder(t, "installed workflow", workflow[wfGateEnd:], anchors)


### PR DESCRIPTION
Closes the half of #262 that needs no infrastructure. The other half — making the push actually land — needs the `LOGMIND_*` App from R18 and is untouched here.

## The defect

`regen-on-main`'s push step exited 0 on **both** "no credential" and "push refused by policy". Only one of those is benign.

```
[main 79d4fa8] [skip-logmind] chore: regen derived docs
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] HEAD -> main
job conclusion: success
```

**Eleven days of green runs over a frozen timeline.** 14 branch decision files never reached `docs/timeline.md`.

## What the contract now says

This is the rule our own outage produced. SPEC 2.0 §3.3:

> Three outcomes, and they **MUST NOT look alike**. Nothing to push is success. No credential to push with is a warning and a successful exit, because a merge that was otherwise fine should not fail over it. **A push that was attempted and refused is a failure, and MUST be reported as one.**

And §6.5 extends it past gates:

> This binds every producer, not only gates. Anything that writes something another party depends on — a regenerated document, a posted check, a filed issue — MUST report a write it attempted and could not complete.

## After

| case | signal | exit |
|---|---|---|
| nothing to push | plain echo | 0 |
| no credential | `::warning` | 0 |
| **push refused** | **`::error`** | **1** |

Warning is a yellow annotation on a green job; error is a red annotation on a failed one. Unmistakable to anyone scanning job status, which is the whole requirement.

## Both messages stopped lying

The old text said main was stale *"by one cycle and will be regenerated on the next merge."* False in both cases, and that false reassurance is exactly why nobody looked for eleven days — the next merge hits the identical refusal. Both now say plainly that it **will not self-heal**, and the refusal message names the actual remedy (the identity is missing from the ruleset bypass; it is a policy refusal, not a token-scope problem).

## Lockstep kept meaningful

`regen-timeline.yml` and its template are a pair enforced by `TestRegenTimelineWorkflow_LockstepWithTemplate`. Marker bumped v10 → v11.

The test previously left gap 3 **entirely unconstrained** — the region containing the push logic was unchecked, which is how the two halves could have drifted here. It now carries a trailing anchor pinning that both sides `exit 1` on refusal, and `TestRegenTimelineTemplate_V10_UnconditionalBlockingGate` asserts the no-PAT block contains `::warning`+`exit 0` while the refusal block contains `::error`+`exit 1` and **must not** contain `::warning`. Strengthened, not adjusted to pass.

## Verification

`go build`, `go vet`, `gofmt` clean; full `go test ./...` green, run without the bogus `init.defaultBranch` override. Lockstep and V10 gate tests re-run individually and pass.

Note the installed `regen-timeline.yml` carries no template marker — pre-existing on `origin/main` (control: the template has one), not introduced here. It is why `doctor --fix` reports it as `markerless` and refuses to touch it, per §5.2.