### PR TITLE
fix(gate): a rename out of docs/ zeroed the count — the shared-evaluation change dropped --no-renames

### DIFF
--- a/docs/decisions-branches/fix__gate-rename-hole.md
+++ b/docs/decisions-branches/fix__gate-rename-hole.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-close-the-rename-hole-the-shared-evaluation-change-opened -->
+- **2026-08-14** — Close the rename hole the shared-evaluation change opened
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:17 - Close the rename hole the shared-evaluation change opened
+
+**Reasoning:** A retrospective panel on merged dev found the gate passing 550 lines of new Go. Unifying the numstat flag lists in #287 dropped --no-renames, which the old bash template carried with a comment saying exactly why. With rename detection on, git renders a cross-directory rename as ONE row whose path field is 'old => new', and IsExcludedPath prefix-matched that whole string — so 'docs/notes.md => src/payload.go' was excluded as docs/ and the count came out zero. Reproduced independently: git mv docs/notes.md src/payload.go plus 150 appended lines, gate says '✓ 0 lines changed (below 20-line threshold)', exit 0. The first repro attempt did NOT trigger it, because appending 150 lines to a 1-line file drops similarity below git's 50% rename threshold; it needs a file large enough to still be detected as a rename.
+
+**Alternatives considered:** Teach IsExcludedPath to parse the rename rendering and test the destination path. Rejected: git has at least two renderings — 'old => new' and the compact '{docs => src}/sub/file' — so a parser owes both plus whatever git adds later, and a parser that falls behind fails OPEN. Refusing to exclude anything carrying ' => ' fails CLOSED; the worst case is asking for a decision that was not owed.
+
+**Implications:**
+- Two layers. gitcli.numstatFlags is now the one list every count runs with, carrying --no-renames, so the three call sites cannot drift apart again — drift is what caused this. IsExcludedPath additionally refuses to exclude any path containing ' => ' as a second line of defence, because the first line was removed once already. Verified with four cases at true exit codes: rename out of docs/ blocks (1), plain 550 lines blocks (1), docs-only passes (0), under-threshold passes (0). Also closes --threshold as a fourth gate-clearer in range mode — worse than --no-fail because it reads as configuration rather than an escape; §3.4 pins the gate's threshold to git.commit_line_threshold and nothing else.
+
+---
+

--- a/docs/decisions-branches/fix__gate-rename-hole.md
+++ b/docs/decisions-branches/fix__gate-rename-hole.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-14 17:57 - Pin the rename fix on git's real output, not on synthetic rows
+
+**Reasoning:** An adversarial panel found the fix's own test was worthless as a guard. It reverted numstatFlags to just --numstat — reproducing #287 verbatim — and the full suite stayed GREEN, because the test asserted on synthetic NumstatLine values and never invoked git. I confirmed it independently before fixing. That is the exact trap: a test on the helper you fixed passes its own mutation and still goes green when the bug ships again. The PR comment even said 'the first line of defence was removed once already' while shipping nothing that would notice a third time.
+
+**Alternatives considered:** Assert on more synthetic rows. Rejected — the bug is in what git EMITS, not in how we classify what we are handed, so no amount of hand-written rows can catch the flag going missing.
+
+**Implications:**
+- The new test drives a real git repository through a real rename and asserts the numstat output carries no ' => ' rendering. Mutation-verified in both directions: removing --no-renames now fails with 'numstat still carries a rename rendering (1 rows)', and removing the IsExcludedPath guard fails the consumer-side test. The source file has to be large enough to stay above git's ~50% rename-similarity threshold or the test passes vacuously, so it builds 400 lines and appends 150 — a guard the test states and checks. Also fixes the panel's other findings: --threshold's range-mode refusal shipped untested and now has one, and both flag-combination guards move ABOVE the not-a-repo check, because an invalid flag combination is an argument error that should not depend on where the process is standing. The config template's comment claiming the threshold is 'shared with check-decisions --threshold' now says what §3.4 actually requires.
+
+---
+

--- a/docs/decisions-branches/fix__gate-rename-hole.md
+++ b/docs/decisions-branches/fix__gate-rename-hole.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-14 21:36 - Make the two guard tests prove the guards, not the tempdir path
+
+**Reasoning:** A re-entry panel applied four mutations. Three died. The fourth — deleting the --no-fail range guard entirely — SURVIVED, and the reason is worth recording: t.TempDir() names the directory after the calling test, so a subtest named '--no-fail is refused in range mode' produced a path CONTAINING the string '--no-fail'. The not-a-repo error echoes opts.cwd, so strings.Contains(err.Error(), "--no-fail") matched the PATH. The test passed for entirely the wrong reason, and would have stayed green while --no-fail --base X --head Y silently cleared every pull request. Its sibling --threshold test escaped only by accident, because its dir happened to be created at parent scope. Confirmed independently before fixing: the temp dir really is named .../TestTempDirNameLeak--no-fail_is_refused_in_range_mode.../001.
+
+**Alternatives considered:** Rename the subtests so the flag string cannot appear in the path. Rejected as coincidence-proofing rather than a fix — the assertion would still be satisfiable by any incidental substring. Both assertions now check text unique to the guard's own refusal, and the shared dir is created at parent scope so no subtest name reaches it.
+
+**Implications:**
+- The panel also found the rename test's anti-vacuity guard was inverted: it asserted no ' => ' rows, which is exactly what 'git never detected a rename' produces. Demonstrated under diff.renames=false in a global gitconfig — the test passed WITH the fix removed. A positive control now runs first and asserts git, left to itself, does emit the rename rendering; if it does not, the test SKIPS with the bare numstat output rather than reporting a green it has not earned. Absence of the rendering means nothing until we know it would otherwise appear. Mutation D now dies, and its failure output shows the path no longer carries the flag name.
+
+---
+

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -142,6 +142,20 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 		return fmt.Errorf("--no-fail cannot be combined with --base/--head: SPEC §3.4 allows exactly two things to clear the gate — the change carries a decision, or it falls under the threshold")
 	}
 
+	// --threshold is the fourth, by exactly the same argument, and it is
+	// worse than --no-fail because it does not look like an escape:
+	// `--threshold 999999` reads as configuration. §3.4 pins the gate's
+	// threshold to `git.commit_line_threshold` and to nothing else, so in
+	// range mode the flag has no legitimate use — the repository already
+	// has a way to say what its threshold is, read from the base ref
+	// precisely so the change under judgement cannot forge it.
+	//
+	// Refused rather than ignored: silently discarding a flag someone
+	// passed deliberately is its own way of lying about what ran.
+	if rangeMode && opts.thresholdExplicit {
+		return fmt.Errorf("--threshold cannot be combined with --base/--head: SPEC §3.4 pins the gate's threshold to git.commit_line_threshold; set it in the repository's .logmind/config.yml instead")
+	}
+
 	// One repository root for the config read AND every git command
 	// below. Resolving them separately is SPEC §3.4's named silent
 	// bypass: "configuration from where the process started, diffs from

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -112,27 +112,6 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 		return fmt.Errorf("--base and --head must be given together")
 	}
 
-	// Running outside a repository is one of §3.4's SIX local allowances,
-	// and like the other five it MUST NOT reach the gate: "every allowance
-	// above that depends on local process state — the environment
-	// variable, a git operation in progress, running outside a repository,
-	// a marker in a commit subject — is invisible to it and MUST NOT be
-	// honoured there. Exactly two things clear the gate."
-	//
-	// In range mode this is the gate, so a missing repository is a hard
-	// error rather than a pass. Otherwise a workflow that resolves its
-	// working directory wrongly — `working-directory:` pointing off the
-	// checkout, or `actions/checkout` with a `path:` — turns every PR
-	// green regardless of size, and reports success while doing it.
-	if !gitcli.IsRepo(opts.cwd) {
-		if rangeMode {
-			return fmt.Errorf("not a git repository: %s (the gate cannot evaluate a range outside a repository; check the job's working directory)", opts.cwd)
-		}
-		// Local path only. Python: click.echo(...) to stdout, no exit.
-		fmt.Fprintln(stdout, "Not a git repository, skipping check.")
-		return nil
-	}
-
 	// §3.4 again: exactly two things clear the gate. --no-fail is a third,
 	// and although it is set by whoever wrote the workflow rather than by
 	// the pull request's author, a repository that adds it has a gate that
@@ -154,6 +133,27 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 	// passed deliberately is its own way of lying about what ran.
 	if rangeMode && opts.thresholdExplicit {
 		return fmt.Errorf("--threshold cannot be combined with --base/--head: SPEC §3.4 pins the gate's threshold to git.commit_line_threshold; set it in the repository's .logmind/config.yml instead")
+	}
+
+	// Running outside a repository is one of §3.4's SIX local allowances,
+	// and like the other five it MUST NOT reach the gate: "every allowance
+	// above that depends on local process state — the environment
+	// variable, a git operation in progress, running outside a repository,
+	// a marker in a commit subject — is invisible to it and MUST NOT be
+	// honoured there. Exactly two things clear the gate."
+	//
+	// In range mode this is the gate, so a missing repository is a hard
+	// error rather than a pass. Otherwise a workflow that resolves its
+	// working directory wrongly — `working-directory:` pointing off the
+	// checkout, or `actions/checkout` with a `path:` — turns every PR
+	// green regardless of size, and reports success while doing it.
+	if !gitcli.IsRepo(opts.cwd) {
+		if rangeMode {
+			return fmt.Errorf("not a git repository: %s (the gate cannot evaluate a range outside a repository; check the job's working directory)", opts.cwd)
+		}
+		// Local path only. Python: click.echo(...) to stdout, no exit.
+		fmt.Fprintln(stdout, "Not a git repository, skipping check.")
+		return nil
 	}
 
 	// One repository root for the config read AND every git command

--- a/internal/cli/check_decisions_test.go
+++ b/internal/cli/check_decisions_test.go
@@ -427,6 +427,13 @@ func revParse(t *testing.T, repo, ref string) string {
 // check" and exited 0. Every pull request would have gone green
 // regardless of size, while reporting success.
 func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
+	// Created at PARENT scope on purpose. t.TempDir() names the directory
+	// after the calling test, so creating it inside a subtest named
+	// "--no-fail …" yields a path containing "--no-fail" — and the
+	// not-a-repo error echoes opts.cwd. That is how the original version of
+	// this test passed while the guard it claimed to cover was deleted.
+	dir := t.TempDir()
+
 	t.Run("not a git repository is a hard error in range mode", func(t *testing.T) {
 		dir := t.TempDir() // deliberately not a git repo
 		var out bytes.Buffer
@@ -450,7 +457,12 @@ func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
 	})
 
 	t.Run("--no-fail is refused in range mode", func(t *testing.T) {
-		dir := t.TempDir()
+		// dir comes from the PARENT scope deliberately. t.TempDir() names the
+		// directory after the subtest, so a subtest called "--no-fail …"
+		// produces a path CONTAINING "--no-fail" — and the not-a-repo error
+		// echoes opts.cwd. An adversarial review found the original assertion
+		// matching that path rather than the guard: deleting the guard
+		// entirely left this test green.
 		var out bytes.Buffer
 		err := runCheckDecisions(checkDecisionsOpts{
 			cwd: dir, base: "a", head: "b", noFail: true,
@@ -458,8 +470,13 @@ func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
 		if err == nil {
 			t.Fatal("--no-fail with --base/--head returned nil; it is a third thing clearing the gate")
 		}
+		// Assert on text unique to the guard, not on a flag name that can
+		// appear in an incidental path.
+		if !strings.Contains(err.Error(), "cannot be combined with --base/--head") {
+			t.Errorf("error is not the guard's refusal, got %v", err)
+		}
 		if !strings.Contains(err.Error(), "--no-fail") {
-			t.Errorf("error should name the refused flag, got %v", err)
+			t.Errorf("refusal should name the flag, got %v", err)
 		}
 	})
 }
@@ -484,8 +501,11 @@ func TestCheckDecisions_RangeMode_RefusesThreshold(t *testing.T) {
 		if err == nil {
 			t.Fatal("--threshold with --base/--head returned nil; it is a third thing clearing the gate")
 		}
+		if !strings.Contains(err.Error(), "cannot be combined with --base/--head") {
+			t.Errorf("error is not the guard's refusal, got %v", err)
+		}
 		if !strings.Contains(err.Error(), "--threshold") {
-			t.Errorf("error should name the refused flag, got %v", err)
+			t.Errorf("refusal should name the flag, got %v", err)
 		}
 	})
 

--- a/internal/cli/check_decisions_test.go
+++ b/internal/cli/check_decisions_test.go
@@ -463,3 +463,40 @@ func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
 		}
 	})
 }
+
+// TestCheckDecisions_RangeMode_RefusesThreshold pins the fourth
+// gate-clearer. Its sibling --no-fail refusal was tested; this one shipped
+// untested and an adversarial review caught the gap.
+//
+// SPEC §3.4 pins the gate's threshold to git.commit_line_threshold and
+// nothing else. --threshold is worse than --no-fail as an escape because
+// it does not look like one: `--threshold 999999` reads as configuration
+// rather than a bypass, so it is the version a reviewer waves through.
+func TestCheckDecisions_RangeMode_RefusesThreshold(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("--threshold is refused in range mode", func(t *testing.T) {
+		var out bytes.Buffer
+		err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, base: "a", head: "b",
+			threshold: 999999, thresholdExplicit: true,
+		}, &out)
+		if err == nil {
+			t.Fatal("--threshold with --base/--head returned nil; it is a third thing clearing the gate")
+		}
+		if !strings.Contains(err.Error(), "--threshold") {
+			t.Errorf("error should name the refused flag, got %v", err)
+		}
+	})
+
+	t.Run("--threshold is still allowed locally", func(t *testing.T) {
+		var out bytes.Buffer
+		// Not a repo, so the local path returns its skip message rather
+		// than evaluating — enough to prove the flag is not refused.
+		if err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, threshold: 999999, thresholdExplicit: true,
+		}, &out); err != nil {
+			t.Fatalf("--threshold alone must not be refused, got %v", err)
+		}
+	})
+}

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -268,7 +268,7 @@ type NumstatLine struct {
 // Returns an empty slice on git failure — check-decisions treats that
 // as "0 lines changed" rather than blowing up the pre-commit hook.
 func DiffCachedNumstat(repoRoot string) []NumstatLine {
-	cmd := exec.Command("git", "diff", "--cached", "--numstat")
+	cmd := exec.Command("git", append([]string{"diff", "--cached"}, numstatFlags...)...)
 	cmd.Dir = repoRoot
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -287,7 +287,7 @@ func DiffCachedNumstat(repoRoot string) []NumstatLine {
 // git commit` stages anything, so `--cached` alone would undercount a
 // change that is still sitting unstaged at evaluation time.
 func DiffNumstat(repoRoot string) []NumstatLine {
-	cmd := exec.Command("git", "diff", "--numstat")
+	cmd := exec.Command("git", append([]string{"diff"}, numstatFlags...)...)
 	cmd.Dir = repoRoot
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -326,16 +326,40 @@ func DiffRangeNames(repoRoot, base, head string) ([]string, error) {
 	return strings.Split(trimmed, "\n"), nil
 }
 
+// numstatFlags is the ONE flag list every substantive-line count runs
+// with. SPEC §3.4 drives all three enforcement points from "one shared
+// evaluation," so the flags live here rather than at each call site —
+// a flag one surface passes and another doesn't is that one evaluation
+// quietly becoming two.
+//
+// --no-renames is load-bearing, and its absence was a live gate hole.
+// With rename detection ON, git renders a cross-directory rename as a
+// SINGLE row whose path field is `old => new`:
+//
+//	150	0	docs/notes.md => src/payload.go
+//
+// guardcommit.IsExcludedPath prefix-matches that whole string, so the
+// row is excluded as `docs/...` and 550 lines of new Go counted zero —
+// the gate passed a change it exists to stop. --no-renames splits it
+// into a deletion under docs/ (correctly excluded) and an addition under
+// src/ (correctly counted).
+//
+// Deliberately NOT fixed by teaching IsExcludedPath to parse `old =>
+// new`: git has two rename renderings (that one, and the compact
+// `{docs => src}/sub/notes.md`), so a parser owes both plus whatever
+// git adds later. Not asking for renames at all has no such surface.
+var numstatFlags = []string{"--numstat", "--no-renames"}
+
 // DiffRangeNumstat parses `git diff --numstat base...head` into typed
 // rows. Same parsing rules as DiffCachedNumstat, same loud-on-failure
 // contract as DiffRangeNames.
 //
-// The flags deliberately match DiffCachedNumstat's exactly (i.e. none
-// beyond --numstat): SPEC §3.4 drives every enforcement point from "one
-// shared evaluation," and a flag one surface passes and another doesn't
-// is that evaluation quietly becoming two.
+// The flags deliberately match DiffCachedNumstat's exactly: SPEC §3.4
+// drives every enforcement point from "one shared evaluation," and a flag
+// one surface passes and another doesn't is that evaluation quietly
+// becoming two. See numstatFlags for why --no-renames is among them.
 func DiffRangeNumstat(repoRoot, base, head string) ([]NumstatLine, error) {
-	out, err := runDiffRange(repoRoot, base, head, "--numstat")
+	out, err := runDiffRange(repoRoot, base, head, numstatFlags...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -586,10 +586,28 @@ func TestNumstat_RenameOutOfDocsIsSplit(t *testing.T) {
 	f.Close()
 	run("add", "-A")
 
+	// POSITIVE CONTROL FIRST. Assert that git, left to itself, DOES render
+	// this as a rename. Without it the whole test is vacuous: an adversarial
+	// review showed that under `diff.renames=false` in a user's gitconfig,
+	// the "no => rows" assertion below passes even with --no-renames removed,
+	// because git never emitted a rename in the first place. Absence of the
+	// rendering only means something once we know it would otherwise appear.
+	bare := exec.Command("git", "diff", "--cached", "--numstat")
+	bare.Dir = repo
+	bareOut, err := bare.Output()
+	if err != nil {
+		t.Fatalf("bare numstat: %v", err)
+	}
+	if !strings.Contains(string(bareOut), " => ") {
+		t.Skipf("git did not render this as a rename (diff.renames disabled, or "+
+			"similarity below threshold) — the test cannot prove anything about "+
+			"--no-renames here. Bare numstat was:\n%s", bareOut)
+	}
+
 	rows := DiffCachedNumstat(repo)
 
-	// Guard against a vacuous pass: if git did not detect a rename at all,
-	// this test proves nothing about the flag.
+	// Now the real assertion: our flags must suppress what the control just
+	// proved git would otherwise emit.
 	var renameRows int
 	for _, r := range rows {
 		if strings.Contains(r.Path, " => ") {

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -2,6 +2,7 @@ package gitcli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -523,5 +524,91 @@ func TestDefaultBranchMergeBase_FallsBackToHEAD_WhenUnresolvable(t *testing.T) {
 
 	if got := DefaultBranchMergeBase(repo); got != "HEAD" {
 		t.Fatalf("DefaultBranchMergeBase = %q; want the \"HEAD\" fallback", got)
+	}
+}
+
+// TestNumstat_RenameOutOfDocsIsSplit runs against a REAL git repository
+// with a REAL rename, and is the pin that the earlier synthetic test was
+// not.
+//
+// The regression it guards: #287 unified the numstat flag lists and
+// dropped --no-renames. With rename detection on, git renders a
+// cross-directory rename as ONE row whose path is `old => new`, so
+// `docs/notes.md => src/payload.go` prefix-matched `docs/` and hundreds
+// of lines of new code counted zero. An adversarial review found that the
+// fix's own test — asserting on synthetic NumstatLine values — stayed
+// GREEN when --no-renames was removed again, because it never invoked
+// git. A test on the helper you fixed is not a test on the bug.
+//
+// This one drives the actual command. Remove --no-renames from
+// numstatFlags and it goes red, because git's output shape changes.
+//
+// The file must be large enough that appending to it stays above git's
+// ~50% rename-similarity threshold; a small file plus many added lines is
+// simply not detected as a rename and the test would pass vacuously.
+func TestNumstat_RenameOutOfDocsIsSplit(t *testing.T) {
+	repo := initRepo(t)
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	var big strings.Builder
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&big, "original line %d\n", i)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "docs", "notes.md"), []byte(big.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "add docs/notes.md")
+
+	// Move it into src/ and append, keeping similarity high enough that
+	// git still calls it a rename.
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run("mv", "docs/notes.md", "src/payload.go")
+	f, err := os.OpenFile(filepath.Join(repo, "src", "payload.go"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 150; i++ {
+		fmt.Fprintf(f, "// added %d\n", i)
+	}
+	f.Close()
+	run("add", "-A")
+
+	rows := DiffCachedNumstat(repo)
+
+	// Guard against a vacuous pass: if git did not detect a rename at all,
+	// this test proves nothing about the flag.
+	var renameRows int
+	for _, r := range rows {
+		if strings.Contains(r.Path, " => ") {
+			renameRows++
+		}
+	}
+	if renameRows > 0 {
+		t.Fatalf("numstat still carries a rename rendering (%d rows) — --no-renames is not in effect:\n%+v", renameRows, rows)
+	}
+
+	// The substantive half must be attributed to src/, not swallowed by
+	// the docs/ prefix.
+	var sawSrc bool
+	for _, r := range rows {
+		if r.Path == "src/payload.go" {
+			sawSrc = true
+		}
+	}
+	if !sawSrc {
+		t.Fatalf("no row for src/payload.go — the rename was not split:\n%+v", rows)
 	}
 }

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -393,6 +393,24 @@ var excludedFiles = func() map[string]bool {
 // markdown wholesale switches the rule off in the repositories where
 // writing *is* the work." Do not add a "*.md" arm here.
 func IsExcludedPath(path string) bool {
+	// A path carrying git's rename rendering is never excluded.
+	//
+	// gitcli.numstatFlags passes --no-renames, so in practice git does not
+	// hand us this shape at all. This is the second line of defence, and it
+	// exists because the first one was removed once already: when the flag
+	// went missing, `docs/notes.md => src/payload.go` prefix-matched
+	// `docs/` and the gate counted 550 lines of new Go as zero.
+	//
+	// Deliberately a refusal rather than a parser. Git has at least two
+	// renderings — `old => new` and the compact `{docs => src}/sub/file` —
+	// so parsing owes both plus whatever git adds later, and a parser that
+	// falls behind fails OPEN. Refusing to exclude fails CLOSED: the worst
+	// case is counting a rename that a correct parser would have excluded,
+	// which asks an author for a decision they did not owe. That is a far
+	// cheaper error than waving through the change the gate exists to stop.
+	if strings.Contains(path, " => ") {
+		return false
+	}
 	if strings.HasPrefix(path, docsPrefix) || strings.HasPrefix(path, configPrefix) {
 		return true
 	}

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -661,3 +661,51 @@ func TestIsSectionHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestSubstantiveLines_RenameOutOfDocsIsCounted pins the gate hole a
+// retrospective panel found on `dev` after PR #287 unified the numstat
+// flag lists and dropped --no-renames in the process.
+//
+// With rename detection ON, git renders a cross-directory rename as ONE
+// row whose path field is `old => new`:
+//
+//	150	0	docs/notes.md => src/payload.go
+//
+// IsExcludedPath prefix-matches that whole string, so the row was
+// excluded as `docs/...` and 550 lines of new Go counted zero — the gate
+// passed exactly the change it exists to stop. gitcli.numstatFlags now
+// carries --no-renames on every count, which splits the row into a
+// deletion under docs/ (excluded) and an addition under src/ (counted).
+//
+// This test pins the CONSUMER side: whatever git hands us, a path that
+// still carries the `=>` rename rendering must not be silently treated as
+// living under an excluded prefix.
+func TestSubstantiveLines_RenameOutOfDocsIsCounted(t *testing.T) {
+	// The exact shape git emits when rename detection is on.
+	rows := []gitcli.NumstatLine{
+		{Added: "150", Removed: "0", Path: "docs/notes.md => src/payload.go"},
+	}
+	if got := SubstantiveLines(rows); got == 0 {
+		t.Errorf("a rename OUT of docs/ counted 0 lines — the gate would pass "+
+			"550 lines of new code; got %d, want non-zero", got)
+	}
+
+	// Control: a genuine docs-only row must still be excluded, or the fix
+	// has simply broken the exclusion it was meant to preserve.
+	docsOnly := []gitcli.NumstatLine{
+		{Added: "550", Removed: "0", Path: "docs/notes.md"},
+	}
+	if got := SubstantiveLines(docsOnly); got != 0 {
+		t.Errorf("a docs-only change must stay excluded (SPEC §3.4); got %d, want 0", got)
+	}
+
+	// Control: the compact rename rendering, which git uses when the two
+	// paths share a prefix. It never looked like a bare docs/ path, so it
+	// was never part of the hole — but it must not regress either.
+	compact := []gitcli.NumstatLine{
+		{Added: "150", Removed: "0", Path: "{docs => src}/sub/notes.md"},
+	}
+	if got := SubstantiveLines(compact); got == 0 {
+		t.Errorf("compact rename rendering counted 0; got %d, want non-zero", got)
+	}
+}

--- a/internal/templates/config.yml.template
+++ b/internal/templates/config.yml.template
@@ -17,7 +17,11 @@ git:
   # Block substantive commits that bypass `logmind log` (commit-msg + Claude
   # Code PreToolUse hooks). Set false to fall back to warn-only for this repo.
   enforce_commits: true
-  # Lines-changed threshold shared with `logmind check-decisions --threshold`.
+  # Lines-changed threshold. SPEC §3.4 makes this the ONE source for every
+  # enforcement point — the commit-msg hook, the harness guard, and the CI
+  # gate. `logmind check-decisions --threshold` overrides it locally, but is
+  # refused alongside `--base/--head`: the gate reads this file and nothing
+  # else, so a pull request cannot raise its own bar.
   commit_line_threshold: 20
 
 # Decision management


### PR DESCRIPTION
A retrospective panel on merged `dev` found the gate **passing 550 lines of new Go**.

## The hole

Unifying the numstat flag lists in #287 dropped `--no-renames`. The old bash template carried it with a comment saying exactly why. With rename detection on, git renders a cross-directory rename as **one row** whose path field is `old => new`, and `IsExcludedPath` prefix-matched that whole string:

```
$ git mv docs/notes.md src/payload.go   # + 150 appended lines
$ git diff --cached --numstat
150	0	docs/notes.md => src/payload.go

$ logmind check-decisions
✓ 0 lines changed (below 20-line threshold).      exit 0
```

Excluded as `docs/…`. Violates §3.4: *"Four things are excluded from the count, and nothing else is"* — `src/payload.go` is not one of them.

**Reproduction note worth keeping:** my first attempt did *not* trigger it. Appending 150 lines to a 1-line file drops similarity below git's 50% rename threshold, so git doesn't call it a rename at all. It needs a file large enough to still be detected as one.

## Fixed in two layers

**Primary — one flag list.** `gitcli.numstatFlags` is now the single list every substantive-line count runs with, carrying `--no-renames`. All three call sites take it. They cannot drift apart again, and drift is precisely what caused this.

**Second line of defence — `IsExcludedPath` refuses any path containing ` => `.** Deliberately a refusal, not a parser:

> Git has at least two renderings — `old => new` and the compact `{docs => src}/sub/file` — so parsing owes both plus whatever git adds later, and **a parser that falls behind fails OPEN**. Refusing to exclude fails CLOSED: the worst case is counting a rename a correct parser would have excluded, which asks an author for a decision they did not owe. Far cheaper than waving through the change the gate exists to stop.

The first line of defence was removed once already. That is why there is a second.

## Also closed: `--threshold` was a fourth gate-clearer

`--threshold 999999` in range mode passed a 60-line change. **Worse than `--no-fail`, because it does not look like an escape** — it reads as configuration. §3.4 pins the gate's threshold to `git.commit_line_threshold` and nothing else. Refused in range mode; still allowed locally. Refused rather than ignored, because silently discarding a flag someone passed deliberately is its own way of lying about what ran.

## Verified at true exit codes

| case | exit | correct |
|---|---|---|
| rename out of `docs/`, 550 new lines | 1 | blocks |
| same 550 lines, no rename | 1 | blocks |
| 550 lines, docs only | 0 | passes |
| 5 lines, under threshold | 0 | passes |
| `--threshold` + range | 1 | refused |
| `--threshold` alone | 0 | still allowed |

Full `go test ./...` exit 0, 20 packages, 0 failures. `vet` and `gofmt` clean.

## Why this was missed

The build agent flagged it: *"if `--no-renames` is wanted it must go on both wrappers, not one."* I recorded it as a decision for the follow-up PR and it shipped instead. The panel caught it four merges later.