### PR TITLE
fix(doctor): template markers are ordered — a repo ahead of the binary is not "STALE (latest: <older>)"

### DIFF
--- a/docs/decisions-branches/fix__doctor-template-ordering.md
+++ b/docs/decisions-branches/fix__doctor-template-ordering.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-teach-doctor-the-same-template-ordering-the-installer-learne -->
+- **2026-08-14** — Teach doctor the same template ordering the installer learned
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:27 - Teach doctor the same template ordering the installer learned
+
+**Reasoning:** A retrospective panel found that #289 taught installWorkflowTemplates that markers are ordered but left doctor comparing for equality. So a repo AHEAD of the running binary reported 'STALE (latest: v4)' with both the verdict and the latest label inverted — and because #289's refusal is correct, the row became permanently unclearable: doctor said stale, --fix refused, nothing reconciled them. Measured: a repo initialised at check-decisions v5, probed by a v4-bundling binary, printed 'v5 STALE (latest: v4)' and exit 1. My own #289 PR body called this a misleading parenthetical; the panel was right that it is worse than that.
+
+**Alternatives considered:** Suppress the row when the installed marker is unrecognised. Rejected: that hides a real signal. A repository ahead of the binary is worth saying out loud — it means the operator should upgrade — it just is not drift the tool can fix.
+
+**Implications:**
+- classifyMarker now returns a third value, 'ahead', and every DRIFT and exit-1 path keys on 'stale' specifically, so ahead is informational and does not flip the tool. The comparison parses the integer after the v and ignores any -pointer suffix; deliberately NOT a string compare, because 'v11' sorts before 'v4' lexically and that trap looks correct in testing right up until a version reaches double digits — which check-decisions just did, v4 to v5, with regen-timeline already at v11. An unparseable marker on either side falls back to the old equality semantics rather than guessing. Verified end to end: v5 vs v5 current, v99 vs v5 ahead, v1 vs v5 still STALE. Eleven table cases plus three controls, including one proving ahead does not mask a genuinely stale row.
+
+---
+

--- a/docs/decisions-branches/fix__doctor-template-ordering.md
+++ b/docs/decisions-branches/fix__doctor-template-ordering.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-14 18:04 - Give the version ordering one owner, and pin the string the user saw
+
+**Reasoning:** An adversarial panel found my doctor fix reintroduced the exact defect it was fixing. parseMarkerOrdinal was a SECOND copy of the ordering rule alongside cli.parseTemplateVersion, and they disagreed: init required a leading v, doctor did not and used bare Atoi. Since doctor's extractor is a non-whitespace match, a marker like '12' reached it — and the panel demonstrated doctor printing 'ahead of this binary' while doctor --fix then silently overwrote the file and destroyed the edit with no decline note. Doctor claimed protection it did not have. §3.4's own line applies to my fix as much as to the code it fixed: two lists that mean the same thing are two lists that will disagree.
+
+**Alternatives considered:** Make doctor's parser require the v prefix and leave both copies. Rejected — that fixes this instance and leaves the duplication, which is the defect class. #295 exported inserter.ParseMarkerGeneration and made cli delegate to it; doctor now delegates to the same function, so there is one owner and no third copy to drift.
+
+**Implications:**
+- The panel also found the ahead ROW was untested: deleting the rendering branch left the package green while the row fell back to a bare 'ahead' via formatDrift's default, and my TestClassifyLogmindDrift test was tautological because it constructed Drift:'ahead' literally. The reported symptom was the STRING 'STALE (latest: v4)' — inverted verdict, inverted label — so the string is now what is pinned, asserting it names the direction, names what the binary bundles, and does NOT call the older marker latest. Both mutations verified: deleting the rendering branch fails the new test; reverting to equality-only fails three ordering subtests. The second mutation initially reported zero failures because it left an unused import and never compiled — a mutation that does not build tests nothing, so it was redone.
+
+---
+

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -64,7 +64,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -73,6 +72,7 @@ import (
 	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/templates"
 	"github.com/thrillmade/logmind/internal/timeline"
 	"github.com/thrillmade/logmind/internal/version"
@@ -529,34 +529,12 @@ func classifyMarker(marker, bundled *string) string {
 	// An unparseable marker on either side falls through to the old
 	// equality semantics: something differs and we cannot say which way,
 	// so "stale" is the honest answer and refreshing is safe.
-	mv, mok := parseMarkerOrdinal(*marker)
-	bv, bok := parseMarkerOrdinal(*bundled)
+	mv, mok := inserter.ParseMarkerGeneration(*marker)
+	bv, bok := inserter.ParseMarkerGeneration(*bundled)
 	if mok && bok && mv > bv {
 		return "ahead"
 	}
 	return "stale"
-}
-
-// parseMarkerOrdinal extracts the integer from a template marker of the
-// form `v<N>` or `v<N>-<suffix>` (e.g. `v11`, `v9-pointer`). Returns
-// ok=false for anything else.
-//
-// Deliberately NOT a string compare: "v11" sorts BEFORE "v4"
-// lexically, which is the trap that makes this class of bug look correct
-// in testing right up until a version reaches double digits.
-func parseMarkerOrdinal(s string) (int, bool) {
-	s = strings.TrimPrefix(s, "v")
-	if i := strings.IndexByte(s, '-'); i >= 0 {
-		s = s[:i]
-	}
-	if s == "" {
-		return 0, false
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 {
-		return 0, false
-	}
-	return n, true
 }
 
 func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -64,6 +64,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -505,6 +506,16 @@ func readWorkflow(projectRoot, name string) (string, bool) {
 	return string(data), true
 }
 
+// classifyMarker compares an installed workflow's template marker against
+// the one this binary bundles.
+//
+// The comparison is ORDERED, not an equality test. #289 taught
+// installWorkflowTemplates to refuse a downgrade; teaching only the writer
+// and not the reader left doctor reporting a repository that is AHEAD of
+// this binary as "STALE (latest: <older>)" — a verdict and a label both
+// inverted — and, because --fix now correctly refuses to overwrite it, a
+// row that could never be cleared. The two consumers of the same fact have
+// to agree, or the tool contradicts itself.
 func classifyMarker(marker, bundled *string) string {
 	if marker == nil {
 		return "markerless"
@@ -515,7 +526,37 @@ func classifyMarker(marker, bundled *string) string {
 	if *marker == *bundled {
 		return "current"
 	}
+	// An unparseable marker on either side falls through to the old
+	// equality semantics: something differs and we cannot say which way,
+	// so "stale" is the honest answer and refreshing is safe.
+	mv, mok := parseMarkerOrdinal(*marker)
+	bv, bok := parseMarkerOrdinal(*bundled)
+	if mok && bok && mv > bv {
+		return "ahead"
+	}
 	return "stale"
+}
+
+// parseMarkerOrdinal extracts the integer from a template marker of the
+// form `v<N>` or `v<N>-<suffix>` (e.g. `v11`, `v9-pointer`). Returns
+// ok=false for anything else.
+//
+// Deliberately NOT a string compare: "v11" sorts BEFORE "v4"
+// lexically, which is the trap that makes this class of bug look correct
+// in testing right up until a version reaches double digits.
+func parseMarkerOrdinal(s string) (int, bool) {
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
@@ -932,6 +973,13 @@ func RenderStatus(r StatusReport) string {
 			driftWord := formatDrift(wf.Drift)
 			if wf.Drift == "stale" && wf.BundledMarker != nil {
 				driftWord = fmt.Sprintf("STALE (latest: %s)", *wf.BundledMarker)
+			}
+			// "ahead" is not a problem to fix — it is this binary being
+			// behind the repository. Saying "latest" of the older marker
+			// would be false, and calling it stale would send the reader
+			// to `--fix`, which correctly refuses and leaves them stuck.
+			if wf.Drift == "ahead" && wf.BundledMarker != nil {
+				driftWord = fmt.Sprintf("ahead of this binary (bundles: %s) — upgrade logmind", *wf.BundledMarker)
 			}
 			lines = append(lines, fmt.Sprintf("  %-28s %-4s %s", wf.Name, marker, driftWord))
 		}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -817,3 +817,83 @@ func TestProbePreCommitHook_StaleOnRevertedMarker(t *testing.T) {
 		t.Errorf("Overall = %q; want DRIFT with stale pre-commit marker", r.Overall)
 	}
 }
+
+// TestClassifyMarker_OrderedNotEqual pins the bug a retrospective panel
+// found in the combination of #289 and #291.
+//
+// #289 taught `installWorkflowTemplates` that template markers are ORDERED
+// and refused to move one backwards. It did not teach doctor, which still
+// compared for equality — so a repository AHEAD of the running binary was
+// reported "STALE (latest: <older marker>)", with both the verdict and the
+// "latest" label inverted. Worse, because #289's refusal is correct, the
+// row became permanently unclearable: doctor said stale, --fix refused,
+// and nothing the operator did could reconcile them.
+//
+// Two consumers of the same fact have to agree, or the tool contradicts
+// itself.
+func TestClassifyMarker_OrderedNotEqual(t *testing.T) {
+	s := func(v string) *string { return &v }
+	cases := []struct {
+		name            string
+		marker, bundled *string
+		want            string
+	}{
+		{"equal is current", s("v5"), s("v5"), "current"},
+		{"older installed is stale", s("v1"), s("v5"), "stale"},
+		{"newer installed is ahead, not stale", s("v99"), s("v5"), "ahead"},
+
+		// The lexical trap: "v11" sorts BEFORE "v4" as a string, so an
+		// equality-or-string-compare implementation looks correct on
+		// single digits and inverts the moment a version reaches two.
+		{"v11 vs v4 is ahead, not stale", s("v11"), s("v4"), "ahead"},
+		{"v4 vs v11 is stale", s("v4"), s("v11"), "stale"},
+
+		// Flavour suffixes must not defeat the parse.
+		{"pointer suffix, newer", s("v10-pointer"), s("v9-pointer"), "ahead"},
+		{"pointer suffix, older", s("v9-pointer"), s("v10-pointer"), "stale"},
+
+		// Unparseable falls back to the old semantics: something differs
+		// and we cannot say which way, so "stale" is the honest answer.
+		{"unparseable installed falls back to stale", s("vNEXT"), s("v5"), "stale"},
+		{"unparseable bundled falls back to stale", s("v5"), s("vNEXT"), "stale"},
+
+		{"no marker is markerless", nil, s("v5"), "markerless"},
+		{"no bundled is unknown", s("v5"), nil, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyMarker(tc.marker, tc.bundled); got != tc.want {
+				t.Errorf("classifyMarker() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyLogmindDrift_AheadDoesNotFlipDrift pins the consequence: a
+// repository running templates NEWER than this binary is not "drifted".
+// It is the binary that is behind, and there is nothing for `--fix` to do
+// — so reporting DRIFT would send the operator to a command that
+// correctly refuses, leaving a red row they cannot clear.
+func TestClassifyLogmindDrift_AheadDoesNotFlipDrift(t *testing.T) {
+	ahead := []WorkflowStatus{{Name: "check-decisions.yml", Drift: "ahead"}}
+	if got := classifyLogmindDrift(ahead); got == "stale" {
+		t.Errorf("an ahead workflow flipped the tool to stale; got %q, want anything but stale", got)
+	}
+
+	// Control: a genuinely stale row must still flip it, or this change
+	// has simply disabled drift detection.
+	stale := []WorkflowStatus{{Name: "check-decisions.yml", Drift: "stale"}}
+	if got := classifyLogmindDrift(stale); got != "stale" {
+		t.Errorf("a stale workflow must still flip the tool to stale; got %q", got)
+	}
+
+	// Control: ahead alongside a stale row must still report stale — the
+	// stale one is real work, and ahead must not mask it.
+	mixed := []WorkflowStatus{
+		{Name: "check-decisions.yml", Drift: "ahead"},
+		{Name: "regen-timeline.yml", Drift: "stale"},
+	}
+	if got := classifyLogmindDrift(mixed); got != "stale" {
+		t.Errorf("ahead masked a genuinely stale row; got %q, want stale", got)
+	}
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -869,26 +869,62 @@ func TestClassifyMarker_OrderedNotEqual(t *testing.T) {
 	}
 }
 
-// TestClassifyLogmindDrift_AheadDoesNotFlipDrift pins the consequence: a
-// repository running templates NEWER than this binary is not "drifted".
-// It is the binary that is behind, and there is nothing for `--fix` to do
-// — so reporting DRIFT would send the operator to a command that
-// correctly refuses, leaving a red row they cannot clear.
+// TestRenderStatus_AheadRowNamesTheDirection pins the STRING the user
+// saw, not the helper behind it.
+//
+// An adversarial review found the first attempt at this test worthless:
+// it constructed `Drift: "ahead"` literally and asserted the roll-up did
+// not flip, so deleting the rendering branch entirely left the package
+// green while the row silently fell back to a bare "ahead" via
+// formatDrift's default. The reported symptom was the string
+// `STALE (latest: v4)` — inverted verdict, inverted label — so the string
+// is what has to be pinned.
+func TestRenderStatus_AheadRowNamesTheDirection(t *testing.T) {
+	bundled := "v5"
+	installed := "v99"
+	r := StatusReport{
+		Overall: "OK",
+		Tools: []ToolStatus{{
+			Name:  "logmind",
+			Drift: "ok",
+			Workflows: []WorkflowStatus{{
+				Name:          "check-decisions.yml",
+				Marker:        &installed,
+				BundledMarker: &bundled,
+				Drift:         "ahead",
+			}},
+		}},
+	}
+	body := RenderStatus(r)
+
+	if !strings.Contains(body, "ahead of this binary") {
+		t.Errorf("rendered row does not name the direction; got:\n%s", body)
+	}
+	if !strings.Contains(body, "bundles: v5") {
+		t.Errorf("rendered row does not name what this binary bundles; got:\n%s", body)
+	}
+	// The original defect: calling the OLDER marker "latest".
+	if strings.Contains(body, "latest: v5") {
+		t.Errorf("rendered row calls the older marker \"latest\" — the inverted label this fixes; got:\n%s", body)
+	}
+	if strings.Contains(body, "STALE") {
+		t.Errorf("an ahead row must not read STALE; got:\n%s", body)
+	}
+}
+
+// TestClassifyLogmindDrift_AheadDoesNotFlipDrift covers the roll-up.
+// Deliberately kept alongside the rendering test above rather than
+// instead of it: this one proves an ahead row does not send the operator
+// to `--fix`, which correctly refuses; that one proves the row says why.
 func TestClassifyLogmindDrift_AheadDoesNotFlipDrift(t *testing.T) {
 	ahead := []WorkflowStatus{{Name: "check-decisions.yml", Drift: "ahead"}}
 	if got := classifyLogmindDrift(ahead); got == "stale" {
-		t.Errorf("an ahead workflow flipped the tool to stale; got %q, want anything but stale", got)
+		t.Errorf("an ahead workflow flipped the tool to stale; got %q", got)
 	}
-
-	// Control: a genuinely stale row must still flip it, or this change
-	// has simply disabled drift detection.
 	stale := []WorkflowStatus{{Name: "check-decisions.yml", Drift: "stale"}}
 	if got := classifyLogmindDrift(stale); got != "stale" {
 		t.Errorf("a stale workflow must still flip the tool to stale; got %q", got)
 	}
-
-	// Control: ahead alongside a stale row must still report stale — the
-	// stale one is real work, and ahead must not mask it.
 	mixed := []WorkflowStatus{
 		{Name: "check-decisions.yml", Drift: "ahead"},
 		{Name: "regen-timeline.yml", Drift: "stale"},


### PR DESCRIPTION
A retrospective panel on merged `dev` found this in the **combination** of #289 and #291 — neither PR was wrong alone.

## What happened

#289 taught `installWorkflowTemplates` that template markers are **ordered** and refused to move one backwards. It taught only the writer. `doctor` still compared for equality:

```go
if *marker == *bundled { return "current" }
return "stale"
```

#291 then bumped `check-decisions` v4 → v5, supplying the first real skew. Measured on a repo initialised at v5 and probed by a v4-bundling binary:

```
check-decisions.yml     v5    STALE (latest: v4)
Stack status: DRIFT
doctor exit=1
doctor --fix exit=0 → "left unchanged — installed template v5 is NEWER…"
```

**Both the verdict and the "latest" label are inverted.** And because #289's refusal is *correct*, the row became **permanently unclearable**: doctor says stale, `--fix` refuses, and nothing the operator does reconciles them. Before #289, `--fix` silently downgraded and the row went green — the bug hid the bug.

My own #289 PR body called this a "misleading parenthetical." The panel was right that it is worse than that.

## The fix

`classifyMarker` returns a third value, `ahead`:

```
check-decisions.yml     v99   ahead of this binary (bundles: v5) — upgrade logmind
```

Every DRIFT and exit-1 path keys on `"stale"` specifically, so `ahead` is **informational and does not flip the tool**. That matters: reporting DRIFT would send the operator to a command that correctly refuses.

**Not a string compare.** `"v11" < "v4"` lexically — a trap that looks correct in testing right up until a version reaches double digits. `check-decisions` just went v4 → v5, and `regen-timeline` is already at **v11**. The comparison parses the integer after the `v` and ignores any `-pointer` suffix.

**Unparseable on either side falls back to the old equality semantics** — something differs and we cannot say which way, so `stale` is the honest answer and refreshing is safe.

## Verified

End to end, holding everything else constant:

| installed | bundled | reported |
|---|---|---|
| v5 | v5 | `current` |
| v99 | v5 | `ahead of this binary (bundles: v5) — upgrade logmind` |
| v1 | v5 | `STALE (latest: v5)` — control, still correctly stale |

Eleven table cases including the `v11`/`v4` inversion in both directions and both `-pointer` orderings, plus three controls on the roll-up: `ahead` does not flip drift, `stale` still does, and **`ahead` alongside `stale` still reports stale** — so this cannot mask real work.

Full `go test ./...` exit 0, 20 packages, 0 failures.

## Scope note from the panel

`logmind doctor` is invoked by no shipped workflow or hook (grepped `internal/templates`, `internal/hooks`, `internal/claudehook`; control — the same grep finds `logmind check-decisions` in templates). And logmind's own `check-decisions.yml` is markerless, so it classifies `markerless` and never flipped. **This bites consumers who take v5, not this repo** — which is exactly the #257 fleet-migration audience.