### PR TITLE
fix(tree): derive the file-structure root from the repository, not the checkout directory — closes #285

### DIFF
--- a/docs/decisions-branches/fix__file-structure-worktree-root.md
+++ b/docs/decisions-branches/fix__file-structure-worktree-root.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-07-derive-the-file-structure-tree-root-from-the-repository-not- -->
+- **2026-08-07** — Derive the file-structure tree root from the repository, not the checkout directory
+<!-- logmind-entry-end -->
+
+## 2026-08-07 17:38 - Derive the file-structure tree root from the repository, not the checkout directory
+
+**Reasoning:** docs/file-structure.md rendered its tree root as the checkout directory's basename. In a normal clone that basename happens to equal the repo name, so the bug was invisible; in a git worktree — which is how parallel agents work — it is agent-<id>, and every regeneration rewrote the root line to garbage. Measured inside a real worktree: git rev-parse --show-toplevel returns the WORKTREE path, so it is the wrong signal. git rev-parse --git-common-dir returns the one shared .git every worktree points at, and basename(dirname(...)) of that gives the real repository name in every case tested — relative from a top-level clone, ../../.git from a subdirectory, absolute from a worktree. A fix was promised in #167 ('the default flip rides v1.0') and never landed.
+
+**Alternatives considered:** Add a config key for the root label. Rejected: one already exists — root_label, honoured for both a literal string and 'auto' — so a new key would be a second way to say the same thing. Config still wins; only the unconfigured default changed.
+
+**Implications:**
+- The normal-clone rendering is byte-identical, which matters because docs/file-structure.md is a derived doc under a byte-comparison CI gate — any change there would churn every repo in the fleet. Verified: internal/tree/testdata/generate-file-structure.golden untouched, and rendering this repo from its normal checkout still emits 'logmind'. A non-git directory keeps the basename fallback and exits 0 rather than erroring. The regression test was checked against the old behaviour by reverting tree.go and watching it fail with resolveRootLabel(main checkout, "") = ""; want "myrepo". The issue's own reproduction now gives myrepo/myrepo where it previously gave myrepo/agent-deadbeef123.
+
+---
+

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -180,6 +181,48 @@ func RemoteRepoName(repoRoot string) string {
 		url = url[i+1:]
 	}
 	return url
+}
+
+// CommonDirRepoName returns the basename of the directory containing the
+// repository's SHARED git dir — `git rev-parse --git-common-dir`. This is
+// deliberately not `--show-toplevel`: inside a `git worktree` checkout,
+// `--show-toplevel` resolves to the WORKTREE's own path (e.g.
+// ".../agent-<id>"), which is exactly the checkout-basename bug this
+// exists to route around. `--git-common-dir` instead points at the ONE
+// .git directory every worktree of a repo shares, so its parent's
+// basename is the actual repository name no matter which worktree (or how
+// deep a subdirectory of one) the command runs from.
+//
+// git prints `--git-common-dir` relative to repoRoot in the common case
+// (".git" at the top level, "../../.git" three directories down) and only
+// switches to an absolute path when relative wouldn't resolve correctly
+// (observed from inside a worktree). We join against repoRoot before
+// taking the parent's basename so both forms resolve the same way.
+//
+// Empty string on any failure (not a repo, missing git binary, unexpected
+// path shape) — callers fall back to the checkout directory's basename,
+// the same degrade pattern as RemoteRepoName.
+func CommonDirRepoName(repoRoot string) string {
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(stdout.String())
+	if dir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(repoRoot, dir)
+	}
+	name := filepath.Base(filepath.Dir(dir))
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
 }
 
 // DiffCachedNames returns the list of staged file paths

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -375,13 +375,27 @@ func GenerateFileStructure(repoRoot string, maxDepth int) (string, error) {
 }
 
 // resolveRootLabel maps the config value to the literal root label.
-// Empty (default) → "" (RenderWithLabel falls back to the checkout basename,
-// byte-parity). "auto" → the git remote repo name, or "" when it can't be
-// resolved (shallow/fork CI, no origin) so it degrades to the basename. Any
-// other value is used verbatim.
+//
+// Empty (default, unconfigured) → the repository's actual name, derived
+// from git's shared common-dir (gitcli.CommonDirRepoName) rather than the
+// checkout directory's basename. In an ordinary top-level clone the two
+// are identical, so this is byte-parity-preserving there; the divergence
+// only shows up in a `git worktree` checkout, where the basename is
+// something like "agent-<id>" but the common-dir-derived name is still the
+// real repo. Falls back to "" (RenderWithLabel then uses the checkout
+// basename) when repoRoot isn't a git repo at all — a plain non-git
+// directory still works, no error.
+//
+// "auto" (explicit opt-in, pre-existing) → the git remote repo name, or ""
+// when it can't be resolved (shallow/fork CI, no origin) so it degrades to
+// the basename. Any other value is used verbatim — an explicit configured
+// label always wins over both derivations above.
 func resolveRootLabel(repoRoot, configured string) string {
 	if configured == "auto" {
 		return gitcli.RemoteRepoName(repoRoot)
+	}
+	if configured == "" {
+		return gitcli.CommonDirRepoName(repoRoot)
 	}
 	return configured
 }

--- a/internal/tree/tree_rootlabel_test.go
+++ b/internal/tree/tree_rootlabel_test.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -78,5 +79,55 @@ func TestResolveRootLabel(t *testing.T) {
 	// "auto" in a non-git dir → "" (degrades to basename downstream).
 	if got := resolveRootLabel(t.TempDir(), "auto"); got != "" {
 		t.Errorf("auto in non-git dir → %q; want \"\"", got)
+	}
+}
+
+// TestResolveRootLabel_WorktreeMatchesMainCheckout is the regression pin
+// for logmind#285: a `git worktree` checkout must resolve to the SAME
+// root label as the main checkout it was created from, even though the
+// two live in differently-named directories (a real repo's checkout dir
+// vs. ".../agent-<id>"). Before the fix, resolveRootLabel's default
+// ("", unconfigured) case fell straight through to "", and
+// RenderWithLabel's basename fallback then picked up whichever directory
+// the command happened to run from — silently corrupting
+// docs/file-structure.md's root line on every regen inside a worktree.
+func TestResolveRootLabel_WorktreeMatchesMainCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v (in %s): %v\n%s", args, dir, err, out)
+		}
+	}
+
+	base := t.TempDir()
+	main := filepath.Join(base, "myrepo")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(main, "init", "-q")
+	run(main, "config", "user.email", "test@test.com")
+	run(main, "config", "user.name", "test")
+	mustWriteTree(t, filepath.Join(main, "README.md"), "hello\n")
+	run(main, "add", "README.md")
+	run(main, "commit", "-q", "-m", "init")
+
+	// Checkout dir name deliberately unrelated to the repo name — mirrors
+	// the parallel-agent worktree layout the issue reports.
+	worktree := filepath.Join(base, "agent-deadbeef123")
+	run(main, "worktree", "add", "-q", worktree, "-b", "wt-branch")
+
+	mainLabel := resolveRootLabel(main, "")
+	worktreeLabel := resolveRootLabel(worktree, "")
+
+	if mainLabel != "myrepo" {
+		t.Errorf("resolveRootLabel(main checkout, \"\") = %q; want %q", mainLabel, "myrepo")
+	}
+	if worktreeLabel != mainLabel {
+		t.Errorf("worktree root label = %q; main checkout root label = %q — the two checkouts of the same repo must agree (logmind#285)", worktreeLabel, mainLabel)
 	}
 }


### PR DESCRIPTION
`docs/file-structure.md` rendered its tree root as the **checkout directory's basename**. In a normal clone that basename happens to equal the repo name, so the bug was invisible. In a `git worktree` — which is how parallel agents work — it is `agent-<id>`, and every regeneration rewrote the root line to garbage.

A fix was promised in #167 (*"the default flip rides v1.0"*) and never landed.

## Measured inside a real worktree, not assumed

| command | returns |
|---|---|
| `git rev-parse --show-toplevel` | the **worktree's own path** — the wrong signal |
| `git rev-parse --git-common-dir` | the one shared `.git` every worktree points at |

`--git-common-dir` returns a *relative* path from a top-level clone (`.git`), `../../.git` from a subdirectory, and an absolute path from a worktree. `basename(dirname(…))` of the resolved value gives the real repository name in every case tested.

## The change

- **`gitcli.CommonDirRepoName`** — resolves a relative result against the repo root, returns the parent directory's basename, and `""` on any failure (not a repo, no git binary).
- **`tree.resolveRootLabel`** returns it for the **unconfigured** case only. An explicit `root_label` — literal string or `"auto"` — still wins. **No new config key**; one already existed, and a second way to say the same thing is the defect this repo keeps finding.
- Non-git directories keep the basename fallback and exit 0 rather than erroring.

## The normal-clone rendering is byte-identical, and that is the point

`docs/file-structure.md` is a derived doc under a **byte-comparison** CI gate, so any change to its rendering would red every repo in the fleet at once. Verified:

- `internal/tree/testdata/generate-file-structure.golden` **untouched** (`git diff` confirms zero golden files changed)
- rendering this repository from its normal checkout still emits `logmind` as the root
- `TestFileStructureTemplate` and the rest of `./internal/tree/...` pass unchanged

## The regression test was checked against the old behaviour

Reverted `tree.go`, re-ran, and watched it fail:

```
--- FAIL: TestResolveRootLabel_WorktreeMatchesMainCheckout (0.29s)
    tree_rootlabel_test.go:128: resolveRootLabel(main checkout, "") = ""; want "myrepo"
```

The test builds a real repo plus a `git worktree add` with a deliberately unrelated directory name and asserts both checkouts resolve to the same label.

**The issue's own reproduction**, end to end: a fresh clone named `myrepo` plus `git worktree add ../agent-deadbeef123` gave `myrepo` vs `agent-deadbeef123` before, and `myrepo` / `myrepo` after.

Full `go test ./...`, `go vet`, `gofmt` all clean.