### PR TITLE
fix(site): the --version example gains the §7.3 areas line at release — closes #279

### DIFF
--- a/docs/decisions-branches/fix__site-areas-line.md
+++ b/docs/decisions-branches/fix__site-areas-line.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-add-the-spec-7-3-areas-line-to-the-site-gated-on-actual-rele -->
+- **2026-08-15** — Add the SPEC §7.3 areas line to the site, gated on actual release
+<!-- logmind-entry-end -->
+
+## 2026-08-15 08:47 - Add the SPEC §7.3 areas line to the site, gated on actual release
+
+**Reasoning:** site/app/page.tsx rendered the --version example from a single-line template. SPEC §7.3 requires two lines. Nothing is wrong on the live site today — it correctly advertises the released v1.2.0, whose binary genuinely prints one line, because the areas line shipped after it. The defect is forward-looking: the file header says releasing v2.0.0 is a three-constant flip, and after that flip the page would have shown the version line and stopped — a --version example missing the line §7.3 makes mandatory, on the page whose whole job is telling people what a correct install prints.
+
+**Alternatives considered:** Hardcode the areas line now. Rejected: that makes the page claim something the downloadable binary does not do, which is exactly the class of error #272 fixed when it stopped the site advertising an unreleased version.
+
+**Implications:**
+- A fourth constant, AREAS, copied verbatim from internal/version/version.go rather than retyped, and gated on the existing IS_NEXT_RELEASED derivation. It is deliberately decoupled from the three release constants because it tracks the declared areas, not the version number — so the tag-time flip stays exactly three lines, and the header comment now says AREAS is only touched if the binary Areas value itself changes. Verified by BUILDING the site and grepping the rendered HTML, not by reading source: today one line unchanged; with the constants temporarily flipped, two lines with a real newline and the exact Areas string. npm run lint fails for want of an eslint config, confirmed pre-existing on origin/dev and unrelated.
+
+---
+

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -15,7 +15,11 @@ const PIP_LEGACY = "pip install 'logmind==0.6.16'";
 // CURRENT_SPEC, CURRENT_RELEASE_DATE) — everything below derives from
 // them, and every "forthcoming" / "in design" caveat on the page clears
 // itself automatically once CURRENT_VERSION === NEXT_VERSION. No other
-// edit is required.
+// edit is required — UNLESS internal/version/version.go's own `Areas`
+// string has changed since AREAS below was last copied. AREAS is not
+// part of the three-line flip: it mirrors what the binary claims under
+// SPEC §7.3, which is orthogonal to the version number, so it only needs
+// touching when the binary's declared areas change, not at every release.
 //
 // CURRENT_* is what `brew install thrillmade/tap/logmind` / curl / the
 // skill installs *today*. Verified against `gh release list --repo
@@ -37,7 +41,17 @@ const CURRENT_SPEC = "0.1.1";
 const CURRENT_RELEASE_DATE = "2026-06-07";
 const NEXT_VERSION: string = "2.0.0";
 const IS_NEXT_RELEASED = CURRENT_VERSION === NEXT_VERSION;
-const VERIFY_OUTPUT = `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})`;
+// SPEC §7.3's second `--version` line — mirrored byte-for-byte from
+// internal/version/version.go's `Areas` (comma-and-space-joined, fixed
+// vocabulary order). The released 1.2.0 binary predates this line — it
+// shipped after 1.2.0, ahead of internal/version/version.go's own
+// CURRENT_VERSION bump — so it's gated on IS_NEXT_RELEASED rather than
+// shown unconditionally; hardcoding it in today's one-line output would
+// claim something the installed binary doesn't print.
+const AREAS = "orient, work, record, propagate, gates";
+const VERIFY_OUTPUT = IS_NEXT_RELEASED
+  ? `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})\nareas: ${AREAS}`
+  : `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})`;
 
 const QUICKSTART = `$ logmind init
 $ git checkout -b feat/auth
@@ -422,7 +436,7 @@ logmind context — token receipt (est. ~4 chars/token, deterministic)
             <div className="border-t border-rule" />
             <p className="marginalia normal-case tracking-normal text-foreground/55 mt-6 text-xs leading-relaxed">
               <code className="font-mono">logmind --version</code> prints{" "}
-              <code className="font-mono">{VERIFY_OUTPUT}</code> for the current release
+              <code className="font-mono whitespace-pre-line">{VERIFY_OUTPUT}</code> for the current release
               {!IS_NEXT_RELEASED && ` (v${NEXT_VERSION} is in design, not yet released)`}.
               The agent skill (03) is optional but recommended — it teaches
               Claude Code, Cursor, Codex et al. when and how to call{" "}


### PR DESCRIPTION
**Nothing is wrong on the live site today**, and that is the crux. The page correctly advertises the released **v1.2.0 (spec 0.1.1)**, and that binary genuinely prints one line — the `areas:` line shipped after it.

The defect is forward-looking. The file's own header says releasing v2.0.0 is a three-constant flip. After that flip the page would have shown `logmind 2.0.0 (spec 2.0.0)` and stopped — a `--version` example missing the line **§7.3 makes mandatory**, on the page whose entire job is telling people what a correct install prints.

## The mechanism

A fourth constant, gated on the existing `IS_NEXT_RELEASED` derivation:

```tsx
const VERIFY_OUTPUT = IS_NEXT_RELEASED
  ? `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})\nareas: ${AREAS}`
  : `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})`;
```

**Hardcoding the areas line today was rejected** — it would make the page claim something the downloadable binary does not do, which is precisely the error #272 fixed when it stopped the site advertising an unreleased version.

`AREAS` is **decoupled from the three release constants** on purpose: it tracks the declared areas, not the version number. So the tag-time flip stays exactly three lines, and the header comment now says `AREAS` is touched only if `internal/version/version.go`'s `Areas` value itself changes.

## Verified by building, not by reading

Both outputs confirmed from the rendered HTML in `.next/server/app/index.html`:

| constants | rendered |
|---|---|
| today (1.2.0 / 0.1.1) | `logmind 1.2.0 (spec 0.1.1)` — one line, unchanged |
| flipped to 2.0.0 (temporarily, reverted) | `logmind 2.0.0 (spec 2.0.0)` + `areas: orient, work, record, propagate, gates` — real newline |

The string is **copied verbatim** from `version.go`, not retyped. Re-checked at commit time: identical byte-for-byte.

`whitespace-pre-line` added to the one consumer so the embedded newline renders as a break rather than collapsing to a space.

## Build

`npm ci` (438 packages) and `npm run build` (Next.js 16.2.6, Turbopack, includes the TypeScript pass) both clean, before and after the temporary flip — 7 routes generated, no type errors.

`npm run lint` fails for want of an `eslint.config.*` file. **Confirmed pre-existing on `origin/dev`** — no eslint config is tracked in `site/` at all — and unrelated to this change.