### PR TITLE
fix(inserter): stop guessing at an AGENTS.md marker this binary has never seen — closes #267

### DIFF
--- a/docs/decisions-branches/fix__agents-md-no-silent-downgrade.md
+++ b/docs/decisions-branches/fix__agents-md-no-silent-downgrade.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-stop-guessing-at-an-agents-md-marker-this-binary-has-never-s -->
+- **2026-08-14** — Stop guessing at an AGENTS.md marker this binary has never seen
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:27 - Stop guessing at an AGENTS.md marker this binary has never seen
+
+**Reasoning:** matchingTemplate recognised an installed AGENTS.md block by hardcoded strings.Contains against every marker generation it knew, so a block carrying a NEWER marker returned empty and EnsureAgentsMD fell through to its own default — silently replacing the repository's block with the slim template. Reproduced: a planted v10-pointer block came back v9-pointer while the command printed 'Refreshed AGENTS.md logmind block to current template'. Same failure shape as #286 but a different root cause: #286 had a version compare running the wrong way, this had no version compare at all, only membership in a hardcoded set. It fires precisely during a staggered rollout, which is the condition #257 creates by construction.
+
+**Alternatives considered:** Extend the enum to include v10, v11 and so on. Rejected as the bug rather than the fix: it fails again at the next generation, and the whole point is behaving correctly against a marker written by a future binary. A test at bundled+1 proves it — an enum extended by one still swallows that case.
+
+**Implications:**
+- The enum is gone. The block's id is read with a regex and parsed into a generation plus a flavour suffix. Flavour comes from the -pointer suffix, so §1.1's full-versus-slim guard survives without any list and a never-before-seen generation lands in the right flavour instead of a default; an unknown suffix refuses. Order compares against the marker read out of our own bundled template, so nothing enumerates generations and the next bump cannot stale it. An unreadable id refuses with a DIFFERENT message naming both bundled markers, because ordering is not a fact there. Signature changes force every caller to handle the refusal — the compiler rejects a swallow — and one formatter beside the #286 one serves init, doctor --fix, self-update, agents update and agents migrate. Mutation-tested three ways with the mutations reverted and run, not reasoned about: restoring the pre-#267 line reproduces #267 verbatim across 11 tests.
+
+---
+

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -312,18 +312,19 @@ Dry-run (default): reports which files would be updated.
 			if err != nil {
 				return err
 			}
-			return runAgentsUpdate(cwd, version.Version, doApply, cmd.OutOrStdout())
+			return runAgentsUpdate(cwd, version.Version, doApply, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().BoolVar(&doApply, "apply", false, "Rewrite stale marker blocks in place. Default is dry-run.")
 	return cmd
 }
 
-func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout io.Writer) error {
-	outdated, err := inserter.FindOutdatedMarkerBlocks(cwd)
+func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout, stderr io.Writer) error {
+	outdated, declined, err := inserter.FindOutdatedMarkerBlocks(cwd)
 	if err != nil {
 		return err
 	}
+	reportAgentsBlockRefusal(stderr, declined)
 	stalePins, err := inserter.FindOutdatedWorkflowPins(cwd, currentVersion)
 	if err != nil {
 		return err
@@ -344,6 +345,12 @@ func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout io.Writer)
 		}
 		if _, ok := inserter.ExtractMarkerBlock(string(data)); !ok {
 			fmt.Fprintln(stdout, "✓ AGENTS.md exists but has no logmind marker block. Run `logmind init` to install one (will preserve existing content above + below the markers).")
+			return nil
+		}
+		if declined != nil {
+			// A block this binary can't read or can't move forward is NOT
+			// "current" — claiming it is was the quiet half of #267.
+			fmt.Fprintln(stdout, "! AGENTS.md logmind block left unchanged — see the note on stderr.")
 			return nil
 		}
 		fmt.Fprintln(stdout, "✓ AGENTS.md logmind block is current (no update needed).")
@@ -427,18 +434,21 @@ func newAgentsMigrateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runAgentsMigrate(cwd, noCommit, cmd.OutOrStdout())
+			return runAgentsMigrate(cwd, noCommit, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().BoolVar(&noCommit, "no-commit", false, "Don't commit the migration changes")
 	return cmd
 }
 
-func runAgentsMigrate(cwd string, noCommit bool, stdout io.Writer) error {
-	messages, err := inserter.MigrateToAgentsMD(cwd)
+func runAgentsMigrate(cwd string, noCommit bool, stdout, stderr io.Writer) error {
+	messages, declined, err := inserter.MigrateToAgentsMD(cwd)
 	if err != nil {
 		return err
 	}
+	// Reported before the messages: migrate consolidates the per-agent
+	// files either way, but AGENTS.md's own block was left alone (#267).
+	reportAgentsBlockRefusal(stderr, declined)
 	if len(messages) == 0 {
 		fmt.Fprintln(stdout, "No agent files to migrate (already consolidated).")
 		return nil

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,7 +197,7 @@ func TestAgentsRemove_CancelOnNoConfirm(t *testing.T) {
 func TestAgentsUpdate_NoAgentsMD(t *testing.T) {
 	dir := t.TempDir()
 	var stdout bytes.Buffer
-	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout); err != nil {
+	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsUpdate: %v", err)
 	}
 	checkGolden(t, "agents_update_no_agents_md.golden", stdout.String())
@@ -211,7 +212,7 @@ func TestAgentsUpdate_AgentsMDNoBlock(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout bytes.Buffer
-	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout); err != nil {
+	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsUpdate: %v", err)
 	}
 	checkGolden(t, "agents_update_no_block.golden", stdout.String())
@@ -225,7 +226,7 @@ func TestAgentsUpdate_Current(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout bytes.Buffer
-	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout); err != nil {
+	if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsUpdate: %v", err)
 	}
 	checkGolden(t, "agents_update_current.golden", stdout.String())
@@ -236,7 +237,7 @@ func TestAgentsUpdate_Current(t *testing.T) {
 func TestAgentsMigrate_Empty(t *testing.T) {
 	dir := t.TempDir()
 	var stdout bytes.Buffer
-	if err := runAgentsMigrate(dir, true, &stdout); err != nil {
+	if err := runAgentsMigrate(dir, true, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsMigrate: %v", err)
 	}
 	checkGolden(t, "agents_migrate_empty.golden", stdout.String())
@@ -254,7 +255,7 @@ func TestAgentsMigrate_WithClaude(t *testing.T) {
 		t.Fatalf("write CLAUDE.md: %v", err)
 	}
 	var stdout bytes.Buffer
-	if err := runAgentsMigrate(dir, true, &stdout); err != nil {
+	if err := runAgentsMigrate(dir, true, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsMigrate: %v", err)
 	}
 	out := stdout.String()

--- a/internal/cli/block_downgrade_test.go
+++ b/internal/cli/block_downgrade_test.go
@@ -1,0 +1,304 @@
+// block_downgrade_test.go — logmind#267 at the command surfaces: a repo
+// whose AGENTS.md block was written by a NEWER binary keeps that block,
+// and every command that could have rewritten it says so on stderr.
+//
+// The refusal has to reach the user through all four: an older binary is
+// exactly what a staggered fleet rollout (#257) leaves lying around, and
+// the pre-#267 failure was invisible in both directions — the old binary
+// reported "Refreshed AGENTS.md logmind block to current template" while
+// walking the block backwards.
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/inserter"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// plantNewerBlock writes an AGENTS.md whose block carries a slim marker
+// one generation ahead of the bundled one, wrapped in user prose so the
+// byte-compare also proves the outer content survived. Returns
+// (installedMarker, bundledMarker, exactBytesWritten).
+func plantNewerBlock(t *testing.T) (string, string, string) {
+	t.Helper()
+	bundled := blockMarkerOf(t, templates.AgentsSlimTemplate())
+	gen, ok := inserter.ParseMarkerGeneration(bundled)
+	if !ok {
+		t.Fatalf("bundled slim template carries no readable block-version marker; got %q", bundled)
+	}
+	installed := fmt.Sprintf("v%d-pointer", gen+1)
+	content := "# AGENTS.md\n\nUser prose above.\n\n<!-- logmind-start -->" +
+		"\n<!-- logmind-block-version: " + installed + " -->\n" +
+		"## Decision logging\nbody written by a newer binary\n" +
+		"<!-- logmind-end -->\n\nUser prose below.\n"
+	writeRel(t, "AGENTS.md", content, 0o644)
+	return installed, bundled, content
+}
+
+// blockMarkerOf pulls the `logmind-block-version` token out of a bundled
+// template body.
+func blockMarkerOf(t *testing.T, templateBody string) string {
+	t.Helper()
+	const open = "<!-- logmind-block-version: "
+	i := strings.Index(templateBody, open)
+	if i < 0 {
+		t.Fatal("template body carries no logmind-block-version marker")
+	}
+	rest := templateBody[i+len(open):]
+	j := strings.Index(rest, " -->")
+	if j < 0 {
+		t.Fatal("logmind-block-version marker is not closed")
+	}
+	return rest[:j]
+}
+
+// assertBlockRefusalReported checks the stderr note names the file, the
+// installed marker, the direction, and what the binary ships.
+func assertBlockRefusalReported(t *testing.T, stderr, installed, bundled string) {
+	t.Helper()
+	mustContain(t, stderr, "AGENTS.md")
+	mustContain(t, stderr, "installed block-version "+installed)
+	mustContain(t, stderr, "NEWER")
+	mustContain(t, stderr, bundled)
+}
+
+// TestInitRefresh_RefusesBlockDowngrade — #267's reported scenario end to
+// end through `logmind init` refresh mode.
+func TestInitRefresh_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})
+		installed, bundled, before := plantNewerBlock(t)
+
+		out, errOut := runInitCapture(t, []string{"init", "--no-git"})
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("init refresh downgraded a newer block:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(out, "Refreshed AGENTS.md logmind block") {
+			t.Errorf("a refused downgrade must not be reported as a refresh:\n%s", out)
+		}
+		assertBlockRefusalReported(t, errOut, installed, bundled)
+	})
+}
+
+// TestInit_RefusesBlockDowngrade — the FIRST-init surface. A fresh init
+// normally creates AGENTS.md, but it can meet one a newer binary already
+// wrote (a half-migrated fleet), and that path reaches EnsureAgentsMD too.
+func TestInit_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		installed, bundled, before := plantNewerBlock(t)
+
+		out, errOut := runInitCapture(t, []string{"init", "--no-git"})
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("init downgraded a newer block:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(out, "Refreshed AGENTS.md logmind block") {
+			t.Errorf("a refused downgrade must not be reported as a refresh:\n%s", out)
+		}
+		assertBlockRefusalReported(t, errOut, installed, bundled)
+	})
+}
+
+// TestDoctorFix_RefusesBlockDowngrade — the other applyRefresh caller.
+func TestDoctorFix_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		installed, bundled, before := plantNewerBlock(t)
+
+		out, errOut := runDoctorFixCmd(t)
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("doctor --fix downgraded a newer block:\n got: %q\nwant: %q", after, before)
+		}
+		mustContain(t, out, "ok doctor-fix")
+		assertBlockRefusalReported(t, errOut, installed, bundled)
+	})
+}
+
+// TestSelfUpdate_RefusesBlockDowngrade — the surface a STALE binary is
+// most likely to be run from, so the one most likely to meet a block a
+// newer binary wrote.
+func TestSelfUpdate_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		installed, bundled, before := plantNewerBlock(t)
+
+		out, errOut := runInitCapture(t, []string{"self-update"})
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("self-update downgraded a newer block:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(out, "Refreshed AGENTS.md logmind block") {
+			t.Errorf("a refused downgrade must not be reported as a refresh:\n%s", out)
+		}
+		if strings.Contains(out, "up to date") {
+			t.Errorf("a block this binary cannot move forward is not \"up to date\":\n%s", out)
+		}
+		assertBlockRefusalReported(t, errOut, installed, bundled)
+	})
+}
+
+// TestAgentsUpdate_RefusesBlockDowngrade — `agents update` always took the
+// right ACTION (it skipped), but silently reported the ahead-of-binary
+// block as "current". Skipping and saying so are both required.
+func TestAgentsUpdate_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		installed, bundled, before := plantNewerBlock(t)
+
+		var stdout, stderr bytes.Buffer
+		if err := runAgentsUpdate(dir, "1.0.0-dev", true, &stdout, &stderr); err != nil {
+			t.Fatalf("runAgentsUpdate: %v", err)
+		}
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("agents update --apply downgraded a newer block:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(stdout.String(), "is current") {
+			t.Errorf("a block this binary cannot move forward is not \"current\":\n%s", stdout.String())
+		}
+		assertBlockRefusalReported(t, stderr.String(), installed, bundled)
+	})
+}
+
+// TestAgentsMigrate_RefusesBlockDowngrade — migrate consolidates the
+// per-agent files either way, but must not walk AGENTS.md's own block
+// backwards while doing it.
+func TestAgentsMigrate_RefusesBlockDowngrade(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		installed, bundled, before := plantNewerBlock(t)
+		writeRel(t, "CLAUDE.md", "# CLAUDE\n\nUser notes worth keeping.\n", 0o644)
+
+		var stdout, stderr bytes.Buffer
+		if err := runAgentsMigrate(dir, true, &stdout, &stderr); err != nil {
+			t.Fatalf("runAgentsMigrate: %v", err)
+		}
+
+		// The block itself is untouched; migrate's own append happens
+		// OUTSIDE the markers, so the planted bytes must still be a prefix.
+		after := readRel(t, "AGENTS.md")
+		if !strings.HasPrefix(after, strings.TrimRight(before, "\n")) {
+			t.Errorf("migrate rewrote the newer block:\n got: %q\nwant prefix: %q", after, before)
+		}
+		assertBlockRefusalReported(t, stderr.String(), installed, bundled)
+	})
+}
+
+// TestDoctorFixJSON_RefusalSurvivesJSON — the note goes to stderr, so it
+// reaches the user without polluting the JSON document on stdout.
+func TestDoctorFixJSON_RefusalSurvivesJSON(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		installed, bundled, _ := plantNewerBlock(t)
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--fix", "--offline", "--json"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor --fix --json: %v\nstderr=%s", err, errOut.String())
+		}
+
+		if !strings.HasPrefix(strings.TrimSpace(out.String()), "{") {
+			t.Errorf("stdout is not a bare JSON document:\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "left unchanged") {
+			t.Errorf("the refusal note must not land on stdout under --json:\n%s", out.String())
+		}
+		assertBlockRefusalReported(t, errOut.String(), installed, bundled)
+	})
+}
+
+// TestInitRefresh_UnreadableMarkerRefusedWithItsOwnMessage — an
+// unreadable id is not an ordering fact, so it gets the "refusing to
+// guess" wording and names both bundled markers instead of claiming the
+// block is newer.
+func TestInitRefresh_UnreadableMarkerRefusedWithItsOwnMessage(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})
+		before := "# AGENTS.md\n\n<!-- logmind-start -->" +
+			"\n<!-- logmind-block-version: vNEXT -->\nhand-edited block\n" +
+			"<!-- logmind-end -->\n"
+		writeRel(t, "AGENTS.md", before, 0o644)
+
+		_, errOut := runInitCapture(t, []string{"init", "--no-git"})
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("an unreadable id was overwritten:\n got: %q\nwant: %q", after, before)
+		}
+		mustContain(t, errOut, "unrecognised block-version marker")
+		mustContain(t, errOut, "found vNEXT")
+		mustContain(t, errOut, blockMarkerOf(t, templates.AgentsTemplate()))
+		mustContain(t, errOut, blockMarkerOf(t, templates.AgentsSlimTemplate()))
+		if strings.Contains(errOut, "NEWER") {
+			t.Errorf("an unreadable id must not be reported as newer:\n%s", errOut)
+		}
+	})
+}
+
+// TestInitRefresh_CurrentBlockStillSilent — the guard must not turn every
+// ordinary run into a note. A repo on the bundled block gets neither a
+// refusal nor a refresh line.
+func TestInitRefresh_CurrentBlockStillSilent(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		runQuiet(t, []string{"init", "--no-git"})
+		before := readRel(t, "AGENTS.md")
+
+		out, errOut := runInitCapture(t, []string{"init", "--no-git"})
+
+		if after := readRel(t, "AGENTS.md"); after != before {
+			t.Errorf("a current block was rewritten:\n got: %q\nwant: %q", after, before)
+		}
+		if strings.Contains(errOut, "left unchanged") {
+			t.Errorf("a current block must not produce a refusal note:\n%s", errOut)
+		}
+		if strings.Contains(out, "Refreshed AGENTS.md logmind block") {
+			t.Errorf("a current block must not report a refresh:\n%s", out)
+		}
+	})
+}
+
+// TestInit_FreshRepoStillGetsABlock — the ordinary create path. An
+// UNRECOGNISED id means "leave it alone"; an ABSENT FILE still means
+// "install one".
+func TestInit_FreshRepoStillGetsABlock(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		runQuiet(t, []string{"init", "--no-git"})
+
+		got := readRel(t, "AGENTS.md")
+		if want := blockMarkerOf(t, templates.AgentsSlimTemplate()); !strings.Contains(got, want) {
+			t.Errorf("a fresh repo must get the bundled slim block (%s); got:\n%s", want, got)
+		}
+		// And the freshly-installed block is not then reported as refused.
+		var stdout, stderr bytes.Buffer
+		if err := runAgentsUpdate(dir, "1.0.0-dev", false, &stdout, &stderr); err != nil {
+			t.Fatalf("runAgentsUpdate: %v", err)
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("a freshly-installed block must not be refused:\n%s", stderr.String())
+		}
+		mustContain(t, stdout.String(), "is current")
+	})
+}
+
+// TestReportAgentsBlockRefusal_NilIsSilent — the formatter is called
+// unconditionally from six places; nil must write nothing at all.
+func TestReportAgentsBlockRefusal_NilIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	reportAgentsBlockRefusal(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("nil refusal wrote %q; want nothing", buf.String())
+	}
+	// And a non-nil one always writes exactly one line.
+	buf.Reset()
+	reportAgentsBlockRefusal(&buf, &inserter.AgentsBlockRefusal{
+		Path: "/repo/AGENTS.md", Installed: "v99-pointer", Bundled: "v9-pointer", Ahead: true,
+	})
+	if got := strings.Count(buf.String(), "\n"); got != 1 {
+		t.Errorf("refusal wrote %d lines; want exactly 1:\n%s", got, buf.String())
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -109,10 +109,12 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return ErrSilent
 	}
 
-	// Refused workflow downgrades (#286) — printed BEFORE the --json branch
-	// below: this is a refusal the user must see on every surface, and
-	// stderr never pollutes the JSON document on stdout.
+	// Refused workflow downgrades (#286) and a refused AGENTS.md block
+	// refresh (#267) — printed BEFORE the --json branch below: these are
+	// refusals the user must see on every surface, and stderr never
+	// pollutes the JSON document on stdout.
 	reportTemplateDowngrades(cmd.ErrOrStderr(), res.WorkflowsDeclined)
+	reportAgentsBlockRefusal(cmd.ErrOrStderr(), res.AgentsMDDeclined)
 
 	// Backfill the §1.6.3 timeline marker into any markerless branch detail
 	// file (main-canonical only) — the deterministic structural half of the

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,7 +40,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -179,8 +178,14 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 	// The Python init runs insert_into_all_ai_files; we delegate to the
 	// EnsureAgentsMD path which writes the slim variant by default and
 	// CreateAgentFile for each enabled agent's stub.
-	if msg, err := inserter.EnsureAgentsMD(cwd); err == nil && msg != "" {
-		fmt.Fprintln(out, msg)
+	// A first-time init normally CREATES AGENTS.md, but a repo can already
+	// carry a block written by a newer binary (a partially-migrated fleet,
+	// #257) — so this surface reports the refusal too.
+	if msg, declined, err := inserter.EnsureAgentsMD(cwd); err == nil {
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+		}
+		reportAgentsBlockRefusal(cmd.ErrOrStderr(), declined)
 	}
 	for _, agentName := range enabled {
 		filePath, err := inserter.CreateAgentFile(agentName, cwd)
@@ -389,6 +394,9 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 	if res.AgentsMDMsg != "" {
 		fmt.Fprintln(out, res.AgentsMDMsg)
 	}
+	// #267's analogue of the workflow refusal above: a block this binary
+	// can't move forward is silence on stdout, so stderr carries it.
+	reportAgentsBlockRefusal(cmd.ErrOrStderr(), res.AgentsMDDeclined)
 	if res.GitattrChanged {
 		fmt.Fprintln(out, "✓ Added logmind block to .gitattributes")
 	}
@@ -519,30 +527,12 @@ func extractTemplateVersion(text string) string {
 // Returns ok=false for anything that isn't a leading "v" followed by at
 // least one digit — callers fall back to the pre-#286 behaviour rather
 // than treating an unreadable marker as a reason to do nothing.
+//
+// Delegates to inserter.ParseMarkerGeneration so the workflow-template
+// guard (#286) and the AGENTS.md block guard (#267) order marker
+// generations by one rule rather than two copies of it.
 func parseTemplateVersion(marker string) (int, bool) {
-	s := strings.TrimSpace(marker)
-	if !strings.HasPrefix(s, "v") {
-		return 0, false
-	}
-	s = strings.TrimPrefix(s, "v")
-	if i := strings.IndexByte(s, '-'); i >= 0 {
-		s = s[:i]
-	}
-	if s == "" {
-		return 0, false
-	}
-	// Reject anything Atoi would tolerate but a marker never contains
-	// (a sign, whitespace) — only bare digits order.
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return 0, false
-		}
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, false
-	}
-	return n, true
+	return inserter.ParseMarkerGeneration(marker)
 }
 
 // enabledAgentList resolves the agents flag. --all-agents wins;

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -41,10 +41,11 @@ import (
 // refreshResult tallies what applyRefresh actually changed. It drives both
 // init's "✓/↻" lines and doctor --fix's quiet `ok` summary.
 type refreshResult struct {
-	WorkflowsCreated   []string            // rel paths
-	WorkflowsRefreshed []string            // rel paths
-	WorkflowsDeclined  []templateDowngrade // refused downgrades (#286) — MUST be reported
-	AgentsMDMsg        string              // "" when no change
+	WorkflowsCreated   []string                     // rel paths
+	WorkflowsRefreshed []string                     // rel paths
+	WorkflowsDeclined  []templateDowngrade          // refused downgrades (#286) — MUST be reported
+	AgentsMDMsg        string                       // "" when no change
+	AgentsMDDeclined   *inserter.AgentsBlockRefusal // refused block refresh (#267) — MUST be reported
 	GitattrChanged     bool
 	MergeDriverSet     bool     // a merge-driver git config key was (re)written
 	HooksRefreshed     []string // subset of {"post-merge","post-rewrite","commit-msg"}
@@ -87,9 +88,10 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 
 	// AGENTS.md marker block + .gitattributes block are repo-content, not
 	// git-state, so they run regardless of opts.git.
-	msg, err := inserter.EnsureAgentsMD(cwd)
+	msg, declined, err := inserter.EnsureAgentsMD(cwd)
 	if err == nil {
 		res.AgentsMDMsg = msg
+		res.AgentsMDDeclined = declined
 	}
 	note(err)
 
@@ -152,4 +154,40 @@ func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 				"refusing to downgrade. Upgrade logmind to move it forward.\n",
 			d.Path, d.Installed, d.Bundled)
 	}
+}
+
+// reportAgentsBlockRefusal writes the one stderr line for a refused
+// AGENTS.md marker-block refresh (#267). Same contract as
+// reportTemplateDowngrades above and the same §3.4 shape — every surface
+// that can hit the refusal calls this, so none of them can swallow it.
+//
+// Two messages, because the two conditions want different remedies:
+//
+//   - AHEAD — the block parses and orders after ours. The repo is running
+//     in front of this binary (a staggered fleet rollout, #257); the fix
+//     is to upgrade logmind, and the block is fine as it stands.
+//   - UNRECOGNISED — the id is absent or unreadable, so there is no
+//     flavour to preserve and no generation to compare. Upgrading may not
+//     help; a human has to look at the block.
+//
+// A no-op on nil so callers can call it unconditionally.
+func reportAgentsBlockRefusal(stderr io.Writer, d *inserter.AgentsBlockRefusal) {
+	if d == nil {
+		return
+	}
+	if d.Ahead {
+		fmt.Fprintf(stderr,
+			"note: %s logmind block left unchanged — installed block-version %s is NEWER than the %s this "+
+				"binary ships; refusing to downgrade. Upgrade logmind to move it forward.\n",
+			d.Path, d.Installed, d.Bundled)
+		return
+	}
+	found := d.Installed
+	if found == "" {
+		found = "none"
+	}
+	fmt.Fprintf(stderr,
+		"note: %s logmind block left unchanged — unrecognised block-version marker (found %s; this binary "+
+			"ships %s); refusing to guess which template it is.\n",
+		d.Path, found, d.Bundled)
 }

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -70,17 +70,26 @@ func runSelfUpdate(cmd *cobra.Command) error {
 	}
 
 	updated := false
+	blockRefused := false
 
-	if msg, err := inserter.EnsureAgentsMD(cwd); err == nil && msg != "" {
-		fmt.Fprintln(out, msg)
-		updated = true
+	if msg, declined, err := inserter.EnsureAgentsMD(cwd); err == nil {
+		if msg != "" {
+			fmt.Fprintln(out, msg)
+			updated = true
+		}
+		// self-update is the surface a stale binary is most likely to be
+		// run from, so it is the most likely to meet a block a newer one
+		// wrote. Say so rather than reporting "up to date" (#267).
+		reportAgentsBlockRefusal(cmd.ErrOrStderr(), declined)
+		blockRefused = declined != nil
 	}
 
 	// Refresh per-agent stubs by detecting drift and rewriting affected
 	// files. The inserter package's FindOutdatedMarkerBlocks +
 	// MigrateToAgentsMD pipeline already covers this; we call them here
-	// in best-effort mode.
-	if entries, err := inserter.FindOutdatedMarkerBlocks(cwd); err == nil {
+	// in best-effort mode. Its refusal is dropped deliberately: it can only
+	// concern the same AGENTS.md EnsureAgentsMD just reported on above.
+	if entries, _, err := inserter.FindOutdatedMarkerBlocks(cwd); err == nil {
 		for _, entry := range entries {
 			refreshed := inserter.ReplaceMarkerBlock(entry.OldBody, entry.NewBody)
 			if err := os.WriteFile(entry.Path, []byte(refreshed), 0o644); err == nil {
@@ -122,7 +131,14 @@ func runSelfUpdate(cmd *cobra.Command) error {
 	}
 
 	if !updated {
-		fmt.Fprintln(out, "✓ logmind templates are up to date.")
+		if blockRefused {
+			// "up to date" would contradict the note on stderr — this repo's
+			// block is one this binary can't move forward, not one it just
+			// verified (#267).
+			fmt.Fprintln(out, "! AGENTS.md logmind block left unchanged — see the note on stderr.")
+		} else {
+			fmt.Fprintln(out, "✓ logmind templates are up to date.")
+		}
 	}
 	fmt.Fprintln(out, "ok self-update applied")
 	return nil

--- a/internal/inserter/block_downgrade_test.go
+++ b/internal/inserter/block_downgrade_test.go
@@ -1,0 +1,359 @@
+// block_downgrade_test.go — logmind#267: EnsureAgentsMD must never
+// silently replace an AGENTS.md block whose version id this binary can't
+// read or can't move forward.
+//
+// The pre-#267 classifier recognised markers by membership in a hardcoded
+// {v5,v6,v7,v8,v7-pointer,v8-pointer,v9-pointer} set, so every FUTURE
+// generation came back "unrecognised" — and EnsureAgentsMD read that as
+// "install the slim default". A repository refreshed by a newer binary
+// was walked BACKWARDS by an older one, reported as
+// "Refreshed AGENTS.md logmind block to current template".
+//
+// Mixed binary versions is the defining condition of a staggered fleet
+// rollout (#257), not an edge case, so these are ordering tests rather
+// than enum tests: they plant a marker generation ABOVE whatever this
+// binary ships and re-derive that number from the bundled template, so
+// they keep testing the same thing across every future bump.
+package inserter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// aheadMarker returns a block-version token `ahead` generations NEWER than
+// the one this binary ships for the given flavour: slim + 1 →
+// "v10-pointer" while the bundled slim marker is v9-pointer.
+//
+// ahead=1 is the load-bearing distance: it is the generation an enum
+// extended by one would have swallowed, so a test at that distance is what
+// separates ORDERING from a longer hardcoded list.
+func aheadMarker(t *testing.T, templateBody string, pointer bool, ahead int) string {
+	t.Helper()
+	bundled := bundledBlockMarker(templateBody)
+	gen, ok := ParseMarkerGeneration(bundled)
+	if !ok {
+		t.Fatalf("bundled template carries no readable block-version marker; got %q", bundled)
+	}
+	suffix := ""
+	if pointer {
+		suffix = pointerSuffix
+	}
+	return fmt.Sprintf("v%d%s", gen+ahead, suffix)
+}
+
+// plantBlock writes an AGENTS.md whose marker block carries `marker`,
+// wrapped in user prose above and below so the byte-comparison also
+// proves the outer content survived. Returns the exact bytes written.
+func plantBlock(t *testing.T, dir, marker string) string {
+	t.Helper()
+	content := "# AGENTS.md\n\nUser prose above.\n\n" + startMarker +
+		"\n<!-- logmind-block-version: " + marker + " -->\n" +
+		"## Decision logging\nbody written by a binary this one has never met\n" +
+		endMarker + "\n\nUser prose below.\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	return content
+}
+
+// TestEnsureAgentsMD_RefusesNewerBlock is the #267 reproduction: a slim
+// block ahead of this binary is left BYTE-IDENTICAL and the refusal is
+// returned, not swallowed.
+//
+// Run at TWO distances on purpose. "the next generation" is what an enum
+// extended by one (v10, v11, ...) would still swallow, so it is the case
+// that separates an ordering guard from a longer hardcoded list; "many
+// generations on" is the same fact at the far end.
+func TestEnsureAgentsMD_RefusesNewerBlock(t *testing.T) {
+	for _, ahead := range []int{1, 90} {
+		t.Run(fmt.Sprintf("bundled+%d", ahead), func(t *testing.T) {
+			dir := t.TempDir()
+			marker := aheadMarker(t, templates.AgentsSlimTemplate(), true, ahead)
+			before := plantBlock(t, dir, marker)
+
+			msg, declined, err := EnsureAgentsMD(dir)
+			if err != nil {
+				t.Fatalf("EnsureAgentsMD: %v", err)
+			}
+
+			after, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+			if err != nil {
+				t.Fatalf("read AGENTS.md: %v", err)
+			}
+			if string(after) != before {
+				t.Errorf("a block newer than this binary was rewritten:\n got: %q\nwant: %q", after, before)
+			}
+			if msg != "" {
+				t.Errorf("a refusal must not report a write; got %q", msg)
+			}
+			if declined == nil {
+				t.Fatal("declined = nil; the refusal must be reported upward, not swallowed")
+			}
+			if declined.Installed != marker {
+				t.Errorf("declined.Installed = %q; want the installed marker %q", declined.Installed, marker)
+			}
+			if want := bundledBlockMarker(templates.AgentsSlimTemplate()); declined.Bundled != want {
+				t.Errorf("declined.Bundled = %q; want the bundled slim marker %q", declined.Bundled, want)
+			}
+			if !declined.Ahead {
+				t.Errorf("declined.Ahead = false; a parseable newer generation is a downgrade, not an unknown id")
+			}
+			if declined.Path != filepath.Join(dir, "AGENTS.md") {
+				t.Errorf("declined.Path = %q; want the AGENTS.md path", declined.Path)
+			}
+		})
+	}
+}
+
+// TestEnsureAgentsMD_RefusesNewerFullBlock — same for the full flavour, so
+// the guard isn't accidentally slim-only (slim is the binary's default, so
+// a slim-only guard would still leave every full repo downgradeable).
+func TestEnsureAgentsMD_RefusesNewerFullBlock(t *testing.T) {
+	dir := t.TempDir()
+	marker := aheadMarker(t, templates.AgentsTemplate(), false, 1)
+	before := plantBlock(t, dir, marker)
+
+	_, declined, err := EnsureAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMD: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if string(after) != before {
+		t.Errorf("a newer FULL block was rewritten:\n got: %q\nwant: %q", after, before)
+	}
+	if declined == nil || !declined.Ahead {
+		t.Fatalf("declined = %+v; want an Ahead refusal naming the full flavour", declined)
+	}
+	if want := bundledBlockMarker(templates.AgentsTemplate()); declined.Bundled != want {
+		t.Errorf("declined.Bundled = %q; want the bundled FULL marker %q — a newer full block must "+
+			"not be compared against (or replaced by) the slim default", declined.Bundled, want)
+	}
+}
+
+// TestEnsureAgentsMD_RefusesUnreadableMarker — an id that isn't v<digits>,
+// a flavour suffix this binary doesn't know, and no marker at all. None of
+// them may be guessed at: "unrecognised" meaning "install the slim
+// default" IS #267.
+func TestEnsureAgentsMD_RefusesUnreadableMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name, marker string
+	}{
+		{"non-numeric generation", "vNEXT-pointer"},
+		{"unknown flavour suffix", "v3-sketch"},
+		{"no v prefix", "9-pointer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			before := plantBlock(t, dir, tc.marker)
+
+			msg, declined, err := EnsureAgentsMD(dir)
+			if err != nil {
+				t.Fatalf("EnsureAgentsMD: %v", err)
+			}
+			after, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+			if err != nil {
+				t.Fatalf("read AGENTS.md: %v", err)
+			}
+			if string(after) != before {
+				t.Errorf("an unreadable id was overwritten:\n got: %q\nwant: %q", after, before)
+			}
+			if msg != "" {
+				t.Errorf("a refusal must not report a write; got %q", msg)
+			}
+			if declined == nil {
+				t.Fatal("declined = nil; an unreadable id must be reported, not silently skipped")
+			}
+			if declined.Ahead {
+				t.Errorf("declined.Ahead = true for %q; an unreadable id is not an ordering fact", tc.marker)
+			}
+			// Both bundled markers named — with no readable flavour there
+			// is no single one to compare against (SPEC §3.4: say what you
+			// looked for and what you found).
+			for _, want := range []string{
+				bundledBlockMarker(templates.AgentsTemplate()),
+				bundledBlockMarker(templates.AgentsSlimTemplate()),
+			} {
+				if !strings.Contains(declined.Bundled, want) {
+					t.Errorf("declined.Bundled = %q; want it to name %q", declined.Bundled, want)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsureAgentsMD_MarkerlessBlockRefused — a marker block carrying no
+// block-version id at all. SPEC §5.2's neighbouring rule ("an artifact
+// carrying no marker at all belongs to the user") points the same way:
+// there is nothing to compare, so leave it.
+func TestEnsureAgentsMD_MarkerlessBlockRefused(t *testing.T) {
+	dir := t.TempDir()
+	before := "# AGENTS.md\n\n" + startMarker + "\nhand-written block, no version id\n" + endMarker + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(before), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	msg, declined, err := EnsureAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMD: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(after) != before {
+		t.Errorf("a markerless block was overwritten:\n got: %q\nwant: %q", after, before)
+	}
+	if msg != "" {
+		t.Errorf("a refusal must not report a write; got %q", msg)
+	}
+	if declined == nil || declined.Installed != "" {
+		t.Fatalf("declined = %+v; want a refusal whose Installed is empty (no marker found)", declined)
+	}
+}
+
+// TestFindOutdatedMarkerBlocks_RefusesNewerBlock — the sibling caller took
+// the right ACTION before #267 (it skipped), but silently, so
+// `agents update` reported an ahead-of-binary block as current. It must
+// skip AND report.
+func TestFindOutdatedMarkerBlocks_RefusesNewerBlock(t *testing.T) {
+	dir := t.TempDir()
+	marker := aheadMarker(t, templates.AgentsSlimTemplate(), true, 1)
+	plantBlock(t, dir, marker)
+
+	out, declined, err := FindOutdatedMarkerBlocks(dir)
+	if err != nil {
+		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("a newer block must not be listed as outdated; got %v", out)
+	}
+	if declined == nil || !declined.Ahead || declined.Installed != marker {
+		t.Fatalf("declined = %+v; want an Ahead refusal naming %q", declined, marker)
+	}
+}
+
+// TestEnsureAgentsMD_KnownOlderStillRefreshesForward pins the forward
+// direction the refusal must not block: the generation BELOW the bundled
+// one refreshes into the current body of its own flavour. Derived from the
+// bundled markers so it survives future bumps.
+func TestEnsureAgentsMD_KnownOlderStillRefreshesForward(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		pointer  bool
+	}{
+		{"full", templates.AgentsTemplate(), false},
+		{"slim", templates.AgentsSlimTemplate(), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundled := bundledBlockMarker(tc.template)
+			gen, ok := ParseMarkerGeneration(bundled)
+			if !ok || gen < 1 {
+				t.Fatalf("bundled %s marker %q must parse to a generation above 0", tc.name, bundled)
+			}
+			suffix := ""
+			if tc.pointer {
+				suffix = pointerSuffix
+			}
+			dir := t.TempDir()
+			plantBlock(t, dir, fmt.Sprintf("v%d%s", gen-1, suffix))
+
+			msg, declined, err := EnsureAgentsMD(dir)
+			if err != nil {
+				t.Fatalf("EnsureAgentsMD: %v", err)
+			}
+			if declined != nil {
+				t.Fatalf("an OLDER block must refresh, not be refused; got %+v", declined)
+			}
+			if msg != "Refreshed AGENTS.md logmind block to current template" {
+				t.Errorf("status = %q; want the refresh status", msg)
+			}
+			got, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			// Refreshed into ITS OWN flavour, and the user prose outside the
+			// markers survived.
+			if marker := bundledBlockMarker(string(got)); marker != bundled {
+				t.Errorf("marker after refresh = %q; want %q (flavour must not flip)", marker, bundled)
+			}
+			for _, prose := range []string{"User prose above.", "User prose below."} {
+				if !strings.Contains(string(got), prose) {
+					t.Errorf("content outside the markers was lost: %q missing", prose)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsureAgentsMD_EqualGenerationIsNotAhead — the bundled generation
+// itself is refreshable (a drifted body at the current id still gets its
+// bytes restored). Pins the boundary as strictly-greater, not
+// greater-or-equal.
+func TestEnsureAgentsMD_EqualGenerationIsNotAhead(t *testing.T) {
+	dir := t.TempDir()
+	plantBlock(t, dir, bundledBlockMarker(templates.AgentsSlimTemplate()))
+
+	msg, declined, err := EnsureAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMD: %v", err)
+	}
+	if declined != nil {
+		t.Fatalf("the bundled generation must not be refused; got %+v", declined)
+	}
+	if msg != "Refreshed AGENTS.md logmind block to current template" {
+		t.Errorf("status = %q; want the drifted body at the current id to be restored", msg)
+	}
+}
+
+// TestParseBlockMarker covers the ordering key and the flavour half
+// together: the generation orders numerically ("v11" > "v9", where a
+// string compare says the opposite), and the suffix is what separates
+// slim from full.
+func TestParseBlockMarker(t *testing.T) {
+	for _, tc := range []struct {
+		marker     string
+		wantGen    int
+		wantSuffix string
+		wantOK     bool
+	}{
+		{"v8", 8, "", true},
+		{"v9-pointer", 9, "-pointer", true},
+		{"v10-pointer", 10, "-pointer", true},
+		{"v11", 11, "", true},
+		{"v0-FAKE", 0, "-FAKE", true},
+		{" v11 ", 11, "", true},
+		{"", 0, "", false},
+		{"v", 0, "", false},
+		{"v-3", 0, "", false},
+		{"v+5", 0, "", false},
+		{"vNOPE", 0, "", false},
+		{"v 4", 0, "", false},
+		{"11", 0, "", false},
+		{"latest", 0, "", false},
+	} {
+		gen, suffix, ok := parseBlockMarker(tc.marker)
+		if gen != tc.wantGen || suffix != tc.wantSuffix || ok != tc.wantOK {
+			t.Errorf("parseBlockMarker(%q) = (%d, %q, %v); want (%d, %q, %v)",
+				tc.marker, gen, suffix, ok, tc.wantGen, tc.wantSuffix, tc.wantOK)
+		}
+	}
+	// The trap itself, asserted: a string compare disagrees with the
+	// numeric one for exactly the generation-rollover pair.
+	if !("v10-pointer" < "v9-pointer") {
+		t.Fatal("premise changed: \"v10-pointer\" is no longer lexically less than \"v9-pointer\"")
+	}
+	a, _ := ParseMarkerGeneration("v10-pointer")
+	b, _ := ParseMarkerGeneration("v9-pointer")
+	if !(a > b) {
+		t.Errorf("v10-pointer must order AFTER v9-pointer; got %d vs %d", a, b)
+	}
+}

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -28,9 +28,11 @@
 //     Drift is
 //     detected by comparing the marker bodies stripped (the Python
 //     code uses .strip() to be whitespace-tolerant; we mirror that).
-//     The matchingTemplate helper accepts every old and new marker
-//     so existing repos refresh into the new body without manual
-//     intervention.
+//     The planBlockRefresh helper reads the flavour and the generation
+//     OFF the installed marker and compares the generation against the
+//     bundled one, so an older marker refreshes forward while a newer
+//     one — written by a binary ahead of this one — is refused rather
+//     than overwritten (SPEC §1.1, issue #267).
 //
 // The inserter package is read-mostly: only the apply paths in
 // `agents update --apply`, `agents add <name>`, and `agents migrate`
@@ -45,6 +47,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/thrillmade/logmind/internal/agents"
@@ -348,56 +351,60 @@ func jsonAgentBody() string {
 //     block refreshes into the current full body, a slim repo into the
 //     current slim body — never a silent full↔slim flip).
 //   - Exists with markers and matching body → no-op (return "").
+//   - Exists with a version id this binary can't move forward (newer
+//     than the one it ships, or unreadable) → REFUSED: the file is left
+//     byte-for-byte alone and the refusal is returned for the caller to
+//     report (#267).
 //
-// Returns a status string when a write happened, or "" for no-op.
+// Returns a status string when a write happened, or "" for no-op, plus a
+// non-nil *AgentsBlockRefusal when the block was deliberately left alone.
 // The status strings match Python's three return values verbatim.
-func EnsureAgentsMD(repoRoot string) (string, error) {
+func EnsureAgentsMD(repoRoot string) (string, *AgentsBlockRefusal, error) {
 	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
-	template := agentsMDTemplate()
 
 	data, err := os.ReadFile(agentsPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		if err := os.WriteFile(agentsPath, []byte(template), 0o644); err != nil {
-			return "", err
+		if err := os.WriteFile(agentsPath, []byte(agentsMDTemplate()), 0o644); err != nil {
+			return "", nil, err
 		}
-		return "Created AGENTS.md (canonical agent instructions)", nil
+		return "Created AGENTS.md (canonical agent instructions)", nil, nil
 	}
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	content := string(data)
 	if !HasLogmindSection(content) {
 		if _, err := InsertLogmindSection(agentsPath); err != nil {
-			return "", err
+			return "", nil, err
 		}
-		return "Added logmind section to existing AGENTS.md", nil
+		return "Added logmind section to existing AGENTS.md", nil, nil
 	}
 
 	installedBlock, iok := ExtractMarkerBlock(content)
 	if !iok {
-		return "", nil
+		return "", nil, nil
 	}
-	// Refresh AGAINST THE INSTALLED FLAVOUR, not an unconditional slim
-	// default: a repo that shipped the full block must refresh into the
-	// current full body, never silently flip full↔slim (that migration is
-	// an explicit init/migrate decision). This mirrors the version-guard
-	// in matchingTemplate / FindOutdatedMarkerBlocks and honours invariant
-	// #3 documented on agentsMDTemplate. When the installed marker is
-	// unrecognized, fall back to the slim default (pre-existing behaviour).
-	refreshTemplate := template
-	if mt := matchingTemplate(installedBlock); mt != "" {
-		refreshTemplate = mt
+	// Refresh AGAINST THE INSTALLED BLOCK'S OWN ID — flavour and
+	// generation both — never against this binary's default. planBlockRefresh
+	// is the single classifier FindOutdatedMarkerBlocks also uses, so the two
+	// cannot drift apart on what an unreadable or newer id means; they used
+	// to, and EnsureAgentsMD's half of that disagreement silently downgraded
+	// the repo's block (#267).
+	plan := planBlockRefresh(installedBlock)
+	if plan.Template == "" {
+		plan.Refusal.Path = agentsPath
+		return "", plan.Refusal, nil
 	}
-	templateBlock, tok := ExtractMarkerBlock(refreshTemplate)
+	templateBlock, tok := ExtractMarkerBlock(plan.Template)
 	if tok && strings.TrimSpace(installedBlock) != strings.TrimSpace(templateBlock) {
 		refreshed := ReplaceMarkerBlock(content, templateBlock)
 		if err := os.WriteFile(agentsPath, []byte(refreshed), 0o644); err != nil {
-			return "", err
+			return "", nil, err
 		}
-		return "Refreshed AGENTS.md logmind block to current template", nil
+		return "Refreshed AGENTS.md logmind block to current template", nil, nil
 	}
-	return "", nil
+	return "", nil, nil
 }
 
 // agentsMDTemplate returns the canonical AGENTS.md body. Defaults to
@@ -413,10 +420,9 @@ func EnsureAgentsMD(repoRoot string) (string, error) {
 //  3. Repos that already shipped the full template stay on full: the
 //     refresh paths (EnsureAgentsMD and FindOutdatedMarkerBlocks) both
 //     select the template flavour matching the installed block-version
-//     marker via matchingTemplate, so a v5 / v6 / v7 / v8 full block
-//     refreshes into the current full body rather than silently
-//     flipping to slim.
-//     See matchingTemplate for the explicit flavour guard.
+//     marker via planBlockRefresh, so an older full block refreshes into
+//     the current full body rather than silently flipping to slim.
+//     See planBlockRefresh for the flavour + ordering guards.
 //
 // Callers that need the full variant (e.g., during `init --no-slim`)
 // can call templates.AgentsTemplate() directly.
@@ -455,81 +461,222 @@ type OutdatedMarkerEntry struct {
 // that shipped slim will compare slim-vs-slim only when the host has
 // skills.sh. We harden the Go side: only refresh when the template
 // flavour matches the installed flavour (same block-version marker).
-func FindOutdatedMarkerBlocks(repoRoot string) ([]OutdatedMarkerEntry, error) {
+//
+// Returns the refusal alongside the entries when the installed id is one
+// this binary can't move forward — skipping was always the right ACTION
+// here, but doing it silently let `agents update` report a block that is
+// ahead of the binary as "current" (#267).
+func FindOutdatedMarkerBlocks(repoRoot string) ([]OutdatedMarkerEntry, *AgentsBlockRefusal, error) {
 	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
 	data, err := os.ReadFile(agentsPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	content := string(data)
 	installed, iok := ExtractMarkerBlock(content)
 	if !iok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Choose the template variant matching the installed block-version
-	// marker. This is the guard that prevents silent full↔slim flips.
-	template := matchingTemplate(installed)
-	if template == "" {
-		return nil, nil
+	// marker. This is the guard that prevents silent full↔slim flips, and
+	// (since #267) silent downgrades of a newer block.
+	plan := planBlockRefresh(installed)
+	if plan.Template == "" {
+		plan.Refusal.Path = agentsPath
+		return nil, plan.Refusal, nil
 	}
-	fresh, tok := ExtractMarkerBlock(template)
+	fresh, tok := ExtractMarkerBlock(plan.Template)
 	if !tok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if strings.TrimSpace(installed) == strings.TrimSpace(fresh) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	return []OutdatedMarkerEntry{{
 		Path: agentsPath, OldBody: installed, NewBody: fresh,
-	}}, nil
+	}}, nil, nil
 }
 
-// matchingTemplate picks the template flavour that matches the
-// block-version marker in the installed body. Returns "" if the
-// installed body carries no recognized marker — in which case we
-// take no action (refusing to guess).
+// blockVersionRE captures the version token out of an AGENTS.md block
+// marker: `<!-- logmind-block-version: v9-pointer -->` → "v9-pointer".
+// Mirrors internal/doctor's logmindBlockVersionRe — doctor PROBES the
+// marker, inserter WRITES against it, so the pattern lives once per side
+// of that boundary.
+var blockVersionRE = regexp.MustCompile(`<!--\s*logmind-block-version:\s*(\S+)\s*-->`)
+
+// pointerSuffix is the flavour tag that distinguishes the slim
+// ("pointer") block from the full one. SPEC §1.1 forbids a silent
+// full↔slim flip, so this suffix — not a hardcoded list of generations —
+// is what decides which template body a block may refresh into.
+const pointerSuffix = "-pointer"
+
+// AgentsBlockRefusal records a REFUSED AGENTS.md marker-block refresh
+// (#267): the installed block carries a version id this binary cannot
+// move forward, so the file was left byte-for-byte alone.
 //
-// v0.6.16 bumped the full template v5→v6 and the slim variant
-// v7-pointer→v8-pointer. Both old + new markers map to the same
-// FLAVOUR (full vs slim) so existing repos with the older marker
-// get refreshed to the new body, while the explicit guard against
-// silent full↔slim flips (the substring of "-pointer") is preserved.
+// Returned by EnsureAgentsMD / FindOutdatedMarkerBlocks / MigrateToAgentsMD
+// and reported by every caller — SPEC §3.4's rule for the analogous
+// fail-open case ("Failing open MUST NOT be silent... MUST say so on
+// stderr, naming what it looked for and what it found") applies here too:
+// a repo whose block this binary declines to touch has to be told.
+type AgentsBlockRefusal struct {
+	Path      string // absolute path to AGENTS.md
+	Installed string // version token found in the block, e.g. "v10-pointer"; "" when the block carries no marker
+	Bundled   string // what this binary ships: the same-flavour marker, or both markers when the flavour is unreadable
+	Ahead     bool   // Installed parsed and orders AFTER Bundled — a downgrade, as opposed to an unreadable id
+}
+
+// blockPlan is the classification of one installed marker-block body:
+// the template flavour it may be refreshed into, or the refusal that says
+// why it may not be touched. Exactly one of the two fields is set.
+type blockPlan struct {
+	Template string              // flavour-matched template body; "" when the block must be left alone
+	Refusal  *AgentsBlockRefusal // non-nil iff Template == ""; Path is filled in by the caller that read the file
+}
+
+// planBlockRefresh decides what may happen to an installed AGENTS.md
+// marker block. Both refresh paths (EnsureAgentsMD and
+// FindOutdatedMarkerBlocks) route through it, so they cannot disagree
+// about what an unreadable id means — the disagreement between them WAS
+// issue #267.
 //
-// The Slice-2 branch-summary wave bumped the full template v6→v7,
-// carrying the branch-summary (headline) convention into the inline
-// procedure. v5 / v6 / v7 all map to the full flavour, so a repo that
-// shipped an older full block refreshes forward into the v7 body while
-// the full↔slim guard still holds.
+// Two guards, both load-bearing:
 //
-// The stale-binary-hardening / enforcement wave bumped the full template
-// v7→v8 and the slim variant v8-pointer→v9-pointer (enforcement prose:
-// the commit-msg + Claude Code PreToolUse hooks BLOCK, not warn). ORDERING
-// IS LOAD-BEARING here: every "-pointer" (slim) check MUST run before every
-// bare-version (full) check. "logmind-block-version: v8-pointer" contains
-// "logmind-block-version: v8" as a literal substring — the bare "v8"
-// marker is a PREFIX of "v8-pointer" — so if the bare-"v8" full-flavour
-// check ran first, a slim v8-pointer body would ALSO match it and get
-// mis-classified as full. That is exactly the full↔slim collision this
-// function's marker ordering exists to prevent; keeping every "-pointer"
-// variant checked first (regardless of how many marker generations pile
-// up) keeps the collision impossible by construction. v8-pointer /
-// v9-pointer map to slim; v5 / v6 / v7 / v8 map to full.
-func matchingTemplate(installedBody string) string {
-	if strings.Contains(installedBody, "logmind-block-version: v7-pointer") ||
-		strings.Contains(installedBody, "logmind-block-version: v8-pointer") ||
-		strings.Contains(installedBody, "logmind-block-version: v9-pointer") {
-		return templates.AgentsSlimTemplate()
+//  1. FLAVOUR (SPEC §1.1). The `-pointer` suffix separates the slim block
+//     from the full one; a repo that shipped full refreshes into the
+//     current full body, a slim repo into the current slim body, never a
+//     silent flip. The suffix is READ OFF the installed marker rather
+//     than enumerated, so a generation this binary has never heard of
+//     still classifies into the right flavour instead of falling into a
+//     default.
+//
+//  2. ORDER (SPEC §1.1: "a tool MUST NOT replace an installed block with
+//     an older id"). The generation compares NUMERICALLY against the
+//     marker this binary ships for that flavour, and a block that orders
+//     AFTER it is refused. This used to be membership in a hardcoded
+//     {v5,v6,v7,v8,v7-pointer,v8-pointer,v9-pointer} set, which made
+//     every FUTURE generation "unrecognised" — and EnsureAgentsMD read
+//     unrecognised as "install the slim default", silently downgrading
+//     any repo a newer binary had moved forward (#267). Extending that
+//     set to v10, v11, ... would re-break at the next bump; ordering
+//     against the bundled marker cannot go stale, because the next
+//     generation is newer by arithmetic rather than by enumeration.
+//     Mixed binary versions is not an edge case during a fleet migration
+//     (#257) — it is the definition of one.
+//
+// An UNREADABLE id — absent, not `v<digits>`, or carrying a flavour
+// suffix this binary doesn't know — is refused as well: there is no
+// flavour to preserve and no generation to compare, and guessing "it's
+// probably slim" is precisely what #267 was.
+func planBlockRefresh(installedBody string) blockPlan {
+	found := ""
+	if m := blockVersionRE.FindStringSubmatch(installedBody); len(m) >= 2 {
+		found = m[1]
 	}
-	if strings.Contains(installedBody, "logmind-block-version: v5") ||
-		strings.Contains(installedBody, "logmind-block-version: v6") ||
-		strings.Contains(installedBody, "logmind-block-version: v7") ||
-		strings.Contains(installedBody, "logmind-block-version: v8") {
-		return templates.AgentsTemplate()
+	gen, suffix, ok := parseBlockMarker(found)
+	var template string
+	if ok {
+		switch suffix {
+		case "":
+			template = templates.AgentsTemplate()
+		case pointerSuffix:
+			template = templates.AgentsSlimTemplate()
+		}
+	}
+	if template == "" {
+		return blockPlan{Refusal: &AgentsBlockRefusal{
+			Installed: found,
+			Bundled:   bundledBlockMarkerList(),
+		}}
+	}
+	bundled := bundledBlockMarker(template)
+	bundledGen, bok := ParseMarkerGeneration(bundled)
+	if !bok {
+		// The template WE ship carries no readable marker — a build-time
+		// defect, not a repo state. Refuse rather than compare against
+		// nothing; the alternative is downgrading on a typo in our own body.
+		return blockPlan{Refusal: &AgentsBlockRefusal{
+			Installed: found,
+			Bundled:   bundledBlockMarkerList(),
+		}}
+	}
+	if gen > bundledGen {
+		return blockPlan{Refusal: &AgentsBlockRefusal{
+			Installed: found,
+			Bundled:   bundled,
+			Ahead:     true,
+		}}
+	}
+	return blockPlan{Template: template}
+}
+
+// bundledBlockMarker returns the version token carried by one of OUR
+// template bodies — the "what this binary knows" side of every compare.
+// Read from the body rather than restated as a constant, so a template
+// bump moves the guard with it.
+func bundledBlockMarker(templateBody string) string {
+	if m := blockVersionRE.FindStringSubmatch(templateBody); len(m) >= 2 {
+		return m[1]
 	}
 	return ""
+}
+
+// bundledBlockMarkerList names both bundled markers for the refusal
+// message when the installed id is unreadable and there's no single
+// flavour to compare against.
+func bundledBlockMarkerList() string {
+	return bundledBlockMarker(templates.AgentsTemplate()) + " (full) or " +
+		bundledBlockMarker(templates.AgentsSlimTemplate()) + " (slim)"
+}
+
+// ParseMarkerGeneration extracts the ORDERING key from a logmind version
+// marker token: "v11" → 11, "v9-pointer" → 9. Only the numeric generation
+// orders — a string compare gets this exactly backwards ("v11" < "v4"
+// lexically), which is the trap #286 fell into for workflow templates and
+// #267 sidestepped entirely by not comparing at all.
+//
+// Shared with internal/cli's workflow-template guard so the two artifacts
+// order by the same rule; the block path additionally needs the flavour
+// suffix, which parseBlockMarker returns.
+//
+// Returns ok=false for anything that isn't a leading "v" followed by at
+// least one digit.
+func ParseMarkerGeneration(marker string) (int, bool) {
+	n, _, ok := parseBlockMarker(marker)
+	return n, ok
+}
+
+// parseBlockMarker splits a marker token into its generation and its
+// flavour suffix: "v9-pointer" → (9, "-pointer", true), "v8" → (8, "",
+// true), "vNOPE" → (0, "", false).
+func parseBlockMarker(marker string) (int, string, bool) {
+	s := strings.TrimSpace(marker)
+	if !strings.HasPrefix(s, "v") {
+		return 0, "", false
+	}
+	s = strings.TrimPrefix(s, "v")
+	suffix := ""
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		suffix, s = s[i:], s[:i]
+	}
+	if s == "" {
+		return 0, "", false
+	}
+	// Reject anything Atoi would tolerate but a marker never contains
+	// (a sign, whitespace) — only bare digits order.
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, "", false
+		}
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, "", false
+	}
+	return n, suffix, true
 }
 
 // OutdatedPinEntry records one stale workflow pin:
@@ -624,11 +771,14 @@ func UpdateWorkflowPin(content, newVersion string) (string, string) {
 // Returns a list of human-readable status messages — the caller
 // prints them to stdout. Returning a slice (rather than a stream)
 // matches Python's accumulator pattern; the migrate command renders
-// the slice line-by-line.
-func MigrateToAgentsMD(repoRoot string) ([]string, error) {
+// the slice line-by-line. The second return is EnsureAgentsMD's refusal
+// (#267): migrate still consolidates the per-agent files, but the caller
+// must say that AGENTS.md's own block was left alone.
+func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 	var messages []string
-	if _, err := EnsureAgentsMD(repoRoot); err != nil {
-		return nil, err
+	_, declined, err := EnsureAgentsMD(repoRoot)
+	if err != nil {
+		return nil, declined, err
 	}
 	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
 	var appendedBlocks []string
@@ -660,7 +810,7 @@ func MigrateToAgentsMD(repoRoot string) ([]string, error) {
 		}
 
 		if err := os.WriteFile(filePath, []byte(templates.Stub()), 0o644); err != nil {
-			return messages, err
+			return messages, declined, err
 		}
 		messages = append(messages,
 			fmt.Sprintf("✓ %s replaced with stub", filepath.Base(filePath)))
@@ -669,16 +819,16 @@ func MigrateToAgentsMD(repoRoot string) ([]string, error) {
 	if len(appendedBlocks) > 0 {
 		existing, err := os.ReadFile(agentsPath)
 		if err != nil {
-			return messages, err
+			return messages, declined, err
 		}
 		// Match Python: existing.rstrip() + "\n\n" + "\n".join(appended).
 		body := strings.TrimRight(string(existing), " \t\n\r") +
 			"\n\n" + strings.Join(appendedBlocks, "\n")
 		if err := os.WriteFile(agentsPath, []byte(body), 0o644); err != nil {
-			return messages, err
+			return messages, declined, err
 		}
 	}
-	return messages, nil
+	return messages, declined, nil
 }
 
 // fileExists returns true when path refers to an existing regular

--- a/internal/inserter/inserter_test.go
+++ b/internal/inserter/inserter_test.go
@@ -226,7 +226,7 @@ func TestFindOutdatedWorkflowPins_SkipsUnknownWorkflows(t *testing.T) {
 // when AGENTS.md doesn't exist.
 func TestEnsureAgentsMD_MissingCreates(t *testing.T) {
 	dir := t.TempDir()
-	msg, err := EnsureAgentsMD(dir)
+	msg, _, err := EnsureAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("EnsureAgentsMD: %v", err)
 	}
@@ -246,10 +246,10 @@ func TestEnsureAgentsMD_MissingCreates(t *testing.T) {
 // second call returns "" (no-op).
 func TestEnsureAgentsMD_NoOpWhenCurrent(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := EnsureAgentsMD(dir); err != nil {
+	if _, _, err := EnsureAgentsMD(dir); err != nil {
 		t.Fatalf("first EnsureAgentsMD: %v", err)
 	}
-	msg, err := EnsureAgentsMD(dir)
+	msg, _, err := EnsureAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("second EnsureAgentsMD: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestEnsureAgentsMD_NoMarkersInserts(t *testing.T) {
 	if err := os.WriteFile(agentsPath, []byte("# AGENTS\n\nNo markers.\n"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	msg, err := EnsureAgentsMD(dir)
+	msg, _, err := EnsureAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("EnsureAgentsMD: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestEnsureAgentsMD_NoMarkersInserts(t *testing.T) {
 // (here a stale v6 full body) must refresh IN PLACE to the CURRENT full
 // body — NOT get silently flipped to the current slim default.
 // Second run is a no-op (idempotent). Mirrors invariant #3 documented on
-// agentsMDTemplate and the version-guard in matchingTemplate.
+// agentsMDTemplate and the version-guard in planBlockRefresh.
 //
 // Deliberately generalized: rather than hardcoding a specific target
 // version marker, this compares against templates.AgentsTemplate() /
@@ -306,7 +306,7 @@ func TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	msg, err := EnsureAgentsMD(dir)
+	msg, _, err := EnsureAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("EnsureAgentsMD: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim(t *testing.T) {
 	}
 
 	// Idempotent: a second pass over the now-current full body is a no-op.
-	msg2, err := EnsureAgentsMD(dir)
+	msg2, _, err := EnsureAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("second EnsureAgentsMD: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestMigrateToAgentsMD_PreservesUserContent(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	msgs, err := MigrateToAgentsMD(dir)
+	msgs, _, err := MigrateToAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("MigrateToAgentsMD: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestMigrateToAgentsMD_Idempotent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(templates.Stub()), 0o644); err != nil {
 		t.Fatalf("write stub: %v", err)
 	}
-	msgs, err := MigrateToAgentsMD(dir)
+	msgs, _, err := MigrateToAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("MigrateToAgentsMD: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestRemoveAgentFile_Missing(t *testing.T) {
 // current").
 func TestFindOutdatedMarkerBlocks_NoFile(t *testing.T) {
 	dir := t.TempDir()
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestFindOutdatedMarkerBlocks_CurrentNoop(t *testing.T) {
 		[]byte(templates.AgentsSlimTemplate()), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -560,14 +560,15 @@ func TestFindOutdatedMarkerBlocks_CurrentNoop(t *testing.T) {
 // for content that still carries the version marker but differs from
 // the template. Asserts FindOutdatedMarkerBlocks reports it.
 //
-// Why we preserve the marker: matchingTemplate returns "" when the
-// installed body has no recognized version marker (the version-guard).
-// Drift detection only applies when the flavour matches.
+// Why we preserve the marker: planBlockRefresh refuses (returns no
+// template) when the installed body has no readable version marker — the
+// version-guard. Drift detection only applies when the flavour matches.
 //
 // v0.6.16 bumped the slim marker v7-pointer→v8-pointer; the drifted
-// body must carry the CURRENT marker so the template-flavour selector
-// (matchingTemplate) returns the slim template rather than "" — that's
-// what triggers the byte-compare that detects drift.
+// body must carry a marker the binary can move forward so the
+// template-flavour selector (planBlockRefresh) returns the slim template
+// rather than a refusal — that's what triggers the byte-compare that
+// detects drift.
 func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	dir := t.TempDir()
 	driftedBody := "\n<!-- logmind-block-version: v8-pointer -->\nDIFFERENT CONTENT BUT SAME VERSION\n"
@@ -575,7 +576,7 @@ func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -587,39 +588,39 @@ func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	}
 }
 
-// TestMatchingTemplate_PointerCheckOrderingGuardsAgainstV8Collision is a
-// DIRECT unit test of matchingTemplate's marker-ordering contract — the
-// exact collision the stale-binary-hardening / enforcement wave's v8/
-// v8-pointer bump introduced: "logmind-block-version: v8-pointer" contains
+// TestPlanBlockRefresh_PointerSuffixSeparatesFlavours is a DIRECT unit
+// test of planBlockRefresh's flavour contract — the exact collision the
+// stale-binary-hardening / enforcement wave's v8/v8-pointer bump
+// introduced: "logmind-block-version: v8-pointer" contains
 // "logmind-block-version: v8" as a literal substring (the bare "v8" marker
-// is a PREFIX of "v8-pointer"). If the bare-"v8" full-flavour branch were
-// ever checked BEFORE the "-pointer" slim branches, a slim v8-pointer body
-// would incorrectly match the full check too and get mis-classified.
-// matchingTemplate's actual ordering (every "-pointer" variant checked
-// first) prevents that; this test proves it two ways:
+// is a PREFIX of "v8-pointer"), so the substring-membership classifier
+// this replaced had to check every "-pointer" variant FIRST or a slim body
+// would be mis-classified as full.
+//
+// Reading the suffix off the parsed marker makes the collision impossible
+// by construction rather than by branch ordering, but the CONTRACT is
+// unchanged and still pinned here two ways:
 //
 //  1. A body carrying the slim "v8-pointer" marker resolves to the SLIM
 //     template — not full — even though it contains "v8" as a substring.
-//  2. A hypothetical FULL body carrying a bare "v8" marker (no "-pointer"
-//     suffix) resolves to the FULL template.
-func TestMatchingTemplate_PointerCheckOrderingGuardsAgainstV8Collision(t *testing.T) {
+//  2. A FULL body carrying a bare "v8" marker (no "-pointer" suffix)
+//     resolves to the FULL template.
+func TestPlanBlockRefresh_PointerSuffixSeparatesFlavours(t *testing.T) {
 	slimV8PointerBody := "\n<!-- logmind-block-version: v8-pointer -->\n## Decision logging\nslim body\n"
-	got := matchingTemplate(slimV8PointerBody)
-	if got != templates.AgentsSlimTemplate() {
-		t.Errorf("matchingTemplate(v8-pointer body) did not resolve to the slim template — " +
-			"the bare-v8 full check must not have run before the -pointer check")
+	if got := planBlockRefresh(slimV8PointerBody); got.Template != templates.AgentsSlimTemplate() {
+		t.Errorf("planBlockRefresh(v8-pointer body) did not resolve to the slim template — " +
+			"the bare \"v8\" substring must not pull a slim block into the full flavour")
 	}
 
-	hypotheticalFullV8Body := "\n<!-- logmind-block-version: v8 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nfull body\n"
-	got = matchingTemplate(hypotheticalFullV8Body)
-	if got != templates.AgentsTemplate() {
-		t.Errorf("matchingTemplate(bare v8 body) did not resolve to the full template")
+	fullV8Body := "\n<!-- logmind-block-version: v8 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nfull body\n"
+	if got := planBlockRefresh(fullV8Body); got.Template != templates.AgentsTemplate() {
+		t.Errorf("planBlockRefresh(bare v8 body) did not resolve to the full template")
 	}
 }
 
 // TestFindOutdatedMarkerBlocks_NeverFlipsFlavour — installed CURRENT full
 // template + Go binary defaults to slim → DO NOT report as outdated.
-// Matches the version-guard documented in matchingTemplate. Also serves as
+// Matches the version-guard documented in planBlockRefresh. Also serves as
 // the "a repo already on the current full body is up-to-date" no-drift
 // case. Dynamically installs templates.AgentsTemplate() so this keeps
 // passing across future version bumps without needing an update.
@@ -631,7 +632,7 @@ func TestFindOutdatedMarkerBlocks_NeverFlipsFlavour(t *testing.T) {
 		[]byte(templates.AgentsTemplate()), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -660,7 +661,7 @@ func TestFindOutdatedMarkerBlocks_OldFullRefreshesToCurrent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -696,7 +697,7 @@ func TestFindOutdatedMarkerBlocks_PriorFullRefreshesToCurrent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -737,7 +738,7 @@ func TestFindOutdatedMarkerBlocks_V7RefreshesToV8(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -775,7 +776,7 @@ func TestFindOutdatedMarkerBlocks_OldSlimRefreshesToCurrent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}
@@ -803,7 +804,7 @@ func TestFindOutdatedMarkerBlocks_V8PointerRefreshesToV9Pointer(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	out, err := FindOutdatedMarkerBlocks(dir)
+	out, _, err := FindOutdatedMarkerBlocks(dir)
 	if err != nil {
 		t.Fatalf("FindOutdatedMarkerBlocks: %v", err)
 	}


### PR DESCRIPTION
`matchingTemplate` recognised an installed `AGENTS.md` block by hardcoded `strings.Contains` against every marker generation it knew. A block carrying a **newer** marker returned `""`, and `EnsureAgentsMD` fell through to its own default — **silently replacing the repository's block with the slim template**.

## Reproduced

```
EnsureAgentsMD msg  = "Refreshed AGENTS.md logmind block to current template"
marker before       = v10-pointer
marker after        = v9-pointer
block preserved     = false
```

Same through `init` refresh and `self-update`. The message says "Refreshed … to current template"; it was a downgrade.

Same failure *shape* as #286, **different root cause**: #286 had a version compare running the wrong way. This had no version compare at all — only membership in a hardcoded set.

It fires precisely during a staggered rollout, which is the condition #257 creates by construction.

## The fix is not an enum extension

Adding v10, v11, … *is* the bug — it fails again at the next generation, and the point is behaving correctly against a marker written by a **future** binary. **A test at bundled+1 proves it: an enum extended by one still swallows that case.**

The 7 `strings.Contains` sites are gone. The block's id is read with a regex and parsed into a **generation** plus a **flavour suffix**:

- **Flavour** comes from the `-pointer` suffix, so §1.1's full↔slim guard survives *without a list* — a never-before-seen generation lands in the right flavour instead of a default. An unknown suffix refuses.
- **Order** compares against the marker read out of **our own bundled template**. Nothing enumerates generations, so the next bump cannot stale it.
- An **unreadable** id refuses with a *different* message, naming both bundled markers — ordering is not a fact there, so claiming it would be a guess.

Bonus: `internal/cli`'s `parseTemplateVersion` from #286 now delegates to `inserter.ParseMarkerGeneration`. **One owner for the ordering rule** — which is the whole lesson of this cluster.

## Every caller is compiler-forced to handle it

Signature changes mean a swallow does not compile. `EnsureAgentsMD`, `FindOutdatedMarkerBlocks` and `MigrateToAgentsMD` all return a refusal; one formatter beside #286's serves `init` (fresh and refresh), `doctor --fix` (before the `--json` branch), `self-update`, `agents update` and `agents migrate`.

`agents update` and `self-update` also **stopped claiming "is current" / "up to date"** for a block they cannot move forward.

## Mutation-tested — reverted and run, not reasoned about

| mutation | result |
|---|---|
| restore the literal pre-#267 line | 4 inserter + 7 cli tests FAIL; output is #267 verbatim — `v10-pointer` → `v9-pointer` |
| drop the `gen > bundledGen` compare | 3 inserter + 6 cli tests FAIL — ordering is load-bearing, not just "unknown" |
| make the refusal formatter a no-op | all 6 caller surfaces FAIL |

Full `go test ./...` exit 0, 22 packages. `vet`/`gofmt` clean.

## Two findings filed, not fixed

1. **`doctor` calls an ahead AGENTS.md block STALE** — the identical defect I am fixing for *workflows* in **#294**. Folding it into that PR so the ordering rule has one owner there too.
2. **Latent bug at `self_update.go:~90`** — `inserter.ReplaceMarkerBlock(entry.OldBody, entry.NewBody)` passes the *block body* where *file content* is expected; it would write only the block over the whole file. Unreachable today because `EnsureAgentsMD` refreshes first so `Find` returns nothing. Filing separately.