### PR TITLE
fix(init): refuse to move a workflow template backwards, and say so — closes #286

### DIFF
--- a/docs/decisions-branches/fix__no-silent-template-downgrade.md
+++ b/docs/decisions-branches/fix__no-silent-template-downgrade.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-07-refuse-to-move-a-workflow-template-backwards-and-say-so -->
+- **2026-08-07** — Refuse to move a workflow template backwards, and say so
+<!-- logmind-entry-end -->
+
+## 2026-08-07 17:35 - Refuse to move a workflow template backwards, and say so
+
+**Reasoning:** installWorkflowTemplates tested marker INEQUALITY, not ordering: 'installedVer != bundledVer' overwrote in either direction. A repo carrying v11 refreshed by a binary bundling v4 was silently rewritten to v4 and told '↻ Refreshed ... to current template', which reads as an upgrade. It was seven marker versions backwards. This is not hypothetical: brew install gives v1.2.0, which bundles v4, so any fleet migration run with a released binary installs v4 AND reverts every repo already moved forward — including protocol, which is taking v11 by hand in protocol#92 right now.
+
+**Alternatives considered:** Compare markers as strings. Rejected outright — 'v11' < 'v4' lexically, so a string compare gets this exactly backwards and would have looked like it worked on v4-vs-v9. The comparison parses the integer after the 'v' and ignores any '-pointer' suffix.
+
+**Implications:**
+- Only the downgrade direction changes; upgrades and equal versions behave exactly as before. An unparseable marker on either side falls back to the old refresh-on-inequality path rather than silently doing nothing, so an unreadable marker cannot become a way to pin a stale template forever. The refusal surfaces through BOTH callers — logmind init and doctor --fix — via refreshResult.WorkflowsDeclined and one shared formatter, placed before doctor's --json branch so the refusal survives --json without polluting stdout. Regression tests fail against the old behaviour, verified by deleting the guard and watching them reproduce #286 verbatim. Probing found the same downgrade shape in the AGENTS.md marker block (different root cause — matchingTemplate's hardcoded enum, which is #267) and in git hooks (where last-binary-wins may be intended); both left alone and reported.
+
+---
+

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -109,6 +109,11 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return ErrSilent
 	}
 
+	// Refused workflow downgrades (#286) — printed BEFORE the --json branch
+	// below: this is a refusal the user must see on every surface, and
+	// stderr never pollutes the JSON document on stdout.
+	reportTemplateDowngrades(cmd.ErrOrStderr(), res.WorkflowsDeclined)
+
 	// Backfill the §1.6.3 timeline marker into any markerless branch detail
 	// file (main-canonical only) — the deterministic structural half of the
 	// branch-summary migration. The rich one-sentence summary stays the

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -199,7 +200,10 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 	var installedWorkflows []string
 	var dependabotChanged bool
 	if f.githubActions {
-		created, _, err := installWorkflowTemplates(cwd, false)
+		// Fresh install: refresh=false never overwrites, so the declined
+		// list is always empty here — only the refresh surfaces can hit a
+		// downgrade.
+		created, _, _, err := installWorkflowTemplates(cwd, false)
 		if err != nil {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: workflow install failed:", err)
 		}
@@ -368,7 +372,12 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 		for _, wf := range res.WorkflowsRefreshed {
 			fmt.Fprintln(out, "↻ Refreshed", wf, "to current template")
 		}
-		if len(res.WorkflowsCreated) == 0 && len(res.WorkflowsRefreshed) == 0 {
+		// A refused downgrade (#286) is neither a create nor a refresh, but
+		// it IS a decision the user has to know about — report it before the
+		// "already current" line, which would otherwise be the only thing a
+		// repo running ahead of the binary ever sees.
+		reportTemplateDowngrades(cmd.ErrOrStderr(), res.WorkflowsDeclined)
+		if len(res.WorkflowsCreated) == 0 && len(res.WorkflowsRefreshed) == 0 && len(res.WorkflowsDeclined) == 0 {
 			fmt.Fprintln(out, "  All workflow templates already current.")
 		}
 		// Dependabot config is init-owned (doctor doesn't probe it, so
@@ -395,22 +404,33 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 	return nil
 }
 
+// templateDowngrade records one REFUSED workflow refresh: the file on disk
+// carries a newer `# logmind-template-version:` marker than this binary
+// bundles, so installWorkflowTemplates left it alone. Reported by both
+// callers (init refresh mode, doctor --fix) — never silent.
+type templateDowngrade struct {
+	Path      string // rel path from repo root
+	Installed string // marker found on disk, e.g. "v11"
+	Bundled   string // marker this binary ships, e.g. "v4"
+}
+
 // installWorkflowTemplates copies internal/templates/github/*.yml.template
 // into .github/workflows/. Two modes:
 //
 //   - refresh=false: don't overwrite existing files.
-//   - refresh=true: overwrite when the installed marker differs from the
+//   - refresh=true: overwrite when the installed marker is OLDER than the
 //     bundled marker. (Go-era workflows use thrillmade/setup-logmind and
 //     carry no pip-install pin, so a matching marker is left as-is.)
 //
-// Returns (created, refreshed, err). Each list is a slice of relative
-// paths from cwd.
-func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string, error) {
+// Returns (created, refreshed, declined, err). Each list is a slice of
+// relative paths from cwd; declined additionally names both markers.
+func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string, []templateDowngrade, error) {
 	workflowsDir := filepath.Join(repoRoot, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var created, refreshed []string
+	var declined []templateDowngrade
 	for _, tmpl := range templates.ListWorkflowTemplates() {
 		// `tmpl` includes the `.template` suffix; strip for the install name.
 		targetName := strings.TrimSuffix(tmpl, ".template")
@@ -419,13 +439,13 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		existing, err := os.ReadFile(target)
 		if errors.Is(err, fs.ErrNotExist) {
 			if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			created = append(created, relativePath(repoRoot, target))
 			continue
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if !refresh {
 			continue
@@ -433,8 +453,28 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		installedVer := extractTemplateVersion(string(existing))
 		bundledVer := extractTemplateVersion(body)
 		if installedVer != "" && bundledVer != "" && installedVer != bundledVer {
+			// ORDER, not inequality (#286). A released binary bundles OLDER
+			// markers than dev (`brew install logmind` → v1.2.0 → v4 while
+			// dev is on v11), so an inequality test makes every refresh run
+			// from a release walk a repo that is deliberately ahead of it
+			// BACKWARDS — silently, and reported as "Refreshed … to current
+			// template". Refuse that direction and report it instead.
+			//
+			// Unparseable on either side falls through to the old
+			// refresh-on-inequality behaviour: an unreadable marker must not
+			// become a way to pin a stale template forever.
+			installedN, iok := parseTemplateVersion(installedVer)
+			bundledN, bok := parseTemplateVersion(bundledVer)
+			if iok && bok && installedN > bundledN {
+				declined = append(declined, templateDowngrade{
+					Path:      relativePath(repoRoot, target),
+					Installed: installedVer,
+					Bundled:   bundledVer,
+				})
+				continue
+			}
 			if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			refreshed = append(refreshed, relativePath(repoRoot, target))
 			continue
@@ -442,7 +482,7 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		// Body marker matches the bundled template — leave the installed
 		// file untouched (no pip-install pin to reconcile anymore).
 	}
-	return created, refreshed, nil
+	return created, refreshed, declined, nil
 }
 
 // renderWorkflowTemplate substitutes install-time placeholders. Currently:
@@ -463,6 +503,46 @@ func extractTemplateVersion(text string) string {
 		}
 	}
 	return ""
+}
+
+// parseTemplateVersion extracts the ORDERING key from a template marker:
+// "v11" → 11, "v9-pointer" → 9. Only the numeric generation orders — a
+// string compare gets this exactly backwards ("v11" < "v4" lexically),
+// which is the trap #286 fell into.
+//
+// Deliberately NOT version.SatisfiesMin: these markers are a single
+// monotonic integer, not a major.minor.patch triple, so that helper can't
+// parse them at all. The variant suffix (the "-pointer" flavour tag, and
+// the "-FAKE" markers the tests plant) is stripped before the compare,
+// mirroring parseVersionCore's suffix handling.
+//
+// Returns ok=false for anything that isn't a leading "v" followed by at
+// least one digit — callers fall back to the pre-#286 behaviour rather
+// than treating an unreadable marker as a reason to do nothing.
+func parseTemplateVersion(marker string) (int, bool) {
+	s := strings.TrimSpace(marker)
+	if !strings.HasPrefix(s, "v") {
+		return 0, false
+	}
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return 0, false
+	}
+	// Reject anything Atoi would tolerate but a marker never contains
+	// (a sign, whitespace) — only bare digits order.
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // enabledAgentList resolves the agents flag. --all-agents wins;

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -28,6 +28,8 @@
 package cli
 
 import (
+	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/thrillmade/logmind/internal/claudehook"
@@ -39,9 +41,10 @@ import (
 // refreshResult tallies what applyRefresh actually changed. It drives both
 // init's "✓/↻" lines and doctor --fix's quiet `ok` summary.
 type refreshResult struct {
-	WorkflowsCreated   []string // rel paths
-	WorkflowsRefreshed []string // rel paths
-	AgentsMDMsg        string   // "" when no change
+	WorkflowsCreated   []string            // rel paths
+	WorkflowsRefreshed []string            // rel paths
+	WorkflowsDeclined  []templateDowngrade // refused downgrades (#286) — MUST be reported
+	AgentsMDMsg        string              // "" when no change
 	GitattrChanged     bool
 	MergeDriverSet     bool     // a merge-driver git config key was (re)written
 	HooksRefreshed     []string // subset of {"post-merge","post-rewrite","commit-msg"}
@@ -75,9 +78,10 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 	}
 
 	if opts.githubActions {
-		created, refreshed, err := installWorkflowTemplates(cwd, true)
+		created, refreshed, declined, err := installWorkflowTemplates(cwd, true)
 		res.WorkflowsCreated = created
 		res.WorkflowsRefreshed = refreshed
+		res.WorkflowsDeclined = declined
 		note(err)
 	}
 
@@ -131,4 +135,21 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 	}
 
 	return res, firstErr
+}
+
+// reportTemplateDowngrades writes one stderr line per refused workflow
+// refresh. Called by BOTH refresh surfaces (init refresh mode, doctor
+// --fix) — the refusal is the whole point of #286, so it can never be
+// left to a caller's discretion.
+//
+// Shape follows SPEC §3.4's rule for the analogous fail-open case ("Failing
+// open MUST NOT be silent... MUST say so on stderr, naming what it looked
+// for and what it found"): name the file, both markers, and the direction.
+func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
+	for _, d := range declined {
+		fmt.Fprintf(stderr,
+			"note: %s left unchanged — installed template %s is NEWER than the %s this binary bundles; "+
+				"refusing to downgrade. Upgrade logmind to move it forward.\n",
+			d.Path, d.Installed, d.Bundled)
+	}
 }

--- a/internal/cli/template_downgrade_test.go
+++ b/internal/cli/template_downgrade_test.go
@@ -1,0 +1,268 @@
+// template_downgrade_test.go — logmind#286: a refresh must never walk a
+// workflow template BACKWARDS. The pre-#286 code tested marker INEQUALITY
+// ("different" == "stale"), so a released binary bundling v4 silently
+// overwrote a repo already carrying v11 and reported it as
+// "↻ Refreshed … to current template".
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// TestParseTemplateVersion covers the ordering key: bare vN, the -pointer
+// flavour suffix, the -FAKE markers other tests plant, and every shape that
+// must report ok=false so the caller falls back to refresh-on-inequality.
+func TestParseTemplateVersion(t *testing.T) {
+	for _, tc := range []struct {
+		marker string
+		want   int
+		wantOK bool
+	}{
+		{"v4", 4, true},
+		{"v11", 11, true},
+		{"v9", 9, true},
+		{"v10", 10, true},
+		{"v0", 0, true},
+		{"v9-pointer", 9, true},
+		{"v11-pointer", 11, true},
+		{"v0-FAKE", 0, true}, // planted by refresh_test.go / doctor_test.go
+		{" v11 ", 11, true},
+		// Unparseable — ok=false, caller keeps the pre-#286 behaviour.
+		{"", 0, false},
+		{"v", 0, false},
+		{"v-3", 0, false},
+		{"v+5", 0, false},
+		{"vNOPE", 0, false},
+		{"v 4", 0, false},
+		{"11", 0, false},
+		{"latest", 0, false},
+	} {
+		got, ok := parseTemplateVersion(tc.marker)
+		if ok != tc.wantOK || got != tc.want {
+			t.Errorf("parseTemplateVersion(%q) = (%d, %v); want (%d, %v)",
+				tc.marker, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestParseTemplateVersion_Ordering pins the compare in BOTH directions.
+// v4 vs v11 is the trap: lexically "v11" < "v4", so a string compare gets
+// the #286 case exactly backwards. v9 vs v10 is the same trap one decade
+// down.
+func TestParseTemplateVersion_Ordering(t *testing.T) {
+	for _, tc := range []struct {
+		older, newer string
+	}{
+		{"v4", "v11"},
+		{"v9", "v10"},
+		{"v4", "v9-pointer"},
+		{"v9-pointer", "v11"},
+	} {
+		o, ook := parseTemplateVersion(tc.older)
+		n, nok := parseTemplateVersion(tc.newer)
+		if !ook || !nok {
+			t.Fatalf("both markers must parse: %q ok=%v, %q ok=%v", tc.older, ook, tc.newer, nok)
+		}
+		if !(n > o) {
+			t.Errorf("%s must order AFTER %s; got %d vs %d", tc.newer, tc.older, n, o)
+		}
+		if !(o < n) {
+			t.Errorf("%s must order BEFORE %s; got %d vs %d", tc.older, tc.newer, o, n)
+		}
+	}
+	// Equal markers are neither newer nor older.
+	a, _ := parseTemplateVersion("v11")
+	b, _ := parseTemplateVersion("v11")
+	if a != b {
+		t.Errorf("equal markers must compare equal; got %d vs %d", a, b)
+	}
+	// The trap itself, asserted: a string compare disagrees with the
+	// numeric one for exactly the #286 pair.
+	if !("v11" < "v4") {
+		t.Fatal("premise changed: \"v11\" is no longer lexically less than \"v4\"")
+	}
+}
+
+// bundledTemplateVersion returns the `# logmind-template-version:` marker
+// this binary ships for one workflow template.
+func bundledTemplateVersion(t *testing.T, name string) string {
+	t.Helper()
+	v := extractTemplateVersion(templates.Workflow(name + ".template"))
+	if v == "" {
+		t.Fatalf("bundled %s carries no template-version marker", name)
+	}
+	return v
+}
+
+// plantNewerWorkflow writes .github/workflows/check-decisions.yml carrying
+// the marker #286 reported on disk (v11) against a binary that bundles v4.
+// Returns (installedMarker, bundledMarker).
+func plantNewerWorkflow(t *testing.T) (string, string) {
+	t.Helper()
+	const installed = "v11"
+	bundled := bundledTemplateVersion(t, "check-decisions.yml")
+	bn, ok := parseTemplateVersion(bundled)
+	in, _ := parseTemplateVersion(installed)
+	if !ok || bn >= in {
+		t.Fatalf("the #286 reproduction needs a bundled check-decisions.yml marker below %s; "+
+			"it is now %s — re-point this test at a marker the binary is behind", installed, bundled)
+	}
+	writeRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"),
+		"# logmind-template-version: "+installed+"\n# hand-taken ahead of the release\n", 0o644)
+	return installed, bundled
+}
+
+// TestInstallWorkflowTemplates_RefusesDowngrade is the unit-level #286
+// reproduction: refresh mode leaves a newer-on-disk template byte-untouched
+// and reports the refusal upward (not as a "refreshed" entry).
+func TestInstallWorkflowTemplates_RefusesDowngrade(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		installed, bundled := plantNewerWorkflow(t)
+		before := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+
+		_, refreshed, declined, err := installWorkflowTemplates(dir, true)
+		if err != nil {
+			t.Fatalf("installWorkflowTemplates: %v", err)
+		}
+
+		after := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+		if after != before {
+			t.Errorf("newer template was overwritten:\n got: %q\nwant: %q", after, before)
+		}
+		for _, r := range refreshed {
+			if strings.Contains(r, "check-decisions.yml") {
+				t.Errorf("a refused downgrade must not be reported as refreshed: %v", refreshed)
+			}
+		}
+		if len(declined) != 1 {
+			t.Fatalf("declined = %v; want exactly one entry", declined)
+		}
+		if declined[0].Installed != installed || declined[0].Bundled != bundled {
+			t.Errorf("declined[0] = %+v; want Installed=%s Bundled=%s", declined[0], installed, bundled)
+		}
+		if !strings.Contains(declined[0].Path, "check-decisions.yml") {
+			t.Errorf("declined[0].Path = %q; want the check-decisions.yml path", declined[0].Path)
+		}
+	})
+}
+
+// TestInstallWorkflowTemplates_StillUpgrades: the narrow fix must not
+// change the forward direction. An older marker on disk is still refreshed
+// to the bundled body.
+func TestInstallWorkflowTemplates_StillUpgrades(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "# logmind-template-version: v1\n# ancient\n", 0o644)
+
+		_, refreshed, declined, err := installWorkflowTemplates(dir, true)
+		if err != nil {
+			t.Fatalf("installWorkflowTemplates: %v", err)
+		}
+		if len(declined) != 0 {
+			t.Errorf("declined = %+v; want none on an upgrade", declined)
+		}
+		want := bundledTemplateVersion(t, "check-decisions.yml")
+		if got := extractTemplateVersion(readRel(t, rel)); got != want {
+			t.Errorf("marker after refresh = %q; want %q", got, want)
+		}
+		found := false
+		for _, r := range refreshed {
+			if strings.Contains(r, "check-decisions.yml") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("refreshed = %v; want it to include check-decisions.yml", refreshed)
+		}
+	})
+}
+
+// TestInstallWorkflowTemplates_UnparseableMarkerStillRefreshes: an
+// unreadable marker must NOT become a way to pin a stale template forever —
+// it falls back to the pre-#286 refresh-on-inequality behaviour.
+func TestInstallWorkflowTemplates_UnparseableMarkerStillRefreshes(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "# logmind-template-version: vNOPE\n# unreadable\n", 0o644)
+
+		_, _, declined, err := installWorkflowTemplates(dir, true)
+		if err != nil {
+			t.Fatalf("installWorkflowTemplates: %v", err)
+		}
+		if len(declined) != 0 {
+			t.Errorf("declined = %+v; want none for an unparseable marker", declined)
+		}
+		want := bundledTemplateVersion(t, "check-decisions.yml")
+		if got := extractTemplateVersion(readRel(t, rel)); got != want {
+			t.Errorf("marker after refresh = %q; want %q (unparseable must not pin)", got, want)
+		}
+	})
+}
+
+// TestInitRefresh_RefusesTemplateDowngrade — #286's reported scenario end to
+// end through `logmind init` refresh mode: a repo carrying v11 refreshed by
+// a binary bundling v4 keeps v11, and the refusal is named on stderr.
+func TestInitRefresh_RefusesTemplateDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})
+		installed, bundled := plantNewerWorkflow(t)
+		before := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+
+		out, errOut := runInitCapture(t, []string{"init", "--no-git"})
+
+		after := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+		if after != before {
+			t.Errorf("init refresh downgraded a newer template:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(out, "↻ Refreshed .github/workflows/check-decisions.yml") {
+			t.Errorf("a downgrade must not be reported as a refresh:\n%s", out)
+		}
+		// The refusal MUST be visible, naming both markers and the direction.
+		mustContain(t, errOut, "check-decisions.yml")
+		mustContain(t, errOut, "installed template "+installed)
+		mustContain(t, errOut, "NEWER")
+		mustContain(t, errOut, bundled)
+	})
+}
+
+// TestDoctorFix_RefusesTemplateDowngrade — the same refusal must surface
+// through the other refresh caller, `logmind doctor --fix`.
+func TestDoctorFix_RefusesTemplateDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		installed, bundled := plantNewerWorkflow(t)
+		before := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+
+		out, stderr := runDoctorFixCmd(t)
+
+		after := readRel(t, filepath.Join(".github", "workflows", "check-decisions.yml"))
+		if after != before {
+			t.Errorf("doctor --fix downgraded a newer template:\n got: %q\nwant: %q", after, before)
+		}
+		mustContain(t, out, "ok doctor-fix")
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "installed template "+installed)
+		mustContain(t, stderr, "NEWER")
+		mustContain(t, stderr, bundled)
+	})
+}
+
+// runInitCapture runs a root command and returns (stdout, stderr) without
+// failing on a non-nil error — refresh mode reports downgrade refusals on
+// stderr while still exiting 0.
+func runInitCapture(t *testing.T, args []string) (string, string) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(args)
+	var out, errOut strings.Builder
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v\nstdout=%s\nstderr=%s", args, err, out.String(), errOut.String())
+	}
+	return out.String(), errOut.String()
+}


### PR DESCRIPTION
`installWorkflowTemplates` tested marker **inequality, not ordering**:

```go
if installedVer != "" && bundledVer != "" && installedVer != bundledVer {
    os.WriteFile(target, []byte(body), 0o644)   // overwrite, either direction
```

So a repository carrying `v11`, refreshed by a binary bundling `v4`, was silently rewritten to v4 — seven marker versions backwards — and told:

```
↻ Refreshed .github/workflows/regen-timeline.yml to current template
```

which reads as an upgrade.

## Why this blocks the fleet migration

`brew install logmind` gives **v1.2.0**, which bundles **v4**. So a migration performed with a released binary installs v4 *and reverts* every repository already moved forward. That includes **protocol**, which is taking v11 by hand in protocol#92 right now — I've warned that thread.

A migration performed by a tool that downgrades on refresh cannot hold. This is a prerequisite for #257, not a cleanup.

## The fix

Ordering comparison, not string comparison — **`"v11" < "v4"` lexically**, so a string compare gets this exactly backwards and would have looked correct on v4-vs-v9. `parseTemplateVersion` takes the integer after the `v` and ignores any `-pointer` suffix. Not `version.SatisfiesMin`: markers are one monotonic integer, not a `major.minor.patch` triple, so that parser cannot read them at all.

**Narrow by construction:**
- upgrades and equal versions behave exactly as before
- an **unparseable** marker on either side falls back to the old refresh-on-inequality path — an unreadable marker must not become a way to pin a stale template forever
- no new flag, no new config key

**The refusal is not silent** — §3.4's principle for the analogous case is that failing open must say so. It surfaces through *both* callers (`logmind init` and `doctor --fix`) via `refreshResult.WorkflowsDeclined` and one shared formatter, placed before doctor's `--json` branch so it survives `--json` without polluting stdout:

```
note: <path> left unchanged — installed template v11 is NEWER than the v4 this
      binary bundles; refusing to downgrade. Upgrade logmind to move it forward.
```

## Verification

Regression tests were checked against the **old** behaviour by deleting the guard and re-running — all three failed, reproducing #286 verbatim (stdout claiming "Refreshed … to current template" while the on-disk marker went `v11` → `v4`). Full suite exit 0, `vet`/`gofmt` clean.

## Same shape elsewhere — found, not fixed

- **AGENTS.md marker block** — same downgrade, *different root cause*: `matchingTemplate` recognises markers by hardcoded `strings.Contains` of known generations, so an unknown *newer* marker returns `""` and `EnsureAgentsMD` falls back to the slim default. No version compare exists to fix. That is **#267**.
- **Git hooks** — `installHook` byte-compares the whole body and never reads the version marker. The marker is the *binary's* version and the body is a function of the binary, so "last binary wins" may be the intended contract — but an older binary still reverts a newer hook and reports success. Worth a decision, not a drive-by.

## One residual, flagged

`doctor --fix`'s re-probe still classifies the refused file as residual `stale` drift and adds "not auto-fixable by doctor --fix (PATH/version, or a hand-written hook)" — true, but the parenthetical misleads. Teaching `internal/doctor`'s probe the same ordering is wider than this PR's scope.