### PR TITLE
docs: correct 19 claims that contradict current source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,7 @@
 
 ## Checklist
 
-- [ ] Tests added / updated; `pytest -q` is green locally
+- [ ] Tests added / updated; `make test` is green locally
 - [ ] `logmind check-links` is green (run it before pushing)
 - [ ] Architectural change? Logged via `logmind log "..."` on this branch
-- [ ] CHANGELOG updated under `[Unreleased]` if user-visible
-- [ ] No committed `dist/`, `__pycache__/`, or other generated artefacts
+- [ ] No committed `bin/`, `*.test`, `*.out`, or other generated artefacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ logmind log "Short summary" -r "why" -a "alt 1" -i "implication"
 
 Branch-aware: feature branches write to
 `docs/decisions-branches/<branch>.md`; the default branch writes to
-`docs/decisions.md`. The PR-merge GH Action then appends a one-line
-summary linking your PR.
+`docs/decisions.md`.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ package handles the docs, the branch routing, and the merge-time
 aggregation.
 
 **Key concept:** Install once, init anywhere, log everything. Feature
-branches get their own decision file; on PR merge a GitHub Action appends
-a one-line summary to `docs/decisions.md` linking the PR + the branch
-detail. `docs/timeline.md` is the main-canonical, source-derived union of
-every decision file in the repo — the one start-here doc for a cold agent.
+branches get their own decision file. `docs/timeline.md` is the
+main-canonical, source-derived union of every decision file in the repo —
+the one start-here doc for a cold agent.
 AGENTS.md is the canonical agent-instruction file; per-tool files
 (CLAUDE.md, .cursorrules, ...) are 2-line stubs pointing to it.
 
@@ -45,15 +44,14 @@ brew install thrillmade/tap/logmind
 curl -fsSL https://logmind.dev/install.sh | bash
 
 # Pin to a specific version on either path:
-LOGMIND_VERSION=v2.0.0 curl -fsSL https://logmind.dev/install.sh | bash
+LOGMIND_VERSION=v1.2.0 curl -fsSL https://logmind.dev/install.sh | bash
 ```
 
 Verify the install:
 
 ```bash
 logmind --version
-# logmind 2.0.0 (spec 2.0.0)
-# areas: orient, work, record, propagate, gates
+# logmind 1.2.0 (spec 0.1.1)
 ```
 
 The curl installer is idempotent — re-running it when the same version
@@ -102,49 +100,37 @@ verification, and the legacy Python path).
 
 ## Recommended repo settings
 
-`docs/timeline.md` and `docs/file-structure.md` are **purely derived** —
-under `derived_docs: {mode: integration-point}` in `.logmind/config.yml`, a
-branch never edits them; they regenerate only on `main`. **This is opt-in**:
-`mode` defaults to `"driver"`, which reproduces the pre-v2.0.0 behavior
-(derived docs regenerate on every branch, nothing restores or blocks
-anything) — set `mode: integration-point` to turn the invariant on. Once
-adopted, it's enforced in layers, each closing a gap the previous one can't
-reach:
+`docs/timeline.md` and `docs/file-structure.md` are **purely derived** — a
+branch never edits them; they regenerate only on `main`. This zero-conflict
+invariant is **unconditional for every repo** — there is no opt-in, no
+config key, nothing to adopt — and is enforced in layers, each closing a
+gap the previous one can't reach:
 
 - **L0** — the `post-merge`/`post-rewrite` git hooks regenerate on the
-  default branch only; a feature branch is never touched. (In driver mode
-  they regenerate on every branch instead.)
+  default branch only; a feature branch is never touched.
 - **L1** — `logmind log` restores both files to `HEAD` before staging, on
   a non-default branch.
 - **L2 (pin-preservation)** — catches a raw `git commit` that L0/L1 can't
   reach, e.g. after `logmind warp` deliberately pulls `main`'s newer copy
   into your working tree for review. **L2a** is a `pre-commit` git hook
   (pure git, no `logmind` binary required, never blocks a commit),
-  installed only in integration-point mode. **L2b** is the same restore run
-  inside the Claude Code harness's PreToolUse guard, before its allow/block
-  decision — this additionally catches `git commit --no-verify` (which
-  skips every git hook, including L2a) and works in a fresh clone (git
-  hooks aren't cloned; `.claude/settings.json` is).
+  installed by `logmind init`. **L2b** is the same restore run inside the
+  Claude Code harness's PreToolUse guard, before its allow/block decision
+  — this additionally catches `git commit --no-verify` (which skips every
+  git hook, including L2a) and works in a fresh clone (git hooks aren't
+  cloned; `.claude/settings.json` is).
 - **L3** — the `regen-timeline.yml` GitHub Action's `check-derived-docs`
-  job first checks whether *this repo* declared integration-point mode; an
-  unadopted (driver-mode) repo passes with an explanatory message instead
-  of blocking. An adopted repo's PR gate **blocks a PR** that modified
-  either derived doc, and on every push to `main` regenerates both files
-  and commits + pushes them back (needs a `LOGMIND_AUTO_REGEN_PAT` secret,
-  fine-grained, repo-scoped, Contents: write; without it, the workflow just
+  job **blocks a PR** that modified either derived doc, and on every push
+  to `main` regenerates both files and commits + pushes them back (via a
+  minted `skdd-steward[bot]` App token; without it, the workflow just
   warns that `main` is momentarily stale — never a conflict risk, only a
   freshness gap).
-
-Set `derived_docs.min_binary` (e.g. `"2.0.0"`) alongside `mode:
-integration-point` — `logmind doctor` warns when the running binary is
-older than that floor.
 
 L0-L2 are local guardrails, not guarantees — every one is bypassable
 (`--no-verify`, a deleted or disabled hook, hand-editing
 `.claude/settings.json`, or a tool that never goes through git or Claude
 Code). **L3 (CI) is the only non-bypassable enforcement**, since it runs
-server-side on every PR regardless of what did or didn't happen locally —
-and even it only applies once a repo has adopted integration-point mode.
+server-side on every PR regardless of what did or didn't happen locally.
 
 For the derived files to stay conflict-free across *concurrent* PRs, the
 following is **recommended** (belt-and-suspenders — L0-L3 already make a

--- a/docs/ai-agent-files.md
+++ b/docs/ai-agent-files.md
@@ -108,7 +108,7 @@ Supported agents: claude, cursor, copilot, windsurf, aider, continue, cody, zed,
 logmind agents add cursor    # Write .cursorrules as a stub pointing to AGENTS.md
 logmind agents add windsurf  # Write .windsurfrules as a stub pointing to AGENTS.md
 logmind agents remove cursor # Remove .cursorrules
-logmind agents update        # Refresh stale logmind blocks + CI workflow pins
+logmind agents update        # Reports stale logmind blocks + CI workflow pins (dry-run; add --apply to rewrite)
 logmind agents migrate       # Consolidate any full per-agent files into stubs
 ```
 

--- a/docs/decisions-branches/docs__staleness-sweep.md
+++ b/docs/decisions-branches/docs__staleness-sweep.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-01-correct-19-documentation-claims-that-contradict-current-sour -->
+- **2026-08-01** — Correct 19 documentation claims that contradict current source
+<!-- logmind-entry-end -->
+
+## 2026-08-01 11:36 - Correct 19 documentation claims that contradict current source
+
+**Reasoning:** A verification sweep of every prose doc against origin/dev found 27 stale claims, 8 of them factually wrong rather than merely dated. README described derived-docs enforcement as opt-in via derived_docs.mode with a min_binary floor — both deleted, the invariant is unconditional. README, CONTRIBUTING and skill/SKILL.md all described a GitHub Action that appends a one-line summary to docs/decisions.md on PR merge; no such action exists (control: grep for 'one-line summary' hit only the three docs asserting it, never a producing workflow). README and docs/install.md told users to pin LOGMIND_VERSION=v2.0.0 and showed --version printing the 2.0.0 two-line output — v2.0.0 has never been tagged, and the released 1.2.0 binary prints one line. README also cited a LOGMIND_AUTO_REGEN_PAT secret that does not exist; regen-timeline.yml mints a skdd-steward[bot] App token. first-decision-example.md carried a fabricated init transcript and a Python-dict template block.
+
+**Alternatives considered:** Fix only the version strings and leave the structural claims. Rejected: the version strings were the least harmful of the set — a reader who follows the derived_docs.mode instructions configures a key that does not exist, and one who waits for the PR-merge Action to write their decision summary waits forever.
+
+**Implications:**
+- Verified against the actually-released binary, not against source: docs now show 'logmind 1.2.0 (spec 0.1.1)', which is byte-identical to what the installed homebrew cask prints. Every reported zero was control-tested — 'derived_docs' returns 0 in README while 'derived doc' still returns 1; 'one-line summary' returns 0 while 'decisions-branches' still returns 3. Four findings are deliberately NOT fixed: the required-reading entries naming docs/decisions.md in AGENTS.md, skill/SKILL.md, docs/ai-agent-files.md and internal/templates/logmind-section.md, because #265 deletes that layout and the template one ships fleet-wide via #257 — changing them ahead of those issues would desync the fleet. Four more live in a dated implementation plan under docs/superpowers/plans/ and correctly record intent at the time; editing them would falsify the record.
+
+---
+

--- a/docs/decisions-branches/docs__staleness-sweep.md
+++ b/docs/decisions-branches/docs__staleness-sweep.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-07 16:38 - Remove the fabricated PR-merge Action claim from the shipped AGENTS.md template
+
+**Reasoning:** The docs sweep fixed this claim in README, CONTRIBUTING and skill/SKILL.md but missed internal/templates/AGENTS.md.template:93, which is the one copy that ships into consumer repositories. It told every repo running logmind that 'On PR merge, a workflow appends a one-line summary to docs/decisions.md linking the PR and the per-branch file.' No such workflow exists — control: grepping 'one-line summary' across live surfaces now returns 0 while the Python-era changelog still returns 2, where it is correct history because the retired Python line genuinely shipped logmind-aggregate.yml. Caught by an adversarial reviewer on PR #282, not by the sweep.
+
+**Alternatives considered:** Defer to #257 with the other template changes, since template edits ship fleet-wide. Rejected after checking how propagation actually works: the deferred items (the docs/decisions.md required-reading entries) are deferred because #265 has to decide what REPLACES them, so changing them early would desync. This one has no pending decision behind it — the workflow does not exist and never will — so deferring would only mean shipping a known falsehood for longer.
+
+**Implications:**
+- Verified the fix actually reaches consumers before landing it: FindOutdatedMarkerBlocks (internal/inserter/inserter.go:458-487) compares block CONTENT — strings.TrimSpace(installed) == strings.TrimSpace(fresh) — and matchingTemplate only selects the full-vs-slim flavour. So a content change is detected as outdated without a block-version bump; I had assumed a v8 to v9 bump was required and that was wrong. Left the surrounding sentence intact because it is still accurate: resolveDecisionsPath (internal/cli/log.go:534) does still route default-branch entries to docs/decisions.md today. That whole model changes under #265.
+
+---
+

--- a/docs/first-decision-example.md
+++ b/docs/first-decision-example.md
@@ -10,17 +10,16 @@ After running `logmind init`, the `docs/decisions.md` file will contain:
 This file contains the 20 most recent decisions. Older decisions are archived in [decisions-archive.md](decisions-archive.md).
 
 ---
-
 ## 2025-10-19 15:42 - Initialize logmind decision tracking
 
 **Reasoning:** Starting structured decision logging for this project to maintain clear documentation of architectural choices and provide context for AI agents.
+
+**Alternatives considered:** Manual decision documentation, ADR (Architecture Decision Records)
 
 **Implications:**
 - All significant decisions should now be logged using `logmind.log()`
 - AI agents will have access to decision history via docs/decisions.md
 - Git history will serve as an audit trail for all decisions
-
-**Alternatives considered:** Manual decision documentation, ADR (Architecture Decision Records)
 
 ---
 
@@ -37,20 +36,13 @@ This file contains the 20 most recent decisions. Older decisions are archived in
 
 ## Template used
 
-```python
-from datetime import datetime
-
-first_decision = {
-    "decision": "Initialize logmind decision tracking",
-    "reasoning": "Starting structured decision logging for this project to maintain clear documentation of architectural choices and provide context for AI agents.",
-    "implications": [
-        "All significant decisions should now be logged using `logmind.log()`",
-        "AI agents will have access to decision history via docs/decisions.md",
-        "Git history will serve as an audit trail for all decisions"
-    ],
-    "alternatives": ["Manual decision documentation", "ADR (Architecture Decision Records)"]
-}
-```
+Rendered by `buildFirstDecisionEntry()` in `internal/cli/init.go` (Go,
+not Python) — the same wording as the markdown above, with the date
+filled in via `time.Now().Format("2006-01-02 15:04")`. Fixed fields:
+summary `"Initialize logmind decision tracking"`, the reasoning sentence
+shown above, `"Manual decision documentation, ADR (Architecture Decision
+Records)"` as alternatives, and the three-line implications list — in
+that order (Reasoning, Alternatives considered, Implications).
 
 ## Subsequent init calls
 
@@ -59,11 +51,16 @@ If `logmind init` is run again in a project that's already initialized:
 ```bash
 $ logmind init
 
-✓ docs/ already exists
-✓ CLAUDE.md already has logmind instructions
-✓ decisions.md already has entries
+Initializing logmind...
 
-logmind is already initialized in this project.
+logmind is already initialized — running in refresh mode.
+
+  All workflow templates already current.
+✓ Refreshed .git/hooks/post-merge
+✓ Refreshed .git/hooks/post-rewrite
+✓ Refreshed .git/hooks/commit-msg
+
+Done. docs/ and .logmind/ left untouched.
 ```
 
 It will **not** add another initialization decision.

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,9 +3,10 @@
 logmind ships as a single self-contained binary. Pick the install method
 that matches your platform and preferences.
 
-> **Heads up:** v2.0.0 is the current release line (Go binary, main
-> branch). v0.6.x Python users — see the
-> [Deprecated: Python install](#deprecated-python-install) section.
+> **Heads up:** v1.2.0 is the latest tagged release (Go binary). Building
+> from `main`/source reports `2.0.0-dev` — that's the in-progress next
+> version, not something you can install yet. v0.6.x Python users — see
+> the [Deprecated: Python install](#deprecated-python-install) section.
 
 ## Homebrew (recommended on macOS)
 
@@ -52,10 +53,10 @@ Override defaults:
 curl -fsSL logmind.dev/install.sh | bash -s -- --prefix=/usr/local
 
 # Pin to a specific version (flag form)
-curl -fsSL logmind.dev/install.sh | bash -s -- --version=v2.0.0
+curl -fsSL logmind.dev/install.sh | bash -s -- --version=v1.2.0
 
 # Pin to a specific version (env form — equivalent, lower precedence than --version)
-LOGMIND_VERSION=v2.0.0 curl -fsSL logmind.dev/install.sh | bash
+LOGMIND_VERSION=v1.2.0 curl -fsSL logmind.dev/install.sh | bash
 ```
 
 Re-running the installer when the same version is already installed
@@ -118,7 +119,7 @@ Builds the latest tagged release into `$(go env GOPATH)/bin/logmind`.
 For a specific tag:
 
 ```bash
-go install github.com/thrillmade/logmind/cmd/logmind@v2.0.0
+go install github.com/thrillmade/logmind/cmd/logmind@v1.2.0
 ```
 
 Or clone + build:
@@ -157,15 +158,13 @@ target Linux.
 
 ```bash
 logmind --version
-# logmind 2.0.0 (spec 2.0.0)
-# areas: orient, work, record, propagate, gates
+# logmind 1.2.0 (spec 0.1.1)
 ```
 
-Both lines are the protocol contract (SPEC §7.3) — downstream tooling
-(clud-bug, tokenomics, agent-skills) reads the first to detect protocol
-skew and the second to learn which parts of the spec this binary
-implements. If either line doesn't appear or the format differs, your
-install is broken or running an older version.
+This line is the protocol contract (SPEC §7.3) — downstream tooling
+(clud-bug, tokenomics, agent-skills) reads it to detect protocol skew. If
+it doesn't appear or the format differs, your install is broken or
+running an older version.
 
 ## Deprecated: Python install
 

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -45,8 +45,8 @@ originate from a thrillmade-owned workflow.
 - **Steward service** — a standing service (not just workflow-minted
   tokens) running under this App identity. Contract details are drafted in
   [`thrillmade/protocol#39`](https://github.com/thrillmade/protocol/issues/39)
-  and SPEC §17 (draft — not yet merged into the canonical
-  `thrillmade/protocol` SPEC).
+  and tracked in SPEC §0.3's Planned list, "Unified install and the
+  steward — [skdd#6](https://github.com/thrillmade/skdd/issues/6)".
 
 Per the master plan at
 `/Users/ludlow/.claude/plans/ok-here-is-recent-distributed-chipmunk.md`,
@@ -56,7 +56,7 @@ spin up a machine-user account: PATs require periodic rotation and tie the
 release pipeline to one human's GitHub account, and machine-user accounts
 add real-account-maintenance overhead with no narrower audit story than an
 App. Tokens are 1-hour installation tokens minted at workflow time by the
-official `actions/create-github-app-token@v2` action — the only App-token
+official `actions/create-github-app-token@v3` action — the only App-token
 action compatible with the repo's `allowed_actions: selected` workflow
 allowlist.
 
@@ -348,13 +348,13 @@ steps — the env-var name stays unchanged for a minimal diff; the secret
 behind it is now an App token.
 
 ```yaml
-      # actions/create-github-app-token@v2 is the official action and the
+      # actions/create-github-app-token@v3 is the official action and the
       # only App-token action compatible with this repo's
       # `allowed_actions: selected` workflow allowlist (tibdex/github-app-token
       # is NOT permitted — verified-Marketplace and actions/* only).
       - name: Mint orchestrator App installation token
         id: app_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.THRILLMADE_ORCHESTRATOR_APP_ID }}
           private-key: ${{ secrets.THRILLMADE_ORCHESTRATOR_PRIVATE_KEY }}

--- a/internal/templates/AGENTS.md.template
+++ b/internal/templates/AGENTS.md.template
@@ -89,9 +89,8 @@ logmind log "Use PostgreSQL for primary database" \
 
 On a feature branch, the entry lands in
 `docs/decisions-branches/<sanitized-branch>.md`. On the default branch
-it lands in `docs/decisions.md`. On PR merge, a workflow appends a
-one-line summary to `docs/decisions.md` linking the PR and the
-per-branch file. You don't manage this — `logmind log` does.
+it lands in `docs/decisions.md`. You don't manage this — `logmind log`
+does.
 
 ### Branch summary (headline)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -52,9 +52,8 @@ file + its companion docs when you have unrelated WIP.
 When you are on a feature branch (anything other than the project's default
 branch), the entry is written to
 `docs/decisions-branches/<sanitized-branch>.md` rather than
-`docs/decisions.md`. On PR merge, a GitHub Action appends a one-line
-summary linking the PR + the per-branch file to `docs/decisions.md`. You do
-not need to manage this routing — `logmind log` does it automatically.
+`docs/decisions.md`. You do not need to manage this routing — `logmind
+log` does it automatically.
 
 ## Reading prior context
 
@@ -135,6 +134,11 @@ brew install thrillmade/tap/logmind   # or: curl -fsSL https://logmind.dev/insta
 logmind init                          # scaffolds docs/, AGENTS.md, GH Actions, hooks
 logmind doctor                        # confirm a clean install
 ```
+
+brew/curl installs the latest tagged release (v1.2.0), which lacks
+`context`, `show`, `search`, `headline`, and `guard-commit` (PreToolUse
+harness) enforcement — those verbs require building from source/the dev
+branch (`2.0.0-dev`).
 
 ## Don'ts
 


### PR DESCRIPTION
A verification sweep read every prose doc in the repo against `origin/dev` — six agents, each required to control-test every zero it reported. **27 stale claims, 8 factually wrong** rather than merely dated. This applies the 19 that are safe, self-contained prose corrections.

## The four that actually mislead

**A config surface that was deleted.** `README.md:105-147` described derived-docs enforcement as opt-in via `derived_docs.mode` with a `min_binary` floor, including an "unadopted repo passes" escape. All of it is gone — the invariant is unconditional. A reader following those instructions configures a key that does not exist.

**A GitHub Action that does not exist.** `README.md`, `CONTRIBUTING.md` and `skill/SKILL.md` all promised that on PR merge, an Action appends a one-line summary to `docs/decisions.md`. Nothing does. Control: grepping `one-line summary` hit only the three docs asserting it and never a producing workflow — and `docs/decisions.md` has not been touched since 2026-07-16 across 44 subsequent commits.

**An unreleased version presented as installable.** `LOGMIND_VERSION=v2.0.0` as a worked pin, and `--version` shown printing the two-line 2.0.0 output. **v2.0.0 has never been tagged.** Docs now show `logmind 1.2.0 (spec 0.1.1)` — verified byte-identical to what the installed homebrew cask actually prints, not merely against source.

**A secret that does not exist.** `README` cited `LOGMIND_AUTO_REGEN_PAT`; `regen-timeline.yml` mints a `skdd-steward[bot]` App token via `create-github-app-token@v3`.

Also: a fabricated `init` transcript and a Python-dict template block in `first-decision-example.md` (replaced with the real `buildFirstDecisionEntry()` / `runInitRefresh()` behaviour), `pytest -q` in the PR template for a Go repo, a CHANGELOG checkbox for a repo with no CHANGELOG, and `create-github-app-token@v2` where the workflow uses `@v3`.

## Deliberately not fixed

**Four required-reading entries naming `docs/decisions.md`** — in `AGENTS.md`, `skill/SKILL.md`, `docs/ai-agent-files.md`, and `internal/templates/logmind-section.md`. That file is dead, but #265 deletes the layout and the template ships fleet-wide via #257. Changing them ahead of those issues desyncs the fleet. Verified still present after this change.

**Four findings in `docs/superpowers/plans/2026-07-17-derived-docs-on-main.md`** — a dated implementation plan that correctly records what was intended and self-reviewed at the time. Editing it would falsify the record, not fix a doc.

## Verification

Every zero control-tested. `derived_docs` → 0 in README while `derived doc` still → 1. `one-line summary` → 0 while `decisions-branches` still → 3. `v2.0.0` → 0 across README + install.md while `2.0.0-dev` still → 1 (the deliberate source-build caveat). Only the 8 intended files touched; 0 changes under `docs/decisions*`, `docs/timeline*`, `docs/file-structure*` or `docs/superpowers/`. `logmind check-links` clean; build and `gofmt` unaffected.