### PR TITLE
feat(auto): `logmind auto` — set the repository up, then hand over to a human — closes #241

### DIFF
--- a/docs/decisions-branches/feat__logmind-auto.md
+++ b/docs/decisions-branches/feat__logmind-auto.md
@@ -1,0 +1,24 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-add-logmind-auto-set-the-repository-up-then-hand-over-to-a-h -->
+- **2026-08-14** — Add logmind auto — set the repository up, then hand over to a human
+<!-- logmind-entry-end -->
+
+## 2026-08-14 21:55 - Add logmind auto — set the repository up, then hand over to a human
+
+**Reasoning:** #241 is pre-tag by Ruling 12 and was blocked on two skills that did not exist. agent-skills#207 merged them as afe8461, so the setup surface can now be built. An operator otherwise hand-assembles the whole rig in-session — pause threshold, checkpoint convention, hard stops, digest expectations — and none of it survives the session, which is what happened on the tokenomics overnight run.
+
+**Alternatives considered:** Ship the profiles the issue named — `logmind auto
+night` and `logmind auto skdd`. Rejected on the merits, and reported for
+override. `night` is refused because the skill was deliberately renamed AWAY from
+the clock during review: #174's own rule is that the hour never starts the mode,
+so a verb called `auto night` would teach the exact vocabulary its policy
+rejects. `skdd` is refused because nothing defines what it would write. Only
+`unattended` ships, and an unknown profile refuses by name rather than falling
+back — which is #267 and #286's rule, now applied a third time.
+
+**Implications:**
+- No new config key. The directive is self-describing — its own marker and profile line — so a copy in config.yml would be exactly the hand-kept duplicate this repository spent the week removing. It carries durable policy only: a test asserts it contains no live-state keys, and another FORBIDS a percentage threshold, because the issue sketched a flat 90% and session-heartbeat explicitly refutes it — the skill wins over the issue that requested it. auto never overwrites an existing directive; a human authored that policy. doctor reports drift as an ADVISORY, not a probe row, because a probe row would flip Overall to DRIFT with no --fix path and make residualProbes' existing note a lie. Eight mutations, all compiled and all died. Two gaps reported not invented: skill install is a report plus the npx command, since the Go binary has no skills.sh integration and SPEC §5.2's subscription model is Planned at skdd#6; and the loop invocation is not printed because the wake mechanism is what the human names at handover.
+
+---
+

--- a/docs/decisions-branches/feat__logmind-auto.md
+++ b/docs/decisions-branches/feat__logmind-auto.md
@@ -22,3 +22,14 @@ back — which is #267 and #286's rule, now applied a third time.
 
 ---
 
+## 2026-08-15 13:59 - auto: refuse to write through a symlink, and pin the percentage guard on the class rather than three literals
+
+**Reasoning:** The panel returned merge with two low findings, and low described the blast radius rather than the standard of the fix. A dangling symlink planted at the directive path made os.WriteFile follow it and create a file outside the logmind directory, which hands anything that can drop a symlink into a repository an arbitrary write out of a tool people run in repositories they did not write. Separately, the guard meant to keep a context percentage out of the directive compared against three literal strings, so a mutation adding pause_at 85 percent shipped green; reinstating the old test against that same mutation confirmed it stayed green while the new one goes red.
+
+**Alternatives considered:** Guard the one call site the finding named. Rejected: a patch at each site plus a promise to remember is how the next writer reintroduces it. The refusal lives inside atomicio.WriteFile itself, so every existing caller inherits it without being touched, and the two lock file paths that cannot use a whole-content replace call the same exported check directly.
+
+**Implications:**
+- A repo-wide audit found no other write targeting the logmind directory: os.Create has zero hits and os.OpenFile only the unix lock, with the Windows path using syscall.CreateFile and checked by reading it. The grep was controlled first against the line the finding named. The percentage guard now matches any digit-led percent or percent-word notation under any key plus bare fractions between zero and one; the fraction case is deliberately kept because one of the three original literals was already a decimal, and dropping it would have narrowed the guarantee while appearing to widen it.
+
+---
+

--- a/docs/decisions-branches/fix__gate-rename-hole.md
+++ b/docs/decisions-branches/fix__gate-rename-hole.md
@@ -1,0 +1,39 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-close-the-rename-hole-the-shared-evaluation-change-opened -->
+- **2026-08-14** — Close the rename hole the shared-evaluation change opened
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:17 - Close the rename hole the shared-evaluation change opened
+
+**Reasoning:** A retrospective panel on merged dev found the gate passing 550 lines of new Go. Unifying the numstat flag lists in #287 dropped --no-renames, which the old bash template carried with a comment saying exactly why. With rename detection on, git renders a cross-directory rename as ONE row whose path field is 'old => new', and IsExcludedPath prefix-matched that whole string — so 'docs/notes.md => src/payload.go' was excluded as docs/ and the count came out zero. Reproduced independently: git mv docs/notes.md src/payload.go plus 150 appended lines, gate says '✓ 0 lines changed (below 20-line threshold)', exit 0. The first repro attempt did NOT trigger it, because appending 150 lines to a 1-line file drops similarity below git's 50% rename threshold; it needs a file large enough to still be detected as a rename.
+
+**Alternatives considered:** Teach IsExcludedPath to parse the rename rendering and test the destination path. Rejected: git has at least two renderings — 'old => new' and the compact '{docs => src}/sub/file' — so a parser owes both plus whatever git adds later, and a parser that falls behind fails OPEN. Refusing to exclude anything carrying ' => ' fails CLOSED; the worst case is asking for a decision that was not owed.
+
+**Implications:**
+- Two layers. gitcli.numstatFlags is now the one list every count runs with, carrying --no-renames, so the three call sites cannot drift apart again — drift is what caused this. IsExcludedPath additionally refuses to exclude any path containing ' => ' as a second line of defence, because the first line was removed once already. Verified with four cases at true exit codes: rename out of docs/ blocks (1), plain 550 lines blocks (1), docs-only passes (0), under-threshold passes (0). Also closes --threshold as a fourth gate-clearer in range mode — worse than --no-fail because it reads as configuration rather than an escape; §3.4 pins the gate's threshold to git.commit_line_threshold and nothing else.
+
+---
+
+## 2026-08-14 17:57 - Pin the rename fix on git's real output, not on synthetic rows
+
+**Reasoning:** An adversarial panel found the fix's own test was worthless as a guard. It reverted numstatFlags to just --numstat — reproducing #287 verbatim — and the full suite stayed GREEN, because the test asserted on synthetic NumstatLine values and never invoked git. I confirmed it independently before fixing. That is the exact trap: a test on the helper you fixed passes its own mutation and still goes green when the bug ships again. The PR comment even said 'the first line of defence was removed once already' while shipping nothing that would notice a third time.
+
+**Alternatives considered:** Assert on more synthetic rows. Rejected — the bug is in what git EMITS, not in how we classify what we are handed, so no amount of hand-written rows can catch the flag going missing.
+
+**Implications:**
+- The new test drives a real git repository through a real rename and asserts the numstat output carries no ' => ' rendering. Mutation-verified in both directions: removing --no-renames now fails with 'numstat still carries a rename rendering (1 rows)', and removing the IsExcludedPath guard fails the consumer-side test. The source file has to be large enough to stay above git's ~50% rename-similarity threshold or the test passes vacuously, so it builds 400 lines and appends 150 — a guard the test states and checks. Also fixes the panel's other findings: --threshold's range-mode refusal shipped untested and now has one, and both flag-combination guards move ABOVE the not-a-repo check, because an invalid flag combination is an argument error that should not depend on where the process is standing. The config template's comment claiming the threshold is 'shared with check-decisions --threshold' now says what §3.4 actually requires.
+
+---
+
+## 2026-08-14 21:36 - Make the two guard tests prove the guards, not the tempdir path
+
+**Reasoning:** A re-entry panel applied four mutations. Three died. The fourth — deleting the --no-fail range guard entirely — SURVIVED, and the reason is worth recording: t.TempDir() names the directory after the calling test, so a subtest named '--no-fail is refused in range mode' produced a path CONTAINING the string '--no-fail'. The not-a-repo error echoes opts.cwd, so strings.Contains(err.Error(), "--no-fail") matched the PATH. The test passed for entirely the wrong reason, and would have stayed green while --no-fail --base X --head Y silently cleared every pull request. Its sibling --threshold test escaped only by accident, because its dir happened to be created at parent scope. Confirmed independently before fixing: the temp dir really is named .../TestTempDirNameLeak--no-fail_is_refused_in_range_mode.../001.
+
+**Alternatives considered:** Rename the subtests so the flag string cannot appear in the path. Rejected as coincidence-proofing rather than a fix — the assertion would still be satisfiable by any incidental substring. Both assertions now check text unique to the guard's own refusal, and the shared dir is created at parent scope so no subtest name reaches it.
+
+**Implications:**
+- The panel also found the rename test's anti-vacuity guard was inverted: it asserted no ' => ' rows, which is exactly what 'git never detected a rename' produces. Demonstrated under diff.renames=false in a global gitconfig — the test passed WITH the fix removed. A positive control now runs first and asserts git, left to itself, does emit the rename rendering; if it does not, the test SKIPS with the bare numstat output rather than reporting a green it has not earned. Absence of the rendering means nothing until we know it would otherwise appear. Mutation D now dies, and its failure output shows the path no longer carries the flag name.
+
+---
+

--- a/internal/atomicio/atomicio.go
+++ b/internal/atomicio/atomicio.go
@@ -19,17 +19,57 @@
 // (and, per audit, three sites — internal/claudehook, internal/hooks,
 // internal/inserter — hadn't derived it at all, using a bare os.WriteFile
 // against an existing file).
+//
+// It also refuses to write through a symlink at the destination — see
+// RefuseSymlink.
 package atomicio
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
+// RefuseSymlink returns a clear error when path already exists as a
+// symlink — dangling or not — instead of silently writing through it.
+//
+// A symlink at a path this tool manages (a directive under .logmind/, a
+// config file, a lock file) turns an ordinary write into an
+// arbitrary-write primitive: a bare os.WriteFile opens through the link
+// (open(2) resolves the final component) and lands its body wherever the
+// link points, dangling target or not. Swapping in the atomic
+// temp-file-plus-rename technique does not fully save this either — a
+// rename onto an EXISTING symlink replaces the link itself rather than
+// following it, but that is still a silent decision about someone else's
+// file this tool did not put there. Refusing loudly, and leaving both the
+// link and whatever it points to untouched, beats guessing which of
+// those two outcomes the caller wanted.
+//
+// A path that does not exist yet, or exists as a regular file or
+// directory, returns nil — there is nothing to refuse.
+func RefuseSymlink(path string) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return nil
+	}
+	if target, rerr := os.Readlink(path); rerr == nil {
+		return fmt.Errorf("refusing to write %s: it is a symlink to %s; remove it and retry", path, target)
+	}
+	return fmt.Errorf("refusing to write %s: it is a symlink; remove it and retry", path)
+}
+
 // WriteFile atomically writes data to path with permission bits perm,
 // whether path already exists or not. On any failure the temp file is
 // removed and path is left completely untouched.
+//
+// Refuses up front, via RefuseSymlink, when path is currently a symlink.
 func WriteFile(path string, data []byte, perm os.FileMode) error {
+	if err := RefuseSymlink(path); err != nil {
+		return err
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err

--- a/internal/atomicio/atomicio_test.go
+++ b/internal/atomicio/atomicio_test.go
@@ -41,15 +41,13 @@ func TestWriteFile_OverwritesExistingFile(t *testing.T) {
 	assertNoTmpResidue(t, dir)
 }
 
-// TestWriteFile_RenameSemantics_DoesNotFollowSymlink proves WriteFile
-// actually takes the temp-file-plus-rename path rather than an in-place
-// truncate+write in disguise: os.Rename replaces the destination NAME
-// itself (swapping a symlink for a regular file) instead of following the
-// symlink and writing through to its target — which is exactly what a
-// bare os.WriteFile(path, ...) on a symlinked path WOULD do. This is the
-// same rename-is-atomic property that makes the technique crash-safe: the
-// destination path only ever changes via one atomic filesystem op.
-func TestWriteFile_RenameSemantics_DoesNotFollowSymlink(t *testing.T) {
+// TestWriteFile_RefusesSymlinkDestination_ExistingTargetUntouched covers
+// the non-dangling case: the destination is a symlink to a real file
+// elsewhere. WriteFile must refuse rather than silently deciding between
+// the two available (and both wrong) behaviours — following the link and
+// clobbering whatever it points to, or swapping the link out for a
+// regular file via rename. Neither the link nor its target may change.
+func TestWriteFile_RefusesSymlinkDestination_ExistingTargetUntouched(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
 	}
@@ -63,25 +61,57 @@ func TestWriteFile_RenameSemantics_DoesNotFollowSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	if err := WriteFile(link, []byte("new content"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
+	err := WriteFile(link, []byte("new content"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFile returned no error for a symlinked destination; want a refusal")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error = %q; want it to name the symlink so the caller knows what to remove", err)
 	}
 
 	fi, err := os.Lstat(link)
 	if err != nil {
 		t.Fatalf("lstat %s: %v", link, err)
 	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Errorf("%s is still a symlink after WriteFile; want it replaced by a regular file (rename semantics)", link)
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("%s was replaced by a regular file; WriteFile must leave a refused symlink exactly as found", link)
 	}
-	assertContent(t, link, "new content")
 
 	targetContent, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("read target: %v", err)
 	}
 	if string(targetContent) != "original target content" {
-		t.Errorf("target content = %q; want unchanged (a naive truncate+write would have followed the symlink and clobbered it)", targetContent)
+		t.Errorf("target content = %q; want unchanged — WriteFile must not follow the link and clobber it", targetContent)
+	}
+}
+
+// TestWriteFile_RefusesDanglingSymlinkDestination is the exact shape of
+// the reported escape: a symlink at the managed path whose target does
+// not exist yet. A bare os.WriteFile follows it via open(2)'s O_CREATE
+// and lands the body at the target — an arbitrary-write primitive out of
+// anything that can plant a symlink in a repo a caller did not write.
+// WriteFile must refuse and create nothing at the target.
+func TestWriteFile_RefusesDanglingSymlinkDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "..", "escaped.json")
+	link := filepath.Join(dir, "settings.json")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := WriteFile(link, []byte("attacker-controlled body"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFile returned no error for a dangling symlinked destination; want a refusal")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error = %q; want it to name the symlink so the caller knows what to remove", err)
+	}
+	if _, statErr := os.Lstat(outside); statErr == nil {
+		t.Errorf("WriteFile created %s by following the dangling symlink", outside)
 	}
 }
 

--- a/internal/auto/auto.go
+++ b/internal/auto/auto.go
@@ -1,0 +1,370 @@
+// Package auto implements `logmind auto <profile>` — one-command setup
+// for a repository that will be handed over to run unattended.
+//
+// What it does, and just as importantly what it does not:
+//
+//   - It writes the standing directive (`.logmind/auto.yml`) — the
+//     durable policy the repo carries: what entry requires, the pause
+//     threshold, where the checkpoint lives, the hard stops, and the
+//     handback slots. NOT scheduler state; see the template's header.
+//   - It REPORTS which required skills are present, and prints the
+//     install command for any that are not. It does not fetch them:
+//     seeding a repository from the catalog is the §5.2 subscription
+//     model (skills-lock.json, origin + ref + content hash, arrive as a
+//     PR), which is Planned and homed at skdd#6 — not something to
+//     reimplement one repo at a time.
+//   - It PRINTS the handover a human must give to start the mode. It
+//     never starts it. `unattended-operation`'s own rule is that the
+//     mode begins only from an explicit human handover and is never
+//     inferred; a tool that started the mode would violate the policy it
+//     just installed. This is also SPEC §2.5's "report; never
+//     auto-apply" for anything nobody is watching.
+//   - It never overwrites an existing directive. That file carries
+//     policy a human authored — repo hard stops, the wake mechanism,
+//     pre-authorized exceptions. Silently rewriting a declared hard stop
+//     is precisely the failure this feature exists to prevent, so a
+//     directive that is stale, newer, markerless, or written for another
+//     profile is REPORTED and left alone.
+//
+// The cobra wiring is internal/cli/auto.go; the drift nudge is
+// internal/doctor.collectAutoAdvisories. Both read through this package
+// so "what is a profile" and "what does the marker mean" have one owner.
+package auto
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/thrillmade/logmind/internal/inserter"
+	"github.com/thrillmade/logmind/internal/skill"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// Profile is one named setup recipe. Profiles are DATA — a new one is a
+// template file plus an entry in the slice below, never a new branch in
+// a switch. An unknown name is refused by Lookup and named against
+// Names(); nothing falls back to a default.
+type Profile struct {
+	// Name is the argument the user types: `logmind auto <Name>`.
+	Name string
+	// Summary is the one-line description shown in --help and in the
+	// unknown-profile refusal.
+	Summary string
+	// Mode is the prose name of what the profile sets up, used in the
+	// printed handover ("logmind does NOT start <Mode>"). Carried as
+	// data so the sentence cannot drift from the registry.
+	Mode string
+	// Skills are the SKILL.md directories this profile's policy depends
+	// on, in load order (mechanism first, policy layered on it).
+	Skills []string
+	// Template is the bundled directive body's filename under
+	// internal/templates/auto/.
+	Template string
+}
+
+// profiles is the registry. Ordered, not a map, so --help and every
+// refusal message list them the same way every run (SPEC §2.7: no
+// ordering that depends on map iteration).
+//
+// Only `unattended` ships. Issue #241 also sketched `skdd` and `night`:
+//
+//   - `night` is deliberately absent. The skill it would install was
+//     renamed night-mode → unattended-operation during review for a
+//     reason this command inherits — the mode is triggered by a human
+//     handover, never by the clock. A `logmind auto night` would teach
+//     the vocabulary the policy rejects. See retiredProfiles.
+//   - `skdd` has no content to write: nothing in the catalog or the
+//     SPEC defines what an "skdd profile" declares that `logmind init`
+//     does not already scaffold. It is refused like any other unknown
+//     name until somebody says what it means.
+var profiles = []Profile{
+	{
+		Name:    "unattended",
+		Summary: "hand the session over to run unattended — heartbeat mechanism + unattended-operation policy",
+		Mode:    "unattended operation",
+		Skills:  []string{"session-heartbeat", "unattended-operation"},
+		// Version marker inside: see templates.AutoDirective.
+		Template: "unattended.yml.template",
+	},
+}
+
+// retiredProfiles maps a name that once meant something to the note the
+// refusal adds. It NEVER resolves to a profile — Lookup does not consult
+// it — so this cannot become the silent fallback the registry exists to
+// prevent. It only makes the refusal teach the current vocabulary.
+var retiredProfiles = map[string]string{
+	"night":      "`night-mode` was renamed `unattended-operation`: the mode is started by a human handover, never by the clock. Use `unattended`.",
+	"night-mode": "`night-mode` was renamed `unattended-operation`: the mode is started by a human handover, never by the clock. Use `unattended`.",
+}
+
+// Profiles returns the registry in declaration order.
+func Profiles() []Profile {
+	out := make([]Profile, len(profiles))
+	copy(out, profiles)
+	return out
+}
+
+// Names returns every known profile name, in declaration order.
+func Names() []string {
+	out := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		out = append(out, p.Name)
+	}
+	return out
+}
+
+// Lookup resolves a profile by exact name. The second return is false
+// for ANY name the registry does not carry — including a retired one.
+// There is no default, no prefix match, and no fallback: a caller that
+// gets false must refuse and name Names().
+func Lookup(name string) (Profile, bool) {
+	for _, p := range profiles {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return Profile{}, false
+}
+
+// RetiredNote returns the explanatory note for a name that used to mean
+// something, and "" for a name that never did.
+func RetiredNote(name string) string {
+	return retiredProfiles[name]
+}
+
+// DirectivePath returns the standing directive's path: `.logmind/auto.yml`,
+// alongside config.yml. Checked in — it is repository policy, not local
+// state (contrast `.logmind/cache/` and `.logmind/.lock`, which the
+// init-time .gitignore block excludes).
+func DirectivePath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".logmind", "auto.yml")
+}
+
+var (
+	// markerRe matches the SPEC §5.2 ownership marker on the directive's
+	// first line — the same shape as the workflow templates'
+	// `# logmind-template-version: vN` and the hooks'
+	// `# logmind-hook-version: <ver>`.
+	markerRe = regexp.MustCompile(`^# logmind-auto-version:\s*(\S+)`)
+	// profileRe reads the directive's own `profile:` key. The profile
+	// name is recorded ONCE, in the YAML body — putting it in the marker
+	// comment too would be a second copy that reads as true until one
+	// quietly isn't.
+	profileRe = regexp.MustCompile(`(?m)^profile:[ \t]*(\S+)`)
+)
+
+// checkpointPlaceholder is substituted at render time, mirroring the
+// workflow templates' __LOGMIND_VERSION__.
+const checkpointPlaceholder = "__LOGMIND_CHECKPOINT__"
+
+// CheckpointCandidates lists the conventional plan-doc paths probed for
+// the checkpoint slot, in priority order. session-heartbeat requires
+// "a durable file the project already reads — the plan doc", so the
+// setup asks the repo what it already has rather than inventing a path.
+// The first entry is also the fallback written when none exists (with
+// the absence reported, never silently created — writing a plan doc's
+// CONTENT is a judgment call, the same boundary `doctor --fix` draws for
+// docs/spec.md).
+var CheckpointCandidates = []string{"docs/plan.md", "PLAN.md", "plan.md"}
+
+// ResolveCheckpoint picks the checkpoint path for repoRoot and reports
+// whether that file exists yet.
+func ResolveCheckpoint(repoRoot string) (relPath string, exists bool) {
+	for _, c := range CheckpointCandidates {
+		if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(c))); err == nil {
+			return c, true
+		}
+	}
+	return CheckpointCandidates[0], false
+}
+
+// BundledBody returns the rendered directive this binary would write for
+// p against the given checkpoint path.
+func BundledBody(p Profile, checkpoint string) string {
+	return strings.ReplaceAll(templates.AutoDirective(p.Template), checkpointPlaceholder, checkpoint)
+}
+
+// BundledMarker returns the version marker embedded in p's template.
+func BundledMarker(p Profile) (string, bool) {
+	return parseMarker(templates.AutoDirective(p.Template))
+}
+
+func parseMarker(body string) (string, bool) {
+	first := body
+	if i := strings.Index(body, "\n"); i >= 0 {
+		first = body[:i]
+	}
+	m := markerRe.FindStringSubmatch(first)
+	if len(m) < 2 {
+		return "", false
+	}
+	return m[1], true
+}
+
+func parseProfile(body string) (string, bool) {
+	m := profileRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return "", false
+	}
+	return m[1], true
+}
+
+// State is what `.logmind/auto.yml` looks like on disk.
+type State struct {
+	// Present is false when no directive is installed.
+	Present bool
+	// Marker is the installed `# logmind-auto-version:` value, "" when
+	// the file carries none. A markerless artifact belongs to the user
+	// and is never overwritten (SPEC §5.2).
+	Marker string
+	// Profile is the installed directive's `profile:` value, "" when
+	// unreadable.
+	Profile string
+}
+
+// Inspect reads the installed directive's markers without writing
+// anything. A read error is indistinguishable from absence on purpose:
+// every caller's response to "cannot read it" is the same as to "it is
+// not there" — do not touch it.
+func Inspect(repoRoot string) State {
+	data, err := os.ReadFile(DirectivePath(repoRoot))
+	if err != nil {
+		return State{}
+	}
+	body := string(data)
+	marker, _ := parseMarker(body)
+	prof, _ := parseProfile(body)
+	return State{Present: true, Marker: marker, Profile: prof}
+}
+
+// Outcome is what Apply did — one value, so a caller renders one line
+// per case rather than reconstructing the decision from a bag of bools.
+type Outcome string
+
+const (
+	// Created — no directive existed; one was written.
+	Created Outcome = "created"
+	// Current — the installed directive is this profile at this
+	// binary's marker. Nothing written. This is the second-run case.
+	Current Outcome = "current"
+	// DeclinedStale — installed marker predates the bundled one. Left
+	// alone: the file carries operator-authored policy.
+	DeclinedStale Outcome = "declined-stale"
+	// DeclinedNewer — installed marker is AHEAD of this binary's. Left
+	// alone; upgrading logmind is the remedy (#286's direction rule).
+	DeclinedNewer Outcome = "declined-newer"
+	// DeclinedMarkerless — no ownership marker, so the file belongs to
+	// the user (SPEC §5.2). Left alone.
+	DeclinedMarkerless Outcome = "declined-markerless"
+	// DeclinedOtherProfile — a directive for a different profile is
+	// installed. Left alone; switching is a deliberate human act.
+	DeclinedOtherProfile Outcome = "declined-other-profile"
+)
+
+// Result is Apply's full report.
+type Result struct {
+	Outcome Outcome
+	// Path is the directive's path relative to repoRoot.
+	Path string
+	// Installed / Bundled are the two markers, for the declined cases.
+	Installed string
+	Bundled   string
+	// InstalledProfile is the profile named by the file on disk
+	// (DeclinedOtherProfile only).
+	InstalledProfile string
+	// Checkpoint is the resolved plan-doc path; CheckpointExists is
+	// false when the repo has no plan doc yet.
+	Checkpoint       string
+	CheckpointExists bool
+	// SkillsPresent / SkillsMissing partition Profile.Skills by whether
+	// `.claude/skills/<name>/SKILL.md` is readable. Order follows the
+	// profile's declared load order.
+	SkillsPresent []string
+	SkillsMissing []string
+}
+
+// Apply performs the setup for p against repoRoot and reports what it
+// found. It writes at most one file — the directive — and only when
+// none is installed. It starts nothing and runs no subprocess.
+func Apply(repoRoot string, p Profile) (Result, error) {
+	checkpoint, checkpointExists := ResolveCheckpoint(repoRoot)
+	res := Result{
+		Path:             filepath.ToSlash(filepath.Join(".logmind", "auto.yml")),
+		Checkpoint:       checkpoint,
+		CheckpointExists: checkpointExists,
+	}
+	bundled, _ := BundledMarker(p)
+	res.Bundled = bundled
+
+	for _, name := range p.Skills {
+		if _, err := os.Stat(skill.MDPath(repoRoot, name)); err == nil {
+			res.SkillsPresent = append(res.SkillsPresent, name)
+			continue
+		}
+		res.SkillsMissing = append(res.SkillsMissing, name)
+	}
+
+	state := Inspect(repoRoot)
+	switch {
+	case !state.Present:
+		body := BundledBody(p, checkpoint)
+		target := DirectivePath(repoRoot)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return res, err
+		}
+		if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+			return res, err
+		}
+		res.Outcome = Created
+		res.Installed = bundled
+		return res, nil
+	case state.Marker == "":
+		res.Outcome = DeclinedMarkerless
+		return res, nil
+	case state.Profile != p.Name:
+		res.Outcome = DeclinedOtherProfile
+		res.Installed = state.Marker
+		res.InstalledProfile = state.Profile
+		return res, nil
+	case state.Marker == bundled:
+		res.Outcome = Current
+		res.Installed = state.Marker
+		return res, nil
+	}
+
+	res.Installed = state.Marker
+	if ahead(state.Marker, bundled) {
+		res.Outcome = DeclinedNewer
+		return res, nil
+	}
+	res.Outcome = DeclinedStale
+	return res, nil
+}
+
+// ahead reports whether the installed marker orders AFTER the bundled
+// one. Order, not inequality (#286): a released binary bundles older
+// markers than dev, and a lexical compare gets "v11" vs "v4" exactly
+// backwards. An unparseable marker on either side is NOT treated as
+// ahead — the caller then reports it as stale, whose remedy (look at
+// the file) is the safe direction.
+//
+// Delegates to inserter.ParseMarkerGeneration so the AGENTS.md block
+// guard (#267), the workflow-template guard (#286) and this one order
+// marker generations by one rule rather than three copies of it.
+func ahead(installed, bundled string) bool {
+	i, iok := inserter.ParseMarkerGeneration(installed)
+	b, bok := inserter.ParseMarkerGeneration(bundled)
+	return iok && bok && i > b
+}
+
+// InstallCommand returns the command an operator runs to install a
+// missing skill from the catalog. Printed, never executed — logmind
+// does not fetch catalog items (see the package comment).
+//
+// Shape matches the install line the AGENTS.md template already
+// publishes for the `logmind` skill, so an operator sees one convention.
+func InstallCommand(skillName string) string {
+	return "npx skills add https://github.com/thrillmade/agent-skills --skill " + skillName
+}

--- a/internal/auto/auto.go
+++ b/internal/auto/auto.go
@@ -37,6 +37,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/skill"
 	"github.com/thrillmade/logmind/internal/templates"
@@ -311,10 +312,11 @@ func Apply(repoRoot string, p Profile) (Result, error) {
 	case !state.Present:
 		body := BundledBody(p, checkpoint)
 		target := DirectivePath(repoRoot)
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return res, err
-		}
-		if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		// atomicio.WriteFile refuses a symlink at target (dangling or
+		// not) instead of following it — see internal/atomicio.
+		// RefuseSymlink. It also creates .logmind/ if missing, so no
+		// separate MkdirAll is needed here.
+		if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
 			return res, err
 		}
 		res.Outcome = Created

--- a/internal/auto/auto_test.go
+++ b/internal/auto/auto_test.go
@@ -11,6 +11,7 @@ package auto
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -201,17 +202,38 @@ func TestDirective_SaysWhatTheSkillsSay(t *testing.T) {
 	}
 }
 
+// percentageShapedRe is the CLASS TestDirective_DoesNotHardcodeAPercentageThreshold
+// guards against: any digit-led percentage notation ("85%", "12.5 %",
+// "90 percent") or a bare 0.NN decimal fraction, in any key, anywhere in
+// the rendered body — not three enumerated literals.
+//
+// This replaces a check that listed "90%", "0.9", and "90 percent" by
+// name. Mutation M300-B shipped `pause_at: 85%` and stayed green: "85%"
+// is the same hardcoded-percentage defect as "90%" but isn't one of the
+// three strings the old check happened to spell out. Matching the SHAPE
+// closes that — any number in that notation fails it, under any key,
+// because the guarantee is "no fixed percentage", not "not these three".
+//
+// The bare-decimal alternative (0.NN with no "%"/"percent" attached) is
+// deliberately kept in scope: "0.9" was one of the three original
+// literals, so dropping decimal notation here would silently narrow the
+// guarantee the original test already covered. It's restricted to the
+// 0.NN shape specifically (not any float) so it only fires on the
+// fraction-of-one notation a percentage threshold would actually use —
+// this directive has no other reason to carry a bare decimal.
+var percentageShapedRe = regexp.MustCompile(`(?i)\d+(\.\d+)?\s*(%|percent\b)|\b0\.\d+\b`)
+
 // TestDirective_DoesNotHardcodeAPercentageThreshold — the issue sketched
 // "90% of session window"; session-heartbeat explicitly refutes that
 // ("Stopping at 90% used only works if nothing you would start costs more
-// than the remaining 10%"). The directive must carry the derivation.
+// than the remaining 10%"). The directive must carry the derivation, not
+// any fixed percentage — see percentageShapedRe for why this pins the
+// class rather than a handful of literal strings.
 func TestDirective_DoesNotHardcodeAPercentageThreshold(t *testing.T) {
 	p, _ := Lookup("unattended")
 	body := BundledBody(p, "docs/plan.md")
-	for _, bad := range []string{"90%", "0.9", "90 percent"} {
-		if strings.Contains(body, bad) {
-			t.Errorf("directive hardcodes %q as the pause threshold; session-heartbeat derives it from the largest dispatch", bad)
-		}
+	if bad := percentageShapedRe.FindString(body); bad != "" {
+		t.Errorf("directive hardcodes %q, a percentage-shaped pause threshold; session-heartbeat derives it from the largest dispatch instead of a fixed number", bad)
 	}
 }
 
@@ -369,5 +391,50 @@ func TestApply_DoesNotFetchSkills(t *testing.T) {
 	if cmd := InstallCommand("session-heartbeat"); !strings.Contains(cmd, "session-heartbeat") ||
 		!strings.Contains(cmd, "thrillmade/agent-skills") {
 		t.Errorf("InstallCommand = %q; want it to name the skill and the catalog", cmd)
+	}
+}
+
+// TestApply_RefusesADanglingSymlinkAtTheDirectivePath is the regression
+// for the symlink-escape finding: a dangling symlink planted at
+// .logmind/auto.yml (by anything that can drop a file into a repo a user
+// did not write — a malicious archive, a compromised dependency's
+// postinstall, a crafted PR checked out locally) must not turn Apply's
+// write into an arbitrary-write primitive that lands the directive body
+// wherever the link points, outside .logmind/ entirely.
+//
+// Pinned on Apply — the actual write path `logmind auto` runs, not on
+// atomicio.WriteFile directly, so this fails if a future call site starts
+// bypassing the shared primitive.
+func TestApply_RefusesADanglingSymlinkAtTheDirectivePath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".logmind"), 0o755); err != nil {
+		t.Fatalf("mkdir .logmind: %v", err)
+	}
+	// The escape: .logmind/auto.yml resolves OUTSIDE the repo entirely,
+	// to a path that does not exist yet.
+	outside := filepath.Join(dir, "..", "escaped-auto.yml")
+	if err := os.Symlink(outside, DirectivePath(dir)); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	p, _ := Lookup("unattended")
+	_, err := Apply(dir, p)
+	if err == nil {
+		t.Fatal("Apply returned no error for a dangling symlink at the directive path; want a clear refusal")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("Apply error = %q; want it to name the symlink so the user knows what to remove", err)
+	}
+	if _, statErr := os.Lstat(outside); statErr == nil {
+		t.Errorf("Apply created %s outside .logmind/ by following the symlink", outside)
+	}
+	// The symlink itself is left exactly as found — Apply neither writes
+	// through it nor silently replaces it.
+	fi, err := os.Lstat(DirectivePath(dir))
+	if err != nil {
+		t.Fatalf("lstat directive path: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf(".logmind/auto.yml was replaced by a regular file; want the symlink left alone for the user to remove")
 	}
 }

--- a/internal/auto/auto_test.go
+++ b/internal/auto/auto_test.go
@@ -1,0 +1,373 @@
+// auto_test.go — the profile registry's refusal contract, Apply's
+// write/decline decisions, and the load-bearing check that the directive
+// this package writes says what the two skills it installs say.
+//
+// The directive test is deliberately pinned on the RENDERED BODY (what an
+// agent reads off disk), not on the template constant or on any helper
+// here — a skill's rule surviving in a helper while the file loses it is
+// exactly the failure this guards.
+package auto
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+func readDirective(t *testing.T, repoRoot string) string {
+	t.Helper()
+	data, err := os.ReadFile(DirectivePath(repoRoot))
+	if err != nil {
+		t.Fatalf("read directive: %v", err)
+	}
+	return string(data)
+}
+
+// TestLookup_UnknownNameNeverResolves is the anti-fallback guard: an
+// unknown profile must not silently become a default. Every name below is
+// outside the registry — including one that used to mean something, one
+// the issue sketched but nobody defined, and a case/prefix variant of a
+// real name.
+func TestLookup_UnknownNameNeverResolves(t *testing.T) {
+	for _, name := range []string{"", "night", "night-mode", "skdd", "UNATTENDED", "unatt", "unattended-operation"} {
+		if p, ok := Lookup(name); ok {
+			t.Errorf("Lookup(%q) resolved to %q; an unknown profile must be refused, never defaulted", name, p.Name)
+		}
+	}
+}
+
+func TestLookup_KnownNameResolvesExactly(t *testing.T) {
+	p, ok := Lookup("unattended")
+	if !ok {
+		t.Fatalf("Lookup(%q) = false; want the registered profile", "unattended")
+	}
+	if p.Name != "unattended" {
+		t.Errorf("Name = %q; want unattended", p.Name)
+	}
+	if got, want := strings.Join(p.Skills, ","), "session-heartbeat,unattended-operation"; got != want {
+		t.Errorf("Skills = %q; want %q (mechanism first, policy layered on it)", got, want)
+	}
+}
+
+// TestNames_ListsEveryProfileInOrder pins the refusal's vocabulary source:
+// whatever Lookup accepts, Names() must be able to name.
+func TestNames_ListsEveryProfileInOrder(t *testing.T) {
+	names := Names()
+	if len(names) != len(Profiles()) {
+		t.Fatalf("Names() = %v (%d); want one per profile (%d)", names, len(names), len(Profiles()))
+	}
+	for i, p := range Profiles() {
+		if names[i] != p.Name {
+			t.Errorf("Names()[%d] = %q; want %q (declaration order)", i, names[i], p.Name)
+		}
+		if _, ok := Lookup(p.Name); !ok {
+			t.Errorf("Lookup(%q) = false for a name the registry lists", p.Name)
+		}
+	}
+}
+
+// TestRetiredNote_NeverResolvesToAProfile — the didactic note for a
+// retired name must stay a MESSAGE. If it ever became a lookup path it
+// would be the silent fallback the registry exists to prevent.
+func TestRetiredNote_NeverResolvesToAProfile(t *testing.T) {
+	if note := RetiredNote("night"); note == "" {
+		t.Errorf("RetiredNote(%q) = \"\"; want the rename explanation", "night")
+	}
+	if _, ok := Lookup("night"); ok {
+		t.Errorf("Lookup(%q) resolved; a retired name is explained, never honoured", "night")
+	}
+	if note := RetiredNote("unattended"); note != "" {
+		t.Errorf("RetiredNote(%q) = %q; a live profile is not retired", "unattended", note)
+	}
+}
+
+// TestEveryProfileTemplateIsSelfConsistent — the template's own
+// `profile:` key must equal the registry name, and its first line must
+// carry the SPEC §5.2 ownership marker. Without both, Inspect classifies a
+// freshly written directive as belonging to somebody else.
+func TestEveryProfileTemplateIsSelfConsistent(t *testing.T) {
+	for _, p := range Profiles() {
+		body := BundledBody(p, "docs/plan.md")
+		marker, ok := BundledMarker(p)
+		if !ok || marker == "" {
+			t.Errorf("profile %q: no `# logmind-auto-version:` marker on the first line", p.Name)
+		}
+		named, ok := parseProfile(body)
+		if !ok || named != p.Name {
+			t.Errorf("profile %q: template declares profile: %q", p.Name, named)
+		}
+		if p.Mode == "" || p.Summary == "" {
+			t.Errorf("profile %q: Mode/Summary must be set — the CLI prints both", p.Name)
+		}
+	}
+}
+
+// TestDirective_SaysWhatTheSkillsSay is the agreement contract. Each case
+// names the skill that owns the rule and a phrase the directive must
+// carry; if a skill changes and the template does not, this fails.
+//
+// Sources:
+//
+//	session-heartbeat     — beat mechanism, threshold, checkpoint slots
+//	unattended-operation  — handover contract, authority, hard stops, digest
+func TestDirective_SaysWhatTheSkillsSay(t *testing.T) {
+	p, _ := Lookup("unattended")
+	body := BundledBody(p, "docs/plan.md")
+
+	required := []struct {
+		rule  string // why the phrase has to be there
+		want  string
+		skill string
+	}{
+		// unattended-operation: "Entry is a handover contract" — the mode
+		// begins from a human handover and is never inferred.
+		{"entry requires a human handover", "requires_human_handover: true", "unattended-operation"},
+		{"handover names the scope", "scope — the named plan items or slice range", "unattended-operation"},
+		{"handover names the hard stops", "hard stops — what ends a lane", "unattended-operation"},
+		{"handover names exceptions BY NAME", "pre-authorized exceptions, by name", "unattended-operation"},
+		{"handover names the wake mechanism", "the wake mechanism, and where parked work is written", "unattended-operation"},
+		{"handover says what to do at a fork", "at a real fork", "unattended-operation"},
+
+		// session-heartbeat: the threshold is DERIVED, not a round number.
+		{"threshold is derived from the largest dispatch", "the ceiling, minus the cost of the largest dispatch you would still start", "session-heartbeat"},
+		{"threshold is enforceable per dispatch", "if this agent cannot finish inside the remaining headroom, do not start it", "session-heartbeat"},
+		{"at the threshold, do not kill what is running", "do NOT kill what is running", "session-heartbeat"},
+		{"wake for the reset, not a retry", "schedule the wake for the reset, not a short retry", "session-heartbeat"},
+
+		// session-heartbeat: the checkpoint's required slots.
+		{"checkpoint records a sha, not a branch", "a sha, never a branch name", "session-heartbeat"},
+		{"checkpoint records what is in flight", "in flight — per agent", "session-heartbeat"},
+		{"checkpoint records occupancy", "occupancy — which trees are not free to merge into", "session-heartbeat"},
+		{"checkpoint pre-decides the next dispatch", "next dispatch, already decided", "session-heartbeat"},
+		{"checkpoint distinguishes paused from died", "next wake time, and why", "session-heartbeat"},
+
+		// unattended-operation: the authority test and its two sides.
+		{"the reversible-and-invisible test", "can it be undone before they are back", "unattended-operation"},
+		{"local commits are the near side", "local commits on local branches", "unattended-operation"},
+		{"pushing a shared ref is the far side", "pushing to a shared ref", "unattended-operation"},
+		{"anything sent is the far side", "anything sent — mail, message, webhook, notification", "unattended-operation"},
+		{"--force/--no-verify/--admin is the far side", "--force, --no-verify, or --admin", "unattended-operation"},
+
+		// unattended-operation: a wake is never consent.
+		{"a scheduled wake is not consent", "a scheduled wake, a task notification", "unattended-operation"},
+		{"a green check is not consent", "a passing suite, a green check, or a clean review", "unattended-operation"},
+		{"another agent's approval is not consent", `another agent reporting "done", "approved"`, "unattended-operation"},
+
+		// unattended-operation: hard stops that hold unnamed.
+		{"a scope change is a standing hard stop", "a change of scope", "unattended-operation"},
+		{"a destructive operation is a standing hard stop", "a destructive operation", "unattended-operation"},
+		{"a human-required gate is a standing hard stop", "a gate that requires a human", "unattended-operation"},
+		{"a second consecutive failure is a standing hard stop", "the second consecutive failure of the same fix", "unattended-operation"},
+
+		// unattended-operation: the six handback slots, outcome first.
+		{"digest slot 1", "where the work stands now — one line", "unattended-operation"},
+		{"digest slot 2", "landed — sha plus one line each", "unattended-operation"},
+		{"digest slot 3", "including what was found and not fixed", "unattended-operation"},
+		{"digest slot 4", `never "needs input"`, "unattended-operation"},
+		{"digest slot 5", "not attempted — in scope, skipped, and why", "unattended-operation"},
+		{"digest slot 6", "standing — budget/limit state", "unattended-operation"},
+
+		// unattended-operation, silent failures: scheduler state committed.
+		{"scheduler state must be git-ignored", "must_be_git_ignored: true", "unattended-operation"},
+	}
+	for _, c := range required {
+		if !strings.Contains(body, c.want) {
+			t.Errorf("directive is missing %s (%s owns this rule); expected to find %q",
+				c.rule, c.skill, c.want)
+		}
+	}
+
+	// Both skills are named as sources, and both are declared as required
+	// loads — a directive that restates a rule without naming its owner
+	// goes stale invisibly.
+	for _, name := range p.Skills {
+		if !strings.Contains(body, "  - "+name) {
+			t.Errorf("directive does not list %q under skills:", name)
+		}
+		if !strings.Contains(body, "skills/"+name) {
+			t.Errorf("directive does not link the %q skill as the rule's owner", name)
+		}
+	}
+}
+
+// TestDirective_DoesNotHardcodeAPercentageThreshold — the issue sketched
+// "90% of session window"; session-heartbeat explicitly refutes that
+// ("Stopping at 90% used only works if nothing you would start costs more
+// than the remaining 10%"). The directive must carry the derivation.
+func TestDirective_DoesNotHardcodeAPercentageThreshold(t *testing.T) {
+	p, _ := Lookup("unattended")
+	body := BundledBody(p, "docs/plan.md")
+	for _, bad := range []string{"90%", "0.9", "90 percent"} {
+		if strings.Contains(body, bad) {
+			t.Errorf("directive hardcodes %q as the pause threshold; session-heartbeat derives it from the largest dispatch", bad)
+		}
+	}
+}
+
+// TestDirective_IsPolicyNotSchedulerState — ruling from
+// unattended-operation's silent-failure table: the wake mechanism's live
+// state must never land as a project artifact. The directive declares
+// WHERE running state goes (the checkpoint path); it never carries the
+// state itself.
+func TestDirective_IsPolicyNotSchedulerState(t *testing.T) {
+	p, _ := Lookup("unattended")
+	body := BundledBody(p, "docs/plan.md")
+	for _, bad := range []string{"next_wake:", "next_wake_at", "in_flight:", "current_sha", "last_beat", "run_started"} {
+		if strings.Contains(body, bad) {
+			t.Errorf("directive carries live scheduler state (%q); it must hold durable policy only", bad)
+		}
+	}
+	if !strings.Contains(body, "path: docs/plan.md") {
+		t.Errorf("directive does not name where running state goes (checkpoint path)")
+	}
+}
+
+func TestResolveCheckpoint_PrefersWhatTheRepoAlreadyHas(t *testing.T) {
+	t.Run("no plan doc falls back to the first candidate and reports absence", func(t *testing.T) {
+		dir := t.TempDir()
+		path, exists := ResolveCheckpoint(dir)
+		if path != CheckpointCandidates[0] || exists {
+			t.Errorf("ResolveCheckpoint = (%q, %v); want (%q, false)", path, exists, CheckpointCandidates[0])
+		}
+	})
+	t.Run("a lower-priority candidate is used when it is the one present", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, "PLAN.md"), "# Plan\n")
+		path, exists := ResolveCheckpoint(dir)
+		if path != "PLAN.md" || !exists {
+			t.Errorf("ResolveCheckpoint = (%q, %v); want (PLAN.md, true)", path, exists)
+		}
+	})
+}
+
+func TestApply_CreatesDirectiveThenLeavesItAlone(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "docs", "plan.md"), "# Plan\n")
+	p, _ := Lookup("unattended")
+
+	first, err := Apply(dir, p)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if first.Outcome != Created {
+		t.Fatalf("first Apply outcome = %q; want %q", first.Outcome, Created)
+	}
+	body1 := readDirective(t, dir)
+	if !strings.Contains(body1, "path: docs/plan.md") {
+		t.Errorf("checkpoint placeholder not rendered:\n%s", body1)
+	}
+	if strings.Contains(body1, "__LOGMIND_CHECKPOINT__") {
+		t.Errorf("placeholder survived into the written directive")
+	}
+
+	second, err := Apply(dir, p)
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if second.Outcome != Current {
+		t.Errorf("second Apply outcome = %q; want %q", second.Outcome, Current)
+	}
+	if body2 := readDirective(t, dir); body2 != body1 {
+		t.Errorf("second Apply rewrote the directive; it must be a no-op")
+	}
+}
+
+// TestApply_NeverOverwritesADirectiveItDoesNotOwn covers all four
+// decline paths. Each one leaves the bytes on disk EXACTLY as found —
+// the file carries policy a human authored.
+func TestApply_NeverOverwritesADirectiveItDoesNotOwn(t *testing.T) {
+	p, _ := Lookup("unattended")
+	bundled, _ := BundledMarker(p)
+
+	cases := []struct {
+		name    string
+		content string
+		want    Outcome
+	}{
+		{
+			name:    "markerless belongs to the user",
+			content: "profile: unattended\nhard_stops:\n  repo: [never push]\n",
+			want:    DeclinedMarkerless,
+		},
+		{
+			name:    "a directive for another profile",
+			content: "# logmind-auto-version: " + bundled + "\nprofile: skdd\n",
+			want:    DeclinedOtherProfile,
+		},
+		{
+			name:    "an older marker",
+			content: "# logmind-auto-version: v0\nprofile: unattended\n",
+			want:    DeclinedStale,
+		},
+		{
+			name:    "a newer marker is not downgraded",
+			content: "# logmind-auto-version: v99\nprofile: unattended\n",
+			want:    DeclinedNewer,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWrite(t, DirectivePath(dir), c.content)
+			res, err := Apply(dir, p)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if res.Outcome != c.want {
+				t.Errorf("outcome = %q; want %q", res.Outcome, c.want)
+			}
+			if got := readDirective(t, dir); got != c.content {
+				t.Errorf("Apply rewrote a directive it does not own:\n got: %q\nwant: %q", got, c.content)
+			}
+		})
+	}
+}
+
+func TestApply_PartitionsSkillsByPresence(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, ".claude", "skills", "session-heartbeat", "SKILL.md"), "---\nname: session-heartbeat\n---\n")
+	p, _ := Lookup("unattended")
+
+	res, err := Apply(dir, p)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, want := strings.Join(res.SkillsPresent, ","), "session-heartbeat"; got != want {
+		t.Errorf("SkillsPresent = %q; want %q", got, want)
+	}
+	if got, want := strings.Join(res.SkillsMissing, ","), "unattended-operation"; got != want {
+		t.Errorf("SkillsMissing = %q; want %q", got, want)
+	}
+}
+
+// TestApply_DoesNotFetchSkills — logmind never pulls catalog items (that
+// is the §5.2 subscription model, Planned at skdd#6). A missing skill is
+// reported with the command a human runs, and the skill directory stays
+// absent.
+func TestApply_DoesNotFetchSkills(t *testing.T) {
+	dir := t.TempDir()
+	p, _ := Lookup("unattended")
+	if _, err := Apply(dir, p); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for _, name := range p.Skills {
+		if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", name)); err == nil {
+			t.Errorf("Apply materialised skill %q; it must only report the install command", name)
+		}
+	}
+	if cmd := InstallCommand("session-heartbeat"); !strings.Contains(cmd, "session-heartbeat") ||
+		!strings.Contains(cmd, "thrillmade/agent-skills") {
+		t.Errorf("InstallCommand = %q; want it to name the skill and the catalog", cmd)
+	}
+}

--- a/internal/cli/auto.go
+++ b/internal/cli/auto.go
@@ -1,0 +1,187 @@
+// auto.go — `logmind auto <profile>` subcommand.
+//
+// Thin cobra shim over internal/auto: resolve the profile (refusing an
+// unknown one by name), apply the setup, and render the result. Every
+// decision — what a profile is, what the directive says, what may be
+// overwritten — lives in internal/auto so `logmind doctor`'s drift nudge
+// reads the same source.
+//
+// The one rule this file exists to hold: `auto` PRINTS the handover, it
+// never performs it. `unattended-operation` starts only from an explicit
+// human handover and is never inferred from a clock, a wake, or a tool —
+// so a setup command that started the mode would break the policy it had
+// just installed. Nothing here spawns a process.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/auto"
+)
+
+func newAutoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "auto <profile>",
+		Short: "Set a repository up for unattended agent operation (prints the handover; never starts it)",
+		Long: "Set this repository up for a named autonomy profile: write the\n" +
+			"standing directive (.logmind/auto.yml), report which required\n" +
+			"skills are installed, and print the handover a human must give\n" +
+			"to start the mode.\n\n" +
+			"`auto` never starts unattended operation. The mode begins only\n" +
+			"from an explicit human handover — never from a clock, a\n" +
+			"scheduled wake, or a tool.\n\n" +
+			"Profiles:\n" + autoProfileHelp(),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			return runAuto(cmd, cwd, args[0])
+		},
+	}
+}
+
+// autoProfileHelp renders the profile registry for --help. Generated from
+// the registry rather than hand-listed, so adding a profile cannot leave
+// the help text quietly wrong.
+func autoProfileHelp() string {
+	var b strings.Builder
+	for _, p := range auto.Profiles() {
+		fmt.Fprintf(&b, "  %-12s %s\n", p.Name, p.Summary)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func runAuto(cmd *cobra.Command, cwd, profileName string) error {
+	q := newQout(quietEnabled(cmd), cmd.OutOrStdout(), cmd.ErrOrStderr())
+
+	profile, ok := auto.Lookup(profileName)
+	if !ok {
+		// REFUSE and name what is known. Never fall back to a default:
+		// a setup verb that quietly configured the wrong autonomy policy
+		// is the same defect as #267 and #286 in another guise. Errors go
+		// to stderr per SPEC §2.7 (and no `ok` receipt is printed, since
+		// this exits non-zero).
+		stderr := cmd.ErrOrStderr()
+		fmt.Fprintf(stderr, "Error: unknown profile %q. Known profiles: %s\n",
+			profileName, strings.Join(auto.Names(), ", "))
+		if note := auto.RetiredNote(profileName); note != "" {
+			fmt.Fprintln(stderr, "note:", note)
+		}
+		return ErrSilent
+	}
+
+	res, err := auto.Apply(cwd, profile)
+	if err != nil {
+		return fmt.Errorf("auto %s: %w", profile.Name, err)
+	}
+
+	q.chat("Setting up %s (profile `%s`) for this repository...\n\n", profile.Mode, profile.Name)
+	reportAutoDirective(q, profile, res)
+	reportAutoSkills(q, profile, res)
+	q.chat("\n%s\n", autoHandoverBlock(profile, res))
+
+	q.ok("auto profile=%s directive=%s checkpoint=%s skills-missing=%d",
+		profile.Name, res.Outcome, res.Checkpoint, len(res.SkillsMissing))
+	return nil
+}
+
+// reportAutoDirective renders what Apply did with `.logmind/auto.yml`.
+//
+// Every declined outcome is REPORTED, never silent — the file was left
+// alone because it carries policy a human authored, and an operator who
+// is not told that will assume the setup they just ran is in force.
+// Refusals go to stderr for the same reason reportTemplateDowngrades
+// puts them there: they survive `--quiet` and any stdout redirect.
+func reportAutoDirective(q qout, p auto.Profile, res auto.Result) {
+	// q.stderr, not q.fail: a refusal must land on stderr in BOTH modes.
+	// q.fail keeps the historical stdout destination in the default mode
+	// for the verbs with Python parity to preserve; `auto` has none.
+	stderr := q.stderr
+	switch res.Outcome {
+	case auto.Created:
+		q.chat("✓ Created %s — the standing directive (profile: %s, %s)\n",
+			res.Path, p.Name, res.Bundled)
+	case auto.Current:
+		q.chat("  %s already current (profile: %s, %s) — left unchanged.\n",
+			res.Path, p.Name, res.Installed)
+	case auto.DeclinedStale:
+		fmt.Fprintf(stderr,
+			"note: %s is at %s; this binary bundles %s — left unchanged, because it carries policy you "+
+				"authored (repo hard stops, the wake mechanism). Move it aside and re-run `logmind auto %s` "+
+				"to take the new directive, then re-apply your repo-specific slots.\n",
+			res.Path, res.Installed, res.Bundled, p.Name)
+	case auto.DeclinedNewer:
+		fmt.Fprintf(stderr,
+			"note: %s left unchanged — installed directive %s is NEWER than the %s this binary bundles; "+
+				"refusing to downgrade. Upgrade logmind to move it forward.\n",
+			res.Path, res.Installed, res.Bundled)
+	case auto.DeclinedMarkerless:
+		fmt.Fprintf(stderr,
+			"note: %s carries no `# logmind-auto-version:` marker, so it belongs to you — left unchanged. "+
+				"Move it aside and re-run `logmind auto %s` if you want the bundled directive.\n",
+			res.Path, p.Name)
+	case auto.DeclinedOtherProfile:
+		fmt.Fprintf(stderr,
+			"note: %s is a directive for profile %q — refusing to overwrite it with %q. Move it aside first.\n",
+			res.Path, res.InstalledProfile, p.Name)
+	}
+
+	q.chat("    checkpoint: %s\n", res.Checkpoint)
+	if !res.CheckpointExists {
+		// Report, never create: what a plan doc should SAY is a judgment
+		// call, the same boundary `doctor --fix` draws for docs/spec.md.
+		fmt.Fprintf(stderr,
+			"note: %s does not exist yet — the checkpoint has nowhere to land, and a resumed session "+
+				"cannot tell paused from died. Create it before entry.\n", res.Checkpoint)
+	}
+}
+
+// reportAutoSkills lists the profile's required skills and, for any that
+// are absent, the command that installs it — printed for the operator to
+// run, not run here. logmind does not fetch catalog items; see
+// internal/auto's package comment for why.
+func reportAutoSkills(q qout, p auto.Profile, res auto.Result) {
+	q.chat("\nSkills this profile's policy depends on (load order):\n")
+	present := map[string]bool{}
+	for _, name := range res.SkillsPresent {
+		present[name] = true
+	}
+	for _, name := range p.Skills {
+		if present[name] {
+			q.chat("  ✓ %s\n", name)
+			continue
+		}
+		q.chat("  ✗ %s — not installed under .claude/skills/\n", name)
+		q.chat("      %s\n", auto.InstallCommand(name))
+	}
+}
+
+// autoHandoverBlock renders the handover a human pastes to start the
+// mode. The five slots are exactly the ones `unattended-operation` says
+// a directive must name; the sixth line is the pre-entry check for the
+// silent failure that same skill names (scheduler state committed as a
+// project artifact).
+//
+// This is printed. It is never executed, and `auto` deliberately has no
+// flag that would execute it.
+func autoHandoverBlock(p auto.Profile, res auto.Result) string {
+	return fmt.Sprintf(`logmind does NOT start %s, and will not: the mode begins only from an
+explicit human handover — never from a clock, a scheduled wake, or a tool.
+Start it yourself, naming all five:
+
+  Run unattended until I'm back.
+    scope:      <the named plan items or slice range — never "keep going">
+    hard stops: <what ends a lane rather than being worked around>
+    you may:    <pre-authorized exceptions, by name; anything unnamed is not authorized>
+    wake:       <your harness's wake mechanism>; park work in %s
+    at a fork:  park it and continue elsewhere
+
+Before entry: confirm your wake mechanism's lock/schedule file is git-ignored.
+Committing it is a named silent failure.`, p.Mode, res.Checkpoint)
+}

--- a/internal/cli/auto_test.go
+++ b/internal/cli/auto_test.go
@@ -1,0 +1,349 @@
+// auto_test.go — exercises `logmind auto <profile>` end to end.
+//
+// Everything here is pinned on what a user observes: the bytes on stdout
+// and stderr, the exit code, and the set of paths the run left behind.
+// Nothing asserts on a helper in auto.go — the regressions worth catching
+// (a fallback profile, a silently-rewritten directive, a command that
+// starts the mode) all show up in exactly those three places.
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// runAutoCmd drives `logmind auto <args...>` in the current cwd and
+// returns (stdout, stderr, err).
+func runAutoCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(append([]string{"auto"}, args...))
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	err := root.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// treeSnapshot maps every regular file under dir to a hash of its
+// contents, plus every directory to "". Comparing two snapshots answers
+// both "did anything change" and "did anything appear".
+func treeSnapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+		if d.IsDir() {
+			snap[filepath.ToSlash(rel)+"/"] = ""
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		sum := sha256.Sum256(data)
+		snap[filepath.ToSlash(rel)] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", dir, err)
+	}
+	return snap
+}
+
+func snapshotDiff(before, after map[string]string) (added, changed, removed []string) {
+	for path, sum := range after {
+		old, ok := before[path]
+		switch {
+		case !ok:
+			added = append(added, path)
+		case old != sum:
+			changed = append(changed, path)
+		}
+	}
+	for path := range before {
+		if _, ok := after[path]; !ok {
+			removed = append(removed, path)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(changed)
+	sort.Strings(removed)
+	return added, changed, removed
+}
+
+// TestAuto_UnknownProfileRefusesAndNamesTheKnownOnes — the anti-fallback
+// guard at the CLI surface: exit non-zero, say what is known, and write
+// nothing. A setup verb that quietly configured a different autonomy
+// policy than the one asked for is the same defect as #267 and #286.
+func TestAuto_UnknownProfileRefusesAndNamesTheKnownOnes(t *testing.T) {
+	for _, name := range []string{"skdd", "night", "nonsense"} {
+		t.Run(name, func(t *testing.T) {
+			dir := withTempCwd(t, func(d string) {
+				out, errOut, err := runAutoCmd(t, name)
+				if !errors.Is(err, ErrSilent) {
+					t.Fatalf("err = %v; want ErrSilent (exit 1)\nstdout:%s\nstderr:%s", err, out, errOut)
+				}
+				mustContain(t, errOut, "unknown profile")
+				mustContain(t, errOut, name)
+				mustContain(t, errOut, "Known profiles: unattended")
+				// SPEC §2.7: no `ok` receipt on a non-zero exit.
+				if strings.Contains(out, "ok auto") {
+					t.Errorf("a refused run printed an ok receipt:\n%s", out)
+				}
+			})
+			if _, err := os.Stat(filepath.Join(dir, ".logmind", "auto.yml")); err == nil {
+				t.Errorf("a refused profile still wrote .logmind/auto.yml")
+			}
+		})
+	}
+}
+
+// TestAuto_RetiredNameExplainsTheRename — `night` is refused like any
+// unknown name, but the refusal teaches the vocabulary the policy
+// actually uses. It must never resolve.
+func TestAuto_RetiredNameExplainsTheRename(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		_, errOut, err := runAutoCmd(t, "night")
+		if !errors.Is(err, ErrSilent) {
+			t.Fatalf("err = %v; want ErrSilent", err)
+		}
+		mustContain(t, errOut, "renamed `unattended-operation`")
+		mustContain(t, errOut, "never by the clock")
+	})
+}
+
+// TestAuto_KnownProfileIsIdempotent — the second run must change nothing
+// on disk and must say so rather than reporting a fresh install.
+func TestAuto_KnownProfileIsIdempotent(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		mustWriteUnder(t, dir, "docs/plan.md", "# Plan\n")
+
+		out1, errOut1, err := runAutoCmd(t, "unattended")
+		if err != nil {
+			t.Fatalf("first run: %v\n%s", err, errOut1)
+		}
+		mustContain(t, out1, "✓ Created .logmind/auto.yml")
+		mustContain(t, out1, "directive=created")
+		afterFirst := treeSnapshot(t, dir)
+
+		out2, errOut2, err := runAutoCmd(t, "unattended")
+		if err != nil {
+			t.Fatalf("second run: %v\n%s", err, errOut2)
+		}
+		afterSecond := treeSnapshot(t, dir)
+
+		added, changed, removed := snapshotDiff(afterFirst, afterSecond)
+		if len(added)+len(changed)+len(removed) != 0 {
+			t.Errorf("second run was not a no-op: added=%v changed=%v removed=%v", added, changed, removed)
+		}
+		mustContain(t, out2, "already current")
+		mustContain(t, out2, "directive=current")
+		if strings.Contains(out2, "✓ Created") {
+			t.Errorf("second run reported a fresh install:\n%s", out2)
+		}
+	})
+}
+
+// TestAuto_PrintsTheHandoverAndStartsNothing is the central ruling:
+// `logmind auto` sets a repository up and hands the invocation to a
+// human. unattended-operation begins only from an explicit handover, so a
+// tool that started it would break the policy it had just installed.
+//
+// "Starts nothing" is pinned on the file system, not on an implementation
+// detail: after the run the ONLY new paths under the repo are the
+// directive and its parent. Anything that launched a loop — a scheduler
+// lock, a checkpoint, a log — would land here and fail this.
+func TestAuto_PrintsTheHandoverAndStartsNothing(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		mustWriteUnder(t, dir, "docs/plan.md", "# Plan\n")
+		before := treeSnapshot(t, dir)
+
+		out, errOut, err := runAutoCmd(t, "unattended")
+		if err != nil {
+			t.Fatalf("auto: %v\n%s", err, errOut)
+		}
+
+		// The handover is PRINTED, and says it is not being performed.
+		mustContain(t, out, "logmind does NOT start unattended operation")
+		mustContain(t, out, "never from a clock, a scheduled wake, or a tool")
+		// All five slots unattended-operation requires a handover to name.
+		mustContain(t, out, "scope:")
+		mustContain(t, out, "hard stops:")
+		mustContain(t, out, "you may:")
+		mustContain(t, out, "wake:")
+		mustContain(t, out, "at a fork:")
+		// The checkpoint the resumed session will read.
+		mustContain(t, out, "park work in docs/plan.md")
+
+		added, changed, removed := snapshotDiff(before, treeSnapshot(t, dir))
+		wantAdded := []string{".logmind/", ".logmind/auto.yml"}
+		if strings.Join(added, ",") != strings.Join(wantAdded, ",") {
+			t.Errorf("auto created %v; want exactly %v — anything else means it started something", added, wantAdded)
+		}
+		if len(changed) != 0 || len(removed) != 0 {
+			t.Errorf("auto mutated existing paths: changed=%v removed=%v", changed, removed)
+		}
+	})
+}
+
+// TestAuto_DirectiveOnDiskCarriesTheSkillRules — the file an agent will
+// actually read, not the template constant.
+func TestAuto_DirectiveOnDiskCarriesTheSkillRules(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		mustWriteUnder(t, dir, "docs/plan.md", "# Plan\n")
+		if _, errOut, err := runAutoCmd(t, "unattended"); err != nil {
+			t.Fatalf("auto: %v\n%s", err, errOut)
+		}
+		body := readFileStr(t, filepath.Join(dir, ".logmind", "auto.yml"))
+
+		for _, want := range []string{
+			"# logmind-auto-version:",                             // SPEC §5.2 ownership marker
+			"profile: unattended",                                 // one owner for the profile name
+			"requires_human_handover: true",                       // unattended-operation: entry
+			"the ceiling, minus the cost of the largest dispatch", // session-heartbeat: threshold
+			"path: docs/plan.md",                                  // session-heartbeat: checkpoint
+			"a sha, never a branch name",                          // session-heartbeat: checkpoint slots
+			"can it be undone before they are back",               // unattended-operation: the test
+			"pushing to a shared ref",                             // unattended-operation: far side
+			"the second consecutive failure of the same fix",      // unattended-operation: hard stops
+			"where the work stands now — one line",                // unattended-operation: digest
+			"must_be_git_ignored: true",                           // unattended-operation: scheduler state
+			"skills/session-heartbeat",                            // the owning skill, linked
+			"skills/unattended-operation",                         // the owning skill, linked
+		} {
+			mustContain(t, body, want)
+		}
+	})
+}
+
+// TestAuto_ReportsMissingSkillsWithoutFetchingThem — logmind does not pull
+// catalog items (§5.2's subscription model is Planned at skdd#6). It says
+// which are absent and prints the command a human runs.
+func TestAuto_ReportsMissingSkillsWithoutFetchingThem(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		mustWriteUnder(t, dir, ".claude/skills/session-heartbeat/SKILL.md", "---\nname: session-heartbeat\n---\n")
+
+		out, errOut, err := runAutoCmd(t, "unattended")
+		if err != nil {
+			t.Fatalf("auto: %v\n%s", err, errOut)
+		}
+		mustContain(t, out, "✓ session-heartbeat")
+		mustContain(t, out, "✗ unattended-operation — not installed")
+		mustContain(t, out, "npx skills add https://github.com/thrillmade/agent-skills --skill unattended-operation")
+		mustContain(t, out, "skills-missing=1")
+
+		if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", "unattended-operation")); err == nil {
+			t.Errorf("auto fetched a skill; it must only print the install command")
+		}
+	})
+}
+
+// TestAuto_MissingPlanDocIsReportedNotCreated — a checkpoint with nowhere
+// to land is the difference between a resumed session telling "paused"
+// from "died". What a plan doc should SAY is a judgment call, so auto
+// reports the absence rather than inventing one (the same boundary
+// `doctor --fix` draws for docs/spec.md).
+func TestAuto_MissingPlanDocIsReportedNotCreated(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		_, errOut, err := runAutoCmd(t, "unattended")
+		if err != nil {
+			t.Fatalf("auto: %v\n%s", err, errOut)
+		}
+		mustContain(t, errOut, "docs/plan.md does not exist yet")
+		if _, statErr := os.Stat(filepath.Join(dir, "docs", "plan.md")); statErr == nil {
+			t.Errorf("auto created the plan doc; it must report the absence instead")
+		}
+	})
+}
+
+// TestAuto_RefusesToRewriteADirectiveItDoesNotOwn — the file carries
+// policy a human authored (repo hard stops, the wake mechanism). Every
+// decline is REPORTED on stderr; silence would leave the operator
+// believing the setup they just ran is in force.
+func TestAuto_RefusesToRewriteADirectiveItDoesNotOwn(t *testing.T) {
+	cases := []struct {
+		name     string
+		content  string
+		wantNote string
+		wantOK   string
+	}{
+		{
+			name:     "markerless",
+			content:  "profile: unattended\nhard_stops:\n  repo: [never touch prod]\n",
+			wantNote: "belongs to you",
+			wantOK:   "directive=declined-markerless",
+		},
+		{
+			name:     "another profile",
+			content:  "# logmind-auto-version: v1\nprofile: skdd\n",
+			wantNote: "refusing to overwrite it with",
+			wantOK:   "directive=declined-other-profile",
+		},
+		{
+			name:     "newer than this binary",
+			content:  "# logmind-auto-version: v99\nprofile: unattended\n",
+			wantNote: "refusing to downgrade",
+			wantOK:   "directive=declined-newer",
+		},
+		{
+			name:     "older than this binary",
+			content:  "# logmind-auto-version: v0\nprofile: unattended\n",
+			wantNote: "left unchanged, because it carries policy you authored",
+			wantOK:   "directive=declined-stale",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			withTempCwd(t, func(dir string) {
+				path := filepath.Join(dir, ".logmind", "auto.yml")
+				mustWriteUnder(t, dir, ".logmind/auto.yml", c.content)
+
+				out, errOut, err := runAutoCmd(t, "unattended")
+				if err != nil {
+					t.Fatalf("auto: %v\n%s", err, errOut)
+				}
+				mustContain(t, errOut, c.wantNote)
+				mustContain(t, out, c.wantOK)
+				if got := readFileStr(t, path); got != c.content {
+					t.Errorf("auto rewrote a directive it does not own:\n got: %q\nwant: %q", got, c.content)
+				}
+			})
+		})
+	}
+}
+
+// TestAuto_QuietEmitsOnlyTheReceipt — §2.7's quiet discipline: one
+// chainable `ok <k=v>` line, no chatter.
+func TestAuto_QuietEmitsOnlyTheReceipt(t *testing.T) {
+	withTempCwd(t, func(dir string) {
+		mustWriteUnder(t, dir, "docs/plan.md", "# Plan\n")
+		out, errOut, err := runAutoCmd(t, "unattended", "--quiet")
+		if err != nil {
+			t.Fatalf("auto --quiet: %v\n%s", err, errOut)
+		}
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		if len(lines) != 1 {
+			t.Fatalf("quiet stdout = %d lines; want exactly 1:\n%s", len(lines), out)
+		}
+		mustContain(t, lines[0], "ok auto profile=unattended directive=created")
+		mustContain(t, lines[0], "checkpoint=docs/plan.md")
+	})
+}

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -112,6 +112,29 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 		return fmt.Errorf("--base and --head must be given together")
 	}
 
+	// §3.4 again: exactly two things clear the gate. --no-fail is a third,
+	// and although it is set by whoever wrote the workflow rather than by
+	// the pull request's author, a repository that adds it has a gate that
+	// reports and never blocks. Refuse the combination outright so the
+	// escape cannot be added quietly to a workflow file.
+	if rangeMode && opts.noFail {
+		return fmt.Errorf("--no-fail cannot be combined with --base/--head: SPEC §3.4 allows exactly two things to clear the gate — the change carries a decision, or it falls under the threshold")
+	}
+
+	// --threshold is the fourth, by exactly the same argument, and it is
+	// worse than --no-fail because it does not look like an escape:
+	// `--threshold 999999` reads as configuration. §3.4 pins the gate's
+	// threshold to `git.commit_line_threshold` and to nothing else, so in
+	// range mode the flag has no legitimate use — the repository already
+	// has a way to say what its threshold is, read from the base ref
+	// precisely so the change under judgement cannot forge it.
+	//
+	// Refused rather than ignored: silently discarding a flag someone
+	// passed deliberately is its own way of lying about what ran.
+	if rangeMode && opts.thresholdExplicit {
+		return fmt.Errorf("--threshold cannot be combined with --base/--head: SPEC §3.4 pins the gate's threshold to git.commit_line_threshold; set it in the repository's .logmind/config.yml instead")
+	}
+
 	// Running outside a repository is one of §3.4's SIX local allowances,
 	// and like the other five it MUST NOT reach the gate: "every allowance
 	// above that depends on local process state — the environment
@@ -131,15 +154,6 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 		// Local path only. Python: click.echo(...) to stdout, no exit.
 		fmt.Fprintln(stdout, "Not a git repository, skipping check.")
 		return nil
-	}
-
-	// §3.4 again: exactly two things clear the gate. --no-fail is a third,
-	// and although it is set by whoever wrote the workflow rather than by
-	// the pull request's author, a repository that adds it has a gate that
-	// reports and never blocks. Refuse the combination outright so the
-	// escape cannot be added quietly to a workflow file.
-	if rangeMode && opts.noFail {
-		return fmt.Errorf("--no-fail cannot be combined with --base/--head: SPEC §3.4 allows exactly two things to clear the gate — the change carries a decision, or it falls under the threshold")
 	}
 
 	// One repository root for the config read AND every git command

--- a/internal/cli/check_decisions_test.go
+++ b/internal/cli/check_decisions_test.go
@@ -427,6 +427,13 @@ func revParse(t *testing.T, repo, ref string) string {
 // check" and exited 0. Every pull request would have gone green
 // regardless of size, while reporting success.
 func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
+	// Created at PARENT scope on purpose. t.TempDir() names the directory
+	// after the calling test, so creating it inside a subtest named
+	// "--no-fail …" yields a path containing "--no-fail" — and the
+	// not-a-repo error echoes opts.cwd. That is how the original version of
+	// this test passed while the guard it claimed to cover was deleted.
+	dir := t.TempDir()
+
 	t.Run("not a git repository is a hard error in range mode", func(t *testing.T) {
 		dir := t.TempDir() // deliberately not a git repo
 		var out bytes.Buffer
@@ -450,7 +457,12 @@ func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
 	})
 
 	t.Run("--no-fail is refused in range mode", func(t *testing.T) {
-		dir := t.TempDir()
+		// dir comes from the PARENT scope deliberately. t.TempDir() names the
+		// directory after the subtest, so a subtest called "--no-fail …"
+		// produces a path CONTAINING "--no-fail" — and the not-a-repo error
+		// echoes opts.cwd. An adversarial review found the original assertion
+		// matching that path rather than the guard: deleting the guard
+		// entirely left this test green.
 		var out bytes.Buffer
 		err := runCheckDecisions(checkDecisionsOpts{
 			cwd: dir, base: "a", head: "b", noFail: true,
@@ -458,8 +470,53 @@ func TestCheckDecisions_RangeMode_RefusesLocalAllowances(t *testing.T) {
 		if err == nil {
 			t.Fatal("--no-fail with --base/--head returned nil; it is a third thing clearing the gate")
 		}
+		// Assert on text unique to the guard, not on a flag name that can
+		// appear in an incidental path.
+		if !strings.Contains(err.Error(), "cannot be combined with --base/--head") {
+			t.Errorf("error is not the guard's refusal, got %v", err)
+		}
 		if !strings.Contains(err.Error(), "--no-fail") {
-			t.Errorf("error should name the refused flag, got %v", err)
+			t.Errorf("refusal should name the flag, got %v", err)
+		}
+	})
+}
+
+// TestCheckDecisions_RangeMode_RefusesThreshold pins the fourth
+// gate-clearer. Its sibling --no-fail refusal was tested; this one shipped
+// untested and an adversarial review caught the gap.
+//
+// SPEC §3.4 pins the gate's threshold to git.commit_line_threshold and
+// nothing else. --threshold is worse than --no-fail as an escape because
+// it does not look like one: `--threshold 999999` reads as configuration
+// rather than a bypass, so it is the version a reviewer waves through.
+func TestCheckDecisions_RangeMode_RefusesThreshold(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("--threshold is refused in range mode", func(t *testing.T) {
+		var out bytes.Buffer
+		err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, base: "a", head: "b",
+			threshold: 999999, thresholdExplicit: true,
+		}, &out)
+		if err == nil {
+			t.Fatal("--threshold with --base/--head returned nil; it is a third thing clearing the gate")
+		}
+		if !strings.Contains(err.Error(), "cannot be combined with --base/--head") {
+			t.Errorf("error is not the guard's refusal, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "--threshold") {
+			t.Errorf("refusal should name the flag, got %v", err)
+		}
+	})
+
+	t.Run("--threshold is still allowed locally", func(t *testing.T) {
+		var out bytes.Buffer
+		// Not a repo, so the local path returns its skip message rather
+		// than evaluating — enough to prove the flag is not refused.
+		if err := runCheckDecisions(checkDecisionsOpts{
+			cwd: dir, threshold: 999999, thresholdExplicit: true,
+		}, &out); err != nil {
+			t.Fatalf("--threshold alone must not be refused, got %v", err)
 		}
 	})
 }

--- a/internal/cli/filelock_unix.go
+++ b/internal/cli/filelock_unix.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
 )
 
 // acquireRepoLock takes an OS-advisory flock on .logmind/.lock inside
@@ -35,6 +37,13 @@ func acquireRepoLock(cwd string) (*fileLock, error) {
 	lockPath := repoLockPath(cwd)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create %s: %w", filepath.Dir(lockPath), err)
+	}
+	// A symlink at lockPath would make O_CREATE follow it and open (and,
+	// for a dangling one, create) whatever it points to — the same class
+	// of escape atomicio.WriteFile refuses for content writes under
+	// .logmind/. Refuse here too rather than silently flock'ing through it.
+	if err := atomicio.RefuseSymlink(lockPath); err != nil {
+		return nil, err
 	}
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {

--- a/internal/cli/filelock_windows.go
+++ b/internal/cli/filelock_windows.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
 )
 
 // errSharingViolation is Windows ERROR_SHARING_VIOLATION (0x20 = 32),
@@ -49,6 +51,13 @@ func acquireRepoLock(cwd string) (*fileLock, error) {
 	lockPath := repoLockPath(cwd)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create %s: %w", filepath.Dir(lockPath), err)
+	}
+	// See filelock_unix.go's matching check: a symlink at lockPath would
+	// make OPEN_ALWAYS follow it (and, for a dangling reparse point,
+	// create whatever it points to) instead of locking the file this
+	// tool actually manages.
+	if err := atomicio.RefuseSymlink(lockPath); err != nil {
+		return nil, err
 	}
 	namePtr, err := syscall.UTF16PtrFromString(lockPath)
 	if err != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -46,6 +46,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitattr"
@@ -558,11 +559,14 @@ func enabledAgentList(flag string, all bool) []string {
 
 // writeFile writes content to path, creating parent directories.
 // Uses 0o644 perms — matches Python's open(...).write defaults.
+//
+// Delegates to atomicio.WriteFile (temp-file-plus-rename, refuses a
+// symlink at path) rather than a bare os.WriteFile — this helper is the
+// one that lands .logmind/config.yml on a fresh `logmind init`, so a
+// symlink planted at that path before init runs must not turn into an
+// arbitrary-write primitive.
 func writeFile(path, content string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(content), 0o644)
+	return atomicio.WriteFile(path, []byte(content), 0o644)
 }
 
 // relativePath returns target's path relative to repoRoot. Best-effort:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -70,7 +70,7 @@ func NewRootCmd() *cobra.Command {
 
 	// Persistent --quiet flag (token-killer Phase 1b). Registered on root so
 	// cobra accepts it ahead of every subcommand's own flags, but only the
-	// WIRED verbs (doctor, file-structure, guard-commit, headline, log,
+	// WIRED verbs (auto, doctor, file-structure, guard-commit, headline, log,
 	// repomap, search, show, timeline) actually read it — §14.1 makes quiet
 	// a SHOULD, not a MUST, so the remaining verbs are free to ignore it.
 	// Opt-in twin of the LOGMIND_QUIET env var — the default (unset) path
@@ -83,7 +83,7 @@ func NewRootCmd() *cobra.Command {
 	// verb" unqualified: cobra shows this same text under every subcommand's
 	// Global Flags section, including the 13 verbs that don't honor it yet.
 	root.PersistentFlags().Bool(quietFlagName, false,
-		"Terse machine output on the read/emit verbs (doctor, file-structure, guard-commit, headline, log, repomap, search, show, timeline): suppress progress chatter, emit one chainable 'ok <k=v>' line (env: LOGMIND_QUIET=1). Errors still go to stderr. Other verbs currently ignore this flag.")
+		"Terse machine output on the read/emit verbs (auto, doctor, file-structure, guard-commit, headline, log, repomap, search, show, timeline): suppress progress chatter, emit one chainable 'ok <k=v>' line (env: LOGMIND_QUIET=1). Errors still go to stderr. Other verbs currently ignore this flag.")
 
 	root.AddCommand(newVersionCmd())
 	// B2: git integration + hooks subcommands.
@@ -136,6 +136,11 @@ func NewRootCmd() *cobra.Command {
 	// resolveDecisionsPath, not the old hardcoded docs/decisions.md.
 	root.AddCommand(newShowCmd())
 	root.AddCommand(newSearchCmd())
+	// #241: one-command setup for a repo that will be handed over to run
+	// unattended — writes the standing directive, reports which required
+	// skills are installed, and PRINTS the handover for a human to give.
+	// It never starts the mode; see internal/cli/auto.go.
+	root.AddCommand(newAutoCmd())
 
 	// Top-level --version flag mirrors `logmind version` so both
 	// `logmind --version` and `logmind version` produce the same line.

--- a/internal/doctor/auto_advisory_test.go
+++ b/internal/doctor/auto_advisory_test.go
@@ -1,0 +1,126 @@
+// auto_advisory_test.go — exercises collectAutoAdvisories / the
+// CollectStatus.AutoAdvisories field (#241): a standing directive that
+// predates the bundled policy, one naming a profile this binary does not
+// know, and one carrying no ownership marker at all.
+//
+// Every case is ADVISORY ONLY — Overall must stay OK. `logmind auto` is
+// an explicit opt-in verb whose directive carries policy a human
+// authored, so none of this is drift and none of it is auto-fixable.
+package doctor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/auto"
+)
+
+func writeDirective(t *testing.T, dir, content string) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, ".logmind", "auto.yml"), content)
+}
+
+// bundledUnattendedMarker is the marker this binary ships for the
+// `unattended` profile — read from the registry rather than hardcoded, so
+// bumping the template's version does not silently rot these tests.
+func bundledUnattendedMarker(t *testing.T) string {
+	t.Helper()
+	p, ok := auto.Lookup("unattended")
+	if !ok {
+		t.Fatalf("the `unattended` profile is not registered")
+	}
+	marker, ok := auto.BundledMarker(p)
+	if !ok {
+		t.Fatalf("the `unattended` template carries no version marker")
+	}
+	return marker
+}
+
+// TestAutoAdvisories_NoDirective_NoAdvisory — the common case. A repo that
+// never ran `logmind auto` is not drifted; it simply never opted in.
+func TestAutoAdvisories_NoDirective_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	r := CollectStatus(dir, true)
+	if len(r.AutoAdvisories) != 0 {
+		t.Errorf("AutoAdvisories = %v; want none (no directive installed)", r.AutoAdvisories)
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; an absent auto directive must never be drift")
+	}
+}
+
+func TestAutoAdvisories_CurrentDirective_NoAdvisory(t *testing.T) {
+	dir := freshRepo(t)
+	writeDirective(t, dir, "# logmind-auto-version: "+bundledUnattendedMarker(t)+"\nprofile: unattended\n")
+	r := CollectStatus(dir, true)
+	if len(r.AutoAdvisories) != 0 {
+		t.Errorf("AutoAdvisories = %v; want none (directive is current)", r.AutoAdvisories)
+	}
+}
+
+// TestAutoAdvisories_StaleDirective — the drift this feature exists to
+// notice: the policy the directive restates has moved on. Advisory only.
+func TestAutoAdvisories_StaleDirective(t *testing.T) {
+	dir := freshRepo(t)
+	writeDirective(t, dir, "# logmind-auto-version: v0\nprofile: unattended\n")
+	r := CollectStatus(dir, true)
+	if len(r.AutoAdvisories) != 1 {
+		t.Fatalf("AutoAdvisories = %v; want exactly 1", r.AutoAdvisories)
+	}
+	got := r.AutoAdvisories[0]
+	for _, want := range []string{".logmind/auto.yml", "v0", bundledUnattendedMarker(t), "logmind auto unattended"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("advisory = %q; want it to mention %q", got, want)
+		}
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the auto advisory must never be drift")
+	}
+	// It must also show up in the rendered table, or it reaches nobody.
+	if !strings.Contains(RenderStatus(r), got) {
+		t.Errorf("RenderStatus omitted the auto advisory")
+	}
+}
+
+// TestAutoAdvisories_UnknownProfile — a directive naming a profile this
+// binary has never heard of. logmind reports it and names what it knows;
+// it never guesses what the file should contain (#267's lesson).
+func TestAutoAdvisories_UnknownProfile(t *testing.T) {
+	dir := freshRepo(t)
+	writeDirective(t, dir, "# logmind-auto-version: v1\nprofile: skdd\n")
+	r := CollectStatus(dir, true)
+	if len(r.AutoAdvisories) != 1 {
+		t.Fatalf("AutoAdvisories = %v; want exactly 1", r.AutoAdvisories)
+	}
+	got := r.AutoAdvisories[0]
+	for _, want := range []string{`"skdd"`, "does not know", "unattended"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("advisory = %q; want it to mention %q", got, want)
+		}
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the auto advisory must never be drift")
+	}
+}
+
+// TestAutoAdvisories_MarkerlessDirective — SPEC §5.2: an artifact with no
+// marker belongs to the user. Doctor says so, because otherwise the file
+// silently never refreshes and nobody knows why.
+func TestAutoAdvisories_MarkerlessDirective(t *testing.T) {
+	dir := freshRepo(t)
+	writeDirective(t, dir, "profile: unattended\nhard_stops:\n  repo: [never touch prod]\n")
+	r := CollectStatus(dir, true)
+	if len(r.AutoAdvisories) != 1 {
+		t.Fatalf("AutoAdvisories = %v; want exactly 1", r.AutoAdvisories)
+	}
+	got := r.AutoAdvisories[0]
+	for _, want := range []string{"logmind-auto-version", "belongs to you"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("advisory = %q; want it to mention %q", got, want)
+		}
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; the auto advisory must never be drift")
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -67,6 +67,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thrillmade/logmind/internal/auto"
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/decisions"
@@ -151,6 +152,19 @@ type StatusReport struct {
 	// spec_file is unset. Like SummariesNeeded, this NEVER affects Overall —
 	// the spec fold-in is a nice-to-have, not a gate.
 	SpecAdvisories []string `json:"spec_advisories"`
+
+	// AutoAdvisories is an ADVISORY list (#241) about `.logmind/auto.yml`,
+	// the standing directive `logmind auto <profile>` writes: a directive
+	// that predates the current bundled policy, one written for a profile
+	// this binary doesn't know, or one carrying no ownership marker. Empty
+	// in the (common) case of a repo that never opted into `logmind auto`.
+	//
+	// Advisory for the same reason SpecAdvisories is: `auto` is an explicit
+	// opt-in verb and its directive carries policy a human authored, so
+	// nothing here is auto-fixable and none of it is drift. Re-running
+	// `logmind auto <profile>` is the deliberate remediation, exactly as
+	// `logmind init --spec` is for the spec nudge.
+	AutoAdvisories []string `json:"auto_advisories"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -223,6 +237,59 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		Suggestions:     suggestions,
 		SummariesNeeded: collectSummariesNeeded(projectRoot),
 		SpecAdvisories:  collectSpecAdvisories(projectRoot),
+		AutoAdvisories:  collectAutoAdvisories(projectRoot),
+	}
+}
+
+// collectAutoAdvisories returns the ADVISORY list for `.logmind/auto.yml`
+// — the standing directive `logmind auto <profile>` writes (#241).
+//
+// A repo that never ran `logmind auto` has no directive and gets nothing:
+// absence is not drift, exactly as a missing workflow or hook is "not
+// installed" rather than "stale". When a directive IS installed, three
+// things are worth saying:
+//
+//   - its ownership marker predates (or postdates) the directive this
+//     binary bundles — the policy it restates has moved on;
+//   - it names a profile this binary does not know — a newer logmind, a
+//     hand-written file, or a typo, and in every case not something to
+//     guess at;
+//   - it carries no marker at all, so it belongs to the user (SPEC §5.2)
+//     and nothing will ever refresh it.
+//
+// Purely informational: like SpecAdvisories, it never feeds Overall.
+// `doctor --fix` deliberately does not act on any of it — the directive
+// carries policy a human authored (repo hard stops, the wake mechanism),
+// and rewriting that from a template is exactly the failure the whole
+// feature exists to prevent.
+func collectAutoAdvisories(projectRoot string) []string {
+	state := auto.Inspect(projectRoot)
+	if !state.Present {
+		return nil
+	}
+	const path = ".logmind/auto.yml"
+	if state.Marker == "" {
+		return []string{
+			path + " carries no `# logmind-auto-version:` marker — it belongs to you, and logmind will " +
+				"never refresh it. Move it aside and re-run `logmind auto <profile>` to adopt a managed directive.",
+		}
+	}
+	profile, known := auto.Lookup(state.Profile)
+	if !known {
+		return []string{
+			fmt.Sprintf("%s names profile %q, which this binary does not know (known: %s) — logmind will not "+
+				"guess what it should contain. Upgrade logmind, or re-run `logmind auto <profile>`.",
+				path, state.Profile, strings.Join(auto.Names(), ", ")),
+		}
+	}
+	bundled, ok := auto.BundledMarker(profile)
+	if !ok || bundled == state.Marker {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("%s is at %s; this binary bundles %s for profile %q — the policy it restates has changed. "+
+			"Move it aside, re-run `logmind auto %s`, then re-apply your repo-specific slots.",
+			path, state.Marker, bundled, profile.Name, profile.Name),
 	}
 }
 
@@ -996,6 +1063,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Canonical spec file (%d):", len(r.SpecAdvisories)))
 		for _, s := range r.SpecAdvisories {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
+		}
+	}
+	if len(r.AutoAdvisories) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Unattended-operation directive (%d):", len(r.AutoAdvisories)))
+		for _, s := range r.AutoAdvisories {
 			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -67,6 +67,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thrillmade/logmind/internal/auto"
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/decisions"
@@ -150,6 +151,19 @@ type StatusReport struct {
 	// spec_file is unset. Like SummariesNeeded, this NEVER affects Overall —
 	// the spec fold-in is a nice-to-have, not a gate.
 	SpecAdvisories []string `json:"spec_advisories"`
+
+	// AutoAdvisories is an ADVISORY list (#241) about `.logmind/auto.yml`,
+	// the standing directive `logmind auto <profile>` writes: a directive
+	// that predates the current bundled policy, one written for a profile
+	// this binary doesn't know, or one carrying no ownership marker. Empty
+	// in the (common) case of a repo that never opted into `logmind auto`.
+	//
+	// Advisory for the same reason SpecAdvisories is: `auto` is an explicit
+	// opt-in verb and its directive carries policy a human authored, so
+	// nothing here is auto-fixable and none of it is drift. Re-running
+	// `logmind auto <profile>` is the deliberate remediation, exactly as
+	// `logmind init --spec` is for the spec nudge.
+	AutoAdvisories []string `json:"auto_advisories"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -222,6 +236,59 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		Suggestions:     suggestions,
 		SummariesNeeded: collectSummariesNeeded(projectRoot),
 		SpecAdvisories:  collectSpecAdvisories(projectRoot),
+		AutoAdvisories:  collectAutoAdvisories(projectRoot),
+	}
+}
+
+// collectAutoAdvisories returns the ADVISORY list for `.logmind/auto.yml`
+// — the standing directive `logmind auto <profile>` writes (#241).
+//
+// A repo that never ran `logmind auto` has no directive and gets nothing:
+// absence is not drift, exactly as a missing workflow or hook is "not
+// installed" rather than "stale". When a directive IS installed, three
+// things are worth saying:
+//
+//   - its ownership marker predates (or postdates) the directive this
+//     binary bundles — the policy it restates has moved on;
+//   - it names a profile this binary does not know — a newer logmind, a
+//     hand-written file, or a typo, and in every case not something to
+//     guess at;
+//   - it carries no marker at all, so it belongs to the user (SPEC §5.2)
+//     and nothing will ever refresh it.
+//
+// Purely informational: like SpecAdvisories, it never feeds Overall.
+// `doctor --fix` deliberately does not act on any of it — the directive
+// carries policy a human authored (repo hard stops, the wake mechanism),
+// and rewriting that from a template is exactly the failure the whole
+// feature exists to prevent.
+func collectAutoAdvisories(projectRoot string) []string {
+	state := auto.Inspect(projectRoot)
+	if !state.Present {
+		return nil
+	}
+	const path = ".logmind/auto.yml"
+	if state.Marker == "" {
+		return []string{
+			path + " carries no `# logmind-auto-version:` marker — it belongs to you, and logmind will " +
+				"never refresh it. Move it aside and re-run `logmind auto <profile>` to adopt a managed directive.",
+		}
+	}
+	profile, known := auto.Lookup(state.Profile)
+	if !known {
+		return []string{
+			fmt.Sprintf("%s names profile %q, which this binary does not know (known: %s) — logmind will not "+
+				"guess what it should contain. Upgrade logmind, or re-run `logmind auto <profile>`.",
+				path, state.Profile, strings.Join(auto.Names(), ", ")),
+		}
+	}
+	bundled, ok := auto.BundledMarker(profile)
+	if !ok || bundled == state.Marker {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("%s is at %s; this binary bundles %s for profile %q — the policy it restates has changed. "+
+			"Move it aside, re-run `logmind auto %s`, then re-apply your repo-specific slots.",
+			path, state.Marker, bundled, profile.Name, profile.Name),
 	}
 }
 
@@ -970,6 +1037,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Canonical spec file (%d):", len(r.SpecAdvisories)))
 		for _, s := range r.SpecAdvisories {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
+		}
+	}
+	if len(r.AutoAdvisories) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Unattended-operation directive (%d):", len(r.AutoAdvisories)))
+		for _, s := range r.AutoAdvisories {
 			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -268,7 +268,7 @@ type NumstatLine struct {
 // Returns an empty slice on git failure — check-decisions treats that
 // as "0 lines changed" rather than blowing up the pre-commit hook.
 func DiffCachedNumstat(repoRoot string) []NumstatLine {
-	cmd := exec.Command("git", "diff", "--cached", "--numstat")
+	cmd := exec.Command("git", append([]string{"diff", "--cached"}, numstatFlags...)...)
 	cmd.Dir = repoRoot
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -287,7 +287,7 @@ func DiffCachedNumstat(repoRoot string) []NumstatLine {
 // git commit` stages anything, so `--cached` alone would undercount a
 // change that is still sitting unstaged at evaluation time.
 func DiffNumstat(repoRoot string) []NumstatLine {
-	cmd := exec.Command("git", "diff", "--numstat")
+	cmd := exec.Command("git", append([]string{"diff"}, numstatFlags...)...)
 	cmd.Dir = repoRoot
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -326,16 +326,40 @@ func DiffRangeNames(repoRoot, base, head string) ([]string, error) {
 	return strings.Split(trimmed, "\n"), nil
 }
 
+// numstatFlags is the ONE flag list every substantive-line count runs
+// with. SPEC §3.4 drives all three enforcement points from "one shared
+// evaluation," so the flags live here rather than at each call site —
+// a flag one surface passes and another doesn't is that one evaluation
+// quietly becoming two.
+//
+// --no-renames is load-bearing, and its absence was a live gate hole.
+// With rename detection ON, git renders a cross-directory rename as a
+// SINGLE row whose path field is `old => new`:
+//
+//	150	0	docs/notes.md => src/payload.go
+//
+// guardcommit.IsExcludedPath prefix-matches that whole string, so the
+// row is excluded as `docs/...` and 550 lines of new Go counted zero —
+// the gate passed a change it exists to stop. --no-renames splits it
+// into a deletion under docs/ (correctly excluded) and an addition under
+// src/ (correctly counted).
+//
+// Deliberately NOT fixed by teaching IsExcludedPath to parse `old =>
+// new`: git has two rename renderings (that one, and the compact
+// `{docs => src}/sub/notes.md`), so a parser owes both plus whatever
+// git adds later. Not asking for renames at all has no such surface.
+var numstatFlags = []string{"--numstat", "--no-renames"}
+
 // DiffRangeNumstat parses `git diff --numstat base...head` into typed
 // rows. Same parsing rules as DiffCachedNumstat, same loud-on-failure
 // contract as DiffRangeNames.
 //
-// The flags deliberately match DiffCachedNumstat's exactly (i.e. none
-// beyond --numstat): SPEC §3.4 drives every enforcement point from "one
-// shared evaluation," and a flag one surface passes and another doesn't
-// is that evaluation quietly becoming two.
+// The flags deliberately match DiffCachedNumstat's exactly: SPEC §3.4
+// drives every enforcement point from "one shared evaluation," and a flag
+// one surface passes and another doesn't is that evaluation quietly
+// becoming two. See numstatFlags for why --no-renames is among them.
 func DiffRangeNumstat(repoRoot, base, head string) ([]NumstatLine, error) {
-	out, err := runDiffRange(repoRoot, base, head, "--numstat")
+	out, err := runDiffRange(repoRoot, base, head, numstatFlags...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -2,6 +2,7 @@ package gitcli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -523,5 +524,109 @@ func TestDefaultBranchMergeBase_FallsBackToHEAD_WhenUnresolvable(t *testing.T) {
 
 	if got := DefaultBranchMergeBase(repo); got != "HEAD" {
 		t.Fatalf("DefaultBranchMergeBase = %q; want the \"HEAD\" fallback", got)
+	}
+}
+
+// TestNumstat_RenameOutOfDocsIsSplit runs against a REAL git repository
+// with a REAL rename, and is the pin that the earlier synthetic test was
+// not.
+//
+// The regression it guards: #287 unified the numstat flag lists and
+// dropped --no-renames. With rename detection on, git renders a
+// cross-directory rename as ONE row whose path is `old => new`, so
+// `docs/notes.md => src/payload.go` prefix-matched `docs/` and hundreds
+// of lines of new code counted zero. An adversarial review found that the
+// fix's own test — asserting on synthetic NumstatLine values — stayed
+// GREEN when --no-renames was removed again, because it never invoked
+// git. A test on the helper you fixed is not a test on the bug.
+//
+// This one drives the actual command. Remove --no-renames from
+// numstatFlags and it goes red, because git's output shape changes.
+//
+// The file must be large enough that appending to it stays above git's
+// ~50% rename-similarity threshold; a small file plus many added lines is
+// simply not detected as a rename and the test would pass vacuously.
+func TestNumstat_RenameOutOfDocsIsSplit(t *testing.T) {
+	repo := initRepo(t)
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	var big strings.Builder
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&big, "original line %d\n", i)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "docs", "notes.md"), []byte(big.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "add docs/notes.md")
+
+	// Move it into src/ and append, keeping similarity high enough that
+	// git still calls it a rename.
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run("mv", "docs/notes.md", "src/payload.go")
+	f, err := os.OpenFile(filepath.Join(repo, "src", "payload.go"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 150; i++ {
+		fmt.Fprintf(f, "// added %d\n", i)
+	}
+	f.Close()
+	run("add", "-A")
+
+	// POSITIVE CONTROL FIRST. Assert that git, left to itself, DOES render
+	// this as a rename. Without it the whole test is vacuous: an adversarial
+	// review showed that under `diff.renames=false` in a user's gitconfig,
+	// the "no => rows" assertion below passes even with --no-renames removed,
+	// because git never emitted a rename in the first place. Absence of the
+	// rendering only means something once we know it would otherwise appear.
+	bare := exec.Command("git", "diff", "--cached", "--numstat")
+	bare.Dir = repo
+	bareOut, err := bare.Output()
+	if err != nil {
+		t.Fatalf("bare numstat: %v", err)
+	}
+	if !strings.Contains(string(bareOut), " => ") {
+		t.Skipf("git did not render this as a rename (diff.renames disabled, or "+
+			"similarity below threshold) — the test cannot prove anything about "+
+			"--no-renames here. Bare numstat was:\n%s", bareOut)
+	}
+
+	rows := DiffCachedNumstat(repo)
+
+	// Now the real assertion: our flags must suppress what the control just
+	// proved git would otherwise emit.
+	var renameRows int
+	for _, r := range rows {
+		if strings.Contains(r.Path, " => ") {
+			renameRows++
+		}
+	}
+	if renameRows > 0 {
+		t.Fatalf("numstat still carries a rename rendering (%d rows) — --no-renames is not in effect:\n%+v", renameRows, rows)
+	}
+
+	// The substantive half must be attributed to src/, not swallowed by
+	// the docs/ prefix.
+	var sawSrc bool
+	for _, r := range rows {
+		if r.Path == "src/payload.go" {
+			sawSrc = true
+		}
+	}
+	if !sawSrc {
+		t.Fatalf("no row for src/payload.go — the rename was not split:\n%+v", rows)
 	}
 }

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -393,6 +393,24 @@ var excludedFiles = func() map[string]bool {
 // markdown wholesale switches the rule off in the repositories where
 // writing *is* the work." Do not add a "*.md" arm here.
 func IsExcludedPath(path string) bool {
+	// A path carrying git's rename rendering is never excluded.
+	//
+	// gitcli.numstatFlags passes --no-renames, so in practice git does not
+	// hand us this shape at all. This is the second line of defence, and it
+	// exists because the first one was removed once already: when the flag
+	// went missing, `docs/notes.md => src/payload.go` prefix-matched
+	// `docs/` and the gate counted 550 lines of new Go as zero.
+	//
+	// Deliberately a refusal rather than a parser. Git has at least two
+	// renderings — `old => new` and the compact `{docs => src}/sub/file` —
+	// so parsing owes both plus whatever git adds later, and a parser that
+	// falls behind fails OPEN. Refusing to exclude fails CLOSED: the worst
+	// case is counting a rename that a correct parser would have excluded,
+	// which asks an author for a decision they did not owe. That is a far
+	// cheaper error than waving through the change the gate exists to stop.
+	if strings.Contains(path, " => ") {
+		return false
+	}
 	if strings.HasPrefix(path, docsPrefix) || strings.HasPrefix(path, configPrefix) {
 		return true
 	}

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -661,3 +661,51 @@ func TestIsSectionHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestSubstantiveLines_RenameOutOfDocsIsCounted pins the gate hole a
+// retrospective panel found on `dev` after PR #287 unified the numstat
+// flag lists and dropped --no-renames in the process.
+//
+// With rename detection ON, git renders a cross-directory rename as ONE
+// row whose path field is `old => new`:
+//
+//	150	0	docs/notes.md => src/payload.go
+//
+// IsExcludedPath prefix-matches that whole string, so the row was
+// excluded as `docs/...` and 550 lines of new Go counted zero — the gate
+// passed exactly the change it exists to stop. gitcli.numstatFlags now
+// carries --no-renames on every count, which splits the row into a
+// deletion under docs/ (excluded) and an addition under src/ (counted).
+//
+// This test pins the CONSUMER side: whatever git hands us, a path that
+// still carries the `=>` rename rendering must not be silently treated as
+// living under an excluded prefix.
+func TestSubstantiveLines_RenameOutOfDocsIsCounted(t *testing.T) {
+	// The exact shape git emits when rename detection is on.
+	rows := []gitcli.NumstatLine{
+		{Added: "150", Removed: "0", Path: "docs/notes.md => src/payload.go"},
+	}
+	if got := SubstantiveLines(rows); got == 0 {
+		t.Errorf("a rename OUT of docs/ counted 0 lines — the gate would pass "+
+			"550 lines of new code; got %d, want non-zero", got)
+	}
+
+	// Control: a genuine docs-only row must still be excluded, or the fix
+	// has simply broken the exclusion it was meant to preserve.
+	docsOnly := []gitcli.NumstatLine{
+		{Added: "550", Removed: "0", Path: "docs/notes.md"},
+	}
+	if got := SubstantiveLines(docsOnly); got != 0 {
+		t.Errorf("a docs-only change must stay excluded (SPEC §3.4); got %d, want 0", got)
+	}
+
+	// Control: the compact rename rendering, which git uses when the two
+	// paths share a prefix. It never looked like a bare docs/ path, so it
+	// was never part of the hole — but it must not regress either.
+	compact := []gitcli.NumstatLine{
+		{Added: "150", Removed: "0", Path: "{docs => src}/sub/notes.md"},
+	}
+	if got := SubstantiveLines(compact); got == 0 {
+		t.Errorf("compact rename rendering counted 0; got %d, want non-zero", got)
+	}
+}

--- a/internal/templates/auto/unattended.yml.template
+++ b/internal/templates/auto/unattended.yml.template
@@ -1,0 +1,128 @@
+# logmind-auto-version: v1
+#
+# Standing directive for unattended operation, written by `logmind auto
+# unattended`. This file is DURABLE POLICY the repository carries: what
+# entry requires, the pause threshold, where the checkpoint lives, the
+# hard stops, and what the handback must contain.
+#
+# It is NOT scheduler state. A wake time, an in-flight agent list, the
+# sha the run currently stands on — none of those belong here. Those go
+# in the checkpoint (below), and the wake mechanism's own lock/schedule
+# file MUST be git-ignored before entry (see scheduler_state).
+#
+# The rules below are OWNED by two skills; this file names the ones that
+# have a repo-specific answer and points at the owner for the rest. When
+# a skill changes, this file is stale — `logmind doctor` says so.
+#
+#   session-heartbeat     the mechanism (beat order, threshold, checkpoint, resume)
+#     https://github.com/thrillmade/agent-skills/tree/main/skills/session-heartbeat
+#   unattended-operation  the policy layered on it (handover, authority, hard stops, digest)
+#     https://github.com/thrillmade/agent-skills/tree/main/skills/unattended-operation
+
+profile: unattended
+
+# Both must be loaded. unattended-operation requires session-heartbeat
+# as background and restates none of the mechanism.
+skills:
+  - session-heartbeat
+  - unattended-operation
+
+entry:
+  # source: unattended-operation — "Entry is a handover contract".
+  # The mode is NEVER inferred from the clock, from silence, or from a
+  # human going quiet. No directive, no mode.
+  requires_human_handover: true
+  # The handover must name all five. If the human left without naming
+  # them, the mode did not start: do the unambiguous work under ordinary
+  # attended discipline and stop at the first judgment call.
+  directive_must_name:
+    - scope — the named plan items or slice range, never "keep going"
+    - hard stops — what ends a lane rather than being worked around
+    - pre-authorized exceptions, by name — anything not named is not authorized
+    - the wake mechanism, and where parked work is written
+    - what to do at a real fork — park it and continue elsewhere is the default
+  # First act inside the window: write back what you heard, so the scope
+  # is on the record.
+  echo_scope_back: true
+
+threshold:
+  # source: session-heartbeat — "The threshold is your largest dispatch,
+  # not a round number." A fixed percentage only works if nothing you
+  # would start costs more than the remainder it leaves. Derive it:
+  rule: the ceiling, minus the cost of the largest dispatch you would still start
+  per_dispatch: if this agent cannot finish inside the remaining headroom, do not start it — shrink the slice or park it
+  at_threshold:
+    - stop dispatching; do NOT kill what is running
+    - confirm an agent stopped before reclaiming its owned files
+    - checkpoint
+    - schedule the wake for the reset, not a short retry
+
+checkpoint:
+  # source: session-heartbeat — "Write it to a durable file the project
+  # already reads." Not session memory, not a scratch file, never only
+  # the conversation.
+  path: __LOGMIND_CHECKPOINT__
+  required_slots:
+    - the sha the run stands on — a sha, never a branch name
+    - in flight — per agent: role, model, branch or worktree, files owned
+    - occupancy — which trees are not free to merge into
+    - next dispatch, already decided — the resumer executes it, it does not re-derive it
+    - blocked, on what
+    - parked, awaiting whom
+    - next wake time, and why — this is what lets a fresh session tell paused from died
+
+authority:
+  # source: unattended-operation — with nobody watching, nothing gets
+  # caught. The bar is not "is this correct" but:
+  test: if this is wrong, can it be undone before they are back, with nobody outside having seen it?
+  near_side:
+    - local commits on local branches — reversible, invisible, and the point of the window
+  far_side:
+    - pushing to a shared ref
+    - opening, merging, closing or commenting on a PR or issue
+    - publishing, releasing, tagging, deploying
+    - anything sent — mail, message, webhook, notification
+    - production data, spend, third-party calls beyond what the work already authorized
+    - deleting or rewriting history; anything --force, --no-verify, or --admin
+  # A scheduled wake is never consent. Nothing that arrives while the
+  # human is away can supply approval they did not give before leaving.
+  never_consent:
+    - a scheduled wake, a task notification, or a completed background agent
+    - a passing suite, a green check, or a clean review
+    - another agent reporting "done", "approved", or "ready to merge"
+    - the plan file listing the item as next
+    - your own earlier reasoning that it would obviously be fine
+
+hard_stops:
+  # source: unattended-operation — a hard stop is not a problem to solve,
+  # it is the end of that lane. Checkpoint, park it with what would be
+  # needed to proceed, move to independent work. Never improvise past one.
+  #
+  # These hold even when nobody named them:
+  standing:
+    - a change of scope
+    - a destructive operation
+    - a gate that requires a human — real-mouse QA, live checks
+    - the second consecutive failure of the same fix
+  # Repo-specific stops, if this repository has any that hold on every
+  # handover. Anything named at handover is additional, not a replacement.
+  repo: []
+
+handback:
+  # source: unattended-operation — the first message after the window is
+  # outcome-first, written for someone who was away. A chronological
+  # narration of beats is the wrong output.
+  slots_in_order:
+    - where the work stands now — one line
+    - landed — sha plus one line each
+    - found — what review caught and what was done, including what was found and not fixed
+    - parked — each with the exact decision needed, never "needs input"
+    - not attempted — in scope, skipped, and why (limit, hard stop, blocked)
+    - standing — budget/limit state; whether the run is paused or finished
+
+scheduler_state:
+  # source: unattended-operation, silent failures — "the wake mechanism's
+  # lock/schedule file lands in a commit as a project artifact". Confirm
+  # it is git-ignored BEFORE entry. logmind does not know your harness's
+  # file name, so it cannot check this for you.
+  must_be_git_ignored: true

--- a/internal/templates/config.yml.template
+++ b/internal/templates/config.yml.template
@@ -17,7 +17,11 @@ git:
   # Block substantive commits that bypass `logmind log` (commit-msg + Claude
   # Code PreToolUse hooks). Set false to fall back to warn-only for this repo.
   enforce_commits: true
-  # Lines-changed threshold shared with `logmind check-decisions --threshold`.
+  # Lines-changed threshold. SPEC §3.4 makes this the ONE source for every
+  # enforcement point — the commit-msg hook, the harness guard, and the CI
+  # gate. `logmind check-decisions --threshold` overrides it locally, but is
+  # refused alongside `--base/--head`: the gate reads this file and nothing
+  # else, so a pull request cannot raise its own bar.
   commit_line_threshold: 20
 
 # Decision management

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -40,6 +40,7 @@ import (
 //go:embed dependabot.yml.template
 //go:embed spec.md.template
 //go:embed github/*.yml.template
+//go:embed auto/*.yml.template
 var embedFS embed.FS
 
 // AgentsTemplate returns the full v8 AGENTS.md template (the inline
@@ -195,6 +196,23 @@ func SpecTemplate() string {
 // placeholders still in place — callers must render via RenderWorkflow.
 func Workflow(name string) string {
 	return readEmbed("github/" + name)
+}
+
+// AutoDirective returns the embedded body of one `logmind auto <profile>`
+// standing-directive template by its bare filename (e.g.
+// "unattended.yml.template"). The body still carries the
+// __LOGMIND_CHECKPOINT__ placeholder — callers render it (see
+// internal/auto.Render), exactly as Workflow bodies carry
+// __LOGMIND_VERSION__.
+//
+// Each body's FIRST line is `# logmind-auto-version: vN`, the SPEC §5.2
+// ownership marker. Bump N whenever the directive's content changes —
+// `logmind doctor` compares the installed marker against this one and
+// nudges when a repo's directive predates the current policy. The bodies
+// restate two skills (session-heartbeat, unattended-operation); a change
+// on either side is what the bump exists to surface.
+func AutoDirective(name string) string {
+	return readEmbed("auto/" + name)
 }
 
 // ListWorkflowTemplates returns the sorted list of bundled GitHub workflow


### PR DESCRIPTION
Pre-tag by **Ruling 12**, and blocked until now on two skills that did not exist. agent-skills#207 merged them as `afe8461`, so the setup surface can be built.

## What it does

`logmind auto unattended` writes `.logmind/auto.yml` — the standing directive an operator otherwise hand-assembles in-session and loses when the session ends.

**It never starts unattended operation.** It sets up and reports; entering the mode stays an explicit human act. That is the issue's own item 4, and it is also `unattended-operation`'s core rule — a tool that auto-started it would violate the policy it installs. Verified: after a run, **0 scheduler artifacts**, control confirms the directive *was* written.

## Two deviations from the issue, for your override

The issue names `logmind auto night` and `logmind auto skdd`. **Neither ships.**

- **`night` is refused** because the skill was deliberately renamed *away* from the clock during review — #174's own rule is that the hour never starts the mode. A verb called `auto night` would teach the exact vocabulary its policy rejects.
- **`skdd` is refused** because nothing defines what it would write.

Only `unattended` ships. An unknown profile refuses **by name** — `Error: unknown profile "skdd". Known profiles: unattended`, exit 1, nothing written. No default, no prefix match, no fallback. That is #267's and #286's rule, applied a third time.

`night`/`night-mode` get a retirement note, but the lookup never consults it — a test pins that.

## Judgement calls worth reading

**No new config key.** The directive is self-describing — its own marker and `profile:` line — so a copy in `config.yml` would be exactly the hand-kept duplicate this repo spent the week removing.

**A test forbids a percentage threshold.** The issue sketched a flat 90%; `session-heartbeat` explicitly refutes it, because 90% still permits starting work you cannot finish. **The skill wins over the issue that requested it**, and the test encodes that.

**`auto` never overwrites an existing directive** — stale, newer, markerless or other-profile all report on stderr with bytes untouched. A human authored that policy.

**doctor reports drift as an advisory, not a probe row.** A probe row would flip `Overall` to DRIFT with no `--fix` path, making `residualProbes`' existing "PATH/version, or a hand-written hook" note a lie.

## Verification

**8 mutations, all compiled, all died** — unknown-profile fallback, overwrite-anyway, non-idempotent bytes, *starting something after printing*, skills-assumed-present, directive-contradicts-skills, doctor-advisory-nil, missing-plan-doc-silent.

`go test ./...` exit 0, 21 packages, 0 failures.

## Gaps reported, not invented

1. **Skill install is a report plus the `npx skills add` command, not a fetch.** The Go binary has no skills.sh integration, and SPEC §5.2's subscription model (`skills-lock.json`, arrives as a PR) is **Planned** at skdd#6.
2. **The loop invocation is not printed** — the wake mechanism is what the human names at handover; logmind cannot know it. It prints the five-slot handover contract instead.
3. README verb list and `docs/plan.md` not updated — outside the assigned file set.

## One repair

The decision entry was written with shell backticks that the shell **executed** as command substitution, blanking every quoted term. Caught by reading the committed blob rather than trusting the write. Repaired and amended before the branch was reviewed — a corrupted write is not history worth preserving.