### PR TITLE
fix(gate): the CI gate calls the verb it claimed to mirror — closes #278, #260, #284

### DIFF
--- a/docs/decisions-branches/fix__gate-one-evaluation.md
+++ b/docs/decisions-branches/fix__gate-one-evaluation.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-07 17:34 - Close three gate-clearing holes an adversarial panel found in the range path
+
+**Reasoning:** The panel BLOCKED PR #287 on a fail-open in the exact code path the CI template will call. runCheckDecisions returned nil for a non-repo directory BEFORE the range-mode split, so 'logmind check-decisions --base X --head Y' from the wrong directory printed 'Not a git repository, skipping check.' and exited 0. SPEC §3.4 names running-outside-a-repository as one of six local allowances and says of the gate: 'every allowance above that depends on local process state ... is invisible to it and MUST NOT be honoured there. Exactly two things clear the gate.' The header comment enumerated the two arms it had deliberately omitted and missed this third. Live repro from a non-repo dir: exit 0. A workflow whose working-directory points off the checkout would have passed every PR while reporting success. Two more: hasReasoning accumulated until a blank line only, so an unseparated next header was swallowed as body and an empty **Reasoning:** read as non-empty; and --no-fail was a third gate-clearer reachable in range mode.
+
+**Alternatives considered:** Fix only the blocking one and file the other two. Rejected: all three are the same failure — something other than 'carries a decision' or 'under threshold' clears the gate — and the panel found them together in one read of §3.4. Splitting would ship two known holes to buy a smaller diff.
+
+**Implications:**
+- Range mode now hard-errors outside a repository (exit 1, verified with the true exit code, not through a pipe) while local mode still skips gracefully at exit 0. --no-fail is refused in combination with --base/--head and still permitted alone. Section bodies terminate at the next bold section header and at the --- entry terminator, not only at a blank line; isSectionHeader is shape-based rather than a fixed list of names because §3.1 says a consumer MUST NOT require a section order. Eight new subtests pin all three. Full suite exit 0, zero FAIL. The panel also REFUTED seven candidate defects, including that a fifth exclusion had crept in — a runtime dump showed exactly AGENTS.md plus all 11 §1.2 rows.
+
+---
+

--- a/docs/decisions-branches/fix__gate-one-evaluation.md
+++ b/docs/decisions-branches/fix__gate-one-evaluation.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-07-give-the-gate-one-shared-evaluation-per-spec-3-4 -->
+- **2026-08-07** — Give the gate one shared evaluation, per SPEC §3.4
+<!-- logmind-entry-end -->
+
+## 2026-08-07 17:09 - Give the gate one shared evaluation, per SPEC §3.4
+
+**Reasoning:** SPEC §3.4 says 'Both interception points and the gate MUST use this one list. Two lists that mean the same thing are two lists that will disagree.' We had two, and neither matched the spec. §3.4 names exactly four exclusions 'and nothing else is': docs/, AGENTS.md plus the §1.2 per-tool files, the toolchain's own config, and forge-reported binary. guardcommit.SubstantiveLines excluded only docs/ and binary — so an AGENTS.md refresh counted as substantive and could block a commit §3.4 exempts. The CI template excluded all four and then added *.md wholesale, which §3.4 names outright: 'A skill file counts. So does an agent definition. Excluding markdown wholesale switches the rule off in the repositories where writing is the work.' Under-excluding locally and over-excluding in CI is the disagreement §3.4 predicts, already fulfilled.
+
+**Alternatives considered:** Patch the four defects separately in the bash. Rejected: the template's own header claims it 'mirrors the local logmind check-decisions hook' and it does not — it reimplements it, and the copy has now drifted five ways. A fifth patch would leave two encodings and a sixth drift.
+
+**Implications:**
+- The §1.2 exclusion set is read from agents.FilePatterns() over the existing registry, never re-listed — a second list is the defect being removed. check-decisions gains --base/--head so CI can call the verb instead of reimplementing it, resolves the git toplevel ONCE for both config and every git command (§3.4's subdirectory-bypass rule), takes its threshold from git.commit_line_threshold, and checks §3.1 well-formedness against the range's ADDED lines rather than accepting a touched file. Full suite green; every pin verified by reverting the behaviour and watching the test fail, not by reasoning. Three §3.4-vs-existing conflicts surfaced: logmind log now warns that a reasoning-less entry will not clear the gate, --no-renames is dropped from BOTH numstat wrappers so they cannot diverge, and §3.1 contradicts §3.4 on whether reasoning is required — raised as thrillmade/protocol#93. The workflow template is deliberately untouched; it ships fleet-wide and follows separately.
+
+---
+

--- a/docs/decisions-branches/fix__gate-template-calls-verb.md
+++ b/docs/decisions-branches/fix__gate-template-calls-verb.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-07-make-the-ci-gate-call-the-verb-it-claimed-to-mirror-and-chec -->
+- **2026-08-07** — Make the CI gate call the verb it claimed to mirror, and check out the base ref
+<!-- logmind-entry-end -->
+
+## 2026-08-07 17:39 - Make the CI gate call the verb it claimed to mirror, and check out the base ref
+
+**Reasoning:** The template's own header said it 'mirrors the local logmind check-decisions pre-commit hook'. It did not mirror it — it reimplemented it in bash, and the copy had drifted five ways: *.md wholesale in the exclusion case (#260), a live-PR-title [skip-logmind] read (#278), a path-match decision test instead of §3.1 shape (#278), a hardcoded THRESHOLD 20 that never read commit_line_threshold (#284), and a second exclusion list that §3.4 says will inevitably disagree with the first. The gate now invokes 'logmind check-decisions --base <base> --head <head>' and the bash decides nothing, so all five die at once rather than needing five patches and inviting a sixth drift.
+
+**Alternatives considered:** Patch the five defects in the bash and keep the reimplementation. Rejected: that leaves two encodings of one rule, which is the defect §3.4 names outright — 'Two lists that mean the same thing are two lists that will disagree.'
+
+**Implications:**
+- The workspace is the BASE ref, never the merge ref, and that is load-bearing rather than incidental: the verb reads git.commit_line_threshold from the checkout, so a merge-ref workspace would let a pull request raise its own threshold in the diff under judgement. Proven live in a scratch repo — a PR setting commit_line_threshold 10000 PASSES from a merge-ref workspace and FAILS from a base-ref one. That is SPEC §6.3, a gate is never satisfiable by the change it judges, and without the base-ref checkout the config threshold added in #287 would itself have been a new self-service escape. permissions drops to contents:read alone, since deleting the PR-title read removed the only consumer of pull-requests:read. logmind's own installed workflow is deliberately NOT regenerated here: setup-logmind installs the latest RELEASE, and --base/--head exists only on the unmerged parent, so regenerating now would red logmind's own gate on every PR including this one. The same ordering binds consumers — the fleet cannot take this template until a release carries the verb.
+
+---
+

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -57,6 +57,25 @@ func All() []Agent {
 	return out
 }
 
+// FilePatterns returns the repo-root-relative path of every registered
+// agent's per-tool file — SPEC §1.2's table — in canonical insertion
+// order. Forward-slash, matching Agent.FilePattern. The returned slice
+// is freshly allocated.
+//
+// The consumer is internal/guardcommit, whose substantive-line count
+// excludes these files (SPEC §3.4: "a refresh rewrites these, carrying
+// no decision of its own"). It reads them from HERE rather than
+// re-listing the filenames so the exclusion set cannot drift from the
+// registry that writes them — SPEC §3.4: "Two lists that mean the same
+// thing are two lists that will disagree."
+func FilePatterns() []string {
+	out := make([]string, 0, len(registryOrder))
+	for _, name := range registryOrder {
+		out = append(out, registry[name].FilePattern)
+	}
+	return out
+}
+
 // Lookup returns the Agent for a registered name, plus an `ok` bool
 // matching the Python "if name in AGENT_REGISTRY" check. Unknown
 // names return the zero value + false; callers print the

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -112,10 +112,34 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 		return fmt.Errorf("--base and --head must be given together")
 	}
 
+	// Running outside a repository is one of §3.4's SIX local allowances,
+	// and like the other five it MUST NOT reach the gate: "every allowance
+	// above that depends on local process state — the environment
+	// variable, a git operation in progress, running outside a repository,
+	// a marker in a commit subject — is invisible to it and MUST NOT be
+	// honoured there. Exactly two things clear the gate."
+	//
+	// In range mode this is the gate, so a missing repository is a hard
+	// error rather than a pass. Otherwise a workflow that resolves its
+	// working directory wrongly — `working-directory:` pointing off the
+	// checkout, or `actions/checkout` with a `path:` — turns every PR
+	// green regardless of size, and reports success while doing it.
 	if !gitcli.IsRepo(opts.cwd) {
-		// Python: click.echo(...) which goes to stdout, no exit.
+		if rangeMode {
+			return fmt.Errorf("not a git repository: %s (the gate cannot evaluate a range outside a repository; check the job's working directory)", opts.cwd)
+		}
+		// Local path only. Python: click.echo(...) to stdout, no exit.
 		fmt.Fprintln(stdout, "Not a git repository, skipping check.")
 		return nil
+	}
+
+	// §3.4 again: exactly two things clear the gate. --no-fail is a third,
+	// and although it is set by whoever wrote the workflow rather than by
+	// the pull request's author, a repository that adds it has a gate that
+	// reports and never blocks. Refuse the combination outright so the
+	// escape cannot be added quietly to a workflow file.
+	if rangeMode && opts.noFail {
+		return fmt.Errorf("--no-fail cannot be combined with --base/--head: SPEC §3.4 allows exactly two things to clear the gate — the change carries a decision, or it falls under the threshold")
 	}
 
 	// One repository root for the config read AND every git command

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -7,86 +7,160 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
 )
 
-// newCheckDecisionsCmd wires `logmind check-decisions [--threshold N] [--no-fail]`.
+// newCheckDecisionsCmd wires
+// `logmind check-decisions [--threshold N] [--no-fail] [--base R --head R]`.
 //
-// Behaviour mirror of src/logmind/cli.check_decisions (cli.py:2425-2519).
-// Output strings are byte-identical to Python v0.6.14:
+// This is SPEC §3.4's THIRD interception point — the `check-decisions`
+// gate of §6.2, "the one that actually blocks a merge." It judges the
+// same rule as the two local points (the commit-msg hook and the harness
+// hook, both served by `logmind guard-commit`) and shares their
+// evaluation: guardcommit.IsExcludedPath / SubstantiveLines decide what
+// counts, here as there. §3.4: "Both interception points and the gate
+// MUST use this one list."
+//
+// What the gate does NOT share is the local allowances. §3.4: every
+// allowance "that depends on local process state — the environment
+// variable, a git operation in progress, running outside a repository, a
+// marker in a commit subject — is invisible to it and MUST NOT be
+// honoured there. Exactly two things clear the gate: the change carries a
+// decision, or it falls under the threshold." So there is deliberately no
+// [skip-logmind] arm and no LOGMIND_ALLOW_GIT_COMMIT arm below.
+//
+// Output strings on the staged path are byte-identical to Python
+// v0.6.14 (cli.py:2425-2519):
 //
 //	not-a-git-repo:      "Not a git repository, skipping check."  (exit 0)
-//	decision file staged: "✓ A decision log file is staged — changes are documented."
+//	decision written:    "✓ A decision log file is staged — changes are documented."
 //	under threshold:     "✓ N lines changed (below T-line threshold)."  (exit 0)
 //	over threshold:      multi-line warning, exit 1 unless --no-fail
-//
-// "Decision file" matches the Python predicate:
-//   - exact path "docs/decisions.md"
-//   - suffix "/decisions.md" (covers nested decisions.md)
-//   - prefix "docs/decisions-branches/" (per-branch decision files)
-//
-// The numstat-based LOC count REPLICATES the Python skip rules:
-//   - filepath beginning with "docs/" is skipped (not code, lives in docs)
-//   - "added == '-'" rows are binary files, skipped
-//   - rows that fail integer-parse are silently swallowed
 func newCheckDecisionsCmd() *cobra.Command {
-	var threshold int
-	var noFail bool
+	var opts checkDecisionsOpts
 	cmd := &cobra.Command{
 		Use:   "check-decisions",
 		Short: "Check that significant code changes have corresponding decision logs",
 		Long: `Check that significant code changes have corresponding decision logs.
 
-Designed for use as a git pre-commit hook. Exits with code 1 if staged
-changes exceed the line threshold without an update to docs/decisions.md.
+Evaluates the staged index by default, which is what a git pre-commit
+hook wants. Pass --base and --head together to evaluate a commit range
+instead — that is the CI shape, judging a pull request's diff against
+its base ref.
+
+Exits with code 1 when the change exceeds the line threshold without
+adding a well-formed decision entry. The threshold comes from
+git.commit_line_threshold in .logmind/config.yml (default 20);
+--threshold overrides it.
 
 To install as a pre-commit hook, run: logmind install-hook
 
 Examples:
     logmind check-decisions
     logmind check-decisions --threshold 50
-    logmind check-decisions --no-fail`,
+    logmind check-decisions --no-fail
+    logmind check-decisions --base origin/main --head HEAD`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
 			}
-			return runCheckDecisions(cwd, threshold, noFail, cmd.OutOrStdout())
+			opts.cwd = cwd
+			opts.thresholdExplicit = cmd.Flags().Changed("threshold")
+			return runCheckDecisions(opts, cmd.OutOrStdout())
 		},
 	}
-	cmd.Flags().IntVarP(&threshold, "threshold", "t", 20,
-		"Minimum lines changed to require a decision log entry (default: 20)")
-	cmd.Flags().BoolVar(&noFail, "no-fail", false,
+	cmd.Flags().IntVarP(&opts.threshold, "threshold", "t", 20,
+		"Minimum lines changed to require a decision log entry (default: git.commit_line_threshold, or 20)")
+	cmd.Flags().BoolVar(&opts.noFail, "no-fail", false,
 		"Warn but exit with code 0 (don't block the commit)")
+	cmd.Flags().StringVar(&opts.base, "base", "",
+		"Base ref of the range to evaluate (requires --head; default: evaluate the staged index)")
+	cmd.Flags().StringVar(&opts.head, "head", "",
+		"Head ref of the range to evaluate (requires --base)")
 	return cmd
+}
+
+// checkDecisionsOpts is runCheckDecisions' input. A struct rather than a
+// parameter list because base/head/threshold-explicitness pushed the
+// positional form past the point of being readable at a call site.
+type checkDecisionsOpts struct {
+	// cwd is the directory to evaluate from — resolved to the repo
+	// toplevel once inside runCheckDecisions and used for BOTH config and
+	// every git command, per SPEC §3.4's "an engine MUST resolve the
+	// repository root once and use that one answer."
+	cwd string
+	// threshold is the --threshold flag's value; thresholdExplicit says
+	// whether the user actually passed it. Unset means config decides.
+	threshold         int
+	thresholdExplicit bool
+	// noFail downgrades a failing check to a warning + exit 0.
+	noFail bool
+	// base and head select range mode. Both or neither.
+	base, head string
 }
 
 // runCheckDecisions is the testable core. Returns ErrSilent to
 // trigger exit 1 without cobra re-printing the message — mirrors
 // the Python sys.exit(1) shape.
-func runCheckDecisions(cwd string, threshold int, noFail bool, stdout io.Writer) error {
-	if !gitcli.IsRepo(cwd) {
+func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
+	rangeMode := opts.base != "" || opts.head != ""
+	if rangeMode && (opts.base == "" || opts.head == "") {
+		return fmt.Errorf("--base and --head must be given together")
+	}
+
+	if !gitcli.IsRepo(opts.cwd) {
 		// Python: click.echo(...) which goes to stdout, no exit.
 		fmt.Fprintln(stdout, "Not a git repository, skipping check.")
 		return nil
 	}
 
-	staged := gitcli.DiffCachedNames(cwd)
-	for _, f := range staged {
-		if guardcommit.IsDecisionFile(f) {
+	// One repository root for the config read AND every git command
+	// below. Resolving them separately is SPEC §3.4's named silent
+	// bypass: "configuration from where the process started, diffs from
+	// where the command ran — silently waves through every commit made
+	// from a subdirectory."
+	repoRoot := opts.cwd
+	if toplevel, ok := gitcli.TopLevel(opts.cwd); ok {
+		repoRoot = toplevel
+	}
+	cfg, _ := config.Load(repoRoot)
+	threshold := resolveThreshold(cfg, opts.threshold, opts.thresholdExplicit)
+
+	names, rows, err := collectCheckDiff(repoRoot, opts)
+	if err != nil {
+		return err
+	}
+
+	// SPEC §3.4: "A decision clears the gate by being written, not by
+	// existing. ... MUST NOT be satisfied by the decision file merely
+	// appearing in the diff." So we read what the change ADDED to each
+	// decision file and require a §3.1-shaped entry in it — a title, a
+	// timestamp, and non-empty reasoning. A touched-but-empty decision
+	// file falls through to the line count below, exactly as if it had
+	// not been touched.
+	for _, f := range names {
+		if !guardcommit.IsDecisionFile(f) {
+			continue
+		}
+		added, err := addedLines(repoRoot, f, opts)
+		if err != nil {
+			return err
+		}
+		if guardcommit.WellFormedDecisionAdded(added) {
 			fmt.Fprintln(stdout, "✓ A decision log file is staged — changes are documented.")
 			return nil
 		}
 	}
 
-	// LOC counting + the docs/-prefix and binary skip rules live in
-	// guardcommit.SubstantiveLines now — shared with `logmind
-	// guard-commit` (internal/guardcommit) so the two enforcement
-	// surfaces can never drift on what counts as "substantive." Mirrors
-	// the Python skip rules verbatim (cli.py:2498-2504).
-	total := guardcommit.SubstantiveLines(gitcli.DiffCachedNumstat(cwd))
+	// The exclusion table and the summing live in
+	// guardcommit.SubstantiveLines — shared with `logmind guard-commit`
+	// so the gate and the two local interception points can never drift
+	// on what counts as "substantive" (SPEC §3.4).
+	total := guardcommit.SubstantiveLines(rows)
 
 	if total >= threshold {
 		// Multi-line warning identical to Python click.secho block.
@@ -96,7 +170,7 @@ func runCheckDecisions(cwd string, threshold int, noFail bool, stdout io.Writer)
 		fmt.Fprintf(stdout, "⚠  %d lines changed without updating docs/decisions.md.\n", total)
 		fmt.Fprintln(stdout, "   Log this decision: logmind log \"Your decision here\"")
 		fmt.Fprintln(stdout, "   To skip this check: git commit --no-verify")
-		if !noFail {
+		if !opts.noFail {
 			return ErrSilent
 		}
 		return nil
@@ -104,4 +178,35 @@ func runCheckDecisions(cwd string, threshold int, noFail bool, stdout io.Writer)
 
 	fmt.Fprintf(stdout, "✓ %d lines changed (below %d-line threshold).\n", total, threshold)
 	return nil
+}
+
+// collectCheckDiff reads the changed paths and their numstat rows for
+// whichever scope opts selects: the staged index (the pre-commit hook
+// shape, and the default) or a base...head range (the CI shape).
+//
+// Range mode propagates git's error instead of degrading to an empty
+// diff. An unresolvable ref and an empty range produce the same zero
+// rows, and only one of them should let a pull request through.
+func collectCheckDiff(repoRoot string, opts checkDecisionsOpts) ([]string, []gitcli.NumstatLine, error) {
+	if opts.base == "" {
+		return gitcli.DiffCachedNames(repoRoot), gitcli.DiffCachedNumstat(repoRoot), nil
+	}
+	names, err := gitcli.DiffRangeNames(repoRoot, opts.base, opts.head)
+	if err != nil {
+		return nil, nil, err
+	}
+	rows, err := gitcli.DiffRangeNumstat(repoRoot, opts.base, opts.head)
+	if err != nil {
+		return nil, nil, err
+	}
+	return names, rows, nil
+}
+
+// addedLines returns the lines opts' scope ADDED to path, for the
+// well-formedness check above.
+func addedLines(repoRoot, path string, opts checkDecisionsOpts) ([]string, error) {
+	if opts.base == "" {
+		return gitcli.DiffCachedAddedLines(repoRoot, path), nil
+	}
+	return gitcli.DiffRangeAddedLines(repoRoot, opts.base, opts.head, path)
 }

--- a/internal/cli/check_decisions_test.go
+++ b/internal/cli/check_decisions_test.go
@@ -412,3 +412,54 @@ func revParse(t *testing.T, repo, ref string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+// TestCheckDecisions_RangeMode_RefusesLocalAllowances pins the BLOCKING
+// finding from PR #287's adversarial review. SPEC §3.4 lists six local
+// allowances and says of the gate: "every allowance above that depends on
+// local process state — the environment variable, a git operation in
+// progress, running outside a repository, a marker in a commit subject —
+// is invisible to it and MUST NOT be honoured there. Exactly two things
+// clear the gate."
+//
+// The not-a-repo arm ran BEFORE the range-mode split, so a gate invoked
+// from the wrong directory — `working-directory:` pointing off the
+// checkout, or `actions/checkout` with a `path:` — printed "skipping
+// check" and exited 0. Every pull request would have gone green
+// regardless of size, while reporting success.
+func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
+	t.Run("not a git repository is a hard error in range mode", func(t *testing.T) {
+		dir := t.TempDir() // deliberately not a git repo
+		var out bytes.Buffer
+		err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, base: "origin/main", head: "HEAD",
+		}, &out)
+		if err == nil {
+			t.Fatalf("range mode outside a repository returned nil (gate would pass); stdout=%q", out.String())
+		}
+	})
+
+	t.Run("not a git repository still skips gracefully in local mode", func(t *testing.T) {
+		dir := t.TempDir()
+		var out bytes.Buffer
+		if err := runCheckDecisions(checkDecisionsOpts{cwd: dir}, &out); err != nil {
+			t.Fatalf("local mode outside a repository must not error, got %v", err)
+		}
+		if !strings.Contains(out.String(), "Not a git repository") {
+			t.Errorf("local mode lost its skip message; got %q", out.String())
+		}
+	})
+
+	t.Run("--no-fail is refused in range mode", func(t *testing.T) {
+		dir := t.TempDir()
+		var out bytes.Buffer
+		err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, base: "a", head: "b", noFail: true,
+		}, &out)
+		if err == nil {
+			t.Fatal("--no-fail with --base/--head returned nil; it is a third thing clearing the gate")
+		}
+		if !strings.Contains(err.Error(), "--no-fail") {
+			t.Errorf("error should name the refused flag, got %v", err)
+		}
+	})
+}

--- a/internal/cli/check_decisions_test.go
+++ b/internal/cli/check_decisions_test.go
@@ -3,18 +3,34 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// wellFormedEntry is a decision entry that satisfies SPEC §3.4's gate
+// check — a title, a timestamp, and a reasoning section that is not
+// empty. Tests that mean "the change carries a decision" write this;
+// tests that mean "the file was merely touched" write something else.
+const wellFormedEntry = "## 2026-08-07 14:30 - Test decision\n\n" +
+	"**Reasoning:** The gate reads what a change wrote, not which files it named.\n\n" +
+	"---\n"
+
+// stagedOpts is the default check-decisions scope: the index, threshold
+// left to config (which defaults to 20).
+func stagedOpts(cwd string) checkDecisionsOpts {
+	return checkDecisionsOpts{cwd: cwd, threshold: 20}
+}
 
 // TestCheckDecisions_NotARepo asserts the early-skip path: not a git
 // repo → "Not a git repository, skipping check." + exit 0.
 func TestCheckDecisions_NotARepo(t *testing.T) {
 	dir := t.TempDir()
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(dir, 20, false, &stdout); err != nil {
+	if err := runCheckDecisions(stagedOpts(dir), &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_not_a_repo.golden", stdout.String())
@@ -25,7 +41,7 @@ func TestCheckDecisions_NotARepo(t *testing.T) {
 func TestCheckDecisions_NoChanges(t *testing.T) {
 	repo := initRepo(t)
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 20, false, &stdout); err != nil {
+	if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_clean.golden", stdout.String())
@@ -37,7 +53,7 @@ func TestCheckDecisions_OverThreshold(t *testing.T) {
 	repo := initRepo(t)
 	stageLines(t, repo, "source.txt", 25)
 	var stdout bytes.Buffer
-	err := runCheckDecisions(repo, 20, false, &stdout)
+	err := runCheckDecisions(stagedOpts(repo), &stdout)
 	if !errors.Is(err, ErrSilent) {
 		t.Fatalf("runCheckDecisions err = %v; want ErrSilent", err)
 	}
@@ -49,30 +65,23 @@ func TestCheckDecisions_OverThreshold(t *testing.T) {
 func TestCheckDecisions_OverThresholdNoFail(t *testing.T) {
 	repo := initRepo(t)
 	stageLines(t, repo, "source.txt", 25)
+	opts := stagedOpts(repo)
+	opts.noFail = true
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 20, true, &stdout); err != nil {
+	if err := runCheckDecisions(opts, &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_over_threshold_nofail.golden", stdout.String())
 }
 
-// TestCheckDecisions_DocsStaged stages docs/decisions.md — must be
-// recognised as documentation and short-circuit to the green path.
+// TestCheckDecisions_DocsStaged stages a well-formed docs/decisions.md
+// entry — must be recognised as a written decision and short-circuit to
+// the green path.
 func TestCheckDecisions_DocsStaged(t *testing.T) {
 	repo := initRepo(t)
-	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
-		t.Fatalf("mkdir docs: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(repo, "docs", "decisions.md"), []byte("decision\n"), 0o644); err != nil {
-		t.Fatalf("write decisions.md: %v", err)
-	}
-	cmd := exec.Command("git", "add", "docs/decisions.md")
-	cmd.Dir = repo
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git add: %v\n%s", err, out)
-	}
+	stageFile(t, repo, "docs/decisions.md", wellFormedEntry)
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 20, false, &stdout); err != nil {
+	if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_docs_staged.golden", stdout.String())
@@ -83,20 +92,9 @@ func TestCheckDecisions_DocsStaged(t *testing.T) {
 // recognised as a decision file.
 func TestCheckDecisions_BranchDecisionStaged(t *testing.T) {
 	repo := initRepo(t)
-	dir := filepath.Join(repo, "docs", "decisions-branches")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "feature.md"), []byte("decision\n"), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	cmd := exec.Command("git", "add", "docs/decisions-branches/feature.md")
-	cmd.Dir = repo
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git add: %v\n%s", err, out)
-	}
+	stageFile(t, repo, "docs/decisions-branches/feature.md", wellFormedEntry)
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 20, false, &stdout); err != nil {
+	if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	// Reuses the docs-staged golden — the success message is the same
@@ -109,8 +107,10 @@ func TestCheckDecisions_BranchDecisionStaged(t *testing.T) {
 func TestCheckDecisions_CustomThreshold(t *testing.T) {
 	repo := initRepo(t)
 	stageLines(t, repo, "source.txt", 25)
+	opts := stagedOpts(repo)
+	opts.threshold, opts.thresholdExplicit = 50, true
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 50, false, &stdout); err != nil {
+	if err := runCheckDecisions(opts, &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_under_threshold.golden", stdout.String())
@@ -121,30 +121,265 @@ func TestCheckDecisions_CustomThreshold(t *testing.T) {
 // changes don't represent decisions-being-made.
 func TestCheckDecisions_DocsLOCIsExempt(t *testing.T) {
 	repo := initRepo(t)
-	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
 	stageLines(t, repo, "docs/random.md", 25)
 	var stdout bytes.Buffer
-	if err := runCheckDecisions(repo, 20, false, &stdout); err != nil {
+	if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
 		t.Fatalf("runCheckDecisions: %v", err)
 	}
 	checkGolden(t, "check_decisions_clean.golden", stdout.String())
+}
+
+// --- SPEC §3.4 regression pins ----------------------------------------
+
+// TestCheckDecisions_TouchedButMalformedDecisionDoesNotClear is the pin
+// for §3.4: "A decision clears the gate by being written, not by
+// existing. ... MUST NOT be satisfied by the decision file merely
+// appearing in the diff. A test that asks only whether the file was
+// touched is passed by a single meaningless line."
+//
+// The old implementation returned green the moment ANY staged path
+// matched IsDecisionFile, so this exact input — one junk line in
+// docs/decisions.md alongside 25 lines of code — passed. It must now
+// fall through to the line count and fail.
+func TestCheckDecisions_TouchedButMalformedDecisionDoesNotClear(t *testing.T) {
+	repo := initRepo(t)
+	stageFile(t, repo, "docs/decisions.md", ".\n")
+	stageLines(t, repo, "source.txt", 25)
+	var stdout bytes.Buffer
+	err := runCheckDecisions(stagedOpts(repo), &stdout)
+	if !errors.Is(err, ErrSilent) {
+		t.Fatalf("runCheckDecisions err = %v; want ErrSilent — a touched-but-empty decision file must not clear the gate (got %q)", err, stdout.String())
+	}
+	checkGolden(t, "check_decisions_over_threshold.golden", stdout.String())
+}
+
+// TestCheckDecisions_ExcludedSurfacesDoNotCount walks SPEC §3.4's
+// exclusion table end-to-end through the verb, one path per row, at a
+// size that would otherwise trip the gate.
+func TestCheckDecisions_ExcludedSurfacesDoNotCount(t *testing.T) {
+	for _, path := range []string{
+		"docs/plan.md",                    // 1. everything under docs/
+		"AGENTS.md",                       // 2. the §1.1 instruction file
+		"CLAUDE.md",                       // 2. a §1.2 per-tool file
+		".github/copilot-instructions.md", // 2. a §1.2 per-tool file in a subdirectory
+		".logmind/config.yml",             // 3. the toolchain's own configuration
+	} {
+		t.Run(path, func(t *testing.T) {
+			repo := initRepo(t)
+			stageLines(t, repo, path, 25)
+			var stdout bytes.Buffer
+			if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
+				t.Fatalf("runCheckDecisions: %v (out: %q)", err, stdout.String())
+			}
+			checkGolden(t, "check_decisions_clean.golden", stdout.String())
+		})
+	}
+}
+
+// TestCheckDecisions_BinaryDoesNotCount pins exclusion 4 — "any file the
+// forge reports as binary ... a line count means nothing there." The
+// staged blob carries a NUL byte so git's numstat reports "-".
+func TestCheckDecisions_BinaryDoesNotCount(t *testing.T) {
+	repo := initRepo(t)
+	stageFile(t, repo, "assets/blob.bin", strings.Repeat("\x00\x01\x02\x03\n", 40))
+	var stdout bytes.Buffer
+	if err := runCheckDecisions(stagedOpts(repo), &stdout); err != nil {
+		t.Fatalf("runCheckDecisions: %v", err)
+	}
+	checkGolden(t, "check_decisions_clean.golden", stdout.String())
+}
+
+// TestCheckDecisions_MarkdownOutsideDocsCounts is the negative half of
+// the table, and the one that matters most. §3.4: "A skill file counts.
+// So does an agent definition. ... Excluding markdown wholesale switches
+// the rule off in the repositories where writing *is* the work."
+func TestCheckDecisions_MarkdownOutsideDocsCounts(t *testing.T) {
+	for _, path := range []string{
+		".claude/skills/logmind/SKILL.md",
+		".claude/agents/reviewer.md",
+		"README.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			repo := initRepo(t)
+			stageLines(t, repo, path, 25)
+			var stdout bytes.Buffer
+			err := runCheckDecisions(stagedOpts(repo), &stdout)
+			if !errors.Is(err, ErrSilent) {
+				t.Fatalf("runCheckDecisions err = %v; want ErrSilent — %s is not excluded by §3.4 (out: %q)", err, path, stdout.String())
+			}
+		})
+	}
+}
+
+// TestCheckDecisions_ThresholdFromConfig pins §3.4's "the threshold is
+// git.commit_line_threshold, and defaults to 20": with no --threshold
+// flag, the repo's config decides. 25 staged lines pass under a
+// configured 50 and fail under a configured 10.
+func TestCheckDecisions_ThresholdFromConfig(t *testing.T) {
+	cases := []struct {
+		configured int
+		wantFail   bool
+	}{
+		{configured: 50, wantFail: false},
+		{configured: 10, wantFail: true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("threshold_%d", tc.configured), func(t *testing.T) {
+			repo := initRepo(t)
+			writeConfig(t, repo, fmt.Sprintf("git:\n  commit_line_threshold: %d\n", tc.configured))
+			stageLines(t, repo, "source.txt", 25)
+			var stdout bytes.Buffer
+			err := runCheckDecisions(stagedOpts(repo), &stdout)
+			if tc.wantFail != errors.Is(err, ErrSilent) {
+				t.Fatalf("commit_line_threshold %d: err = %v, wantFail = %v (out: %q)",
+					tc.configured, err, tc.wantFail, stdout.String())
+			}
+			if !tc.wantFail && !strings.Contains(stdout.String(), fmt.Sprintf("below %d-line threshold", tc.configured)) {
+				t.Fatalf("output %q does not report the configured threshold %d", stdout.String(), tc.configured)
+			}
+		})
+	}
+}
+
+// TestCheckDecisions_ExplicitThresholdBeatsConfig keeps the documented
+// precedence: an explicit --threshold still overrides config.
+func TestCheckDecisions_ExplicitThresholdBeatsConfig(t *testing.T) {
+	repo := initRepo(t)
+	writeConfig(t, repo, "git:\n  commit_line_threshold: 10\n")
+	stageLines(t, repo, "source.txt", 25)
+	opts := stagedOpts(repo)
+	opts.threshold, opts.thresholdExplicit = 50, true
+	var stdout bytes.Buffer
+	if err := runCheckDecisions(opts, &stdout); err != nil {
+		t.Fatalf("runCheckDecisions: %v", err)
+	}
+	checkGolden(t, "check_decisions_under_threshold.golden", stdout.String())
+}
+
+// --- range mode (--base/--head), the CI shape -------------------------
+
+// TestCheckDecisions_RangeMode exercises the base...head scope the
+// check-decisions gate of §6.2 needs: a branch whose commits are already
+// made (nothing staged) is judged against its base ref.
+func TestCheckDecisions_RangeMode(t *testing.T) {
+	repo := initRepo(t)
+	base := revParse(t, repo, "HEAD")
+
+	stageLines(t, repo, "source.txt", 25)
+	commit(t, repo, "add source [skip-logmind]")
+	head := revParse(t, repo, "HEAD")
+
+	opts := stagedOpts(repo)
+	opts.base, opts.head = base, head
+	var stdout bytes.Buffer
+	err := runCheckDecisions(opts, &stdout)
+	if !errors.Is(err, ErrSilent) {
+		t.Fatalf("runCheckDecisions err = %v; want ErrSilent (out: %q)", err, stdout.String())
+	}
+	checkGolden(t, "check_decisions_over_threshold.golden", stdout.String())
+
+	// The staged index is empty, so today's default scope sees nothing —
+	// which is precisely why CI needs the range.
+	var staged bytes.Buffer
+	if err := runCheckDecisions(stagedOpts(repo), &staged); err != nil {
+		t.Fatalf("staged-scope runCheckDecisions: %v", err)
+	}
+	checkGolden(t, "check_decisions_clean.golden", staged.String())
+}
+
+// TestCheckDecisions_RangeModeDecisionClears — the same range, with a
+// well-formed decision committed alongside the code, clears.
+func TestCheckDecisions_RangeModeDecisionClears(t *testing.T) {
+	repo := initRepo(t)
+	base := revParse(t, repo, "HEAD")
+
+	stageLines(t, repo, "source.txt", 25)
+	stageFile(t, repo, "docs/decisions-branches/feature.md", wellFormedEntry)
+	commit(t, repo, "add source with a decision [skip-logmind]")
+
+	opts := stagedOpts(repo)
+	opts.base, opts.head = base, revParse(t, repo, "HEAD")
+	var stdout bytes.Buffer
+	if err := runCheckDecisions(opts, &stdout); err != nil {
+		t.Fatalf("runCheckDecisions: %v (out: %q)", err, stdout.String())
+	}
+	checkGolden(t, "check_decisions_docs_staged.golden", stdout.String())
+}
+
+// TestCheckDecisions_RangeModeMalformedDecisionDoesNotClear — the gate's
+// well-formedness check applies to the range scope too, reading the
+// lines the range ADDED rather than the file's whole contents. The
+// decision file here already holds a valid entry from before the base,
+// and the range adds only junk to it.
+func TestCheckDecisions_RangeModeMalformedDecisionDoesNotClear(t *testing.T) {
+	repo := initRepo(t)
+	stageFile(t, repo, "docs/decisions-branches/feature.md", wellFormedEntry)
+	commit(t, repo, "seed the decision file [skip-logmind]")
+	base := revParse(t, repo, "HEAD")
+
+	stageFile(t, repo, "docs/decisions-branches/feature.md", wellFormedEntry+".\n")
+	stageLines(t, repo, "source.txt", 25)
+	commit(t, repo, "append junk [skip-logmind]")
+
+	opts := stagedOpts(repo)
+	opts.base, opts.head = base, revParse(t, repo, "HEAD")
+	var stdout bytes.Buffer
+	err := runCheckDecisions(opts, &stdout)
+	if !errors.Is(err, ErrSilent) {
+		t.Fatalf("runCheckDecisions err = %v; want ErrSilent — a pre-existing entry must not clear a range that added none (out: %q)", err, stdout.String())
+	}
+	checkGolden(t, "check_decisions_over_threshold.golden", stdout.String())
+}
+
+// TestCheckDecisions_RangeModeBadRefFails — an unresolvable ref must be
+// reported, not silently counted as an empty diff. "git couldn't resolve
+// the range" and "the range changed nothing" produce identical numbers,
+// and only one of them should let a pull request through.
+func TestCheckDecisions_RangeModeBadRefFails(t *testing.T) {
+	repo := initRepo(t)
+	opts := stagedOpts(repo)
+	opts.base, opts.head = "no-such-ref", "HEAD"
+	var stdout bytes.Buffer
+	if err := runCheckDecisions(opts, &stdout); err == nil {
+		t.Fatalf("runCheckDecisions returned nil for an unresolvable base ref (out: %q)", stdout.String())
+	}
+}
+
+// TestCheckDecisions_RangeModeRequiresBothRefs — half a range is a usage
+// error, not a silent fallback to the staged scope.
+func TestCheckDecisions_RangeModeRequiresBothRefs(t *testing.T) {
+	repo := initRepo(t)
+	for _, opts := range []checkDecisionsOpts{
+		{cwd: repo, threshold: 20, base: "HEAD"},
+		{cwd: repo, threshold: 20, head: "HEAD"},
+	} {
+		var stdout bytes.Buffer
+		if err := runCheckDecisions(opts, &stdout); err == nil {
+			t.Fatalf("runCheckDecisions(%+v) = nil; want a usage error", opts)
+		}
+	}
 }
 
 // stageLines writes `count` lines of "line N\n" to `name` inside
 // repo, then `git add` it.
 func stageLines(t *testing.T, repo, name string, count int) {
 	t.Helper()
-	full := filepath.Join(repo, name)
-	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
 	var b bytes.Buffer
 	for i := 1; i <= count; i++ {
 		b.WriteString("line\n")
 	}
-	if err := os.WriteFile(full, b.Bytes(), 0o644); err != nil {
+	stageFile(t, repo, name, b.String())
+}
+
+// stageFile writes body to `name` inside repo (creating parents) and
+// `git add`s it.
+func stageFile(t *testing.T, repo, name, body string) {
+	t.Helper()
+	full := filepath.Join(repo, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	cmd := exec.Command("git", "add", name)
@@ -152,4 +387,28 @@ func stageLines(t *testing.T, repo, name string, count int) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git add %s: %v\n%s", name, err, out)
 	}
+}
+
+// commit records whatever is staged. The subject carries
+// [skip-logmind] so a developer machine with logmind's own commit-msg
+// hook installed globally can't interfere — these repos are t.TempDir()
+// scratch and the hook is not what's under test here.
+func commit(t *testing.T, repo, subject string) {
+	t.Helper()
+	cmd := exec.Command("git", "commit", "-q", "-m", subject)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+}
+
+func revParse(t *testing.T, repo, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s: %v", ref, err)
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -248,8 +248,26 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	// flag, but warn so agents get the nudge. We don't error out:
 	// log_first_decision passes reasoning, and follow-up logs often
 	// only carry a summary in scripted use.
+	//
+	// The warning names the GATE, not just the lost value, because the
+	// consequence is now concrete: SPEC §3.4 requires `check-decisions`
+	// to reject an entry whose reasoning section is empty ("A decision
+	// clears the gate by being written, not by existing"). So a
+	// reasoning-less entry does not merely lose value — it fails to
+	// clear the merge gate for any change over the threshold, and the
+	// author finds out in CI rather than here.
+	//
+	// Deliberately still a warning and not an error. SPEC §3.1 says an
+	// entry "MUST carry a title and a timestamp, and SHOULD carry the
+	// reasoning", and states outright that "an entry of title plus `---`
+	// is well-formed" — so refusing to write one would over-implement
+	// the record format. §3.1 and §3.4 disagree about this; raised as
+	// thrillmade/protocol#93. Until that resolves, logmind writes what
+	// §3.1 permits and warns about what §3.4 will do to it.
 	if strings.TrimSpace(f.reasoning) == "" {
-		fmt.Fprintln(stderr, "Warning: -r/--reasoning is empty. Decision logs without reasoning lose most of their value.")
+		fmt.Fprintln(stderr, "Warning: -r/--reasoning is empty. Decision logs without reasoning lose most of their value,")
+		fmt.Fprintln(stderr, "         and the check-decisions gate rejects a reasoning-less entry (SPEC §3.4) — so this")
+		fmt.Fprintln(stderr, "         entry will NOT clear CI for a change above the line threshold.")
 	}
 
 	cfg, _ := config.Load(cwd)

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -255,6 +255,137 @@ func DiffNumstat(repoRoot string) []NumstatLine {
 	return parseNumstat(stdout.String())
 }
 
+// rangeSpec renders the three-dot range `check-decisions --base/--head`
+// evaluates: base...head is the diff of head against the MERGE BASE of
+// the two, which is what a pull request actually proposes to add. A
+// two-dot range would also attribute everything that landed on base
+// since the branch forked, failing a PR for its neighbours' lines.
+func rangeSpec(base, head string) string { return base + "..." + head }
+
+// DiffRangeNames returns the file paths a base...head range touches
+// (`git diff --name-only base...head`).
+//
+// Unlike DiffCachedNames this reports an ERROR rather than degrading to
+// an empty slice. Its caller is the `check-decisions` gate, which is the
+// point that actually blocks a merge (SPEC §3.4) — a bad ref there must
+// fail loudly, because "git couldn't resolve the range" and "the range
+// changed nothing" are the same empty result and only one of them should
+// let a pull request through.
+func DiffRangeNames(repoRoot, base, head string) ([]string, error) {
+	out, err := runDiffRange(repoRoot, base, head, "--name-only")
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimRight(out, "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+// DiffRangeNumstat parses `git diff --numstat base...head` into typed
+// rows. Same parsing rules as DiffCachedNumstat, same loud-on-failure
+// contract as DiffRangeNames.
+//
+// The flags deliberately match DiffCachedNumstat's exactly (i.e. none
+// beyond --numstat): SPEC §3.4 drives every enforcement point from "one
+// shared evaluation," and a flag one surface passes and another doesn't
+// is that evaluation quietly becoming two.
+func DiffRangeNumstat(repoRoot, base, head string) ([]NumstatLine, error) {
+	out, err := runDiffRange(repoRoot, base, head, "--numstat")
+	if err != nil {
+		return nil, err
+	}
+	return parseNumstat(out), nil
+}
+
+// DiffCachedAddedLines returns the lines the staged diff ADDS to one
+// path, with git's leading "+" stripped. Nil on any failure, matching
+// its DiffCached* siblings.
+//
+// -U0 asks for no context lines, so every "+" line inside a hunk is
+// genuinely new content rather than an unchanged neighbour. Callers use
+// this to judge what a change WROTE to a file, not what the file
+// contains — SPEC §3.4: "A decision clears the gate by being written,
+// not by existing."
+func DiffCachedAddedLines(repoRoot, path string) []string {
+	cmd := exec.Command("git", "diff", "--cached", "-U0", "--", path)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	return parseAddedLines(stdout.String())
+}
+
+// DiffRangeAddedLines is DiffCachedAddedLines over a base...head range,
+// with DiffRangeNames' loud-on-failure contract.
+func DiffRangeAddedLines(repoRoot, base, head, path string) ([]string, error) {
+	out, err := runDiffRange(repoRoot, base, head, "-U0", "--", path)
+	if err != nil {
+		return nil, err
+	}
+	return parseAddedLines(out), nil
+}
+
+// runDiffRange runs `git diff <flags...> base...head` (with the range
+// inserted ahead of any pathspec the caller passed after "--") and
+// returns stdout. Shared by the three DiffRange* wrappers so the range
+// spelling and the error shape live in one place.
+func runDiffRange(repoRoot, base, head string, flags ...string) (string, error) {
+	args := []string{"diff"}
+	spec := rangeSpec(base, head)
+	inserted := false
+	for _, f := range flags {
+		if f == "--" && !inserted {
+			args = append(args, spec)
+			inserted = true
+		}
+		args = append(args, f)
+	}
+	if !inserted {
+		args = append(args, spec)
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", ErrGitNotFound
+		}
+		return "", &GitError{Op: "diff " + spec, Err: err, Stderr: stderr.String()}
+	}
+	return stdout.String(), nil
+}
+
+// parseAddedLines pulls the added-content lines out of a unified diff,
+// stripping the leading "+".
+//
+// It tracks hunk state rather than filtering on a "+++" prefix: a real
+// added line whose own content begins with "++" renders as "+++...", so
+// a prefix test would silently drop it. Only lines after a "@@" header
+// are content; a "diff --git" line starts the next file's header block
+// and ends the current one.
+func parseAddedLines(out string) []string {
+	var lines []string
+	inHunk := false
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			inHunk = false
+		case strings.HasPrefix(line, "@@ "):
+			inHunk = true
+		case inHunk && strings.HasPrefix(line, "+"):
+			lines = append(lines, strings.TrimPrefix(line, "+"))
+		}
+	}
+	return lines
+}
+
 // UntrackedFiles returns the repo-relative paths of every untracked
 // file (`git status --porcelain -z --untracked-files=all`, "??" rows).
 // `--untracked-files=all` expands untracked directories to their

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -290,6 +290,19 @@ func WellFormedDecisionAdded(added []string) bool {
 // `logmind log` writes) or on the lines that follow it up to the first
 // blank line (a hand-written entry that wrapped). A marker with neither
 // is an empty section and does not count.
+//
+// A section also ends at the NEXT section header, not only at a blank
+// line. §3.1's entry format separates sections with a blank line, but an
+// entry that omits it is still an entry a consumer "MUST treat ... as
+// absent rather than as a parse error" — and without this the following
+// header's own text is swallowed as the previous section's body, so
+//
+//	**Reasoning:**
+//	**Alternatives considered:** none
+//
+// reads as non-empty reasoning when §3.1 defines it as an empty section.
+// That is the "single meaningless line" §3.4 rejects, one blank line away
+// from being caught.
 func hasReasoning(raw string) bool {
 	lines := strings.Split(raw, "\n")
 	for i, line := range lines {
@@ -298,16 +311,39 @@ func hasReasoning(raw string) bool {
 		}
 		body := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), reasoningMarker))
 		for _, next := range lines[i+1:] {
-			if strings.TrimSpace(next) == "" {
+			trimmed := strings.TrimSpace(next)
+			if trimmed == "" || isSectionHeader(trimmed) || trimmed == entryTerminator {
 				break
 			}
-			body += strings.TrimSpace(next)
+			body += trimmed
 		}
 		if body != "" {
 			return true
 		}
 	}
 	return false
+}
+
+// entryTerminator is the `---` that ends an entry per SPEC §3.1 ("`---`
+// terminating the entry"). Reasoning cannot run past it.
+const entryTerminator = "---"
+
+// isSectionHeader reports whether a trimmed line opens a new §3.1 section
+// — a bolded label, e.g. `**Alternatives considered:**`. Deliberately
+// shape-based rather than a fixed list of the known section names: §3.1
+// says a consumer "MUST NOT require a section order", and a hand-written
+// entry may carry a section this build has never heard of. Anything that
+// opens a bold run and carries a colon terminates the previous section.
+func isSectionHeader(trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "**") {
+		return false
+	}
+	rest := trimmed[2:]
+	end := strings.Index(rest, "**")
+	if end < 0 {
+		return false
+	}
+	return strings.Contains(rest[:end], ":")
 }
 
 // docsPrefix and configPrefix are the two directory exclusions of SPEC

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -31,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitcli"
 )
 
@@ -246,25 +248,143 @@ func IsDecisionFile(path string) bool {
 	return false
 }
 
-// SubstantiveLines sums added+removed lines across rows, applying the same
-// skip rules check-decisions has always used (moved verbatim from
-// internal/cli/check_decisions.go's runCheckDecisions loop):
+// reasoningMarker opens SPEC §3.1's reasoning section. §3.1 lets a
+// producer omit an empty section's header entirely, so a marker present
+// with nothing under it is malformed, not merely sparse.
+const reasoningMarker = "**Reasoning:**"
+
+// WellFormedDecisionAdded reports whether the lines a diff ADDED to a
+// decision file carry an entry well-formed enough to clear the
+// `check-decisions` gate.
 //
-//   - a row whose Path starts with "docs/" is skipped (documentation
-//     changes aren't the kind of decision this gate is watching for)
+// SPEC §3.4: "A decision clears the gate by being written, not by
+// existing. The gate MUST check that the added entry is well-formed under
+// §3.1 — a title, a timestamp, and a reasoning section that is not empty
+// — and MUST NOT be satisfied by the decision file merely appearing in
+// the diff. A test that asks only whether the file was touched is passed
+// by a single meaningless line."
+//
+// added is the diff's added lines with git's leading "+" already
+// stripped, in file order. Title and timestamp come free from
+// decisions.SplitRawBytes, which only opens an entry on a line matching
+// `## YYYY-MM-DD HH:MM - <title>` whose date/time actually parses — the
+// same boundary rule every other reader in this codebase uses. This
+// function adds §3.4's one extra requirement on top: non-empty reasoning.
+//
+// Note this is shape, not quality — §3.4 is explicit that "a determined
+// author can still write three plausible sentences that explain nothing,
+// and no gate can catch that." What it removes is the version that costs
+// nothing.
+func WellFormedDecisionAdded(added []string) bool {
+	_, entries := decisions.SplitRawBytes(strings.Join(added, "\n"))
+	for _, e := range entries {
+		if hasReasoning(e.Raw) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasReasoning reports whether raw carries a reasoningMarker section with
+// content under it. Content may sit on the marker's own line (what
+// `logmind log` writes) or on the lines that follow it up to the first
+// blank line (a hand-written entry that wrapped). A marker with neither
+// is an empty section and does not count.
+func hasReasoning(raw string) bool {
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), reasoningMarker) {
+			continue
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), reasoningMarker))
+		for _, next := range lines[i+1:] {
+			if strings.TrimSpace(next) == "" {
+				break
+			}
+			body += strings.TrimSpace(next)
+		}
+		if body != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// docsPrefix and configPrefix are the two directory exclusions of SPEC
+// §3.4's table: the decision record plus the documents derived from it,
+// and the toolchain's own configuration.
+const (
+	docsPrefix   = "docs/"
+	configPrefix = ".logmind/"
+)
+
+// instructionFile is SPEC §1.1's single instruction file, named in its
+// own right by §3.4's table alongside "the per-tool files of §1.2". The
+// §1.2 set is NOT listed here — it comes from agents.FilePatterns(), the
+// registry that writes those files (see excludedFiles).
+const instructionFile = "AGENTS.md"
+
+// excludedFiles is the exact-match half of §3.4's exclusion table:
+// AGENTS.md plus every per-tool file of §1.2, derived from the agents
+// registry so the two can't disagree. Codex's registry entry is also
+// "AGENTS.md" (§1.2 lists it as reading the instruction file directly),
+// so the two sources overlap by one — harmless for a set.
+var excludedFiles = func() map[string]bool {
+	set := map[string]bool{instructionFile: true}
+	for _, p := range agents.FilePatterns() {
+		set[p] = true
+	}
+	return set
+}()
+
+// IsExcludedPath reports whether a repo-root-relative path is excluded
+// from the substantive-line count by SPEC §3.4's table. Three of the four
+// exclusions are path rules:
+//
+//   - everything under "docs/" — the decision record and the documents
+//     derived from it
+//   - AGENTS.md and the per-tool files of §1.2 — "a refresh rewrites
+//     these, carrying no decision of its own"
+//   - ".logmind/", the toolchain's own configuration — same reason
+//
+// The fourth ("any file the forge reports as binary") is not a path rule
+// at all: it's git's numstat "-" marker, which SubstantiveLines skips
+// separately.
+//
+// §3.4 says "four things are excluded from the count, and NOTHING ELSE
+// IS." In particular markdown is NOT excluded merely for being markdown:
+// "A skill file counts. So does an agent definition. ... Excluding
+// markdown wholesale switches the rule off in the repositories where
+// writing *is* the work." Do not add a "*.md" arm here.
+func IsExcludedPath(path string) bool {
+	if strings.HasPrefix(path, docsPrefix) || strings.HasPrefix(path, configPrefix) {
+		return true
+	}
+	return excludedFiles[path]
+}
+
+// SubstantiveLines sums added+removed lines across rows, applying SPEC
+// §3.4's exclusion table:
+//
+//   - a row whose Path is excluded by IsExcludedPath is skipped
 //   - a row with Added == "-" is a binary file (git's numstat marker) and
-//     is skipped
+//     is skipped — §3.4's fourth exclusion, "a line count means nothing
+//     there"
 //   - a row that fails to parse as integers is silently swallowed
+//     (inherited from the Python original; not a SPEC rule)
 //
 // Taking a flat []gitcli.NumstatLine (rather than a repoRoot + diff mode)
 // is deliberate: it lets WorkingTreeUnion feed rows from three different
 // git commands (staged, unstaged-tracked, untracked) through the exact
 // same skip logic as StagedOnly's single source, with no risk of the two
-// modes' counting rules drifting apart.
+// modes' counting rules drifting apart. The `check-decisions` gate
+// (internal/cli/check_decisions.go) feeds it a base...head range through
+// the same function for the same reason — §3.4: "driven by one shared
+// evaluation so they cannot disagree."
 func SubstantiveLines(rows []gitcli.NumstatLine) int {
 	total := 0
 	for _, row := range rows {
-		if strings.HasPrefix(row.Path, "docs/") {
+		if IsExcludedPath(row.Path) {
 			continue
 		}
 		if row.Added == "-" {

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/agents"
 	"github.com/thrillmade/logmind/internal/gitcli"
 )
 
@@ -416,5 +417,178 @@ func TestSubstantiveLines_SkipsDocsAndBinaryAndUnparseable(t *testing.T) {
 	want := 10 + 2 + 3 + 1
 	if got != want {
 		t.Fatalf("SubstantiveLines = %d; want %d", got, want)
+	}
+}
+
+// --- SPEC §3.4's exclusion table, one case per row --------------------
+//
+// "Four things are excluded from the count, and nothing else is."
+// Everything below is a regression PIN, not incidental coverage: each
+// row is a rule the SPEC states, and a change that flips one has changed
+// what the gate enforces.
+
+// TestIsExcludedPath_DocsTree pins exclusion 1 — "everything under
+// docs/", the decision record and the documents derived from it.
+func TestIsExcludedPath_DocsTree(t *testing.T) {
+	for _, p := range []string{
+		"docs/plan.md",
+		"docs/timeline.md",
+		"docs/decisions-branches/feature__x.md",
+		"docs/nested/deep/thing.go",
+	} {
+		if !IsExcludedPath(p) {
+			t.Errorf("IsExcludedPath(%q) = false; want true (SPEC §3.4: everything under docs/)", p)
+		}
+	}
+}
+
+// TestIsExcludedPath_InstructionAndPerToolFiles pins exclusion 2 —
+// AGENTS.md and the per-tool files of SPEC §1.2. The expected set is
+// read from the agents registry rather than retyped here, because a
+// second copy of the list is exactly the defect §3.4 warns about ("two
+// lists that mean the same thing are two lists that will disagree") and
+// a test that carries its own copy would pass while the two drifted.
+func TestIsExcludedPath_InstructionAndPerToolFiles(t *testing.T) {
+	if !IsExcludedPath("AGENTS.md") {
+		t.Errorf("IsExcludedPath(%q) = false; want true (SPEC §1.1 instruction file)", "AGENTS.md")
+	}
+	patterns := agents.FilePatterns()
+	if len(patterns) == 0 {
+		t.Fatal("agents.FilePatterns() is empty — the exclusion set has no source")
+	}
+	for _, p := range patterns {
+		if !IsExcludedPath(p) {
+			t.Errorf("IsExcludedPath(%q) = false; want true (SPEC §1.2 per-tool file)", p)
+		}
+	}
+}
+
+// TestIsExcludedPath_ToolchainConfig pins exclusion 3 — "the toolchain's
+// own configuration."
+func TestIsExcludedPath_ToolchainConfig(t *testing.T) {
+	for _, p := range []string{".logmind/config.yml", ".logmind/nested/whatever.yml"} {
+		if !IsExcludedPath(p) {
+			t.Errorf("IsExcludedPath(%q) = false; want true (SPEC §3.4: the toolchain's own configuration)", p)
+		}
+	}
+}
+
+// TestSubstantiveLines_BinaryRowsExcluded pins exclusion 4 — "any file
+// the forge reports as binary," which git's numstat marks with "-"
+// rather than a count. It is a numstat rule, not a path rule, so it
+// lives on SubstantiveLines and not on IsExcludedPath.
+func TestSubstantiveLines_BinaryRowsExcluded(t *testing.T) {
+	if IsExcludedPath("assets/logo.png") {
+		t.Error("IsExcludedPath(\"assets/logo.png\") = true; binary is a numstat rule, not a path rule")
+	}
+	rows := []gitcli.NumstatLine{{Added: "-", Removed: "-", Path: "assets/logo.png"}}
+	if got := SubstantiveLines(rows); got != 0 {
+		t.Fatalf("SubstantiveLines(binary row) = %d; want 0", got)
+	}
+}
+
+// TestSubstantiveLines_MarkdownOutsideDocsCounts is the load-bearing
+// negative of the table: markdown is NOT excluded for being markdown.
+//
+// SPEC §3.4: "A skill file counts. So does an agent definition. ...
+// Excluding markdown wholesale switches the rule off in the repositories
+// where writing *is* the work." The `*.md` arm the CI workflow carries
+// today is the bug this pins against.
+func TestSubstantiveLines_MarkdownOutsideDocsCounts(t *testing.T) {
+	rows := []gitcli.NumstatLine{
+		{Added: "40", Removed: "0", Path: ".claude/skills/logmind/SKILL.md"},
+		{Added: "30", Removed: "0", Path: ".claude/agents/reviewer.md"},
+		{Added: "20", Removed: "0", Path: "README.md"},
+		{Added: "10", Removed: "0", Path: ".github/PULL_REQUEST_TEMPLATE.md"},
+	}
+	for _, row := range rows {
+		if IsExcludedPath(row.Path) {
+			t.Errorf("IsExcludedPath(%q) = true; want false — markdown outside docs/ counts (SPEC §3.4)", row.Path)
+		}
+	}
+	if got, want := SubstantiveLines(rows), 100; got != want {
+		t.Fatalf("SubstantiveLines = %d; want %d", got, want)
+	}
+}
+
+// --- §3.4's well-formedness requirement on the gate -------------------
+
+// TestWellFormedDecisionAdded pins "a decision clears the gate by being
+// written, not by existing": title + timestamp + non-empty reasoning in
+// the lines the diff ADDED, and nothing less.
+func TestWellFormedDecisionAdded(t *testing.T) {
+	cases := []struct {
+		name  string
+		added []string
+		want  bool
+	}{
+		{
+			name: "complete entry",
+			added: []string{
+				"## 2026-08-07 14:30 - Share one evaluation",
+				"",
+				"**Reasoning:** Two lists that mean the same thing will disagree.",
+				"",
+				"---",
+			},
+			want: true,
+		},
+		{
+			// The shape §3.4 names outright: "a test that asks only
+			// whether the file was touched is passed by a single
+			// meaningless line."
+			name:  "single meaningless line",
+			added: []string{"."},
+			want:  false,
+		},
+		{
+			name:  "header only, no reasoning",
+			added: []string{"## 2026-08-07 14:30 - Untitled thought", "", "---"},
+			want:  false,
+		},
+		{
+			name:  "reasoning header with nothing under it",
+			added: []string{"## 2026-08-07 14:30 - Empty", "", "**Reasoning:**", "", "---"},
+			want:  false,
+		},
+		{
+			name:  "reasoning without a decision header",
+			added: []string{"**Reasoning:** orphaned prose with no entry above it"},
+			want:  false,
+		},
+		{
+			name:  "malformed timestamp",
+			added: []string{"## 2026-13-45 99:99 - Bad clock", "", "**Reasoning:** nope.", "", "---"},
+			want:  false,
+		},
+		{
+			name:  "no seconds allowed — §3.1 forbids them, so the header is not one",
+			added: []string{"## 2026-08-07 14:30:11 - Seconds", "", "**Reasoning:** nope.", "", "---"},
+			want:  false,
+		},
+		{
+			name:  "nothing added at all",
+			added: nil,
+			want:  false,
+		},
+		{
+			name: "reasoning wrapped onto the following line",
+			added: []string{
+				"## 2026-08-07 14:30 - Wrapped",
+				"",
+				"**Reasoning:**",
+				"the prose starts on the next line instead.",
+				"",
+				"---",
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WellFormedDecisionAdded(tc.added); got != tc.want {
+				t.Fatalf("WellFormedDecisionAdded(%q) = %v; want %v", tc.added, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -592,3 +592,72 @@ func TestWellFormedDecisionAdded(t *testing.T) {
 		})
 	}
 }
+
+// TestHasReasoning_SectionEndsAtNextHeader pins the hole an adversarial
+// review found in PR #287: the body accumulator stopped only at a blank
+// line, so an entry whose next section header is NOT blank-separated had
+// that header's own text swallowed as the previous section's body —
+// making an empty **Reasoning:** read as non-empty. SPEC §3.1 defines
+// that shape as an empty section, and §3.4 rejects exactly this "single
+// meaningless line". One blank line was all that separated a caught case
+// from an uncaught one.
+func TestHasReasoning_SectionEndsAtNextHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{
+			name: "empty reasoning, next header not blank-separated",
+			raw:  "## 2026-08-07 10:00 - t\n\n**Reasoning:**\n**Alternatives considered:** none\n\n---\n",
+			want: false,
+		},
+		{
+			name: "empty reasoning, entry terminator immediately after",
+			raw:  "## 2026-08-07 10:00 - t\n\n**Reasoning:**\n---\n",
+			want: false,
+		},
+		{
+			name: "real reasoning on the marker line",
+			raw:  "## 2026-08-07 10:00 - t\n\n**Reasoning:** because\n\n---\n",
+			want: true,
+		},
+		{
+			name: "real reasoning wrapped onto following lines",
+			raw:  "## 2026-08-07 10:00 - t\n\n**Reasoning:**\nit wrapped onto\nthe next line\n\n---\n",
+			want: true,
+		},
+		{
+			name: "wrapped reasoning still ends at an unseparated next header",
+			raw:  "## 2026-08-07 10:00 - t\n\n**Reasoning:**\nreal content\n**Implications:** x\n\n---\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasReasoning(tc.raw); got != tc.want {
+				t.Errorf("hasReasoning() = %v, want %v\nraw:\n%s", got, tc.want, tc.raw)
+			}
+		})
+	}
+}
+
+// TestIsSectionHeader covers the shape test directly. It is deliberately
+// shape-based rather than a fixed list of known section names, because
+// SPEC §3.1 says a consumer "MUST NOT require a section order beyond the
+// title coming first" — a hand-written entry may carry a section this
+// build has never heard of.
+func TestIsSectionHeader(t *testing.T) {
+	yes := []string{"**Reasoning:**", "**Alternatives considered:** none", "**Anything At All:**"}
+	no := []string{"", "plain text", "**bold but no colon**", "*single star:*", "**unterminated:"}
+	for _, s := range yes {
+		if !isSectionHeader(s) {
+			t.Errorf("isSectionHeader(%q) = false, want true", s)
+		}
+	}
+	for _, s := range no {
+		if isSectionHeader(s) {
+			t.Errorf("isSectionHeader(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/templates/github/check-decisions.yml.template
+++ b/internal/templates/github/check-decisions.yml.template
@@ -1,10 +1,34 @@
-# logmind-template-version: v4
+# logmind-template-version: v5
 name: logmind / check-decisions
 
-# Fail PRs that introduce >20 lines of non-docs code changes without
-# updating docs/decisions.md or a docs/decisions-branches/<branch>.md file.
-# Mirrors the local `logmind check-decisions` pre-commit hook but against
-# the PR diff. Installed by `logmind init`.
+# SPEC §6.2's `check-decisions` gate — the third interception point of
+# §3.4, and the one that actually blocks a merge. Installed by
+# `logmind init`.
+#
+# v5: this workflow no longer decides anything. It calls
+# `logmind check-decisions --base <base sha> --head <head sha>`, the same
+# verb (and the same evaluation) the commit-msg and harness hooks run
+# locally. §3.4: "Both interception points and the gate MUST use this one
+# list. Two lists that mean the same thing are two lists that will
+# disagree." v4's bash WAS the second list, and it had drifted five ways:
+#
+#   1. it excluded `*.md` wholesale — §3.4 forbids that outright:
+#      "Excluding markdown wholesale switches the rule off in the
+#      repositories where writing is the work." A skill file counts.
+#   2. it read the PR title for a `[skip-logmind]` override — §3.4: "The
+#      gate has no self-service escape, and MUST NOT be given one." The
+#      only route past is the ruleset bypass of §6.6, which belongs to
+#      people. The title read is gone, not relocated.
+#   3. it passed any PR whose diff merely TOUCHED a decision file — §3.4:
+#      a decision "clears the gate by being written, not by existing",
+#      and the gate "MUST NOT be satisfied by the decision file merely
+#      appearing in the diff." The verb checks §3.1 shape instead.
+#   4. it hardcoded the threshold at 20 and never read
+#      `git.commit_line_threshold`, so raising the key in config moved
+#      the local hooks and left the gate where it was.
+#   5. it carried its own copy of the exclusion list.
+#
+# All five die the same way: the bash stops deciding anything.
 
 on:
   pull_request:
@@ -12,93 +36,80 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read # fetch the live PR title (Enforce step) so a retitle+rerun honors [skip-logmind]
+  # `contents: read` and nothing else. v4 also took `pull-requests: read`,
+  # solely for the `gh pr view` title fetch behind the removed override;
+  # with that gone, no step here touches pull-request data through the API.
 
 jobs:
   check-decisions:
+    name: check-decisions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # The WORKSPACE is the base ref, deliberately — never the PR's own
+      # content. §6.3: "Anything that decides whether a change may merge —
+      # the ruleset, a repository's configuration (§1.6), a gating
+      # workflow's own logic — MUST be read from the pull request's base
+      # ref. Never from the head ref, and never from a workspace populated
+      # with the pull request's content." The threshold this gate enforces
+      # is `git.commit_line_threshold` in .logmind/config.yml, so a default
+      # (merge-ref) checkout would let a PR raise its own threshold in the
+      # very diff being judged. The PR's content is read only as git
+      # objects, through the range passed to the verb below.
+      - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
-      - name: Compute diff vs base
-        id: diff
+      # The base checkout carries the base branch's history; the range also
+      # needs the PR's head commit, which for a fork PR sits on no branch
+      # of this repository. `refs/pull/N/head` reaches it either way. If
+      # this fetch fails the range is unresolvable and the job goes red —
+      # §6.5: a gate that cannot run says so, rather than exiting green.
+      # This leans on checkout's default `persist-credentials: true` for
+      # origin's auth header; turning that off above would break fork PRs
+      # here while same-repo PRs (whose head is already under refs/heads/*)
+      # kept passing, which is the worst way for it to break.
+      - name: Fetch the PR head commit
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+
+      # A RELEASED binary from a pinned action — never one built from the
+      # checkout above. §6.3: "a gate is never satisfiable by the change it
+      # judges", and a pull request that can rebuild the binary judging it
+      # has rewritten its own gate: a one-line edit to the exclusion table
+      # would pass itself. Dependabot bumps this pin (see the
+      # `.github/dependabot.yml` block `logmind init` installs), so the gate
+      # tracks releases without any PR getting a say in which binary runs.
+      # `token:` is REQUIRED — composite actions can't default an input to
+      # `github.token`, and without it setup-logmind's release lookup is
+      # anonymous and 403s on shared runner IPs (setup-logmind#4).
+      #
+      # The release this resolves to MUST carry `check-decisions
+      # --base/--head`. An older binary fails the flag parse, which fails
+      # the job — red, not quietly green — but the failure is the gate's,
+      # not the PR's, so this template belongs downstream of that release.
+      - uses: thrillmade/setup-logmind@v1.0.0
+        with:
+          token: ${{ github.token }}
+
+      - name: Enforce the decision rule
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_TITLE: ${{ github.event.pull_request.title }}
-          GH_TOKEN: ${{ github.token }}
-          THRESHOLD: "20"
         run: |
           set -euo pipefail
-
-          # Count non-docs lines added+removed
-          total=0
-          while IFS=$'\t' read -r added removed path; do
-            [ -z "$path" ] && continue
-            # Skip docs/, the .logmind config, and the agent files — those
-            # are documentation surfaces, not the code logging should track.
-            case "$path" in
-              docs/*|.logmind/*|AGENTS.md|CLAUDE.md|.cursorrules|.windsurfrules|.continuerules|.clinerules|CONVENTIONS.md|.amazonq/*|.sourcegraph/*|.zed/*|.github/copilot-instructions.md|.github/*.md|*.md)
-                continue
-                ;;
-            esac
-            # Binary diffs render added/removed as "-"; skip them.
-            [ "$added" = "-" ] && continue
-            total=$((total + added + removed))
-            # --no-renames so a src→docs rename isn't double-counted as src.
-          done < <(git diff --numstat --no-renames "$BASE_SHA...$HEAD_SHA")
-
-          # Did the PR add a decision log update?
-          decision_touched=0
-          if git diff --name-only "$BASE_SHA...$HEAD_SHA" | grep -qE '^docs/decisions(\.md|-branches/.+\.md)$'; then
-            decision_touched=1
+          # No --threshold: the verb reads git.commit_line_threshold from
+          # the base ref's .logmind/config.yml (default 20). Exactly two
+          # things clear this gate (§3.4) — the change carries a well-formed
+          # decision, or it falls under that threshold.
+          if logmind check-decisions --base "$BASE_SHA" --head "$HEAD_SHA"; then
+            exit 0
           fi
-
-          # [skip-logmind] is a NORMATIVE maintainer override (protocol SPEC
-          # §15.3 / Appendix A.2), not just a convenience. github.event.
-          # pull_request.title is frozen at trigger time, so re-running a
-          # failed check after a maintainer retitles the PR would still
-          # judge the STALE title — the override would silently not take
-          # effect (issue #212). Fetch the LIVE title instead. PR_NUMBER
-          # comes from the event too, but it IS stable across reruns (a PR
-          # keeps its number for life; only the title payload goes stale).
-          # This workflow only triggers on `pull_request`, so there's no
-          # non-PR event to guard against. Fail OPEN to the event payload
-          # title if the API call errors (rate limit, transient outage,
-          # etc.) — a `gh` hiccup must never crash this check.
-          live_title="$(gh pr view "$PR_NUMBER" --json title -q .title 2>/dev/null)" || live_title=""
-          if [ -z "$live_title" ]; then
-            live_title="$EVENT_TITLE"
-          fi
-          skip_logmind=false
-          case "$live_title" in
-            *"[skip-logmind]"*) skip_logmind=true ;;
-          esac
-
-          {
-            echo "total_lines=$total"
-            echo "decision_touched=$decision_touched"
-            echo "skip_logmind=$skip_logmind"
-          } >> "$GITHUB_OUTPUT"
-          echo "Non-docs lines changed: $total (threshold: $THRESHOLD)"
-          echo "Decision log touched: $decision_touched"
-          echo "skip-logmind override: $skip_logmind"
-
-      - name: Enforce
-        # Gate trips when the PR exceeds THRESHOLD non-docs lines without
-        # touching a decision log. `[skip-logmind]` in the PR title bypasses
-        # the gate for one-off overrides (handled by maintainers). Reads
-        # steps.diff.outputs.skip_logmind, resolved from the LIVE PR title
-        # above — NOT github.event.pull_request.title, which is frozen at
-        # trigger time and would miss a retitle+rerun (issue #212).
-        if: steps.diff.outputs.total_lines >= fromJSON(env.THRESHOLD) && steps.diff.outputs.decision_touched == '0' && steps.diff.outputs.skip_logmind != 'true'
-        env:
-          THRESHOLD: "20"
-        run: |
-          echo "::error::This PR changes ${{ steps.diff.outputs.total_lines }} lines of non-docs code without updating docs/decisions.md or docs/decisions-branches/<branch>.md."
-          echo "::error::Log a decision with: logmind log \"summary\" -r \"reasoning\" -a \"alternative\" -i \"implication\""
-          echo "::error::Or override on a one-off basis by adding [skip-logmind] to the PR title (handled by maintainers)."
+          echo "::error title=check-decisions failed::A substantive change must carry a decision (SPEC §3.4). The \`logmind check-decisions\` output above has the line count and the threshold it was judged against — or, if the range could not be resolved, the git error that stopped the gate running."
+          echo "::error::Log a decision, then push: logmind log \"summary\" -r \"reasoning\" -a \"alternative\" -i \"implication\" — it lands in docs/decisions-branches/<branch>.md. The entry must be well-formed: a title, a timestamp, and non-empty reasoning."
+          echo "::error::There is no PR-title override, by design. Exactly two things clear this gate: the change carries a decision, or it falls under git.commit_line_threshold."
           exit 1

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -135,12 +135,13 @@ func TestDependabotTemplate_HasMarkerAndShape(t *testing.T) {
 // distribution-lock change: workflow templates must use the new
 // `thrillmade/setup-logmind@vX.Y.Z` action and NOT the legacy
 // `pip install logmind==X.Y.Z` line. check-doc-links, regen-timeline,
-// and logmind-self-update are all asserted here.
+// logmind-self-update and check-decisions are all asserted here.
 func TestWorkflowTemplates_UseSetupLogmindAction(t *testing.T) {
 	for _, name := range []string{
 		"check-doc-links.yml.template",
 		"regen-timeline.yml.template",
 		"logmind-self-update.yml.template",
+		"check-decisions.yml.template",
 	} {
 		body := Workflow(name)
 		if !strings.Contains(body, "thrillmade/setup-logmind@v") {
@@ -171,6 +172,7 @@ func TestWorkflowTemplates_SetupLogmindStepsCarryToken(t *testing.T) {
 		"check-doc-links.yml.template",
 		"regen-timeline.yml.template",
 		"logmind-self-update.yml.template",
+		"check-decisions.yml.template",
 	} {
 		body := Workflow(name)
 		lines := strings.Split(body, "\n")
@@ -459,54 +461,112 @@ func TestCheckDocLinksTemplate_V8_AdvisoryNoStrand(t *testing.T) {
 	}
 }
 
-// TestCheckDecisionsTemplate_V4_LivePRTitle pins the issue #212 fix: the
-// `[skip-logmind]` override (a NORMATIVE escape hatch — protocol SPEC
-// §15.3 / Appendix A.2) must be read from the LIVE PR title at run time,
-// not from github.event.pull_request.title, which is frozen at trigger
-// time and goes stale across a maintainer retitle+rerun.
-func TestCheckDecisionsTemplate_V4_LivePRTitle(t *testing.T) {
+// TestCheckDecisionsTemplate_V5_CallsTheVerb pins the v5 shape: the
+// workflow INVOKES `logmind check-decisions --base/--head` instead of
+// reimplementing the decision rule in bash. SPEC §3.4: "Both interception
+// points and the gate MUST use this one list. Two lists that mean the
+// same thing are two lists that will disagree" — v4's bash was that
+// second list, and each assertion below pins one of the five ways it had
+// already drifted from the verb.
+func TestCheckDecisionsTemplate_V5_CallsTheVerb(t *testing.T) {
 	body := Workflow("check-decisions.yml.template")
+	// The must-NOT-contain assertions below run against the workflow with
+	// whole-line comments removed, so they bind what the job DOES rather
+	// than what its header says about what v4 used to do — the header
+	// names every removed mechanism, and naming them is the point.
+	active := stripCommentLines(body)
 
-	// Marker bump v3 → v4.
-	if !strings.Contains(body, "# logmind-template-version: v4") {
-		t.Errorf("check-decisions template missing v4 marker")
-	}
-
-	// The Enforce step's `if:` must no longer trust the frozen event
-	// payload title for the skip-logmind check — that's the bug: a
-	// re-run after a retitle replays the ORIGINAL payload.
-	if strings.Contains(body, "contains(github.event.pull_request.title, '[skip-logmind]')") {
-		t.Errorf("check-decisions v4 Enforce step must not gate on the frozen github.event.pull_request.title (issue #212)")
-	}
-	// Instead it must key off a step output resolved from the live title.
-	if !strings.Contains(body, "steps.diff.outputs.skip_logmind != 'true'") {
-		t.Errorf("check-decisions v4 Enforce step must gate on steps.diff.outputs.skip_logmind (resolved from the live PR title)")
+	// Marker bump v4 → v5.
+	if !strings.Contains(body, "# logmind-template-version: v5") {
+		t.Errorf("check-decisions template missing v5 marker")
 	}
 
-	// The live title must be fetched via `gh pr view` using the PR number
-	// from the event (stable across reruns) — not the title.
-	if !strings.Contains(body, `gh pr view "$PR_NUMBER" --json title -q .title`) {
-		t.Errorf("check-decisions v4 missing the live-title fetch via `gh pr view \"$PR_NUMBER\" --json title -q .title`")
+	// The one thing this workflow does: call the verb over the PR's range.
+	if !strings.Contains(body, `logmind check-decisions --base "$BASE_SHA" --head "$HEAD_SHA"`) {
+		t.Errorf("check-decisions v5 must invoke `logmind check-decisions --base \"$BASE_SHA\" --head \"$HEAD_SHA\"` — the gate does not reimplement the rule")
 	}
-	if !strings.Contains(body, "PR_NUMBER: ${{ github.event.pull_request.number }}") {
-		t.Errorf("check-decisions v4 missing PR_NUMBER sourced from the event (stable across reruns, unlike the title)")
-	}
-
-	// A `gh` API hiccup must fail OPEN to the old behavior (the event
-	// payload title), never crash the check.
-	if !strings.Contains(body, `live_title="$EVENT_TITLE"`) {
-		t.Errorf("check-decisions v4 missing the fail-open fallback to the event payload title on a `gh pr view` error")
-	}
-	if !strings.Contains(body, "EVENT_TITLE: ${{ github.event.pull_request.title }}") {
-		t.Errorf("check-decisions v4 missing EVENT_TITLE (the fail-open fallback source)")
+	if !strings.Contains(body, "BASE_SHA: ${{ github.event.pull_request.base.sha }}") ||
+		!strings.Contains(body, "HEAD_SHA: ${{ github.event.pull_request.head.sha }}") {
+		t.Errorf("check-decisions v5 missing the BASE_SHA/HEAD_SHA env pair the verb's range is built from")
 	}
 
-	// `gh pr view` needs read access to pull request data; the workflow
-	// token must grant it explicitly (the block already restricts
-	// everything else to none).
-	if !strings.Contains(body, "pull-requests: read") {
-		t.Errorf("check-decisions v4 missing pull-requests: read permission (required for `gh pr view`)")
+	// Drift 1: `*.md` in the exclusion list. §3.4 forbids it outright —
+	// "Excluding markdown wholesale switches the rule off in the
+	// repositories where writing is the work." Drift 5: the exclusion
+	// list itself, which now lives only in guardcommit.IsExcludedPath.
+	if strings.Contains(active, "docs/*|.logmind/*") || strings.Contains(active, "|*.md)") {
+		t.Errorf("check-decisions v5 must not carry its own exclusion `case` — one list, in the verb (SPEC §3.4)")
 	}
+
+	// Drift 2: the PR-title read. §3.4: "The gate has no self-service
+	// escape, and MUST NOT be given one." Not relocated — deleted.
+	for _, banned := range []string{
+		"gh pr view",
+		"skip_logmind",
+		"[skip-logmind]",
+		"github.event.pull_request.title",
+		"EVENT_TITLE",
+	} {
+		if strings.Contains(active, banned) {
+			t.Errorf("check-decisions v5 must not reference %q — the gate has no self-service escape (SPEC §3.4)", banned)
+		}
+	}
+	// ...and with the title fetch gone, so is the permission it needed.
+	if strings.Contains(active, "pull-requests:") {
+		t.Errorf("check-decisions v5 must not request pull-requests permission — nothing here reads PR data via the API")
+	}
+
+	// Drift 3: a path match standing in for §3.1 shape. §3.4: the gate
+	// "MUST NOT be satisfied by the decision file merely appearing in the
+	// diff."
+	if strings.Contains(active, "git diff --name-only") || strings.Contains(active, "decision_touched") {
+		t.Errorf("check-decisions v5 must not decide on a decision-file path match — the verb checks §3.1 shape")
+	}
+
+	// Drift 4: a hardcoded threshold. It is git.commit_line_threshold,
+	// which the verb reads; the workflow must not pass or restate it.
+	if strings.Contains(active, "THRESHOLD") || strings.Contains(active, "--threshold") {
+		t.Errorf("check-decisions v5 must not hardcode or pass a threshold — it is git.commit_line_threshold, read by the verb")
+	}
+
+	// SPEC §6.3: a gate is never satisfiable by the change it judges. The
+	// binary comes from the pinned release action; a PR that could rebuild
+	// it from its own checkout would be rewriting its own gate.
+	if !strings.Contains(active, "uses: thrillmade/setup-logmind@v") {
+		t.Errorf("check-decisions v5 must install the binary via the pinned thrillmade/setup-logmind action (SPEC §6.3)")
+	}
+	for _, banned := range []string{"setup-go", "make build", "go build", "./bin/logmind"} {
+		if strings.Contains(active, banned) {
+			t.Errorf("check-decisions v5 must not build logmind from the PR's checkout (%q) — SPEC §6.3", banned)
+		}
+	}
+
+	// §6.3 again, on the OTHER input: the threshold lives in the
+	// repository's configuration, which MUST be read from the base ref.
+	// A default pull_request checkout lands the merge ref, and a PR could
+	// then raise the threshold it is judged against in the same diff.
+	if !strings.Contains(active, "ref: ${{ github.event.pull_request.base.sha }}") {
+		t.Errorf("check-decisions v5 must check out the BASE ref, so config comes from the base (SPEC §6.3)")
+	}
+
+	// The failure path stays actionable: it names the command to run.
+	if !strings.Contains(active, `logmind log \"summary\" -r \"reasoning\" -a \"alternative\" -i \"implication\"`) {
+		t.Errorf("check-decisions v5 failure annotation must tell the author what to run")
+	}
+}
+
+// stripCommentLines drops every whole-line `#` comment (YAML's and, inside
+// a `run:` block, the shell's — they are the same syntax and neither one
+// executes). What survives is what the workflow actually does.
+func stripCommentLines(body string) string {
+	var kept []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
 }
 
 // TestDecisionsBranchHeader_Shape pins the v1.2.0 backlink header


### PR DESCRIPTION
**Stacked on #287** — it consumes the `--base`/`--head` range mode that PR adds. Merge #287 first; this retargets to `dev` automatically.

The template's own header said it *"mirrors the local `logmind check-decisions` pre-commit hook."* It did not mirror it — it **reimplemented** it in bash, and the copy had drifted five ways:

| # | drift | issue |
|---|---|---|
| 1 | `*.md` wholesale in the exclusion `case` | #260 |
| 2 | live-PR-title `[skip-logmind]` read | #278 |
| 3 | path-match decision test instead of §3.1 shape | #278 |
| 4 | hardcoded `THRESHOLD: "20"`, never read `commit_line_threshold` | #284 |
| 5 | a **second** exclusion list | §3.4 |

The gate now invokes the verb and the bash decides nothing, so all five die at once — rather than five patches inviting a sixth drift.

## The base-ref checkout is load-bearing, not incidental

The workspace is `github.event.pull_request.base.sha`, **never the merge ref**. That matters because the verb reads `git.commit_line_threshold` **from the checkout** — so a merge-ref workspace would let a pull request raise its own threshold *in the diff under judgement*.

Proven live in a scratch repo. A PR setting `commit_line_threshold: 10000` in its own diff:

| workspace | result |
|---|---|
| merge ref | `✓ 30 lines changed (below 10000-line threshold)` — **passes** |
| base ref | `⚠ 30 lines changed…`, **exit 1** |

That is SPEC §6.3 — *a gate is never satisfiable by the change it judges*. Without the base-ref checkout, the config threshold added in #287 **would itself have been a new self-service escape**. Found by the build agent, and it is the single most important line in this diff.

## Shape

1. `actions/checkout@v7` at the base sha, `fetch-depth: 0`
2. `git fetch --no-tags origin +refs/pull/N/head` — the range needs the head commit, which for a fork PR is on no branch here
3. `thrillmade/setup-logmind@v1.0.0` — a **pinned release**, never built from the PR's checkout; a PR that can rebuild the binary can rewrite its own gate
4. `logmind check-decisions --base "$BASE_SHA" --head "$HEAD_SHA"`, three `::error::` lines, `exit 1`

`permissions:` drops to `contents: read` alone — deleting the PR-title read removed the only consumer of `pull-requests: read`.

## Deliberately NOT done

**logmind's own `.github/workflows/check-decisions.yml` is not regenerated here.** `setup-logmind` installs the latest *release*, and `--base`/`--head` exists only on the unmerged parent — regenerating now turns logmind's own gate red on every PR, including this one.

**The same ordering binds every consumer: the fleet cannot take this template until a release carries the verb.** That is now a documented prerequisite on #257 alongside #288 and #289.

## Tests

`TestCheckDecisionsTemplate_V4_LivePRTitle` → `…_V5_CallsTheVerb`, pinning the marker, the verb invocation, and each of the five defects as a must-not-contain — scanned against a comment-stripped body so the header can still name what it removed. Added to `TestWorkflowTemplates_UseSetupLogmindAction` and `…SetupLogmindStepsCarryToken`.

Rendered through a real `logmind init`, parsed with PyYAML, and `actionlint` (with shellcheck) exit 0. Full suite exit 0, all 21 packages.

## Two findings recorded, not fixed

- The verb's over-threshold text prints `To skip this check: git commit --no-verify` — a local-hook hint that is meaningless at the gate and reads as an escape §3.4 forbids. Lives in the parent branch under a byte-identical-output contract.
- logmind's own `check-decisions.yml` is **already** drifted: no version marker, `checkout@v7` vs the old template's `@v6`. No lockstep pair-diff test exists for it — only `TestRegenTimelineWorkflow_LockstepWithTemplate`. Worth adding when it is regenerated.