### PR TITLE
fix(hooks): the commit gate now reports its own absence — closes #270

### DIFF
--- a/docs/decisions-branches/fix__hooks-engine-resolution.md
+++ b/docs/decisions-branches/fix__hooks-engine-resolution.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-make-the-commit-gate-report-its-own-absence -->
+- **2026-08-14** — Make the commit gate report its own absence
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:28 - Make the commit gate report its own absence
+
+**Reasoning:** The git hooks located their engine by bare name, so the hook bound to whatever PATH answered rather than the binary that installed it. Combined with §3.4's mandatory fail-open, an unrelated or older install disabled the gate silently. Reproduced against the REAL released v1.2.0 built from its tag, which genuinely lacks the verb: 'Error: unknown command guard-commit', then '[master a389240] 40 substantive lines, no decision logged', exit 0. Control with the current binary on PATH: blocked, exit 1. §3.4 names the gap exactly — 'Failing open MUST NOT be silent. A hook that cannot run the engine it was installed for MUST say so on stderr, naming what it looked for and what it found' — and 'a gate that cannot report its own absence will be trusted long after it stopped working.'
+
+**Alternatives considered:** §3.4 offers pinning the engine path resolved at install. Rejected because ruling 4 forbids it: probeHook byte-compares the installed file against BuildCommitMsgBody() and commit-msg.golden pins the same bytes, so the body must be a pure function of version.Version. A pinned path makes it a function of the installing machine's filesystem — every correct hook on a machine whose logmind lives elsewhere would read as content drift, and no golden could be checked in at all. It also breaks on reinstall to a new prefix and needs a PATH fallback, reintroducing the bare-name binding.
+
+**Implications:**
+- The handshake is an environment variable, LOGMIND_HOOK_VERSION, not a flag. An engine that does not know the variable ignores it; an unknown FLAG errors out, which would convert 'the gate ran against an older engine' into 'the gate did not run' — in exactly the mid-migration fleet §3.4 cares about. The engine complains on MAJOR skew only, because a per-patch notice fires on every commit everywhere and gets ignored. What this remedy misses that pinning would catch: an unrelated logmind that exits 0 on guard-commit. post-merge and post-rewrite are left alone deliberately — they are regenerators, not gates, quiet by design for contributors without logmind, and carry the Python byte-identical contract. Ten mutations run and all killed, including notices-to-stdout, fail-closed-on-missing-engine, and skew-notice-blocks.
+
+---
+

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -34,6 +34,7 @@ import (
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
+	"github.com/thrillmade/logmind/internal/version"
 )
 
 func newGuardCommitCmd() *cobra.Command {
@@ -413,6 +414,8 @@ func guardCommitGitHook(repoRootFlag, msgFile string, thresholdFlag int, thresho
 		return 0, nil // the repo off-ramp: git.enforce_commits: false
 	}
 
+	reportEngineSkew(stderr, os.Getenv(hookVersionEnv))
+
 	subject, err := firstLineOfFile(msgFile)
 	if err != nil {
 		return 0, err
@@ -430,6 +433,54 @@ func guardCommitGitHook(repoRootFlag, msgFile string, thresholdFlag int, thresho
 	}
 	fmt.Fprintln(stderr, d.Reason)
 	return exGitHookBlock, nil
+}
+
+// hookVersionEnv names the environment variable the commit-msg hook body
+// sets around its own `logmind guard-commit` invocation, carrying the
+// version of logmind that INSTALLED that hook (see
+// internal/hooks.BuildCommitMsgBody). It is the engine half of issue #270's
+// skew handshake: the hook resolves its engine by bare name off PATH, so the
+// binary answering need not be the one that wrote the hook, and SPEC §3.4
+// requires an installer to "make that skew visible".
+//
+// An env var rather than a flag, deliberately: an engine that predates the
+// handshake ignores an unknown variable and still runs the gate, whereas an
+// unknown FLAG would make cobra error out — converting "the gate ran against
+// an older engine" into "the gate did not run" across exactly the
+// mixed-version fleet the handshake exists for. The handshake must never be
+// able to break a gate that was working.
+const hookVersionEnv = "LOGMIND_HOOK_VERSION"
+
+// reportEngineSkew writes the §3.4 skew notice to stderr when the logmind
+// that installed the calling hook (hookVer) and the logmind now running as
+// its engine disagree on MAJOR version. Advisory only — it NEVER touches the
+// allow/block decision or the exit code, because a skewed engine has still
+// evaluated the change and its answer stands.
+//
+// Never routed through qout: like a block reason, this is a report about the
+// gate's own integrity, and §3.4 keeps those off stdout and out of reach of a
+// quiet flag. The caller only reaches this after the git.enforce_commits
+// off-ramp, so a repo that deliberately turned local enforcement off does not
+// get nagged about which binary would have enforced it.
+//
+// Major is the reporting boundary, not exact equality — see
+// version.SameMajor's doc comment for why (a per-patch notice would print on
+// every commit in every un-refreshed repo, and `logmind doctor` already
+// reports minor/patch hook staleness on demand).
+func reportEngineSkew(stderr io.Writer, hookVer string) {
+	if hookVer == "" || version.SameMajor(hookVer, version.Version) {
+		return
+	}
+	// os.Executable is what the hook actually resolved off PATH — "what it
+	// found", in §3.4's terms. Degrade to the bare name rather than dropping
+	// the notice if the platform can't answer.
+	engine, err := os.Executable()
+	if err != nil || engine == "" {
+		engine = "logmind"
+	}
+	fmt.Fprintf(stderr,
+		"logmind: commit gate ran a DIFFERENT logmind than the one that installed this hook — hook installed by logmind %s, engine answering PATH is logmind %s (%s). Enforcement may differ across that boundary; refresh with `logmind doctor --fix`.\n",
+		hookVer, version.Version, engine)
 }
 
 // exGitHookBlock is the git-hook layer's distinctive block exit code —

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/version"
 )
 
 // writeGuardCommitConfig writes a minimal .logmind/config.yml under repo
@@ -490,6 +492,139 @@ func TestRunGuardCommit_GitHook_MissingMsgFileOnDisk_PropagatesRealError(t *test
 	}
 	if err == nil || err == ErrSilent {
 		t.Fatalf("err = %v; want a plain os.ReadFile error", err)
+	}
+}
+
+// --- the git-hook layer's engine-skew handshake (issue #270) --------------
+
+// The commit-msg hook resolves its engine by bare name off PATH, so the
+// binary that answers need not be the one that installed the hook. SPEC §3.4
+// requires an installer to "make that skew visible", offering two ways and
+// leaving the choice open: pin the engine resolved at install, or check the
+// engine's version at run and complain. logmind checks at run — the hook
+// hands its own installed-by version over in LOGMIND_HOOK_VERSION and the
+// engine compares it against its own.
+//
+// The comparison is on MAJOR version (see version.SameMajor for why), and it
+// is advisory in the strictest sense: it never moves the exit code, in
+// either direction.
+
+func TestRunGuardCommit_GitHook_ReportsMajorEngineSkew(t *testing.T) {
+	repo := initRepo(t)
+	stageLines(t, repo, "small.go", 5)
+	msgFile := writeMsgFile(t, repo, "a small change")
+	t.Setenv(hookVersionEnv, "1.2.0") // the hook was written by a 1.x logmind
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil — a skew notice must never change the decision", exitCode, err)
+	}
+	for _, must := range []string{"DIFFERENT logmind", "1.2.0", version.Version} {
+		if !strings.Contains(stderr.String(), must) {
+			t.Errorf("skew notice missing %q; stderr = %q", must, stderr.String())
+		}
+	}
+	// stdout carries guard-commit's own chatty allow line; the skew notice
+	// must not be anywhere near it.
+	if strings.Contains(stdout.String(), "DIFFERENT logmind") {
+		t.Errorf("skew notice leaked to stdout: %q", stdout.String())
+	}
+}
+
+// A skew notice must not be able to rescue — or to cause — a block. Pin both
+// halves against the same 1.x hook version.
+func TestRunGuardCommit_GitHook_SkewNoticeLeavesTheBlockIntact(t *testing.T) {
+	repo := initRepo(t)
+	stageLines(t, repo, "big.go", 25)
+	msgFile := writeMsgFile(t, repo, "a big change")
+	t.Setenv(hookVersionEnv, "1.2.0")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &stdout, &stderr)
+	if exitCode != 65 || err != nil {
+		t.Fatalf("exitCode=%d err=%v; want 65,nil (the block still stands under skew)", exitCode, err)
+	}
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; want the skew notice alongside the block reason", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Errorf("stderr = %q; want the block reason too", stderr.String())
+	}
+}
+
+// The quiet contract: §3.4 keeps a gate's reports about itself off stdout and
+// out of reach of a quiet flag, exactly like a block reason.
+func TestRunGuardCommit_GitHook_SkewNoticeSurvivesQuiet(t *testing.T) {
+	repo := initRepo(t)
+	stageLines(t, repo, "small.go", 5)
+	msgFile := writeMsgFile(t, repo, "a small change")
+	t.Setenv(hookVersionEnv, "1.2.0")
+
+	var stdout, stderr bytes.Buffer
+	if _, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, true,
+		nil, &stdout, &stderr); err != nil {
+		t.Fatalf("runGuardCommit: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; the skew notice must not be suppressible by --quiet", stderr.String())
+	}
+}
+
+// The noise floor. A notice that fires on every commit in every repo whose
+// hooks predate the last release teaches its reader to ignore the one
+// message that matters, so only a MAJOR difference is reported — an
+// unset variable, a matching major, and a version string this binary cannot
+// parse all stay silent. Minor/patch hook staleness is still reported, on
+// demand, by `logmind doctor`'s hook-drift probe.
+func TestRunGuardCommit_GitHook_SkewNoticeStaysSilentWhenItShould(t *testing.T) {
+	sameMajor := "2.99.99"
+	if !version.SameMajor(sameMajor, version.Version) {
+		t.Fatalf("fixture is stale: %q is no longer the same major as %q", sameMajor, version.Version)
+	}
+	for name, hookVer := range map[string]string{
+		"unset":       "",
+		"same major":  sameMajor,
+		"unparseable": "not-a-version",
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := initRepo(t)
+			stageLines(t, repo, "small.go", 5)
+			msgFile := writeMsgFile(t, repo, "a small change")
+			t.Setenv(hookVersionEnv, hookVer)
+
+			var stdout, stderr bytes.Buffer
+			if _, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+				nil, &stdout, &stderr); err != nil {
+				t.Fatalf("runGuardCommit: %v", err)
+			}
+			if strings.Contains(stderr.String(), "DIFFERENT logmind") {
+				t.Errorf("skew notice fired for %s hook version %q; stderr = %q", name, hookVer, stderr.String())
+			}
+		})
+	}
+}
+
+// git.enforce_commits:false is the repo's own decision to run without the
+// local gate. It should not then be nagged about which binary would have
+// enforced it — the off-ramp returns before the notice.
+func TestRunGuardCommit_GitHook_NoSkewNoticeWhenEnforcementIsOff(t *testing.T) {
+	repo := initRepo(t)
+	writeGuardCommitConfig(t, repo, "git:\n  enforce_commits: false\n")
+	stageLines(t, repo, "big.go", 25)
+	msgFile := writeMsgFile(t, repo, "a big change")
+	t.Setenv(hookVersionEnv, "1.2.0")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "git-hook", msgFile, 20, true, false,
+		nil, &stdout, &stderr)
+	if exitCode != 0 || err != nil {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil (enforce_commits:false off-ramp)", exitCode, err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q; want silence when the repo has turned local enforcement off", stderr.String())
 	}
 }
 

--- a/internal/cli/install_hook.go
+++ b/internal/cli/install_hook.go
@@ -164,7 +164,17 @@ const preCommitMarker = "logmind check-decisions"
 //
 //   - Missing binary: the `command -v logmind` guard makes it a clean no-op
 //     (fall through to the end of the script → exit 0) instead of a
-//     `command not found` non-zero that would wrongly block the commit.
+//     `command not found` non-zero that would wrongly block the commit. As
+//     of issue #270 it is not a SILENT no-op: SPEC §3.4 requires a gate that
+//     fails open to say so on stderr, "naming what it looked for and what it
+//     found". This hook is opt-in — the user asked for it by running
+//     `logmind install-hook` — so it not running is exactly what they need
+//     told. Exit status is unchanged (still 0).
+//   - Stale binary: unlike the commit-msg hook, no skew handshake is needed
+//     here. This block PRESERVES check-decisions' exit code, so an engine
+//     that doesn't know the subcommand exits nonzero and BLOCKS — noisy and
+//     visible, never a silent allow. Missing is the only way this gate can
+//     disappear quietly, and that is the branch made loud below.
 //   - Normal completion: check-decisions' own exit code is PRESERVED —
 //     `exit 0` when clean/under-threshold, `exit 1` when it blocks an
 //     undocumented over-threshold change (its designed pre-commit behavior).
@@ -179,7 +189,9 @@ const preCommitMarker = "logmind check-decisions"
 const preCommitGuardedCall = "# logmind check-decisions — hang-guarded (issue #213): run under a\n" +
 	"# deadline so a wedged logmind binary can never stall `git commit`.\n" +
 	"# Fail OPEN (exit 0) on timeout/crash; preserve a real block exit code\n" +
-	"# on the normal path. A missing binary is a clean no-op.\n" +
+	"# on the normal path. A missing binary is a clean no-op — but not a\n" +
+	"# silent one (issue #270): a gate that cannot report its own absence\n" +
+	"# gets trusted long after it stopped working.\n" +
 	"if command -v logmind >/dev/null 2>&1; then\n" +
 	"    logmind check-decisions &\n" +
 	"    __lm_pid=$!\n" +
@@ -193,6 +205,8 @@ const preCommitGuardedCall = "# logmind check-decisions — hang-guarded (issue 
 	"        exit 0\n" +
 	"    fi\n" +
 	"    exit \"$__lm_rc\"\n" +
+	"else\n" +
+	"    printf 'logmind: check-decisions NOT RUN — looked for `logmind` on PATH, found nothing. Commit allowed.\\n' >&2\n" +
 	"fi\n"
 
 // ErrSilent is the cli-layer alias of clierr.ErrSilent. Backward-compat

--- a/internal/cli/install_hook_test.go
+++ b/internal/cli/install_hook_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -50,6 +51,7 @@ func TestInstallHook_FreshInstall(t *testing.T) {
 		"( sleep 10; kill",          // the deadline watchdog
 		"wait \"$__lm_pid\"",        // capture the real exit code
 		"-gt 128",                   // timeout/crash → fail open
+		"check-decisions NOT RUN",   // #270: the no-op is not a SILENT one
 	} {
 		if !strings.Contains(string(body), must) {
 			t.Errorf("pre-commit body missing %q", must)
@@ -130,6 +132,46 @@ func TestInstallHook_ForeignWithForce(t *testing.T) {
 	want := "#!/bin/sh\necho custom\n" + preCommitGuardedCall
 	if string(got) != want {
 		t.Fatalf("hook body = %q; want %q", got, want)
+	}
+}
+
+// TestInstallHook_NoEngineOnPath_FailsOpenLoudly is the issue #270
+// regression for this hook: `logmind install-hook` is opt-in — the user
+// asked for the gate — so a run where nothing on PATH answers to `logmind`
+// must still allow the commit (exit 0, per SPEC §3.4's mandatory fail-open)
+// AND must say on stderr that it did not run. The stale-engine case needs no
+// equivalent here: this body preserves check-decisions' own exit code, so an
+// engine that doesn't know the subcommand exits nonzero and BLOCKS — noisy
+// by construction, never a silent allow.
+//
+// Runs the hook script directly under an empty PATH, the hermetic way to say
+// "nothing answers to logmind" — filtering the host's real PATH would depend
+// on where this machine keeps git and logmind (often one directory).
+func TestInstallHook_NoEngineOnPath_FailsOpenLoudly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX sh hook body; not applicable on Windows")
+	}
+	repo := initRepo(t)
+	if err := runInstallHook(repo, false, &bytes.Buffer{}); err != nil {
+		t.Fatalf("runInstallHook: %v", err)
+	}
+
+	cmd := exec.Command("/bin/sh", filepath.Join(repo, ".git", "hooks", "pre-commit"))
+	cmd.Dir = repo
+	cmd.Env = []string{"PATH="}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook exited non-zero with no engine on PATH: %v\nstderr: %s", err, stderr.String())
+	}
+	for _, must := range []string{"check-decisions NOT RUN", "found nothing"} {
+		if !strings.Contains(stderr.String(), must) {
+			t.Errorf("stderr missing %q; got: %q", must, stderr.String())
+		}
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("hook wrote to stdout: %q; the notice belongs on stderr", stdout.String())
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -659,6 +659,72 @@ func revertClaudeHookMarker(t *testing.T, dir string) {
 	}
 }
 
+// --- probeCommitMsgHook (the §3.4 commit gate) ---------------------------
+
+// probeHook's whole drift signal rests on the hook body being a pure
+// function of internal/version.Version: it byte-compares the installed file
+// against hooks.BuildCommitMsgBody(). Issue #270 weighed pinning the
+// installing binary's absolute PATH into that body and rejected it for
+// exactly this reason — a body that varied by machine would make every
+// correctly-installed hook look like content drift. These two tests are the
+// pin on that reasoning: a hook this binary just wrote is CURRENT, and one
+// byte of hand-editing is STALE.
+
+func TestProbeCommitMsgHook_CurrentAfterInstall(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	if _, err := hooks.InstallCommitMsg(dir); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	row := probeCommitMsgHook(dir)
+	if row.Drift != "current" {
+		t.Errorf("Drift = %q; want current — a correctly-installed hook must not be reported as drifted", row.Drift)
+	}
+	if row.Marker == nil || *row.Marker != version.Version {
+		t.Errorf("Marker = %v; want %v", row.Marker, version.Version)
+	}
+
+	r := CollectStatus(dir, true)
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK", r.Overall)
+	}
+}
+
+// TestProbeCommitMsgHook_ContentDriftOnHandEdit hand-edits ONE line of the
+// installed hook — the fail-open branch, i.e. the line someone silencing the
+// gate would reach for — leaving the version marker untouched, so only the
+// byte-compare can catch it.
+func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
+	dir := freshRepo(t)
+	fakeGitDir(t, dir)
+	if _, err := hooks.InstallCommitMsg(dir); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	path := filepath.Join(dir, ".git", "hooks", "commit-msg")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read commit-msg: %v", err)
+	}
+	edited := strings.Replace(string(data), `if [ "$rc" -eq 65 ]; then`, `if [ "$rc" -eq 66 ]; then`, 1)
+	if edited == string(data) {
+		t.Fatalf("fixture is stale: the rc==65 block guard is no longer in the installed body")
+	}
+	mustWrite(t, path, edited)
+
+	row := probeCommitMsgHook(dir)
+	if row.Drift != "stale" {
+		t.Errorf("Drift = %q; want stale — a hand-edited hook body must be detected", row.Drift)
+	}
+	if row.Marker == nil || !strings.Contains(*row.Marker, "content drift") {
+		t.Errorf("Marker = %v; want it to say content drift (the version marker is untouched)", row.Marker)
+	}
+
+	r := CollectStatus(dir, true)
+	if r.Overall != "DRIFT" {
+		t.Errorf("Overall = %q; want DRIFT with a hand-edited commit-msg hook", r.Overall)
+	}
+}
+
 // --- probePreCommitHook (L2a / v2.0.0 derived-docs pin-preservation) -----
 
 // fakeGitDir plants a bare `.git/hooks/` directory under dir — enough for

--- a/internal/hooks/commit_msg_enforce_test.go
+++ b/internal/hooks/commit_msg_enforce_test.go
@@ -153,7 +153,80 @@ func TestCommitMsgHook_StaleBinaryOnPath_FailsOpen(t *testing.T) {
 					staleExitCode, err, out)
 			}
 			assertCommitCount(t, dir, binDir, 2)
+
+			// Issue #270 / SPEC §3.4: failing open must not be SILENT. The
+			// hook has to name what it looked for, what it found (the
+			// resolved engine path and its exit status), and which logmind
+			// installed it — otherwise a repository whose gate has been off
+			// for weeks looks exactly like one where every commit complied.
+			// The stale binary's own "unknown command" line does not count:
+			// it says nothing about the gate not having run.
+			for _, must := range []string{
+				"commit gate NOT RUN",
+				filepath.Join(staleDir, "logmind"),
+				fmt.Sprintf("exit %d", staleExitCode),
+				"installed by logmind " + hookVersion(),
+			} {
+				if !strings.Contains(out, must) {
+					t.Errorf("fail-open notice missing %q; git output was:\n%s", must, out)
+				}
+			}
 		})
+	}
+}
+
+// TestCommitMsgHook_NoEngineOnPath_FailsOpenLoudly is the other half of the
+// issue #270 regression: not a WRONG engine but NO engine. §3.4 requires the
+// commit to be allowed (exit 0) and requires the hook to say so, naming what
+// it looked for and what it found.
+//
+// Runs the installed hook script directly under an empty PATH rather than
+// through `git commit`. That is the hermetic way to express "nothing on PATH
+// answers to logmind" — filtering the host's real PATH would depend on where
+// this machine happens to keep git and logmind (often the same directory).
+// git contributes nothing to this path anyway: it runs the hook file and
+// takes its exit code, which is exactly what this asserts.
+func TestCommitMsgHook_NoEngineOnPath_FailsOpenLoudly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX sh hook body; not applicable on Windows")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallCommitMsg(dir); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	msgFile := filepath.Join(dir, "COMMIT_EDITMSG")
+	if err := os.WriteFile(msgFile, []byte("substantive change, no decision log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("/bin/sh", filepath.Join(dir, ".git", "hooks", "commit-msg"), msgFile)
+	cmd.Dir = dir
+	cmd.Env = []string{"PATH="} // nothing on PATH answers to `logmind`
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	// Fail OPEN — a missing engine must never block a commit.
+	if err != nil {
+		t.Fatalf("hook exited non-zero with no engine on PATH: %v\nstderr: %s", err, stderr.String())
+	}
+	// ...but loudly, and on stderr: stdout belongs to whatever is capturing
+	// git's output, and §3.4 keeps a gate's report about itself off it.
+	for _, must := range []string{
+		"commit gate NOT RUN",
+		"found nothing",
+		"installed by logmind " + hookVersion(),
+	} {
+		if !strings.Contains(stderr.String(), must) {
+			t.Errorf("stderr missing %q; got: %q", must, stderr.String())
+		}
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("hook wrote to stdout: %q; the notice belongs on stderr", stdout.String())
 	}
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -279,6 +279,45 @@ func BuildPostRewriteBody() string {
 // is always available. A missing binary fails open (exit 0) — logmind
 // not being installed should never block a commit.
 //
+// Loud fail-open + engine-skew handshake (issue #270, SPEC §3.4). Fail-open
+// is REQUIRED and unchanged — "a missing, stale or crashing engine MUST
+// allow the commit" — but §3.4 also says "Failing open MUST NOT be silent. A
+// hook that cannot run the engine it was installed for MUST say so on
+// stderr, naming what it looked for and what it found." This body used to
+// say nothing at all: a `logmind` on PATH that predates `guard-commit` (the
+// released v1.2.0 does) exits 1, fell through the rc!=65 path below, and the
+// commit landed with the gate silently off. Two changes close that:
+//
+//   - Every no-decision exit from this hook now prints a one-line stderr
+//     notice naming what it looked for (`logmind` on PATH, able to run
+//     `guard-commit`), what it found (nothing, or the resolved absolute path
+//     and its exit code), and which logmind version installed this hook. The
+//     exit code is still 0 in both cases.
+//   - The invocation carries LOGMIND_HOOK_VERSION — this hook's own
+//     installed-by version — so the engine can compare it against its own
+//     and complain on a MAJOR skew (§3.4: "An installer MUST make that skew
+//     visible ... checking the engine's version at run and complaining").
+//     See reportEngineSkew in internal/cli/guard_commit.go.
+//
+// Why an ENVIRONMENT VARIABLE and not a `--hook-version` flag: an engine
+// that doesn't recognise the variable ignores it, while an engine that
+// doesn't recognise a flag ERRORS OUT — which would turn "the gate ran
+// against a slightly older engine" into "the gate did not run" for exactly
+// the mixed-version fleet §3.4 says this matters most for. The handshake
+// must never be able to break a gate that was working.
+//
+// Why not pin the installing binary's absolute path (§3.4's OTHER offered
+// remedy): the hook body is byte-compared in two places — internal/doctor's
+// probeHook diffs the installed file against BuildCommitMsgBody(), and
+// testdata/commit-msg.golden pins the same bytes in CI. Both require the
+// body to be a pure function of internal/version.Version. A path resolved at
+// install time makes it a function of the installing machine's filesystem
+// instead, so every correctly-installed hook on a machine whose logmind
+// lives anywhere else would be reported as content drift, and no golden
+// could be checked in at all. A pinned path also breaks on a reinstall to a
+// different prefix and needs a PATH fallback to stay fail-open — which
+// reintroduces the bare-name binding it was meant to remove.
+//
 // Stale-binary hardening (CTO design amendment, post-PR2): this body used
 // to do `logmind guard-commit --layer git-hook --msg-file "$MSG_FILE"; exit $?`
 // — i.e. relay ANY nonzero exit from `logmind` straight into the hook's own
@@ -318,7 +357,18 @@ func BuildCommitMsgBody() string {
 		"# rebase/merge/cherry-pick in progress).\n" +
 		"#\n" +
 		"# Fails open when logmind isn't on PATH: a missing binary should never\n" +
-		"# block a commit.\n" +
+		"# block a commit. Fail-open is NOT silent though (issue #270): every\n" +
+		"# path that allows a commit without a decision from the engine prints a\n" +
+		"# one-line notice to stderr naming what was looked for, what was found,\n" +
+		"# and which logmind installed this hook. A gate that cannot report its\n" +
+		"# own absence gets trusted long after it stopped working.\n" +
+		"#\n" +
+		"# LOGMIND_HOOK_VERSION carries this hook's installed-by version to the\n" +
+		"# engine so it can complain about a major-version skew between the\n" +
+		"# binary that WROTE this hook and the one now RUNNING it. Deliberately\n" +
+		"# an env var, not a flag: an engine that doesn't know the variable\n" +
+		"# ignores it, whereas an engine that doesn't know a flag would error\n" +
+		"# out — turning a working gate into a skipped one.\n" +
 		"#\n" +
 		"# Stale-binary hardening: 65 is guard-commit's OWN distinctive block\n" +
 		"# signal (EX_DATAERR). Any other nonzero exit — including a STALE\n" +
@@ -344,18 +394,25 @@ func BuildCommitMsgBody() string {
 		"if [ -z \"$MSG_FILE\" ] || [ ! -f \"$MSG_FILE\" ]; then\n" +
 		"    exit 0\n" +
 		"fi\n" +
-		"if command -v logmind >/dev/null 2>&1; then\n" +
-		"    logmind guard-commit --layer git-hook --msg-file \"$MSG_FILE\" &\n" +
-		"    __lm_pid=$!\n" +
-		"    ( sleep 10; kill \"$__lm_pid\" 2>/dev/null ) >/dev/null 2>&1 &\n" +
-		"    __lm_watcher=$!\n" +
-		"    wait \"$__lm_pid\" 2>/dev/null\n" +
-		"    rc=$?\n" +
-		"    kill \"$__lm_watcher\" 2>/dev/null\n" +
-		"    wait \"$__lm_watcher\" 2>/dev/null\n" +
-		"    if [ \"$rc\" -eq 65 ]; then\n" +
-		"        exit 1\n" +
-		"    fi\n" +
+		"__lm_want='" + hookVersion() + "'\n" +
+		"__lm_engine=$(command -v logmind 2>/dev/null || true)\n" +
+		"if [ -z \"$__lm_engine\" ]; then\n" +
+		"    printf 'logmind: commit gate NOT RUN — looked for `logmind` on PATH, found nothing (this hook was installed by logmind %s). Commit allowed.\\n' \"$__lm_want\" >&2\n" +
+		"    exit 0\n" +
+		"fi\n" +
+		"LOGMIND_HOOK_VERSION=\"$__lm_want\" logmind guard-commit --layer git-hook --msg-file \"$MSG_FILE\" &\n" +
+		"__lm_pid=$!\n" +
+		"( sleep 10; kill \"$__lm_pid\" 2>/dev/null ) >/dev/null 2>&1 &\n" +
+		"__lm_watcher=$!\n" +
+		"wait \"$__lm_pid\" 2>/dev/null\n" +
+		"rc=$?\n" +
+		"kill \"$__lm_watcher\" 2>/dev/null\n" +
+		"wait \"$__lm_watcher\" 2>/dev/null\n" +
+		"if [ \"$rc\" -eq 65 ]; then\n" +
+		"    exit 1\n" +
+		"fi\n" +
+		"if [ \"$rc\" -ne 0 ]; then\n" +
+		"    printf 'logmind: commit gate NOT RUN — %s could not run `guard-commit` (exit %s); this hook was installed by logmind %s. Commit allowed; run `logmind doctor`.\\n' \"$__lm_engine\" \"$rc\" \"$__lm_want\" >&2\n" +
 		"fi\n" +
 		"exit 0\n"
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -83,6 +83,118 @@ func TestCommitMsgBody_DelegatesToGuardCommit(t *testing.T) {
 	}
 }
 
+// TestCommitMsgBody_FailsOpenLoudlyAndHandshakesVersion is the issue #270
+// guard. Fail-open itself is REQUIRED and pinned above; what this pins is
+// SPEC §3.4's other half — "Failing open MUST NOT be silent. A hook that
+// cannot run the engine it was installed for MUST say so on stderr, naming
+// what it looked for and what it found" — plus the run-time engine-version
+// check §3.4 requires an installer to make skew visible with.
+//
+// The defect it exists to catch: this body used to resolve its engine by
+// bare name and say nothing when that engine turned out not to know
+// `guard-commit` (the released v1.2.0 doesn't — it exits 1). The commit
+// landed, correctly, and the gate had silently ceased to exist.
+func TestCommitMsgBody_FailsOpenLoudlyAndHandshakesVersion(t *testing.T) {
+	body := BuildCommitMsgBody()
+
+	// The engine is RESOLVED, not merely probed: the resolved path is the
+	// "what it found" half of §3.4's naming requirement.
+	if !strings.Contains(body, `__lm_engine=$(command -v logmind 2>/dev/null || true)`) {
+		t.Errorf("commit-msg body must capture the resolved engine path in $__lm_engine")
+	}
+
+	// The hook's own installed-by version, and the handshake carrying it to
+	// the engine. An environment variable, NEVER a flag: an engine that
+	// predates the handshake ignores an unknown variable and still runs the
+	// gate, whereas an unknown flag makes cobra error out — which would turn
+	// "the gate ran against an older engine" into "the gate did not run" for
+	// exactly the mixed-version fleet §3.4 says this matters most for.
+	if !strings.Contains(body, "__lm_want='"+hookVersion()+"'\n") {
+		t.Errorf("commit-msg body must pin its installed-by version in $__lm_want")
+	}
+	if !strings.Contains(body, `LOGMIND_HOOK_VERSION="$__lm_want" logmind guard-commit --layer git-hook`) {
+		t.Errorf("commit-msg body must hand LOGMIND_HOOK_VERSION to the engine on the guard-commit invocation")
+	}
+	if strings.Contains(body, "--hook-version") {
+		t.Errorf("commit-msg body must not pass the hook version as a FLAG — an engine that doesn't know it would error out and skip the gate entirely")
+	}
+
+	// Both allow-without-a-decision paths announce themselves, on stderr,
+	// naming the version that installed this hook.
+	notices := 0
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "printf ") {
+			continue
+		}
+		notices++
+		if !strings.HasSuffix(trimmed, ">&2") {
+			t.Errorf("notice must go to stderr, never stdout: %q", trimmed)
+		}
+		if !strings.Contains(trimmed, "NOT RUN") {
+			t.Errorf("notice must say the gate did not run: %q", trimmed)
+		}
+		if !strings.Contains(trimmed, `"$__lm_want"`) {
+			t.Errorf("notice must name the logmind that installed this hook: %q", trimmed)
+		}
+	}
+	if notices != 2 {
+		t.Errorf("commit-msg body emits %d stderr notices; want 2 (no engine on PATH, and an engine that could not run guard-commit)", notices)
+	}
+
+	// The no-engine branch must be loud AND self-terminating: falling
+	// through into the guard-commit invocation with no engine would be a
+	// `command not found` on every commit.
+	noEngine := blockAfter(t, body, `if [ -z "$__lm_engine" ]; then`)
+	if !strings.Contains(noEngine, "printf ") || !strings.Contains(noEngine, "exit 0") {
+		t.Errorf("the no-engine branch must print a notice and exit 0; got:\n%s", noEngine)
+	}
+
+	// The could-not-run branch names what it found — the resolved path and
+	// the exit status the engine produced.
+	failedRun := blockAfter(t, body, `if [ "$rc" -ne 0 ]; then`)
+	for _, must := range []string{`"$__lm_engine"`, `"$rc"`} {
+		if !strings.Contains(failedRun, must) {
+			t.Errorf("the could-not-run notice must name %s; got:\n%s", must, failedRun)
+		}
+	}
+
+	// Fail-open is untouched: the ONLY `exit 1` STATEMENT in the body is
+	// still the rc==65 block, and it still sits under that exact guard.
+	// (Counted over statement lines, not the whole string — the comment
+	// header discusses a stale binary's own "exit 1" in prose.)
+	nonZeroExits := 0
+	for _, line := range strings.Split(body, "\n") {
+		if t := strings.TrimSpace(line); strings.HasPrefix(t, "exit ") && t != "exit 0" {
+			nonZeroExits++
+		}
+	}
+	if nonZeroExits != 1 {
+		t.Errorf("commit-msg body has %d non-zero `exit` statements; want exactly 1 (the rc==65 block)", nonZeroExits)
+	}
+	if !strings.Contains(body, "if [ \"$rc\" -eq 65 ]; then\n    exit 1\n") {
+		t.Errorf("the sole `exit 1` must sit directly under the rc==65 guard")
+	}
+}
+
+// blockAfter returns the lines between `guard` and the `fi` that closes it,
+// so a test can assert about ONE branch of the hook body rather than about
+// the script as a whole. The hook bodies nest no `if` inside an `if`, so the
+// first following top-of-block `fi` is the closing one.
+func blockAfter(t *testing.T, body, guard string) string {
+	t.Helper()
+	i := strings.Index(body, guard)
+	if i < 0 {
+		t.Fatalf("body missing guard %q", guard)
+	}
+	rest := body[i+len(guard):]
+	j := strings.Index(rest, "\nfi\n")
+	if j < 0 {
+		t.Fatalf("guard %q is never closed by an `fi`", guard)
+	}
+	return rest[:j]
+}
+
 // TestPreCommitBody_MatchesGolden pins the L2a pre-commit hook body — the
 // derived-docs pin-preservation guardrail. No Python ancestor (this hook is
 // v2.0.0+/Go-only), same as commit-msg's golden: exists purely so a future

--- a/internal/hooks/testdata/commit-msg.golden
+++ b/internal/hooks/testdata/commit-msg.golden
@@ -10,7 +10,18 @@
 # rebase/merge/cherry-pick in progress).
 #
 # Fails open when logmind isn't on PATH: a missing binary should never
-# block a commit.
+# block a commit. Fail-open is NOT silent though (issue #270): every
+# path that allows a commit without a decision from the engine prints a
+# one-line notice to stderr naming what was looked for, what was found,
+# and which logmind installed this hook. A gate that cannot report its
+# own absence gets trusted long after it stopped working.
+#
+# LOGMIND_HOOK_VERSION carries this hook's installed-by version to the
+# engine so it can complain about a major-version skew between the
+# binary that WROTE this hook and the one now RUNNING it. Deliberately
+# an env var, not a flag: an engine that doesn't know the variable
+# ignores it, whereas an engine that doesn't know a flag would error
+# out — turning a working gate into a skipped one.
 #
 # Stale-binary hardening: 65 is guard-commit's OWN distinctive block
 # signal (EX_DATAERR). Any other nonzero exit — including a STALE
@@ -36,17 +47,24 @@ MSG_FILE="$1"
 if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
     exit 0
 fi
-if command -v logmind >/dev/null 2>&1; then
-    logmind guard-commit --layer git-hook --msg-file "$MSG_FILE" &
-    __lm_pid=$!
-    ( sleep 10; kill "$__lm_pid" 2>/dev/null ) >/dev/null 2>&1 &
-    __lm_watcher=$!
-    wait "$__lm_pid" 2>/dev/null
-    rc=$?
-    kill "$__lm_watcher" 2>/dev/null
-    wait "$__lm_watcher" 2>/dev/null
-    if [ "$rc" -eq 65 ]; then
-        exit 1
-    fi
+__lm_want='2.0.0-dev'
+__lm_engine=$(command -v logmind 2>/dev/null || true)
+if [ -z "$__lm_engine" ]; then
+    printf 'logmind: commit gate NOT RUN — looked for `logmind` on PATH, found nothing (this hook was installed by logmind %s). Commit allowed.\n' "$__lm_want" >&2
+    exit 0
+fi
+LOGMIND_HOOK_VERSION="$__lm_want" logmind guard-commit --layer git-hook --msg-file "$MSG_FILE" &
+__lm_pid=$!
+( sleep 10; kill "$__lm_pid" 2>/dev/null ) >/dev/null 2>&1 &
+__lm_watcher=$!
+wait "$__lm_pid" 2>/dev/null
+rc=$?
+kill "$__lm_watcher" 2>/dev/null
+wait "$__lm_watcher" 2>/dev/null
+if [ "$rc" -eq 65 ]; then
+    exit 1
+fi
+if [ "$rc" -ne 0 ]; then
+    printf 'logmind: commit gate NOT RUN — %s could not run `guard-commit` (exit %s); this hook was installed by logmind %s. Commit allowed; run `logmind doctor`.\n' "$__lm_engine" "$rc" "$__lm_want" >&2
 fi
 exit 0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -188,6 +188,42 @@ func SatisfiesMin(v, min string) bool {
 	return true // equal
 }
 
+// SameMajor reports whether a and b share a major version, using the same
+// tolerant parse as SatisfiesMin (leading "v" and any prerelease/build
+// suffix stripped before comparing).
+//
+// Added for the commit-msg hook's engine-skew handshake (issue #270, SPEC
+// §3.4: "An installer MUST make that skew visible"). The hook tells the
+// engine which logmind installed it via LOGMIND_HOOK_VERSION; the engine
+// compares that against its own Version and complains on stderr when the
+// two MAJORS disagree — see reportEngineSkew in internal/cli/guard_commit.go.
+//
+// Major, not exact equality, is the deliberate boundary. This repo bumps
+// the major for a contract change (the enforcement gate itself arrived in
+// 2.0.0; SpecVersion moves with it), so a major difference is the skew that
+// can actually change what the gate decides. Complaining on every patch
+// difference instead would print on every commit in every repo whose hooks
+// hadn't been refreshed since the last release — noise that trains a reader
+// to ignore the one message that matters. Minor/patch staleness is still
+// reported, on demand, by `logmind doctor`'s hook-drift probe.
+//
+// Unparseable input on either side returns true — the same fail-open stance
+// SatisfiesMin takes. A skew notice fired off a version string this helper
+// cannot read would be a false alarm, and the case that actually disables
+// the gate (an engine that cannot run `guard-commit` at all) is caught by
+// the hook body's own loud fail-open, not by this compare.
+func SameMajor(a, b string) bool {
+	ap, ok := parseVersionCore(a)
+	if !ok {
+		return true
+	}
+	bp, ok := parseVersionCore(b)
+	if !ok {
+		return true
+	}
+	return ap[0] == bp[0]
+}
+
 // parseVersionCore extracts the [major, minor, patch] integer triple from a
 // version string, stripping a leading "v" and any trailing
 // prerelease/build suffix (from the first '-' or '+' onward) first. Returns

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -43,6 +43,55 @@ func TestSatisfiesMin_NewerOrEqualSucceeds(t *testing.T) {
 	}
 }
 
+// TestSameMajor_ReportsOnlyAMajorDifference pins the reporting boundary the
+// commit-msg hook's engine-skew notice uses (issue #270). A dev prerelease
+// and its release share a major; so do a patch and a minor apart. Only a
+// major step across is skew worth interrupting a commit to mention — a
+// per-patch notice would fire on every commit in every repo whose hooks
+// predate the last release, and be ignored within a day.
+func TestSameMajor_ReportsOnlyAMajorDifference(t *testing.T) {
+	same := []struct{ a, b string }{
+		{"2.0.0-dev", "2.0.0"},
+		{"2.0.0", "2.9.9"},
+		{"v2.1.0", "2.0.0"},
+		{"1.2.0", "1.0.1"},
+	}
+	for _, c := range same {
+		if !SameMajor(c.a, c.b) {
+			t.Errorf("SameMajor(%q, %q) = false; want true", c.a, c.b)
+		}
+	}
+	differ := []struct{ a, b string }{
+		{"1.2.0", "2.0.0-dev"},
+		{"2.0.0-dev", "3.0.0"},
+		{"0.6.16", "2.0.0"},
+	}
+	for _, c := range differ {
+		if SameMajor(c.a, c.b) {
+			t.Errorf("SameMajor(%q, %q) = true; want false", c.a, c.b)
+		}
+	}
+}
+
+// TestSameMajor_UnparseableFailsOpen: same stance as SatisfiesMin. A skew
+// notice fired off a version string this helper cannot read would be a false
+// alarm, and the case that actually disables the gate — an engine that
+// cannot run `guard-commit` at all — is caught by the hook body's own loud
+// fail-open, not by this compare.
+func TestSameMajor_UnparseableFailsOpen(t *testing.T) {
+	cases := []struct{ a, b string }{
+		{"", "2.0.0"},
+		{"2.0.0", ""},
+		{"not-a-version", "2.0.0"},
+		{"2.0", "2.0.0"},
+	}
+	for _, c := range cases {
+		if !SameMajor(c.a, c.b) {
+			t.Errorf("SameMajor(%q, %q) = false; want true (fail open on unparseable input)", c.a, c.b)
+		}
+	}
+}
+
 // TestSatisfiesMin_UnparseableFailsOpen: a floor check is advisory-only —
 // an unparseable version string (either side) must never manufacture a
 // bogus warning, so SatisfiesMin returns true (satisfied) rather than


### PR DESCRIPTION
The git hooks located their engine by **bare name**, so the hook bound to whatever PATH answered rather than the binary that installed it. With §3.4's mandatory fail-open, an unrelated or older install disabled the gate **silently**.

## Reproduced with the real v1.2.0, not a stub

Built from its tag; it genuinely lacks the verb.

```
--- command -v logmind -> …/stale/logmind (logmind 1.2.0 (spec 0.1.1))
Error: unknown command "guard-commit" for "logmind"
[master a389240] 40 substantive lines, no decision logged
exit=0
```

**Control** (same repo, current binary on PATH): blocked, `exit=1`. So the probe hits.

After:

```
logmind: commit gate NOT RUN — …/stale/logmind could not run `guard-commit` (exit 1);
         this hook was installed by logmind 2.0.0-dev. Commit allowed; run `logmind doctor`.
exit=0
```

Fail-open intact — §3.4: *"a missing, stale or crashing engine MUST allow the commit."* The gate now reports its own absence — §3.4: *"**Failing open MUST NOT be silent** … naming what it looked for and what it found."*

## Why remedy (b), the run-time version check

§3.4 offers two and leaves the choice open. **Pinning the install-time path is impossible here**, and the reason is structural:

`probeHook` byte-compares the installed file against `BuildCommitMsgBody()`, and `commit-msg.golden` pins the same bytes. Both require the body to be **a pure function of `version.Version`**. A pinned path makes it a function of *the installing machine's filesystem* — so every correct hook on a machine whose logmind lives elsewhere reads as content drift, and **no golden could be checked in at all**. It also breaks on reinstall-to-a-new-prefix and needs a PATH fallback, which reintroduces the bare-name binding it was meant to remove.

**The handshake is an env var (`LOGMIND_HOOK_VERSION`), not a flag.** An engine that doesn't know the variable ignores it; an unknown **flag errors out**, converting *"the gate ran against an older engine"* into *"the gate did not run"* — in exactly the mid-migration fleet §3.4 cares about.

**Major skew only.** A per-patch notice fires on every commit everywhere and gets ignored.

**What this misses that pinning would catch:** an unrelated `logmind` that exits 0 on `guard-commit`. Stating it rather than pretending the remedy is complete.

## Deliberately untouched

`post-merge` and `post-rewrite` are **regenerators, not gates** — quiet by design for contributors without logmind, and under the Python byte-identical contract.

## Verification

- Only `commit-msg.golden` changed (−13/+31). `sh -n` and `dash -n` pass.
- Doctor drift still works both ways: freshly installed → `current`/`OK`; one hand-edited line with the marker untouched → `stale`/"content drift"/`DRIFT`.
- **10 mutations, all killed** — dropped notice ×2, notices→stdout, dropped handshake, fail-*closed* on missing engine, dropped skew report, `SameMajor`→true, dropped doctor byte-compare, dropped install-hook notice, skew-notice-blocks.
- `go test ./...` exit 0, 22 packages. `vet`/`gofmt` clean.

## Finding filed, not fixed

`internal/claudehook.CanonicalCommand` has **the same bare-name exposure with no notice at all** — a missing binary exits 127, PreToolUse allows, silently. That is the harness layer of the same defect. Filing separately; `docs/plan.md:172-179` describes the git layer as "fails open on any other error", which is still true but now incomplete.