### PR TITLE
feat(version): declare spec 2.0.0 and the areas implemented — closes #264

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ LOGMIND_VERSION=v2.0.0 curl -fsSL https://logmind.dev/install.sh | bash
 Verify the install:
 
 ```bash
-logmind --version  # logmind 2.0.0 (spec 1.5.0)
+logmind --version
+# logmind 2.0.0 (spec 2.0.0)
+# areas: orient, work, record, propagate, gates
 ```
 
 The curl installer is idempotent — re-running it when the same version

--- a/docs/decisions-branches/feat__spec-version-areas.md
+++ b/docs/decisions-branches/feat__spec-version-areas.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-01 02:07 - Qualify the archived-SPEC path with its repository
+
+**Reasoning:** The previous commit introduced a false citation while fixing false citations: docs/spec.md pointed at 'docs/SPEC-0.7.2-archive.md' as a bare repo-relative path, which reads as a file in this repository. It is not one — git ls-tree finds it absent from the tree and 'git log --all --diff-filter=A' shows it was never added in any commit (control: the same probe finds docs/spec.md, so the method is sound). The file exists in thrillmade/protocol at that path, 324993 bytes, confirmed via the contents API. internal/version/version.go:88 carried the identical unqualified path.
+
+**Alternatives considered:** Leave version.go alone as out-of-delta, which is how the reviewer scoped it. Rejected for the same reason the docs/spec.md fix was folded into this PR at all: a known-false citation left in place because of diff-scope purism is the exact failure this branch exists to correct, and it sits in a file the branch already edits.
+
+**Implications:**
+- Both occurrences now read 'thrillmade/protocol:docs/SPEC-0.7.2-archive.md' and say explicitly that it lives in the protocol repository, not this one. Zero unqualified occurrences remain. Found by an adversarial review lens run on the 51d2cee..4006470 delta after the first panel had already approved 51d2cee — the delta introduced it, so the earlier approval could not have covered it.
+
+---
+

--- a/docs/decisions-branches/feat__spec-version-areas.md
+++ b/docs/decisions-branches/feat__spec-version-areas.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-01-repoint-every-spec-citation-at-spec-2-0-s-live-numbering -->
+- **2026-08-01** — Repoint every spec citation at SPEC 2.0's live numbering
+<!-- logmind-entry-end -->
+
+## 2026-08-01 01:50 - Repoint every spec citation at SPEC 2.0's live numbering
+
+**Reasoning:** The PR advanced SpecVersion to 2.0.0 but left the surfaces that STATE the spec version citing the archived predecessor's numbering. docs/spec.md — the file whose entire job is declaring which spec version and sections logmind implements — cited §15, §16 and §3.1.1; all three return zero against the live 1475-line SPEC (control: 'Section 3' returns 1). README.md and docs/install.md showed '(spec 1.5.0)' as the expected --version output, and site/app/page.tsx published that same stale string to the public site. version.go contradicted itself: its SpecVersion docstring correctly noted 1.5.0 was measured against the archived document, while its package docstring cited §15/§16/§3.1.1 as if current.
+
+**Alternatives considered:** Leave docs/spec.md for a follow-up issue, since the PR title is scoped to the version constant. Rejected: that file is the declaration this PR changes, so shipping the constant while the declaration still points at dead numbering is a half-change, and the adversarial panel is the only gate that reads it.
+
+**Implications:**
+- Every section number now in docs/spec.md was verified present in the live SPEC (§1.5 cold-start payload, §2.7/2.8 token discipline, §3 Record, §5.2 nomination, §6.2 the checks, §7.3 what a tool declares) with an absent-section control. The two-line --version output in the docs is byte-identical to the binary's. The dead numbering survives in ~20 code comments (internal/cli/log.go §3.1.1, templates §15.3) and in docs/plan.md + docs/orchestrator-app.md — a systematic sweep filed separately, deliberately not folded into a version PR.
+
+---
+

--- a/docs/decisions-branches/worktree-agent-a258c8aa60c8bdc9f.md
+++ b/docs/decisions-branches/worktree-agent-a258c8aa60c8bdc9f.md
@@ -1,0 +1,19 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-01-logmind-264-implement-spec-7-3-s-version-areas-line-advance- -->
+- **2026-08-01** — logmind#264: implement SPEC §7.3's --version areas line, advance SpecVersion to 2.0.0
+<!-- logmind-entry-end -->
+
+## 2026-08-01 01:24 - logmind#264: implement SPEC §7.3's --version areas line, advance SpecVersion to 2.0.0
+
+**Reasoning:** Fetched the live thrillmade/protocol SPEC.md@main (never the archived docs/SPEC-0.7.2-archive.md, which has different section numbers). §7.3 requires a second --version line, 'areas: <words>', from the fixed seven-word vocabulary (orient, work, record, review, propagate, gates, versioning), claimed only where code implements any part of that area (§0.4: a tool 'does not claim the ones it does not'). Audited the codebase against each area: orient (AGENTS.md block templating, .logmind/config.yml, 'logmind context' matching §1.5's cold-start envelope), work (§2.1 skill-file validation, §2.7/§2.8 LOGMIND_QUIET + truncation markers), record (§3's logmind log / docs/decisions-branches / derived timeline+file-structure), propagate (logmind skill push implements §5.2's upward catalog-nomination PR flow), and gates (§6.2's check-decisions/check-derived-docs/check-links, all installed by logmind's own templates). review and versioning were deliberately omitted: review is clud-bug's job (logmind sync only consumes clud-bug's review output, it never performs a review), and versioning (§7) governs the SPEC document's own version-agreement checks, not a tool declaring its own version. Also advanced SpecVersion from the stale '1.5.0' (measured against the retired predecessor numbering) to '2.0.0', matching the live document's own header ('<!-- spec-version: 2.0.0 -->', Status: Draft); §7.2 makes a tag unnecessary for a Draft version, and §7.4 confirms tools are expected to declare major-version support before it is cut final, not after.
+
+**Alternatives considered:** Leave SpecVersion at 1.5.0 until a spec-v2.0.0 tag exists, Claim only orient/record/gates per the issue's illustrative example, skipping the independently-verified work and propagate claims, List all seven vocabulary words defensively instead of auditing which are actually implemented
+
+**Implications:**
+- COMPATIBILITY.md generation (skdd#10) and top-down contract-change routing (skdd#9, SPEC §5.3) both read this exact areas line as their only input — an inaccurate claim here silently mis-routes or omits this tool from future notifications
+- internal/cli/testdata/version.golden now pins a 2-line, single-trailing-newline output; any future change to versionLine()/areasLine() must regenerate it deliberately via 'go test ./internal/cli/... -run TestVersionLine_InProcess -update'
+- The prior '1.5.0' SpecVersion no longer corresponds to any section numbering in the live SPEC (it was measured against the archived predecessor document); this decision closes that skew
+
+---
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -157,13 +157,15 @@ target Linux.
 
 ```bash
 logmind --version
-# logmind 2.0.0 (spec 1.5.0)
+# logmind 2.0.0 (spec 2.0.0)
+# areas: orient, work, record, propagate, gates
 ```
 
-The `--version` line is the protocol contract — downstream tooling
-(clud-bug, tokenomics, agent-skills) reads it to detect protocol skew.
-If the line doesn't appear or the format differs, your install is broken
-or running an older version.
+Both lines are the protocol contract (SPEC §7.3) — downstream tooling
+(clud-bug, tokenomics, agent-skills) reads the first to detect protocol
+skew and the second to learn which parts of the spec this binary
+implements. If either line doesn't appear or the format differs, your
+install is broken or running an older version.
 
 ## Deprecated: Python install
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,6 +1,10 @@
 <!-- Pointer, not a mirror. logmind's canonical forward-looking contract
      lives in the sibling protocol repo; context.spec_file is repo-relative
-     by design (SPEC §16), so this committed pointer is the in-repo spec. -->
+     by design (SPEC §1.5), so this committed pointer is the in-repo spec.
+
+     Section numbers below are from the LIVE SPEC.md. SPEC 2.0 was a
+     from-scratch rewrite and its numbering does NOT map to the predecessor
+     archived at docs/SPEC-0.7.2-archive.md — never reason from that file. -->
 
 # logmind — Spec
 
@@ -9,8 +13,23 @@
 logmind's canonical, forward-looking contract is the SkDD protocol SPEC:
 <https://github.com/thrillmade/protocol/blob/main/SPEC.md>
 
-logmind v2.0.0 implements SPEC 1.5.0+ (see `internal/version.SpecVersion`),
-including §15 (decision-logging enforcement), §16 (this canonical
-spec-file contract), and the §3.1.1 pulse. logmind v2.0.0 is the current
-release line; see [docs/plan.md](plan.md) for architecture and the
-forward roadmap.
+logmind implements **SPEC 2.0.0** (see `internal/version.SpecVersion`). The
+authoritative statement of which parts is the binary's own declaration —
+`logmind --version` prints the areas line required by §7.3:
+
+```
+logmind 2.0.0 (spec 2.0.0)
+areas: orient, work, record, propagate, gates
+```
+
+In section terms that is §1 (orient — the instruction file, decision record,
+derived views, cold-start payload), §2.7–2.8 (token discipline and truncation
+markers), §3 (record — decisions, the history and the map, steering commits
+through the log), §5.2's upward nomination path only, and the §6.2 checks
+logmind's own templates install.
+
+`review` and `versioning` are deliberately not claimed: logmind consumes a
+review's output but performs none, and declaring a version is a §7.3
+obligation rather than an implementation of §7.
+
+See [docs/plan.md](plan.md) for architecture and the forward roadmap.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3,8 +3,9 @@
      by design (SPEC §1.5), so this committed pointer is the in-repo spec.
 
      Section numbers below are from the LIVE SPEC.md. SPEC 2.0 was a
-     from-scratch rewrite and its numbering does NOT map to the predecessor
-     archived at docs/SPEC-0.7.2-archive.md — never reason from that file. -->
+     from-scratch rewrite and its numbering does NOT map to the predecessor,
+     which is archived in the protocol repository (not this one) at
+     thrillmade/protocol:docs/SPEC-0.7.2-archive.md — never reason from it. -->
 
 # logmind — Spec
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,17 +14,37 @@ import (
 	"github.com/thrillmade/logmind/internal/version"
 )
 
-// versionLine returns the canonical `--version` output. Centralised so
-// the version subcommand and the cobra root's --version flag both emit
-// byte-identical text — the snapshot test pins this exact string.
+// versionLine returns the first line of `--version` output — the tool
+// identity line. Centralised so the version subcommand and the cobra
+// root's --version flag both emit byte-identical text — the snapshot
+// test pins this exact string.
 //
-// Format: `logmind <version> (spec <spec-version>)`
+// Format: `logmind <version> (spec <spec-version>)` — SPEC §7.3's
+// `<tool-name> <tool-semver> (spec <spec-semver>)`.
 //
 // This is the protocol contract — downstream tooling (clud-bug,
 // tokenomics, agent-skills) greps this line to detect skew. Don't
 // change the format without bumping SpecVersion.
 func versionLine() string {
 	return fmt.Sprintf("logmind %s (spec %s)", version.Version, version.SpecVersion)
+}
+
+// areasLine returns the second line of `--version` output — SPEC §7.3's
+// coarse area declaration: `areas: <comma-separated words>`, drawn from
+// the fixed seven-word vocabulary (orient, work, record, review,
+// propagate, gates, versioning). See version.Areas for which words this
+// binary claims and the evidence for each.
+func areasLine() string {
+	return "areas: " + version.Areas
+}
+
+// fullVersionOutput returns the complete `--version` payload: the tool
+// identity line, a newline, then the areas line — with no trailing
+// newline of its own, so every caller (printVersion's Fprintln, cobra's
+// "{{.Version}}\n" template) adds exactly one, giving SPEC §7.3's
+// required single trailing newline rather than one per line.
+func fullVersionOutput() string {
+	return versionLine() + "\n" + areasLine()
 }
 
 // NewRootCmd returns a fresh cobra root command. Each call constructs
@@ -121,7 +141,7 @@ func NewRootCmd() *cobra.Command {
 	// `logmind --version` and `logmind version` produce the same line.
 	// This matches the Python click ergonomics users are used to.
 	root.SetVersionTemplate("{{.Version}}\n")
-	root.Version = versionLine()
+	root.Version = fullVersionOutput()
 
 	return root
 }
@@ -146,6 +166,6 @@ func newVersionCmd() *cobra.Command {
 }
 
 func printVersion(w io.Writer) error {
-	_, err := fmt.Fprintln(w, versionLine())
+	_, err := fmt.Fprintln(w, fullVersionOutput())
 	return err
 }

--- a/internal/cli/testdata/version.golden
+++ b/internal/cli/testdata/version.golden
@@ -1,1 +1,2 @@
-logmind 2.0.0-dev (spec 1.5.0)
+logmind 2.0.0-dev (spec 2.0.0)
+areas: orient, work, record, propagate, gates

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -18,17 +18,18 @@ import (
 var update = flag.Bool("update", false, "regenerate testdata/*.golden files from current Go output")
 
 // TestVersionLine_InProcess locks the `--version` output format from the
-// versionLine() function alone (no subprocess). Fast, runs without a
+// fullVersionOutput() function alone (no subprocess). Fast, runs without a
 // pre-built binary, and serves as the canonical assertion that the
 // protocol-contract format hasn't drifted.
 //
-// Format: `logmind <version> (spec <spec-version>)`
+// Format (SPEC §7.3): `logmind <version> (spec <spec-version>)`, then
+// `areas: <words>`, single trailing newline.
 //
 // This is the BYTE-IDENTICAL parity contract. Subsequent waves' golden
 // files will follow the same testdata/<command>.golden pattern.
 func TestVersionLine_InProcess(t *testing.T) {
 	golden := goldenPath(t, "version.golden")
-	got := versionLine() + "\n"
+	got := fullVersionOutput() + "\n"
 
 	if *update {
 		writeGolden(t, golden, got)
@@ -37,7 +38,7 @@ func TestVersionLine_InProcess(t *testing.T) {
 
 	want := readGolden(t, golden)
 	if got != want {
-		t.Fatalf("versionLine() drifted from %s\n--- want ---\n%q\n--- got ---\n%q",
+		t.Fatalf("fullVersionOutput() drifted from %s\n--- want ---\n%q\n--- got ---\n%q",
 			golden, want, got)
 	}
 }
@@ -201,5 +202,85 @@ func TestVersionLine_HasSpecSegment(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, "logmind ") {
 		t.Fatalf("versionLine() missing `logmind ` prefix: %q", got)
+	}
+}
+
+// specAreaVocabulary is SPEC §7.3's fixed seven-word area vocabulary, in
+// its documented order. Copied here (not imported from anywhere — the
+// spec has no Go representation) so a claimed area that isn't one of
+// these seven words fails loudly instead of silently shipping a typo.
+var specAreaVocabulary = map[string]bool{
+	"orient":     true,
+	"work":       true,
+	"record":     true,
+	"review":     true,
+	"propagate":  true,
+	"gates":      true,
+	"versioning": true,
+}
+
+// TestAreasLine_Format guards SPEC §7.3's `areas:` line: every word must
+// come from the fixed vocabulary, order must match the vocabulary's own
+// order (not claim-order or alphabetical), and there must be no duplicate
+// or empty entries. A typo'd or reordered area is exactly the silent
+// drift §7.3 exists to prevent, so this fails the build rather than the
+// golden file quietly encoding a mistake.
+func TestAreasLine_Format(t *testing.T) {
+	got := areasLine()
+	const prefix = "areas: "
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("areasLine() missing %q prefix: %q", prefix, got)
+	}
+	words := strings.Split(strings.TrimPrefix(got, prefix), ", ")
+	seen := make(map[string]bool, len(words))
+	vocabOrder := []string{"orient", "work", "record", "review", "propagate", "gates", "versioning"}
+	lastVocabIdx := -1
+	for _, w := range words {
+		if w == "" {
+			t.Fatalf("areasLine() has an empty area word: %q", got)
+		}
+		if !specAreaVocabulary[w] {
+			t.Fatalf("areasLine() claims %q, not in SPEC §7.3's fixed vocabulary: %q", w, got)
+		}
+		if seen[w] {
+			t.Fatalf("areasLine() claims %q more than once: %q", w, got)
+		}
+		seen[w] = true
+		idx := -1
+		for i, v := range vocabOrder {
+			if v == w {
+				idx = i
+				break
+			}
+		}
+		if idx <= lastVocabIdx {
+			t.Fatalf("areasLine() area %q is out of the vocabulary's fixed order: %q", w, got)
+		}
+		lastVocabIdx = idx
+	}
+}
+
+// TestFullVersionOutput_SingleTrailingNewline verifies SPEC §7.3's "A
+// single trailing newline is REQUIRED" byte-for-byte: exactly one '\n' at
+// the very end, none in the middle beyond the one line separator, and no
+// second/blank trailing line.
+func TestFullVersionOutput_SingleTrailingNewline(t *testing.T) {
+	root := NewRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stdout)
+	root.SetArgs([]string{"--version"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("logmind --version failed: %v\nstdout:\n%s", err, stdout.String())
+	}
+	got := stdout.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("output does not end in a newline: %q", got)
+	}
+	if strings.HasSuffix(got, "\n\n") {
+		t.Fatalf("output ends in more than one newline: %q", got)
+	}
+	if n := strings.Count(got, "\n"); n != 2 {
+		t.Fatalf("expected exactly 2 newlines (one per line, single trailing), got %d: %q", n, got)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -85,7 +85,8 @@ var Version = "2.0.0-dev"
 // released a version implementing it" — so declaring 2.0.0 now, while
 // Draft, is the expected order of operations, not a jump of the gun. The
 // prior "1.5.0" was measured against the archived predecessor document's
-// numbering (docs/SPEC-0.7.2-archive.md) and does not correspond to
+// numbering (thrillmade/protocol:docs/SPEC-0.7.2-archive.md — it lives in
+// the protocol repository, NOT this one) and does not correspond to
 // anything in the live SPEC-2 text.
 var SpecVersion = "2.0.0"
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,9 +11,12 @@
 // bumped to "1.0.0" 2026-07-04 (the coordinated SPEC 1.0.0 that REMOVES
 // the branch-divergent timeline model: §1.6.4 main-canonical union
 // assembly is now the sole, unconditional timeline. See v2.0.0 below),
-// then advanced to "1.5.0" ahead of the v2.0.0 tag (§15 decision-logging
-// enforcement, §16 the canonical spec-file contract, §3.1.1 the pulse —
-// see docs/spec.md), then to the current "2.0.0" for logmind#264: the
+// then advanced to "1.5.0" ahead of the v2.0.0 tag (for what were THEN
+// numbered §15 decision-logging enforcement, §16 the canonical spec-file
+// contract, and §3.1.1 the pulse — those three numbers are from the
+// archived predecessor document and address nothing in the live SPEC;
+// they are recorded here as history, not as citations to follow), then
+// to the current "2.0.0" for logmind#264: the
 // document was rewritten and renumbered as SPEC-2, restarting its own
 // version at 2.0.0 (Status: Draft) — the old "1.5.0" no longer
 // corresponds to anything in the live section numbering. See SpecVersion's

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,9 +11,13 @@
 // bumped to "1.0.0" 2026-07-04 (the coordinated SPEC 1.0.0 that REMOVES
 // the branch-divergent timeline model: §1.6.4 main-canonical union
 // assembly is now the sole, unconditional timeline. See v2.0.0 below),
-// then advanced to the current "1.5.0" ahead of the v2.0.0 tag (§15
-// decision-logging enforcement, §16 the canonical spec-file contract,
-// §3.1.1 the pulse — see docs/spec.md).
+// then advanced to "1.5.0" ahead of the v2.0.0 tag (§15 decision-logging
+// enforcement, §16 the canonical spec-file contract, §3.1.1 the pulse —
+// see docs/spec.md), then to the current "2.0.0" for logmind#264: the
+// document was rewritten and renumbered as SPEC-2, restarting its own
+// version at 2.0.0 (Status: Draft) — the old "1.5.0" no longer
+// corresponds to anything in the live section numbering. See SpecVersion's
+// own doc comment below for the full evidence trail.
 package version
 
 import (
@@ -63,7 +67,78 @@ var Version = "2.0.0-dev"
 // this binary implements. Reported via `logmind --version` so downstream
 // tools can detect protocol skew without parsing the binary version.
 // Overridable via -ldflags at build time; see package docstring.
-var SpecVersion = "1.5.0"
+//
+// Bumped to "2.0.0" for logmind#264 (SPEC §7.3 — "What a tool declares").
+// Fetched from thrillmade/protocol SPEC.md@main: the document header reads
+// `<!-- spec-version: 2.0.0 -->` / `**Version:** 2.0.0` / `**Status:**
+// Draft`. §7.2 — "`Status: Draft` names the version being drafted, not the
+// last one released, and requires no tag" — so the absence of a
+// `spec-v2.0.0` tag (`gh api repos/thrillmade/protocol/tags` tops out at
+// `spec-v0.6.3`, then jumps straight to `spec-pre-rewrite-2026-07-31`: the
+// 0.x/1.x line was retired and renumbered as this SPEC-2 document starting
+// at 2.0.0) does not block declaring it. §7.4 confirms tools are meant to
+// declare support for a major version BEFORE it is cut final — "A major
+// version MUST NOT be declared final until every first-party tool has
+// released a version implementing it" — so declaring 2.0.0 now, while
+// Draft, is the expected order of operations, not a jump of the gun. The
+// prior "1.5.0" was measured against the archived predecessor document's
+// numbering (docs/SPEC-0.7.2-archive.md) and does not correspond to
+// anything in the live SPEC-2 text.
+var SpecVersion = "2.0.0"
+
+// Areas is the comma-and-space-joined SPEC §7.3 area declaration this
+// binary claims, in the vocabulary's fixed order (orient, work, record,
+// review, propagate, gates, versioning — only the ones actually
+// implemented are listed). Printed as the second line of `--version`
+// output: `areas: <Areas>`.
+//
+// Coarse by design (§7.3: "Claiming an area is deliberately coarse... A
+// tool claims an area when it implements any part of it"), and each word
+// below is backed by shipped code, not aspiration (§0.4: a tool "does not
+// claim the ones it does not [implement]"):
+//
+//   - orient  — §1: the AGENTS.md tool-owned block (internal/templates),
+//     `.logmind/config.yml` (internal/config, §1.6), and `logmind context`
+//     assembling the cold-start payload verbatim to §1.5's envelope order
+//     (internal/cli/context.go).
+//   - work    — §2.1/§2.2: skill-file authoring, frontmatter validation
+//     and `kind` routing (internal/skill/{scaffold,validate}.go); §2.7/2.8:
+//     the LOGMIND_QUIET / `ok <k=v>` discipline (internal/cli/quiet.go)
+//     and the `ceil(bytes/4)` token estimate plus "(N omitted)" truncation
+//     markers used throughout internal/tree, internal/repomap,
+//     internal/cli/context.go and internal/cli/file_structure.go.
+//   - record  — §3 in full: `logmind log` writes
+//     `docs/decisions-branches/<branch>.md` entries in the §3.1 format,
+//     branch-sanitizes per §3.2, and regenerates the derived
+//     `docs/timeline.md` / `docs/file-structure.md` per §3.3
+//     (internal/decisions, internal/inserter, internal/timeline,
+//     internal/repomap).
+//   - propagate — §5.2's upward "nomination" path specifically (a pull
+//     request against the catalog, opened by the repository that homes
+//     the item, refusing to target a catalog the repo has not named):
+//     `logmind skill push` (internal/skill/push.go,
+//     internal/cli/skill_push.go). Not the harness's downward
+//     distribution/seeding/skills-lock machinery of §5.1/§5.2 — that is
+//     skdd's job, not logmind's, so only the part actually shipped is
+//     claimed.
+//   - gates   — §6.2's canonical checks: `check-decisions`,
+//     `check-derived-docs` and `check-links` are all installed and
+//     produced by logmind's own templates and CLI verbs
+//     (internal/cli/check_decisions.go, internal/cli/check_links.go,
+//     internal/timeline/canonical.go, internal/templates/github/*.yml.template).
+//
+// Deliberately NOT claimed:
+//
+//   - review     — clud-bug's job (§0.1); logmind never examines a change
+//     or emits a finding. `logmind sync` only consumes clud-bug's already-
+//     written review output to update local skill PROVENANCE.md — reading
+//     a review's output is not performing one.
+//   - versioning — §7 governs the SPEC document's own version-agreement
+//     and tag rules, checked by the protocol repository's own tooling;
+//     declaring this binary's own version (this file) is a §7.3
+//     obligation every conformant tool has, not an implementation of §7's
+//     rules for others.
+var Areas = "orient, work, record, propagate, gates"
 
 // SatisfiesMin reports whether v is at least min, using a simple
 // major.minor.patch integer compare — NOT full semver precedence. Originally

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -382,8 +382,12 @@ logmind context — token receipt (est. ~4 chars/token, deterministic)
             <div className="border-t border-rule" />
             <p className="marginalia normal-case tracking-normal text-foreground/55 mt-6 text-xs leading-relaxed">
               <code className="font-mono">logmind --version</code> should print{" "}
-              <code className="font-mono">logmind 2.0.0 (spec 1.5.0)</code>.
-              The agent skill (03) is optional but recommended — it teaches
+              <code className="font-mono">logmind 2.0.0 (spec 2.0.0)</code>,
+              then{" "}
+              <code className="font-mono">
+                areas: orient, work, record, propagate, gates
+              </code>
+              . The agent skill (03) is optional but recommended — it teaches
               Claude Code, Cursor, Codex et al. when and how to call{" "}
               <code className="font-mono">logmind log</code> in any project
               that has logmind installed.


### PR DESCRIPTION
First PR through the `dev` path. Closes #264.

## What §7.3 requires

> The first line's format is exactly `<tool-name> <tool-semver> (spec <spec-semver>)`. A single trailing newline is REQUIRED… The second line names areas… vocabulary is fixed — `orient, work, record, review, propagate, gates, versioning` — and a tool claims an area when it implements any part of it.

## Output

```
logmind 2.0.0-dev (spec 2.0.0)
areas: orient, work, record, propagate, gates
```

Trailing newline verified byte-exact rather than by eye — `od -c` ends `... g a t e s \n`, one newline, no blank line.

## SpecVersion 1.5.0 → 2.0.0

The live header reads `<!-- spec-version: 2.0.0 -->` / **Status: Draft**. §7.2: *"`Status: Draft` names the version being drafted… and requires no tag"* — and no 2.x tag exists (`gh api` tops out at `spec-v0.6.3`, then `spec-pre-rewrite-2026-07-31`). §7.4 confirms tools declare a major **before** it is cut final, so declaring 2.0.0 while Draft is the intended order.

The old `1.5.0` measured against the archived predecessor's numbering and corresponds to nothing in the live document.

## Each area word, and one I want checked

- **orient** — §1: AGENTS.md block, `.logmind/config.yml`, `logmind context` assembling §1.5's envelope
- **work** — §2.7/2.8: `LOGMIND_QUIET` / `ok <k=v>`, `ceil(bytes/4)`, `(N omitted)` markers
- **record** — §3 in full
- **gates** — §6.2's three checks, installed by our own templates
- **propagate** — §5.2's *upward nomination path only*: `logmind skill push` opens a PR against the named catalog. Explicitly **not** §5.1/§5.2's downward distribution, seeding or `skills-lock` machinery — that is skdd's.

**`review` and `versioning` deliberately omitted.** `logmind sync` consumes clud-bug's review output but performs no review; §7 governs the document's own version-agreement, and declaring your version is a §7.3 obligation rather than an implementation of §7.

### The one I flagged rather than decided

**`propagate` is contestable.** It rests entirely on `skill push` — control-tested: zero files for `skills-lock`, placement map, `catalogSources` or `subscribed`. And skdd#7 formally asks skdd to take that exact verb.

I nearly dropped it. Kept it because §7.3's test is *"implements any part"* and we ship it **today** — skdd has no implementation yet, so if §5.2's nomination rules change while we still own `skill push`, we want that routed to us (§5.3 derives routing from this declaration).

Worth noting the protocol brief listed our sections as *"§1 Orient, §3 Record, §6.2/§6.7, §2.7–2.8"* — no §5. If that list was exhaustive rather than a summary, drop `propagate` and I will. Raising it rather than quietly picking.

## Verification

`go build`, `go vet`, `gofmt` clean; `go test ./...` green. Two new tests: a vocabulary/order guard, and a byte-level single-trailing-newline check. `version.golden` regenerated deliberately via `-update`, now two lines.

`Version` left at `2.0.0-dev` — goreleaser injects the real value via ldflags at release (verified in `.goreleaser.yaml`); hand-editing it would ship a wrong string.