### PR TITLE
docs: make docs/roadmap.md the source of truth for sequencing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ records the "why" behind changes via `logmind log`, and keeps the derived
 `docs/timeline.md` + `docs/file-structure.md` in sync as agent-readable
 context. One leg of the thrillmade SkDD toolchain (with clud-bug = review,
 agent-skills = catalog). Entry point `cmd/logmind/main.go`; code under
-`internal/`. See [docs/plan.md](docs/plan.md) for architecture + roadmap.
+`internal/`. See [docs/plan.md](docs/plan.md) for architecture, and
+[docs/roadmap.md](docs/roadmap.md) for what ships next and in what order.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ tests, release workflow).
 ## Documentation
 
 - **[Install](docs/install.md)** - Full install matrix (brew, curl, go install, manual, legacy Python)
-- **[Plan & Architecture](docs/plan.md)** - Vision, approach, and technical details
+- **[Architecture](docs/plan.md)** - Vision, approach, and technical details
+- **[Roadmap](docs/roadmap.md)** - What ships next, in what order, and why
 - **[AI Agent Files](docs/ai-agent-files.md)** - How logmind integrates with AI instruction files
 - **[First Decision Example](docs/first-decision-example.md)** - What the initial decision looks like
 
@@ -304,7 +305,8 @@ tests, release workflow).
 - **AI-friendly:** Recent decisions + file structure = complete context
 - **Automatic:** Commits and pushes on every log
 
-See [docs/plan.md](docs/plan.md) for complete architecture and roadmap.
+See [docs/plan.md](docs/plan.md) for the architecture and
+[docs/roadmap.md](docs/roadmap.md) for the roadmap.
 
 ## Legacy install (Python, frozen at v0.6.16)
 

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -48,3 +48,14 @@
 
 ---
 
+## 2026-08-15 14:12 - roadmap: remove the branch-tip pin from the header — the file's own rule, broken in the file's own header
+
+**Reasoning:** The fourth review found the verification header naming the dev and main tips it was checked against, two paragraphs above the rule forbidding exactly that. Worse, the pin was already wrong when written: the commit introducing it is timestamped three minutes after PR 302 moved dev past the SHA it names. A rule stated and then broken in the same document teaches readers the rule is decorative.
+
+**Alternatives considered:** Update the header to the current tip. Rejected for the fourth time on the same grounds: any branch tip written into this file is wrong within hours, and the previous three corrections all proved it. The SPEC blob pin stays because a blob hash is immutable and cannot rot; a branch tip is a moving reference that this file may not own.
+
+**Implications:**
+- The header now pins only the SPEC blob and tells the reader to run git rev-parse for the tips. The absence is documented rather than silent, so the next person does not helpfully add it back. A grep for a dev or main tip in the file returns nothing, controlled against the two immutable commit references in the historical sections, which are allowed and still present.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-15 09:18 - roadmap: state the command, not the answer, for every fact git already owns
+
+**Reasoning:** This file went stale twice, the second time during the adversarial panel that was checking it, which blocked it. The cause was structural rather than careless: the file copied SHAs, commit counts, ahead-counts and open-PR counts that git and gh already own, and a hand-kept second copy reads as true until one quietly is not. That is the one-owner-per-fact rule the file exists to enforce, and it was not being applied to the file itself. The State section and the landed-commits table now carry the commands that produce those numbers instead of the numbers.
+
+**Alternatives considered:** Correct the numbers a third time and keep the shape. Rejected because the failure repeats on a timescale shorter than the review that catches it. The nine findings the panel raised were almost all instances of one defect wearing nine faces, and correcting instances leaves the tenth to be found by a reader who trusts it.
+
+**Implications:**
+- Numbers that survive are load-bearing for a judgment rather than descriptive of the moment, and each is stamped with the date it was measured and the command that measures it again. Also corrected in this pass, all re-measured against live gh: the protocol bot-commit share is 43 of 109 on the last ten merged pull requests rather than 42 of 98, there are two push failures rather than one, skdd carries regen-timeline at v11 rather than nothing, check-decisions has no push trigger at all, and agent-skills 207 is merged.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-14 21:24 - Correct seven defects an adversarial panel found in the roadmap
+
+**Reasoning:** The file whose entire purpose is being accurate had seven. Two drove what gets built next. FIRST: it said the steward App was on no ruleset bypass list and called that the tightest constraint on the tag — measured now, there are two active rulesets not three, reporulez-default 18292242 returns 404, and both survivors carry Integration:3951953 which IS skdd-steward. Their updated_at is 2026-08-07T17:1x, a week before that commit, so it was likely never true when written. I had verified the bypass was granted and said so out loud, then wrote the opposite into the file from older survey text. SECOND: 'seven success runs, the single push event failed' — actually 503 runs, 15 on push, 13 of them green. The conclusion survived, the evidence did not, and an auditor who finds thirteen greens discounts the section that is right.
+
+**Alternatives considered:** Fix the two critical ones and file the rest. Rejected: five of the seven are the file describing a state that is not the current one, which is the single failure mode it exists to avoid. A roadmap that is 70% accurate is worse than none, because it is trusted.
+
+**Implications:**
+- The #288 section is rewritten around what is actually unresolved: the bypass is granted, the push has still never landed a commit, and the reason is not a refusal — 13 green push runs with 0 commits means the job finds the docs current and exits before pushing. The one failure, on 0aa9049, predates the bypass by six days, so the original diagnosis was right when filed and the remedy has since been applied. skdd was misread across two branches: main has no workflows at all, dev carries check-decisions v4, and the earlier 'already on v11, migrating is a no-op' would have dropped a repo that genuinely needs migrating. One-owner-per-fact was claimed and not achieved — AGENTS.md, README twice and docs/spec.md all still pointed at plan.md for the roadmap, so all four are repointed. #243 carried its own ordering table that reversed this file's, recreating the two-owners defect one revision after the split; its body is rewritten to point here. Four pre-existing issues were unplaced and now are. The verified date was impossible — 2026-08-07 against a SHA created 2026-08-14.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-make-docs-roadmap-md-the-source-of-truth-for-sequencing -->
+- **2026-08-14** — Make docs/roadmap.md the source of truth for sequencing
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:02 - Make docs/roadmap.md the source of truth for sequencing
+
+**Reasoning:** The roadmap lived in a scratchpad HTML file that the artifact was published from. That file was wiped twice today by session restarts, taking the only copy of the sequencing with it — the published page survived but could not be updated, so it drifted to showing 26 issues and a superseded critical path while the real count was 31 and the critical path had changed to #288. A roadmap that cannot survive a restart is not a source of truth. It now lives in the repository, versioned and reviewable, and the artifact renders FROM it rather than being it.
+
+**Alternatives considered:** Keep the roadmap inside docs/plan.md. Rejected on half-life: plan.md is architecture and changes yearly; the release board changed six times in one day. Fusing them is exactly why plan.md spent weeks describing a derived_docs.mode config gate that had already been deleted.
+
+**Implications:**
+- One owner per fact, stated in both files: if a date, count, issue number or ordering appears in both, roadmap.md is right and plan.md is stale. plan.md is retitled from 'Plan & Architecture' to 'Architecture' to stop implying it owns sequencing. Every number in roadmap.md carries the command that produced it, and every claimed zero carries a control proving the probe finds a non-zero when one exists — including the load-bearing one that regen bot commits have a null author.login, so a login-keyed probe reports zero on every PR and looks clean. All seven SPEC citations verified LIVE against blob cd64e5c; check-links passes.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -37,3 +37,14 @@
 
 ---
 
+## 2026-08-15 13:53 - roadmap: make each shown command reproduce its own number, and drop a claim that was false when written
+
+**Reasoning:** The re-panel blocked on two defects. Both gh api calls over a pull request commit list omitted --paginate, so the command printed beside the number answered a different question than the number: PR 75 carries 63 commits over three pages, and without the flag gh returns only the first, which counts 15 against a stated 30. A command shown to make a number self-verifying is worse than no command when it does not reproduce it. Separately, the file asserted that issue 244 still contradicted Ruling 12 in its body. That body was corrected on 2026-08-01, two weeks before the claim was written, and I had verified it myself earlier in the same session and left the stale sentence standing.
+
+**Alternatives considered:** Drop the commands and keep only the prose numbers. Rejected because the command is the whole mechanism by which this file avoids the staleness that blocked it twice; the answer is to make the commands correct rather than to remove the check. Also rejected: leaving the 244 paragraph as a harmless overstatement, since a roadmap that invents remaining work is exactly as misleading as one that hides it.
+
+**Implications:**
+- Both aggregate and single-PR probes now carry --paginate, and re-running them yields 109 commits with 43 from the regen bot, a 39.4 percent share, matching what the file states. The control confirms the probe distinguishes bot from human rather than matching everything.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,4 +1,13 @@
-# logmind: Plan & Architecture
+# logmind: Architecture
+
+> **Sequencing lives in [roadmap.md](roadmap.md), not here.** This document is
+> the durable half — what logmind is, how the enforcement layers fit together,
+> and why the load-bearing calls were made. It changes yearly. The release
+> board changes weekly, and fusing the two is what let the combined document
+> describe a config gate for weeks after that gate was deleted.
+>
+> One owner per fact: if a date, a count, an issue number or an ordering appears
+> in both files, `roadmap.md` is right and this one is stale.
 
 ## Vision
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,225 @@
+# logmind — roadmap to v2.0.0
+
+> **This file is the source of truth for sequencing.** The roadmap artifact
+> renders from it; [#243](https://github.com/thrillmade/logmind/issues/243)
+> points at it. Architecture lives in [plan.md](plan.md) — that changes yearly,
+> this changes weekly, and fusing them is why the old combined document went
+> stale.
+>
+> **Every number here was measured, with the command shown.** Nothing is carried
+> from memory or from an issue body. A claimed zero is stated with the control
+> that proves the probe finds a non-zero when one exists.
+
+**Verified 2026-08-07** against `origin/dev a0f6339`, `origin/main 0aa9049`, and
+the live SPEC at `thrillmade/protocol` blob `cd64e5c` (1,475 lines, Sections 0–8,
+no appendices).
+
+---
+
+## State
+
+| | |
+|---|---|
+| latest **release** | **v1.2.0** (2026-06-07) — what `brew install` gives |
+| `main` | `0aa9049` |
+| `dev` | `a0f6339`, **7 ahead** of main |
+| open issues | 31 |
+| open PRs | 0 |
+
+Everything built since June is unreleased. The released binary predates the
+commit gate, the harness guard, the zero-conflict invariant, and the `areas:`
+declaration.
+
+### How work is verified
+
+`dev` deliberately has **no CI** — both workflows trigger on
+`push: branches: [main]` only. The bar is a **local adversarial panel** per
+change, plus the full suite run against integrated `dev`. Pull requests into
+`dev` still get CI on their own merge-ref (the `pull_request` trigger carries no
+branch filter); what the panel and the local suite cover is the *integrated*
+result, which PR-level CI never sees.
+
+---
+
+## Landed on `dev`, not yet on `main`
+
+| commit | what | closes on merge to main |
+|---|---|---|
+| `a0f6339` | CI gate calls the verb it claimed to mirror | #278, #260, #284 |
+| `4499da1` | file-structure root from the repository, not the checkout dir | #285 |
+| `4120584` | refuse to move a workflow template backwards | #286 |
+| `9889a25` | one shared §3.4 evaluation | — |
+| `575272b` | 19 documentation claims corrected | — |
+| `46a3a58` | `plan.md` refreshed against SPEC 2.0 | — |
+| `d79c430` | declare spec 2.0.0 + the §7.3 `areas:` line | #264 |
+
+Those issues stay **open** until `dev` reaches `main` — `closes #N` only fires on
+the default branch. That is expected, not drift.
+
+---
+
+## Blocked on a person
+
+### #288 — the steward App is on no ruleset bypass list
+
+**The tightest constraint on the tag.** `regen-on-main` has never once pushed.
+
+```
+$ gh api 'repos/thrillmade/logmind/commits?sha=main&per_page=100' \
+    --jq '[.[] | select((.commit.message|split("\n")[0])|test("^chore: regen derived docs"))] | length'
+0
+```
+
+**Control** — the same subject-line probe on `thrillmade/protocol` PR#75 returns
+**30**, so the matcher works.
+
+The seven `success` runs of `regen-timeline.yml` are all `pull_request` events,
+which execute only the gate job. `regen-on-main` runs on `push`, and the single
+`push` event **failed**. The success column never described it.
+
+Three active rulesets cover `main` and none admits an App by identity class:
+
+| ruleset | id | bypass actors |
+|---|---|---|
+| `org-baseline` | 18502737 | `OrganizationAdmin` |
+| `org-default-protection` | 16898453 | `RepositoryRole 2`, `RepositoryRole 5` |
+| `reporulez-default` | 18292242 | *(empty)* |
+
+`branches/main/protection` returns 404 "Branch not protected" — that is the
+legacy endpoint and **must not** be read as unprotected; protection here is
+entirely ruleset-based.
+
+**To close:** add `skdd-steward[bot]` as an **Integration** bypass actor, then
+prove it with a push that actually lands a commit. Seven green runs already
+proved nothing. `reporulez-default` is empty on every repo surveyed and looks
+machine-generated, so a UI edit may be reverted on its next sync.
+
+### Awaiting protocol rulings
+
+| issue | question | blocks |
+|---|---|---|
+| protocol#77 | who owns the §1.2 per-tool redirect files | skdd#6 scope |
+| protocol#89 | is `!pattern` valid in `file_structure.ignore_patterns` | the fix shape for #269 |
+| protocol#90 | §7.3's example declares 3 areas for logmind; we implement 5 | what the tag bakes in |
+| protocol#93 | §3.4 requires non-empty reasoning; §3.1 says an entry without it is well-formed | nothing — gate follows §3.4 today |
+
+### #241 — pre-tag by Ruling 12, but unbuildable as written
+
+Underspecified, and blocked on agent-skills#173 and #174, both unbuilt.
+
+---
+
+## The order
+
+Gate integrity came first because **#257 is a distribution mechanism**: anything
+wrong in the binary, hooks or templates when it ships is pushed to every consumer
+repo and must then be fixed twice.
+
+### 1 — Gate integrity ✅ on `dev`
+
+#278 · #260 · #284 · #286 · #285. All landed.
+
+### 2 — Prerequisites for the fleet migration
+
+Each is a hard gate on #257, not a parallel cleanup.
+
+| | why it blocks |
+|---|---|
+| **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
+| **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
+| **template v12** | the shipped `regen-timeline` template pushes with a raw `LOGMIND_AUTO_REGEN_PAT`; logmind's own copy mints a `skdd-steward[bot]` token via `create-github-app-token@v3`. Shipping as-is deploys the credential path logmind abandoned. Also fix the action-pin regression — the template pins `setup-logmind@v1.0.0` while five repos run `@v1.0.1`. |
+
+### 3 — Remaining pre-tag work
+
+**#261** — gate logic inline on `pull_request` (§6.3). *Reordered:* originally
+ahead of the gate cluster; doing it after means relocating a **correct**
+evaluation rather than a wrong one. Its remedy restructures `regen-timeline.yml`,
+so that file moves twice regardless of what else we do.
+
+**#267** — `EnsureAgentsMD` silently downgrades a newer `AGENTS.md` block. Same
+*shape* as #286 but a different root cause: `matchingTemplate` recognises markers
+by hardcoded `strings.Contains` of known generations, so an unknown newer marker
+returns `""` and the slim default is applied. No version compare exists to fix.
+Fires exactly during a staggered rollout — the condition #257 creates.
+
+**#270** — hooks resolve their engine by bare name, so PATH skew silently
+disables the local gate. §3.4 requires fail-open *and* requires that failing open
+not be silent; today it is.
+
+**#269** — `ignore_patterns` replaces the 16 built-in defaults instead of merging.
+§1.4 line 202 says the three sources are **merged**, so this is a spec violation,
+not a wart. Fix shape depends on protocol#89.
+
+**#279** — the site's `--version` example is one line; §7.3 requires two, and the
+tag-time flip will not add the `areas:` line.
+
+### 4 — #265 + #257, together
+
+One fleet move, per standing constraint. #265 collapses the decision layout —
+main is a branch like any other, no cap, no archive, `rotateDecisions` deleted
+rather than ported — and adds `docs/timeline-archive.md` as a **third** derived
+file that every restore path and `check-derived-docs` must learn. All of them
+name two today.
+
+### 5 — After the tag
+
+#263 (§6.7 pre-push gate, wholly new scope) · #251 · #271 · #280 · #210 · #217 ·
+#258 · #268 · #273 · #274 · #283.
+
+---
+
+## The fleet, measured
+
+Read from each repository's **installed** file, not inferred from what this repo
+ships.
+
+| repo | `check-decisions` | `regen-timeline` | pushes to PR branch |
+|---|---|---|---|
+| protocol | `v2` | `v4` | **yes** |
+| clud-bug | `v2` | `v4` | **yes** |
+| clud-bug-app | `v2` | `v4` | **yes** |
+| agent-skills | `v2` | `v4` | **yes** |
+| reporulez | *unversioned* | *unmarked* | no |
+| skdd | *absent* | `v11` on `dev` | no |
+
+**logmind ships** `check-decisions` at the version merged in #291 and
+`regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
+v4" is not one number.
+
+Two corrections to #257's original inventory:
+
+- **reporulez is structurally unreachable by refresh.** `installWorkflowTemplates`
+  guards on `installedVer != ""`, so a file with no `# logmind-template-version`
+  marker is skipped **forever**. It needs hand-replacement or it is silently left
+  behind.
+- **skdd is already on v11**, so migrating it is a no-op. Do not read its clean
+  `check-derived-docs` history as validation — it is green because neither
+  derived doc exists on any skdd branch.
+
+### The cost of not migrating
+
+`thrillmade/protocol`, last 10 pull requests: **98 commits, 42 of them
+`logmind-auto-regen[bot]` — 42%.** PR#75 alone carries 30, every subject
+byte-identical. 1:1 alternation confirmed by timestamp. PR#70 contains a *human*
+commit titled `[skip-logmind] chore: regen derived docs` — someone hand-running
+the regeneration to pre-empt the bot.
+
+It has already produced one governance failure: **protocol#75, the SPEC 2.0
+rewrite itself, merged over a red required `check-derived-docs` via admin
+bypass.** A repository where every push needs a rebase is one where people start
+bypassing gates.
+
+> **Method note, load-bearing.** Those bot commits have `.author.login == null` —
+> no linked account. A probe keyed on `.author.login` reports **zero on every
+> pull request** and looks like a clean result. Identity must be read from
+> `.commit.author.name`.
+
+---
+
+## Pre-tag checklist
+
+1. `dev` → `main`, which closes #264, #278, #260, #284, #285, #286.
+2. Run `release.yml` with `dry_run=true`.
+3. **Separately** re-confirm the homebrew-tap ruleset bypass — the dry run skips
+   that push, so it never exercises the identity that failed with GH013.
+4. Tag. That is the CEO's action, not the lane's.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,8 +105,11 @@ The push has still never landed a commit, and the reason is *not* a refusal.
 ```sh
 $ git log origin/main --format='%s' | grep -c '^chore: regen derived docs$'
 0
-$ gh api repos/thrillmade/protocol/pulls/75/commits --jq '[.[] | select(.commit.author.name == "logmind-auto-regen[bot]")] | length'
+$ gh api repos/thrillmade/protocol/pulls/75/commits --paginate \
+    --jq '[.[] | select(.commit.author.name == "logmind-auto-regen[bot]")] | length'
 30
+# --paginate is load-bearing: PR#75 has 63 commits over 3 pages and `gh api`
+# returns only the first without it, which answers 15.
 $ gh api "repos/thrillmade/logmind/actions/workflows/277546816/runs?per_page=100&event=push" \
     --paginate --jq '.workflow_runs[] | .conclusion' | sort | uniq -c
      13 success
@@ -211,9 +214,9 @@ to unblock itself has bought exactly what §3.4's gate exists to prevent.
 
 **#244** — branch→issue binding plus comment-back on merge. Pre-tag by **Ruling
 12**, not by defect: nothing in current behaviour is wrong, the feature simply
-does not exist. Recorded here rather than in §5 so the ruling stays visible —
-its own issue body still says "after the v2.0.0 tag", which contradicts the
-ruling that governs it and needs correcting.
+does not exist. Recorded here rather than in §5 so the ruling stays visible.
+Its body no longer contradicts the ruling: it was corrected 2026-08-01 and now
+opens "Pre-tag — in v2.0.0 scope by Ruling 12." Nothing to do.
 
 **#241** — `logmind auto`. Also pre-tag by Ruling 12. It previously needed two
 skills that did not exist; those shipped in agent-skills#207 (merged
@@ -287,7 +290,7 @@ Two corrections to #257's original inventory:
 $ gh api "repos/thrillmade/protocol/pulls?state=closed&sort=created&direction=desc&per_page=30" \
     --jq '[.[] | select(.merged_at != null)] | .[0:10] | .[].number'
 $ for pr in 92 88 85 84 83 80 76 75 70 69; do
-    gh api "repos/thrillmade/protocol/pulls/$pr/commits" \
+    gh api "repos/thrillmade/protocol/pulls/$pr/commits" --paginate \
       --jq '[.[] | .commit.author.name]'
   done
 # 109 commits total, 43 with .commit.author.name == "logmind-auto-regen[bot]"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,15 @@
 # logmind — roadmap to v2.0.0
 
 > **This file is the source of truth for sequencing.** The roadmap artifact
-> renders from it; [#243](https://github.com/thrillmade/logmind/issues/243)
-> points at it. Architecture lives in [plan.md](plan.md) — that changes yearly,
+> renders from it.
+>
+> [#243](https://github.com/thrillmade/logmind/issues/243) is the tracking
+> thread and points here. It carried its own ordering table until 2026-08-14,
+> which meant two orderings of record — the exact defect this split was made to
+> remove, recreated one revision later. That table is gone; if the two ever
+> disagree again, this file is right.
+>
+> Architecture lives in [plan.md](plan.md) — that changes yearly,
 > this changes weekly, and fusing them is why the old combined document went
 > stale.
 >
@@ -10,7 +17,7 @@
 > from memory or from an issue body. A claimed zero is stated with the control
 > that proves the probe finds a non-zero when one exists.
 
-**Verified 2026-08-07** against `origin/dev a0f6339`, `origin/main 0aa9049`, and
+**Verified 2026-08-14** against `origin/dev 7b2b4f8`, `origin/main 0aa9049`, and
 the live SPEC at `thrillmade/protocol` blob `cd64e5c` (1,475 lines, Sections 0–8,
 no appendices).
 
@@ -60,39 +67,59 @@ the default branch. That is expected, not drift.
 
 ## Blocked on a person
 
-### #288 — the steward App is on no ruleset bypass list
+### #288 — the bypass is granted; it has never been exercised
 
-**The tightest constraint on the tag.** `regen-on-main` has never once pushed.
+**Not a blocker on the tag.** An earlier revision of this file said the steward
+App was on no bypass list and called that "the tightest constraint on the tag."
+**That was wrong**, and the correction matters more than the original claim.
 
 ```
-$ gh api 'repos/thrillmade/logmind/commits?sha=main&per_page=100' \
-    --jq '[.[] | select((.commit.message|split("\n")[0])|test("^chore: regen derived docs"))] | length'
-0
+$ gh api repos/thrillmade/logmind/rulesets --jq '.[]|"\(.id) \(.name)"'
+18502737 org-baseline
+16898453 org-default-protection
+
+$ gh api repos/thrillmade/logmind/rulesets/18502737 \
+    --jq '[.bypass_actors[]|"\(.actor_type):\(.actor_id)"]'
+["OrganizationAdmin:null", "Integration:3951953"]
+
+$ gh api /apps/skdd-steward --jq .id
+3951953
 ```
 
-**Control** — the same subject-line probe on `thrillmade/protocol` PR#75 returns
-**30**, so the matcher works.
+Two active rulesets, not three — `reporulez-default` (18292242) returns **404**
+here and no longer covers this repository. Both survivors carry
+`Integration:3951953`, which is `skdd-steward`. Their `updated_at` is
+**2026-08-07T17:1x**.
 
-The seven `success` runs of `regen-timeline.yml` are all `pull_request` events,
-which execute only the gate job. `regen-on-main` runs on `push`, and the single
-`push` event **failed**. The success column never described it.
+### What is actually unresolved
 
-Three active rulesets cover `main` and none admits an App by identity class:
+The push has still never landed a commit, and the reason is *not* a refusal:
 
-| ruleset | id | bypass actors |
-|---|---|---|
-| `org-baseline` | 18502737 | `OrganizationAdmin` |
-| `org-default-protection` | 16898453 | `RepositoryRole 2`, `RepositoryRole 5` |
-| `reporulez-default` | 18292242 | *(empty)* |
+| probe | result |
+|---|---|
+| regen commits on `main`, by subject line | **0** |
+| control — same probe, protocol PR#75 | **30** |
+| `regen-timeline` runs, all events | 503 |
+| runs on the `push` event | **15** |
+| `push` runs that **succeeded** | **13** |
 
-`branches/main/protection` returns 404 "Branch not protected" — that is the
-legacy endpoint and **must not** be read as unprotected; protection here is
-entirely ruleset-based.
+Thirteen green push runs and zero commits means the job runs, finds the derived
+docs already current, and exits 0 on that path — it never reaches the push at
+all. The one `push` failure, on `0aa9049`, carried the GH013 annotation and dates
+to **2026-08-01**, six days *before* the bypass was added. So the original
+diagnosis was correct when filed and the remedy has since been applied.
 
-**To close:** add `skdd-steward[bot]` as an **Integration** bypass actor, then
-prove it with a push that actually lands a commit. Seven green runs already
-proved nothing. `reporulez-default` is empty on every repo surveyed and looks
-machine-generated, so a UI edit may be reverted on its next sync.
+**The bypass is therefore untested, not missing.** It gets exercised the first
+time `main` receives a merge that leaves a derived doc stale — which is the
+`dev` → `main` merge at the tag, not something to manufacture beforehand.
+
+> **A caution this file has already earned.** An earlier revision reported
+> "seven `success` runs, and the single `push` event failed." The real figures
+> are 15 push runs and 13 successes. The conclusion — that the green column
+> never described `regen-on-main` — survived, but the evidence for it did not,
+> and an auditor who finds thirteen greens discounts the section that is right.
+> Every count in this file names the command that produced it for exactly this
+> reason.
 
 ### Awaiting protocol rulings
 
@@ -150,6 +177,24 @@ not be silent; today it is.
 §1.4 line 202 says the three sources are **merged**, so this is a spec violation,
 not a wart. Fix shape depends on protocol#89.
 
+**#259** — the derived-doc restore does not refuse while a merge, rebase,
+cherry-pick or revert is in progress. Restoring mid-conflict discards the
+resolution someone is part-way through, and the restore paths run automatically.
+
+**#266** — `logmind config set` has no refusal for gate settings. §1.6's point is
+that some keys are humans-only; an agent that can lower `commit_line_threshold`
+to unblock itself has bought exactly what §3.4's gate exists to prevent.
+
+**#244** — branch→issue binding plus comment-back on merge. Pre-tag by **Ruling
+12**, not by defect: nothing in current behaviour is wrong, the feature simply
+does not exist. Recorded here rather than in §5 so the ruling stays visible —
+its own issue body still says "after the v2.0.0 tag", which contradicts the
+ruling that governs it and needs correcting.
+
+**#241** — `logmind auto`. Also pre-tag by Ruling 12, and the longest pole among
+them: it installs two skills that did not exist, so those had to be written
+first (agent-skills#207, open). Build once that merges.
+
 **#279** — the site's `--version` example is one line; §7.3 requires two, and the
 tag-time flip will not add the `areas:` line.
 
@@ -160,6 +205,13 @@ main is a branch like any other, no cap, no archive, `rotateDecisions` deleted
 rather than ported — and adds `docs/timeline-archive.md` as a **third** derived
 file that every restore path and `check-derived-docs` must learn. All of them
 name two today.
+
+**#277 rides here too.** It reports `check-derived-docs` enforcing the opposite
+of §3.3 — regenerating from the branch's own sources and failing on the diff, so
+it demands the branch commit exactly what §3.3 forbids. logmind's own copy and
+its shipped `v11` template are **already correct**; the defect is a stale
+installed copy in the consumer repos. So it is a #257 payload, not code to write
+here, and it closes when the fleet takes the current template.
 
 ### 5 — After the tag
 
@@ -180,10 +232,9 @@ ships.
 | clud-bug-app | `v2` | `v4` | **yes** |
 | agent-skills | `v2` | `v4` | **yes** |
 | reporulez | *unversioned* | *unmarked* | no |
-| skdd | *absent* | `v11` on `dev` | no |
+| skdd | *absent* on `main`, **`v4`** on `dev` | — | no |
 
-**logmind ships** `check-decisions` at the version merged in #291 and
-`regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
+**logmind ships** `check-decisions` at **`v5`** and `regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
 Two corrections to #257's original inventory:
@@ -192,9 +243,13 @@ Two corrections to #257's original inventory:
   guards on `installedVer != ""`, so a file with no `# logmind-template-version`
   marker is skipped **forever**. It needs hand-replacement or it is silently left
   behind.
-- **skdd is already on v11**, so migrating it is a no-op. Do not read its clean
-  `check-derived-docs` history as validation — it is green because neither
-  derived doc exists on any skdd branch.
+- **skdd was misread, and the misreading mixed two branches.** Its `main` has no
+  `.github/workflows` at all (404); its `dev` carries `check-decisions` at **v4**,
+  added 2026-08-01. An earlier revision of this file said "already on v11, so
+  migrating it is a no-op" — that was wrong in both halves, and it would have
+  removed a repository from the migration list that genuinely needs migrating.
+  Its clean `check-derived-docs` history is still no validation: green because
+  neither derived doc exists on any skdd branch.
 
 ### The cost of not migrating
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@
 > from memory or from an issue body. A claimed zero is stated with the control
 > that proves the probe finds a non-zero when one exists.
 
-**Verified 2026-08-14** against `origin/dev 7b2b4f8`, `origin/main 0aa9049`, and
+**Verified 2026-08-15** against `origin/dev 2a8e10a`, `origin/main 0aa9049`, and
 the live SPEC at `thrillmade/protocol` blob `cd64e5c` (1,475 lines, Sections 0–8,
 no appendices).
 
@@ -25,40 +25,45 @@ no appendices).
 
 ## State
 
-| | |
-|---|---|
-| latest **release** | **v1.2.0** (2026-06-07) — what `brew install` gives |
-| `main` | `0aa9049` |
-| `dev` | `a0f6339`, **7 ahead** of main |
-| open issues | 31 |
-| open PRs | 0 |
+**This file does not carry SHAs, counts, or "N ahead".** Two revisions tried and
+both were stale within hours — once *during* the review that checked them. Git
+already owns those facts, and a hand-kept second copy reads as true until one
+quietly isn't. That is the same one-owner-per-fact rule this file was created to
+enforce, applied to itself.
 
-Everything built since June is unreleased. The released binary predates the
-commit gate, the harness guard, the zero-conflict invariant, and the `areas:`
-declaration.
+Run these instead:
+
+```sh
+git fetch origin --prune
+git log --oneline origin/main..origin/dev          # what is on dev, not yet on main
+gh issue list --state open --limit 60              # open issues
+gh pr list --state open                            # open pull requests
+gh release list --limit 1                          # what `brew install` gives
+```
+
+The one durable fact worth stating: **everything built since June is unreleased.**
+The released binary predates the commit gate, the harness guard, the zero-conflict
+invariant and the `areas:` declaration — so `brew install` does not get any of
+them until the tag.
 
 ### How work is verified
 
-`dev` deliberately has **no CI** — both workflows trigger on
-`push: branches: [main]` only. The bar is a **local adversarial panel** per
-change, plus the full suite run against integrated `dev`. Pull requests into
-`dev` still get CI on their own merge-ref (the `pull_request` trigger carries no
-branch filter); what the panel and the local suite cover is the *integrated*
-result, which PR-level CI never sees.
+`dev` deliberately has **no CI** — of the two workflows, only
+`check-derived-docs` (`regen-timeline.yml`) carries a `push: branches: [main]`
+trigger. `check-decisions` has **no push trigger at all**; it runs only on
+`pull_request`. The bar is a **local adversarial panel** per change, plus the
+full suite run against integrated `dev`. Pull requests into `dev` still get
+CI on their own merge-ref (both workflows' `pull_request` trigger carries no
+`branches:` filter); what the panel and the local suite cover is the
+*integrated* result, which PR-level CI never sees.
 
 ---
 
 ## Landed on `dev`, not yet on `main`
 
-| commit | what | closes on merge to main |
-|---|---|---|
-| `a0f6339` | CI gate calls the verb it claimed to mirror | #278, #260, #284 |
-| `4499da1` | file-structure root from the repository, not the checkout dir | #285 |
-| `4120584` | refuse to move a workflow template backwards | #286 |
-| `9889a25` | one shared §3.4 evaluation | — |
-| `575272b` | 19 documentation claims corrected | — |
-| `46a3a58` | `plan.md` refreshed against SPEC 2.0 | — |
-| `d79c430` | declare spec 2.0.0 + the §7.3 `areas:` line | #264 |
+```sh
+git log --oneline origin/main..origin/dev
+```
 
 Those issues stay **open** until `dev` reaches `main` — `closes #N` only fires on
 the default branch. That is expected, not drift.
@@ -93,21 +98,36 @@ here and no longer covers this repository. Both survivors carry
 
 ### What is actually unresolved
 
-The push has still never landed a commit, and the reason is *not* a refusal:
+The push has still never landed a commit, and the reason is *not* a refusal.
+**Measured 2026-08-15** against `logmind / check-derived-docs`
+(`.github/workflows/regen-timeline.yml`, workflow id `277546816`):
+
+```sh
+$ git log origin/main --format='%s' | grep -c '^chore: regen derived docs$'
+0
+$ gh api repos/thrillmade/protocol/pulls/75/commits --jq '[.[] | select(.commit.author.name == "logmind-auto-regen[bot]")] | length'
+30
+$ gh api "repos/thrillmade/logmind/actions/workflows/277546816/runs?per_page=100&event=push" \
+    --paginate --jq '.workflow_runs[] | .conclusion' | sort | uniq -c
+     13 success
+      2 failure
+```
 
 | probe | result |
 |---|---|
-| regen commits on `main`, by subject line | **0** |
-| control — same probe, protocol PR#75 | **30** |
-| `regen-timeline` runs, all events | 503 |
-| runs on the `push` event | **15** |
+| regen commits on `main`, by exact subject line | **0** |
+| control — same probe, protocol PR#75 bot commits | **30** |
+| `push`-event runs of `regen-timeline` | **15** |
 | `push` runs that **succeeded** | **13** |
+| `push` runs that **failed** | **2** |
 
 Thirteen green push runs and zero commits means the job runs, finds the derived
 docs already current, and exits 0 on that path — it never reaches the push at
-all. The one `push` failure, on `0aa9049`, carried the GH013 annotation and dates
-to **2026-08-01**, six days *before* the bypass was added. So the original
-diagnosis was correct when filed and the remedy has since been applied.
+all. **Both** `push` failures carry the GH013 `Changes must be made through a
+pull request` refusal: `fcf7268` (**2026-07-25**) and `0aa9049`
+(**2026-08-01**), each dated *before* the bypass was added
+(**2026-08-07**). So the original diagnosis was correct when filed and the
+remedy has since been applied.
 
 **The bypass is therefore untested, not missing.** It gets exercised the first
 time `main` receives a merge that leaves a derived doc stale — which is the
@@ -132,7 +152,13 @@ time `main` receives a merge that leaves a derived doc stale — which is the
 
 ### #241 — pre-tag by Ruling 12, but unbuildable as written
 
-Underspecified, and blocked on agent-skills#173 and #174, both unbuilt.
+Underspecified — the setup surface itself has open questions (profile
+vocabulary, whether the limit-watch is tooled or purely behavioural). It is
+**no longer blocked on missing skills**: agent-skills#207 (merged
+2026-08-15) shipped both `session-heartbeat` and `unattended-operation`,
+implementing agent-skills#173 and #174. Those two tracking issues remain
+open on GitHub — that is bookkeeping, not a build blocker; the skills exist
+in the catalog today.
 
 ---
 
@@ -144,11 +170,19 @@ repo and must then be fixed twice.
 
 ### 1 — Gate integrity ✅ on `dev`
 
-#278 · #260 · #284 · #286 · #285. All landed.
+#278 · #260 · #284 · #286 · #285 · #267 · #270. All landed.
 
 ### 2 — Prerequisites for the fleet migration
 
-Each is a hard gate on #257, not a parallel cleanup.
+Each is a hard gate on #257, not a parallel cleanup. **#257 itself is
+post-tag, not pre-tag** — `setup-logmind` installs from `/releases/latest`,
+and the released v1.2.0 answers `logmind check-decisions --base` with
+`Error: unknown flag: --base` (ruling recorded in #243). The fleet cannot
+take the new gate template until v2.0.0 exists, so this whole cluster —
+including #288 below and #265+#257 in §4 — runs after the tag by
+construction, even though it is numbered ahead of "§3 — Remaining pre-tag
+work" in this list: numbering here is dependency order, not calendar order
+across the tag boundary.
 
 | | why it blocks |
 |---|---|
@@ -162,16 +196,6 @@ Each is a hard gate on #257, not a parallel cleanup.
 ahead of the gate cluster; doing it after means relocating a **correct**
 evaluation rather than a wrong one. Its remedy restructures `regen-timeline.yml`,
 so that file moves twice regardless of what else we do.
-
-**#267** — `EnsureAgentsMD` silently downgrades a newer `AGENTS.md` block. Same
-*shape* as #286 but a different root cause: `matchingTemplate` recognises markers
-by hardcoded `strings.Contains` of known generations, so an unknown newer marker
-returns `""` and the slim default is applied. No version compare exists to fix.
-Fires exactly during a staggered rollout — the condition #257 creates.
-
-**#270** — hooks resolve their engine by bare name, so PATH skew silently
-disables the local gate. §3.4 requires fail-open *and* requires that failing open
-not be silent; today it is.
 
 **#269** — `ignore_patterns` replaces the 16 built-in defaults instead of merging.
 §1.4 line 202 says the three sources are **merged**, so this is a spec violation,
@@ -191,14 +215,17 @@ does not exist. Recorded here rather than in §5 so the ruling stays visible —
 its own issue body still says "after the v2.0.0 tag", which contradicts the
 ruling that governs it and needs correcting.
 
-**#241** — `logmind auto`. Also pre-tag by Ruling 12, and the longest pole among
-them: it installs two skills that did not exist, so those had to be written
-first (agent-skills#207, open). Build once that merges.
+**#241** — `logmind auto`. Also pre-tag by Ruling 12. It previously needed two
+skills that did not exist; those shipped in agent-skills#207 (merged
+2026-08-15). What remains is #241's own underspecification — see above.
 
 **#279** — the site's `--version` example is one line; §7.3 requires two, and the
-tag-time flip will not add the `areas:` line.
+tag-time flip would not have added the `areas:` line. **Built and on `dev`**
+(#302). The issue stays open until `dev` reaches `main`, per the rule above.
+The panel verified it by building the site in both states rather than reading
+the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
 
-### 4 — #265 + #257, together
+### 4 — #265 + #257, together (post-tag — see §2)
 
 One fleet move, per standing constraint. #265 collapses the decision layout —
 main is a branch like any other, no cap, no archive, `rotateDecisions` deleted
@@ -232,7 +259,7 @@ ships.
 | clud-bug-app | `v2` | `v4` | **yes** |
 | agent-skills | `v2` | `v4` | **yes** |
 | reporulez | *unversioned* | *unmarked* | no |
-| skdd | *absent* on `main`, **`v4`** on `dev` | — | no |
+| skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
 
 **logmind ships** `check-decisions` at **`v5`** and `regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
@@ -253,11 +280,24 @@ Two corrections to #257's original inventory:
 
 ### The cost of not migrating
 
-`thrillmade/protocol`, last 10 pull requests: **98 commits, 42 of them
-`logmind-auto-regen[bot]` — 42%.** PR#75 alone carries 30, every subject
-byte-identical. 1:1 alternation confirmed by timestamp. PR#70 contains a *human*
-commit titled `[skip-logmind] chore: regen derived docs` — someone hand-running
-the regeneration to pre-empt the bot.
+`thrillmade/protocol`, last 10 **merged** pull requests by creation date
+(#92, #88, #85, #84, #83, #80, #76, #75, #70, #69) — **measured 2026-08-15**:
+
+```sh
+$ gh api "repos/thrillmade/protocol/pulls?state=closed&sort=created&direction=desc&per_page=30" \
+    --jq '[.[] | select(.merged_at != null)] | .[0:10] | .[].number'
+$ for pr in 92 88 85 84 83 80 76 75 70 69; do
+    gh api "repos/thrillmade/protocol/pulls/$pr/commits" \
+      --jq '[.[] | .commit.author.name]'
+  done
+# 109 commits total, 43 with .commit.author.name == "logmind-auto-regen[bot]"
+```
+
+**109 commits, 43 of them `logmind-auto-regen[bot]` — 39%.** PR#75 alone
+carries 30, every subject byte-identical (`chore: regen derived docs`); its 63
+commits alternate human/bot 1:1 for the first 60, confirmed by commit order.
+PR#70 contains a *human* commit titled `[skip-logmind] chore: regen derived docs` —
+someone hand-running the regeneration to pre-empt the bot.
 
 It has already produced one governance failure: **protocol#75, the SPEC 2.0
 rewrite itself, merged over a red required `check-derived-docs` via admin
@@ -273,7 +313,7 @@ bypassing gates.
 
 ## Pre-tag checklist
 
-1. `dev` → `main`, which closes #264, #278, #260, #284, #285, #286.
+1. `dev` → `main`, which closes #264, #278, #260, #284, #285, #286, #267, #270.
 2. Run `release.yml` with `dry_run=true`.
 3. **Separately** re-confirm the homebrew-tap ruleset bypass — the dry run skips
    that push, so it never exercises the identity that failed with GH013.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,9 +17,16 @@
 > from memory or from an issue body. A claimed zero is stated with the control
 > that proves the probe finds a non-zero when one exists.
 
-**Verified 2026-08-15** against `origin/dev 2a8e10a`, `origin/main 0aa9049`, and
-the live SPEC at `thrillmade/protocol` blob `cd64e5c` (1,475 lines, Sections 0–8,
-no appendices).
+**Verified 2026-08-15** against the live SPEC at `thrillmade/protocol` blob
+`cd64e5c` (1,475 lines, Sections 0–8, no appendices) — an immutable blob, so
+that pin cannot rot.
+
+This line used to name the `dev` and `main` SHAs it was checked against. Those
+are gone, and their absence is the point: the pin was stale three minutes before
+the commit that introduced it, which is the fourth recurrence of the defect this
+file exists to prevent — in the file's own header, two paragraphs above the rule
+forbidding it. A branch tip is not a fact this file may own. Run
+`git rev-parse --short origin/dev origin/main` instead.
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,4 +33,5 @@ logmind's own templates install.
 review's output but performs none, and declaring a version is a §7.3
 obligation rather than an implementation of §7.
 
-See [docs/plan.md](plan.md) for architecture and the forward roadmap.
+See [docs/plan.md](plan.md) for architecture and [docs/roadmap.md](roadmap.md)
+for the forward roadmap.


### PR DESCRIPTION
The roadmap lived in a **scratchpad HTML file** that the artifact was published from. That file was wiped **twice today** by session restarts, taking the only copy of the sequencing with it. The published page survived but could no longer be updated — so it drifted to showing 26 issues and a superseded critical path while the real count was 31 and the critical path had moved to #288.

A roadmap that cannot survive a restart is not a source of truth.

## What changes

- **New `docs/roadmap.md`** — versioned, reviewable, in the repo. The artifact renders *from* it instead of *being* it.
- **`docs/plan.md` retitled** "Plan & Architecture" → "Architecture", with a header stating that sequencing lives in roadmap.md.
- **One owner per fact**, stated in both files: if a date, count, issue number or ordering appears in both, `roadmap.md` is right and `plan.md` is stale.

## Why not just keep it in plan.md

Half-life. `plan.md` is architecture and changes yearly; the release board changed six times in one day. Fusing them is exactly why plan.md spent weeks describing a `derived_docs.mode` config gate that had already been deleted from the codebase.

## Discipline the file holds itself to

Every number carries the command that produced it. Every claimed zero carries a control proving the probe finds a non-zero when one exists — including the load-bearing one:

> Those bot commits have `.author.login == null` — no linked account. A probe keyed on `.author.login` reports **zero on every pull request** and looks like a clean result. Identity must be read from `.commit.author.name`.

That distinction is why the storm went unmeasured for weeks.

## Verification

- All **seven** SPEC citations verified LIVE against blob `cd64e5c`, with a control on a section known to exist — not just one known to be absent. (My first run of that check reported all seven DEAD; the cause was `/tmp/SPEC-live.md` having been wiped, and my control was too weak to distinguish that from a real failure. Re-fetched and re-run properly.)
- `logmind check-links` — all markdown links resolve, no orphans.
- Content re-measured against `origin/dev a0f6339` today, not carried from memory.

## Not in this PR

Re-publishing the artifact from this file. That happens once this lands, so the published page and the repo file agree from the start rather than diverging again immediately.