### PR TITLE
fix(inserter): make a block body where a whole file belongs impossible to express

### DIFF
--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-inserter-make-a-block-body-where-a-whole-file-belongs-imposs -->
+- **2026-08-15** — inserter: make a block body where a whole file belongs impossible to express, and collapse the two marker extractors to one
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:00 - inserter: make a block body where a whole file belongs impossible to express, and collapse the two marker extractors to one
+
+**Reasoning:** Two issues turned out to be one class: a partial write landing on a whole artifact the user owns, against SPEC line 1101. Self-update passed a block body where ReplaceMarkerBlock's first parameter is the whole file, then wrote the result over all of AGENTS.md, destroying everything outside the markers. Doctor read the template marker from line one only while init scanned every line, so a marker displaced to line two was markerless to one and versioned to the other, and doctor --fix then overwrote the file it had misjudged.
+
+**Alternatives considered:** Correct the argument at the call site and align the two regexes. Rejected: both defects existed because the shapes permitted them. ReplaceMarkerBlock is now unexported, since returning its input unchanged when markers are absent is a safe contract for a pure function and a data-loss contract for anything that writes the result. RefreshMarkerBlockFile owns the read, so no whole-file parameter is left to get wrong, and OutdatedMarkerEntry's OldBody field is deleted because a struct offering a path and a body side by side is what made the wrong call look plausible.
+
+**Implications:**
+- The self-update call site was deleted rather than repaired: FindOutdatedMarkerBlocks only ever reported AGENTS.md, which EnsureAgentsMD had already refreshed through the same classifier, making it a second refresher of one path against SPEC 1.1. Being unreachable is why its wrong argument survived untested. First-line-only extraction wins, because any-line makes ownership a substring search and a substring search over a user's file claims it; a workflow merely quoting the marker in a heredoc would be adopted and then overwritten. Displacement becomes its own reported state rather than collapsing into markerless. Four mutations, all compiled, all died.
+
+---
+

--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -11,7 +11,7 @@
 **Alternatives considered:** Correct the argument at the call site and align the two regexes. Rejected: both defects existed because the shapes permitted them. ReplaceMarkerBlock is now unexported, since returning its input unchanged when markers are absent is a safe contract for a pure function and a data-loss contract for anything that writes the result. RefreshMarkerBlockFile owns the read, so no whole-file parameter is left to get wrong, and OutdatedMarkerEntry's OldBody field is deleted because a struct offering a path and a body side by side is what made the wrong call look plausible.
 
 **Implications:**
-- The self-update call site was deleted rather than repaired: FindOutdatedMarkerBlocks only ever reported AGENTS.md, which EnsureAgentsMD had already refreshed through the same classifier, making it a second refresher of one path against SPEC 1.1. Being unreachable is why its wrong argument survived untested. First-line-only extraction wins, because any-line makes ownership a substring search and a substring search over a user's file claims it; a workflow merely quoting the marker in a heredoc would be adopted and then overwritten. Displacement becomes its own reported state rather than collapsing into markerless. Four mutations, all compiled, all died.
+- The self-update call site was deleted rather than repaired: FindOutdatedMarkerBlocks only ever reported AGENTS.md, which EnsureAgentsMD had already refreshed through the same classifier, making it a second refresher of one path against SPEC 5.2. Being unreachable is why its wrong argument survived untested. First-line-only extraction wins, because any-line makes ownership a substring search and a substring search over a user's file claims it; a workflow merely quoting the marker in a heredoc would be adopted and then overwritten. Displacement becomes its own reported state rather than collapsing into markerless. Four mutations, all compiled, all died.
 
 ---
 
@@ -34,6 +34,17 @@
 
 **Implications:**
 - Both are whole-file overwrites with no append or partial semantics, so neither earns an exception. The explicit directory creation before the first was removed as redundant, since the primitive makes its own parent. Two mutations, both compiled, both died. One of the new tests plants a non-dangling symlink pointing at a real file elsewhere, which is the harder case: the read succeeds, so a guard that only considers dangling links would pass it.
+
+---
+
+## 2026-08-15 15:48 - guard the write primitive rather than the path, and close the escape doctor --fix still had
+
+**Reasoning:** The test I had accepted as strengthened was weaker than the one it replaced: the panel restored the literal defect this branch exists to fix and the test passed, as it did for four other real second writers, because it matched on how the path was spelled. Path spellings are unbounded and write primitives are a closed set, so the guard now parses the syntax tree for the primitives instead. All five evasions were replanted individually, each compiled, each went red. Separately the panel found doctor --fix still writing six thousand bytes outside the repository through a dangling symlink, in two branches of init that this branch had not touched.
+
+**Alternatives considered:** Replace the source scan with a behavioural test that fails when the file is written twice. Rejected on measurement rather than taste: with the defect restored, the byte-survival test still passes, because the offending loop finds nothing to do once the earlier refresh has run. That is precisely why the original defect survived untested, and it means no behavioural test can cover this class. The guard states that limit rather than implying completeness.
+
+**Implications:**
+- Seventeen citations pointing at section 1.1 were corrected to 5.2, including one in a string the user reads, after checking both sentences against the live specification rather than against another comment. The unreadable-binary case now reports that a logmind on the path could not be asked its version, instead of claiming the user owns an unmarked artifact. Two write sites in another lane's files are recorded in the allowlist with the finding written down rather than edited across a boundary, and a second guard of the same kind now exists in that lane, which is one list too many and is being folded into one.
 
 ---
 

--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -48,3 +48,14 @@
 
 ---
 
+## 2026-08-15 16:23 - init: one refused artifact must not cost the others, and a refusal must not be reported as success
+
+**Reasoning:** A symlinked workflow made init abandon the remaining three templates, exit zero, and print that the repository initialised successfully; re-running then claimed everything was already current, so the gap never healed. Self-update had the same shape from a different cause: the refusal was returned into a condition testing only for the absence of an error, with no branch for its presence, so the command reported templates up to date while the block stayed stale. Both are the failure this branch exists to prevent, reached through the error path rather than the write path.
+
+**Alternatives considered:** Keep the guard I built and patch its blind spots. Rejected: it matched the identifier spelled o-s, so an aliased import defeated it while the literal defect this branch fixes sat restored in the tree and the suite stayed green. It had traded a path spelling for a package spelling. The sibling lane already resolves primitives from the import declarations and keys its ledger by enclosing function, so this one is deleted rather than patched a third time, and what is temporarily uncovered is recorded rather than assumed closed.
+
+**Implications:**
+- The refusal is recorded on the existing declined list rather than a second one, and it lives in the shared loop body so every mode inherits it. Displacement became its own reported state on the probe, so a marker on the second line is no longer described as no marker at all, which the specification reserves for artifacts carrying none. Nothing unguarded remains in the affected trees today; the absent coverage is prospective only, and was measured rather than asserted.
+
+---
+

--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-15 14:50 - refresh: name a remedy that works, and route every inserter write through the symlink-refusing primitive
+
+**Reasoning:** The panel found the new refusal told the user to paste the bundled marker version as the file's first line, which is exactly the value installWorkflowTemplates treats as nothing to do, since it rewrites only on version inequality. The advice therefore guaranteed the file would never be refreshed again while doctor reported it current, and it was the only path the message offered. The working remedy, delete the file and re-run doctor --fix, was never mentioned. Verified end to end after the change: the file is left alone, the message names deletion, deleting and re-running regenerates the real gate body rather than the inert stub, and doctor then reports it current for a file that actually matches.
+
+**Alternatives considered:** Make doctor verify content rather than marker version, so a file claiming the current version with arbitrary content cannot be believed. Rejected on the SPEC: section 5.2 defines drift purely as a marker that does not match the current version, and reserves content hashing for catalog-subscribed items through skills-lock.json, a different artifact class. Marker-only freshness is the deliberate take-this-file-back escape hatch, consistent across workflows, hooks and the AGENTS.md block, so the message was the whole bug.
+
+**Implications:**
+- Five raw writes in inserter now route through atomicio.WriteFile, which refuses to follow a symlink; the line numbers in the report I was handed were wrong, and re-deriving them by exhaustive search found exactly five rather than the five named. The underlying hazard was reproduced directly: a dangling symlink at a managed path makes os.ReadFile return not-exist, the caller concludes the file is absent, and a bare os.WriteFile then creates it wherever the link points. Eight mutations, all compiled, all died, including one that plants a second AGENTS.md writer in a different file under a different symbol, which the previous single-file substring test would have missed.
+
+---
+

--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -59,3 +59,14 @@
 
 ---
 
+## 2026-08-15 21:42 - init: pin the four failure sites whose abort would have gone unnoticed
+
+**Reasoning:** Behaviour was correct at all seven sites in the install loop, but only three were pinned: mutating the other four from continue to return compiled cleanly and left the suite green. That is the abort-the-loop defect this branch spent three rounds removing, able to return through most of its own surface. The downgrade refusal matters most because it is not a failure-injection corner at all, it is the case the code's own comment documents, where an installed template is newer than the one the binary bundles.
+
+**Alternatives considered:** Rely on the three existing pins, since they cover the same loop. Rejected on measurement: the ownership test places its newer marker on the template that sorts last, so an abort there abandons nothing and the test cannot see it. Sort order decided whether a guard worked, which is exactly the kind of accident a passing test hides.
+
+**Implications:**
+- The downgrade site is pinned by the reachable scenario rather than a forced error, with the newer marker on the template that sorts first so an abort has three others left to abandon. Two of the four need injection because there is no natural way to fail a brand-new file's write; one uses a directory in the file's place rather than permission bits, so it runs the same on every machine and needs no root check. All four mutations compiled and died, and the three earlier pins stayed green throughout, so the new coverage sits alongside the old rather than displacing it.
+
+---
+

--- a/docs/decisions-branches/fix__marker-block-overwrite.md
+++ b/docs/decisions-branches/fix__marker-block-overwrite.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-15 14:55 - inserter: two more raw writes in dependabot.go, found by a sweep of the whole tree rather than of this package
+
+**Reasoning:** The earlier pass routed five sites and recorded that as the whole of this package, which was wrong. A tree-wide sweep found two more in dependabot.go: a create branch reading not-exist as absent, the same shape as the AGENTS.md create path, and a merge branch overwriting the whole file after a successful read. Neither was in the panel report or in my brief, because both were derived from a list of this file rather than from a search of the package. A count taken from a report is not a measurement.
+
+**Alternatives considered:** Leave them to the sweep lane that found them. Rejected: that lane deliberately reported them as an unowned gap rather than editing a package another branch held, which is the right instinct, and the fix belongs where the surrounding tests and the rest of the routing already are.
+
+**Implications:**
+- Both are whole-file overwrites with no append or partial semantics, so neither earns an exception. The explicit directory creation before the first was removed as redundant, since the primitive makes its own parent. Two mutations, both compiled, both died. One of the new tests plants a non-dangling symlink pointing at a real file elsewhere, which is the harder case: the read succeeds, so a guard that only considers dangling links would pass it.
+
+---
+

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -388,14 +388,11 @@ func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout, stderr io
 		return nil
 	}
 
-	// Apply path: rewrite each file in place.
+	// Apply path: rewrite each file in place through the one write
+	// primitive, which owns the read, requires the markers to actually be
+	// there, and writes the WHOLE file back (#297).
 	for _, e := range outdated {
-		data, err := os.ReadFile(e.Path)
-		if err != nil {
-			return err
-		}
-		refreshed := inserter.ReplaceMarkerBlock(string(data), e.NewBody)
-		if err := os.WriteFile(e.Path, []byte(refreshed), 0o644); err != nil {
+		if err := inserter.RefreshMarkerBlockFile(e.Path, e.NewBody); err != nil {
 			return err
 		}
 		rel, _ := filepath.Rel(cwd, e.Path)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -154,14 +154,14 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 
 // residualCause names WHY a residual probe is still drifted after --fix, so
 // the note printed for it is accurate rather than a one-size-fits-all guess.
-// The three residualProbes drift values mean three different things:
+// The four residualProbes drift values mean four different things:
 //
 //   - "stale" — an actual version mismatch --fix cannot resolve on its own
 //     (the PATH binary, or a hook whose installed version trails the one
 //     running).
 //   - "foreign" — a hand-written git hook occupies the path; --fix leaves a
 //     foreign hook alone by design (see probePreCommitHook).
-//   - "markerless" — SPEC §1.1: the artifact carries no marker (or a
+//   - "markerless" — SPEC §5.2: the artifact carries no marker (or a
 //     displaced one) --fix is willing to act on, so it is the user's and was
 //     left untouched. Before #306 this row was invisible because --fix
 //     silently overwrote exactly this case; now that it is refused and
@@ -169,12 +169,20 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 //     hook" is only true of the "foreign" case above, and a bare workflow or
 //     AGENTS.md block with no marker is neither PATH/version drift nor a
 //     hook at all.
+//   - "unreadable" — a logmind IS on PATH but its `--version` could not be
+//     executed or could not be parsed (probePathResolution). This case used
+//     to be filed as "markerless" too, which made the note above claim SPEC
+//     §5.2 ownership over a binary on PATH — an artifact that has no marker
+//     concept in the first place, and that logmind never claims to own. The
+//     row is real drift; only its stated cause was wrong.
 func residualCause(drift string) string {
 	switch drift {
 	case "foreign":
 		return "still drifted — a hand-written hook is installed in its place, which `doctor --fix` leaves alone"
 	case "markerless":
-		return "still drifted — it carries no logmind marker `doctor --fix` can act on, so SPEC §1.1 treats it as yours and leaves it alone"
+		return "still drifted — it carries no logmind marker `doctor --fix` can act on, so SPEC §5.2 treats it as yours and leaves it alone"
+	case "unreadable":
+		return "still drifted — a logmind is on PATH but its `--version` could not be read, so `doctor --fix` cannot tell whether it matches the running binary"
 	default: // "stale"
 		return "still drifted — not auto-fixable by `doctor --fix` (PATH/version)"
 	}
@@ -199,15 +207,16 @@ func driftCount(r doctor.StatusReport) int {
 
 // residualProbes returns the probes still drifted after a fix pass: PATH/
 // version drift ("stale"), an unmarked or displaced-marker artifact --fix
-// refuses to touch per SPEC §1.1 ("markerless"), and a hand-written hook
-// occupying a managed path ("foreign") — three different reasons --fix
+// refuses to touch per SPEC §5.2 ("markerless"), a hand-written hook
+// occupying a managed path ("foreign"), and a PATH binary whose --version
+// could not be read ("unreadable") — four different reasons --fix
 // deliberately leaves the row alone. Callers that need to explain WHY use
 // residualCause(wf.Drift) rather than assuming any single cause.
 func residualProbes(r doctor.StatusReport) []doctor.WorkflowStatus {
 	var out []doctor.WorkflowStatus
 	for _, t := range r.Tools {
 		for _, wf := range t.Workflows {
-			if wf.Drift == "stale" || wf.Drift == "markerless" || wf.Drift == "foreign" {
+			if wf.Drift == "stale" || wf.Drift == "markerless" || wf.Drift == "foreign" || wf.Drift == "unreadable" {
 				out = append(out, wf)
 			}
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -145,13 +145,39 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		return nil
 	}
 
-	cmd.Println(formatDoctorFixOK(res, residual, summariesBackfilled))
-	for _, name := range residual {
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"note: %q still drifted — not auto-fixable by `doctor --fix` "+
-				"(PATH/version, or a hand-written hook). See `logmind doctor`.\n", name)
+	cmd.Println(formatDoctorFixOK(res, len(residual), summariesBackfilled))
+	for _, wf := range residual {
+		fmt.Fprintf(cmd.ErrOrStderr(), "note: %q %s. See `logmind doctor`.\n", wf.Name, residualCause(wf.Drift))
 	}
 	return nil
+}
+
+// residualCause names WHY a residual probe is still drifted after --fix, so
+// the note printed for it is accurate rather than a one-size-fits-all guess.
+// The three residualProbes drift values mean three different things:
+//
+//   - "stale" — an actual version mismatch --fix cannot resolve on its own
+//     (the PATH binary, or a hook whose installed version trails the one
+//     running).
+//   - "foreign" — a hand-written git hook occupies the path; --fix leaves a
+//     foreign hook alone by design (see probePreCommitHook).
+//   - "markerless" — SPEC §1.1: the artifact carries no marker (or a
+//     displaced one) --fix is willing to act on, so it is the user's and was
+//     left untouched. Before #306 this row was invisible because --fix
+//     silently overwrote exactly this case; now that it is refused and
+//     correctly reported, it needs its own explanation — "a hand-written
+//     hook" is only true of the "foreign" case above, and a bare workflow or
+//     AGENTS.md block with no marker is neither PATH/version drift nor a
+//     hook at all.
+func residualCause(drift string) string {
+	switch drift {
+	case "foreign":
+		return "still drifted — a hand-written hook is installed in its place, which `doctor --fix` leaves alone"
+	case "markerless":
+		return "still drifted — it carries no logmind marker `doctor --fix` can act on, so SPEC §1.1 treats it as yours and leaves it alone"
+	default: // "stale"
+		return "still drifted — not auto-fixable by `doctor --fix` (PATH/version)"
+	}
 }
 
 // driftCount counts probe rows that are "stale" — the drift signal that flips
@@ -171,15 +197,18 @@ func driftCount(r doctor.StatusReport) int {
 	return n
 }
 
-// residualProbes returns the names of probes still drifted after a fix pass:
-// PATH/version drift and foreign (markerless, or — for the pre-commit hook
-// specifically — "foreign") hooks, which --fix deliberately does not touch.
-func residualProbes(r doctor.StatusReport) []string {
-	var out []string
+// residualProbes returns the probes still drifted after a fix pass: PATH/
+// version drift ("stale"), an unmarked or displaced-marker artifact --fix
+// refuses to touch per SPEC §1.1 ("markerless"), and a hand-written hook
+// occupying a managed path ("foreign") — three different reasons --fix
+// deliberately leaves the row alone. Callers that need to explain WHY use
+// residualCause(wf.Drift) rather than assuming any single cause.
+func residualProbes(r doctor.StatusReport) []doctor.WorkflowStatus {
+	var out []doctor.WorkflowStatus
 	for _, t := range r.Tools {
 		for _, wf := range t.Workflows {
 			if wf.Drift == "stale" || wf.Drift == "markerless" || wf.Drift == "foreign" {
-				out = append(out, wf.Name)
+				out = append(out, wf)
 			}
 		}
 	}
@@ -210,7 +239,7 @@ func claudeAgentEnabledFromConfig(cwd string) bool {
 }
 
 // formatDoctorFixOK renders the single quiet `ok` summary line.
-func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled int) string {
+func formatDoctorFixOK(res refreshResult, residualCount, summariesBackfilled int) string {
 	state := func(changed bool, changedWord string) string {
 		if changed {
 			return changedWord
@@ -226,7 +255,7 @@ func formatDoctorFixOK(res refreshResult, residual []string, summariesBackfilled
 		len(res.HooksRefreshed),
 		state(res.ClaudeHookChanged, "changed"),
 		summariesBackfilled,
-		len(residual),
+		residualCount,
 	)
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -104,17 +104,29 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 		git:                true,
 		claudeAgentEnabled: claudeAgentEnabledFromConfig(cwd),
 	})
+	// Refused workflow downgrades (#286), a refused AGENTS.md block refresh
+	// (#267) and a path --fix could not write at all (#306) — printed BEFORE
+	// the failure check and BEFORE the --json branch below: these are refusals
+	// the user must see on every surface, and stderr never pollutes the JSON
+	// document on stdout. The run that is ABOUT TO FAIL is exactly the run
+	// whose partial results have no other way of reaching the user: --fix
+	// installs the remaining templates now, and returning first reported that
+	// as a total failure.
+	reportTemplateDowngrades(cmd.ErrOrStderr(), res.WorkflowsDeclined)
+	reportAgentsBlockRefusal(cmd.ErrOrStderr(), res.AgentsMDDeclined)
+
 	if refreshErr != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "error: doctor --fix:", refreshErr)
 		return ErrSilent
 	}
-
-	// Refused workflow downgrades (#286) and a refused AGENTS.md block
-	// refresh (#267) — printed BEFORE the --json branch below: these are
-	// refusals the user must see on every surface, and stderr never
-	// pollutes the JSON document on stdout.
-	reportTemplateDowngrades(cmd.ErrOrStderr(), res.WorkflowsDeclined)
-	reportAgentsBlockRefusal(cmd.ErrOrStderr(), res.AgentsMDDeclined)
+	// A path --fix could not write is a FAILED fix, not a repository state it
+	// may report an `ok` line over — the notes above named each one. The
+	// ownership refusals (markerless / displaced / ahead) deliberately do NOT
+	// land here: those are stable states --fix is correct to leave alone, and
+	// they surface as residual rows below.
+	if unwritableCount(res.WorkflowsDeclined) > 0 {
+		return ErrSilent
+	}
 
 	// Backfill the §1.6.3 timeline marker into any markerless branch detail
 	// file (main-canonical only) — the deterministic structural half of the
@@ -147,7 +159,7 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 
 	cmd.Println(formatDoctorFixOK(res, len(residual), summariesBackfilled))
 	for _, wf := range residual {
-		fmt.Fprintf(cmd.ErrOrStderr(), "note: %q %s. See `logmind doctor`.\n", wf.Name, residualCause(wf.Drift))
+		fmt.Fprintf(cmd.ErrOrStderr(), "note: %q %s. See `logmind doctor`.\n", wf.Name, residualCause(wf))
 	}
 	return nil
 }
@@ -161,25 +173,40 @@ func runDoctorFix(cmd *cobra.Command, offline, asJSON bool) error {
 //     running).
 //   - "foreign" — a hand-written git hook occupies the path; --fix leaves a
 //     foreign hook alone by design (see probePreCommitHook).
-//   - "markerless" — SPEC §5.2: the artifact carries no marker (or a
-//     displaced one) --fix is willing to act on, so it is the user's and was
-//     left untouched. Before #306 this row was invisible because --fix
-//     silently overwrote exactly this case; now that it is refused and
-//     correctly reported, it needs its own explanation — "a hand-written
-//     hook" is only true of the "foreign" case above, and a bare workflow or
-//     AGENTS.md block with no marker is neither PATH/version drift nor a
-//     hook at all.
+//   - "markerless" — SPEC §5.2: the artifact carries no marker --fix is
+//     willing to act on, so it is the user's and was left untouched. Before
+//     #306 this row was invisible because --fix silently overwrote exactly
+//     this case; now that it is refused and correctly reported, it needs its
+//     own explanation — "a hand-written hook" is only true of the "foreign"
+//     case above, and a bare workflow or AGENTS.md block with no marker is
+//     neither PATH/version drift nor a hook at all.
 //   - "unreadable" — a logmind IS on PATH but its `--version` could not be
 //     executed or could not be parsed (probePathResolution). This case used
 //     to be filed as "markerless" too, which made the note above claim SPEC
 //     §5.2 ownership over a binary on PATH — an artifact that has no marker
 //     concept in the first place, and that logmind never claims to own. The
 //     row is real drift; only its stated cause was wrong.
-func residualCause(drift string) string {
-	switch drift {
+//
+// "markerless" is then SPLIT AGAIN, by WorkflowStatus.Displaced: it is one
+// VERDICT covering two different facts, and only one of them is an ownership
+// claim. SPEC §5.2 gives the file to the user when it carries "no marker at
+// all" — a marker sitting on line 2 is not that. Reporting both under the
+// ownership sentence made a single `doctor --fix` run print, of one file,
+// both "its marker is on line 2, not line 1, so logmind cannot tell whether
+// the file is yours or its own" and "it carries no logmind marker … so SPEC
+// §5.2 treats it as yours" — two mutually exclusive accounts of one refusal.
+func residualCause(wf doctor.WorkflowStatus) string {
+	switch wf.Drift {
 	case "foreign":
 		return "still drifted — a hand-written hook is installed in its place, which `doctor --fix` leaves alone"
 	case "markerless":
+		if wf.Displaced {
+			// NOT the §5.2 ownership sentence: this file does carry a marker,
+			// so §5.2's "no marker at all" does not apply to it. Matches the
+			// declineDisplaced note reportTemplateDowngrades prints for the
+			// same file in the same run — one refusal, one account of it.
+			return "still drifted — it carries a logmind marker, but not on line 1, so `doctor --fix` cannot tell whether the file is yours or its own and leaves it alone"
+		}
 		return "still drifted — it carries no logmind marker `doctor --fix` can act on, so SPEC §5.2 treats it as yours and leaves it alone"
 	case "unreadable":
 		return "still drifted — a logmind is on PATH but its `--version` could not be read, so `doctor --fix` cannot tell whether it matches the running binary"

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -423,7 +423,7 @@ const (
 	// declineDowngrade — the file carries a NEWER marker than this binary
 	// bundles (#286). Ours, but ahead of us.
 	declineDowngrade declineReason = iota
-	// declineUnmarked — no logmind marker at all. SPEC §1.1: the artifact
+	// declineUnmarked — no logmind marker at all. SPEC §5.2: the artifact
 	// belongs to the user and MUST NOT be overwritten.
 	declineUnmarked
 	// declineDisplaced — a marker exists but not on line 1 (#299). Neither
@@ -467,7 +467,17 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		body := renderWorkflowTemplate(templates.Workflow(tmpl))
 		existing, err := os.ReadFile(target)
 		if errors.Is(err, fs.ErrNotExist) {
-			if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+			// ENOENT-AS-ABSENT (#306). os.ReadFile FOLLOWS a symlink, so a
+			// DANGLING symlink at target — one pointing at a path that does
+			// not exist — lands here reporting fs.ErrNotExist, exactly as a
+			// genuinely missing file does. A bare os.WriteFile then follows
+			// that same link and creates the rendered workflow wherever it
+			// points, which need not be inside the repo, while --fix reports
+			// `workflows=1` as though it had installed one. Same shape as
+			// inserter.EnsureDependabot's create branch. atomicio.WriteFile
+			// refuses instead (atomicio.RefuseSymlink) and makes its own
+			// parent directory.
+			if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
 				return nil, nil, nil, err
 			}
 			created = append(created, relativePath(repoRoot, target))
@@ -522,7 +532,13 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 				})
 				continue
 			}
-			if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+			// The refresh branch's symlink case (#306): a NON-dangling
+			// symlink at target reads fine through os.ReadFile above and
+			// carries a real, stale-looking marker, so control arrives here
+			// and a bare os.WriteFile would rewrite whatever file the link
+			// points at — a file logmind did not install and does not own.
+			// Refuse rather than guess, same as the create branch above.
+			if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
 				return nil, nil, nil, err
 			}
 			refreshed = append(refreshed, relativePath(repoRoot, target))
@@ -647,10 +663,13 @@ func ensureGitignoreBlock(path string) (bool, error) {
 	if existing != "" && !strings.HasSuffix(existing, "\n\n") {
 		existing += "\n"
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return false, err
-	}
-	if err := os.WriteFile(path, []byte(existing+b.String()), 0o644); err != nil {
+	// Through writeFile (atomicio) for the same reason as the workflow
+	// installs above: os.ReadFile at the top of this function follows a
+	// symlink, so a link planted at .gitignore reads as an ordinary file and
+	// a bare os.WriteFile would append logmind's block into whatever it
+	// points at. atomicio.WriteFile refuses, and makes its own parent
+	// directory — so the explicit MkdirAll this replaced is no longer needed.
+	if err := writeFile(path, existing+b.String()); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -673,7 +692,10 @@ func logFirstDecision(docsPath string) error {
 	// The template ends with `---\n`. Append entry directly so the
 	// `## YYYY-MM-DD ...` line sits on the next line, matching Python.
 	newContent := strings.TrimRight(string(existing), "\n") + "\n" + entry + "\n"
-	return os.WriteFile(path, []byte(newContent), 0o644)
+	// atomicio via writeFile: docs/decisions.md is the decision record itself,
+	// so a torn write here loses history, and a symlink at the path would send
+	// the first decision somewhere logmind does not own.
+	return writeFile(path, newContent)
 }
 
 // buildFirstDecisionEntry renders the same markdown shape Python's

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -413,14 +413,34 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 	return nil
 }
 
-// templateDowngrade records one REFUSED workflow refresh: the file on disk
-// carries a newer `# logmind-template-version:` marker than this binary
-// bundles, so installWorkflowTemplates left it alone. Reported by both
-// callers (init refresh mode, doctor --fix) — never silent.
+// declineReason says WHY installWorkflowTemplates left an existing file
+// alone. One list with a reason, rather than one list per reason: two lists
+// that both mean "we declined to write this path" are two lists that will
+// disagree about whether a path is on them.
+type declineReason int
+
+const (
+	// declineDowngrade — the file carries a NEWER marker than this binary
+	// bundles (#286). Ours, but ahead of us.
+	declineDowngrade declineReason = iota
+	// declineUnmarked — no logmind marker at all. SPEC §1.1: the artifact
+	// belongs to the user and MUST NOT be overwritten.
+	declineUnmarked
+	// declineDisplaced — a marker exists but not on line 1 (#299). Neither
+	// clearly ours nor clearly theirs, so it is refused and named rather
+	// than guessed at.
+	declineDisplaced
+)
+
+// templateDowngrade records one REFUSED workflow refresh: installWorkflowTemplates
+// left the file on disk byte-for-byte alone. Reported by both callers (init
+// refresh mode, doctor --fix) — never silent.
 type templateDowngrade struct {
-	Path      string // rel path from repo root
-	Installed string // marker found on disk, e.g. "v11"
-	Bundled   string // marker this binary ships, e.g. "v4"
+	Path      string        // rel path from repo root
+	Installed string        // marker found on disk, e.g. "v11"; "" when there is none
+	Bundled   string        // marker this binary ships, e.g. "v4"
+	Reason    declineReason // why the write was refused
+	Line      int           // 1-based line the marker sat on; only meaningful for declineDisplaced
 }
 
 // installWorkflowTemplates copies internal/templates/github/*.yml.template
@@ -459,8 +479,27 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		if !refresh {
 			continue
 		}
-		installedVer := extractTemplateVersion(string(existing))
-		bundledVer := extractTemplateVersion(body)
+		// OWNERSHIP FIRST (#299). Whether we may write this path at all is a
+		// separate question from whether its version is behind ours, and it
+		// is answered by the same extractor `doctor` reports from — so a file
+		// doctor calls the user's can no longer be one --fix overwrites.
+		installed := inserter.ExtractTemplateMarker(string(existing))
+		if !installed.Writable() {
+			reason := declineUnmarked
+			if installed.Ownership == inserter.MarkerDisplaced {
+				reason = declineDisplaced
+			}
+			declined = append(declined, templateDowngrade{
+				Path:      relativePath(repoRoot, target),
+				Installed: installed.Version,
+				Bundled:   inserter.ExtractTemplateMarker(body).Version,
+				Reason:    reason,
+				Line:      installed.Line,
+			})
+			continue
+		}
+		installedVer := installed.Version
+		bundledVer := inserter.ExtractTemplateMarker(body).Version
 		if installedVer != "" && bundledVer != "" && installedVer != bundledVer {
 			// ORDER, not inequality (#286). A released binary bundles OLDER
 			// markers than dev (`brew install logmind` → v1.2.0 → v4 while
@@ -479,6 +518,7 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 					Path:      relativePath(repoRoot, target),
 					Installed: installedVer,
 					Bundled:   bundledVer,
+					Reason:    declineDowngrade,
 				})
 				continue
 			}
@@ -501,18 +541,16 @@ func renderWorkflowTemplate(text string) string {
 	return strings.ReplaceAll(text, "__LOGMIND_VERSION__", version.Version)
 }
 
-// extractTemplateVersion reads the `# logmind-template-version: vN` line.
-// Returns "" when no marker is present (the user stripped it; treat as
-// customised).
-func extractTemplateVersion(text string) string {
-	for _, line := range strings.Split(text, "\n") {
-		const prefix = "# logmind-template-version:"
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
-		}
-	}
-	return ""
-}
+// extractTemplateVersion is GONE — see inserter.ExtractTemplateMarker (#299).
+//
+// It prefix-matched every line of the file, while internal/doctor matched an
+// anchored regex against line 1 only. A workflow whose marker sat on line 2
+// was markerless to the reporter and versioned to the writer, so `doctor`
+// printed "markerless" and `doctor --fix` then overwrote the file — the
+// component that DECIDED the rule was not the component that APPLIED it.
+// Both now call one extractor, which also settles a second disagreement the
+// two had: on `# logmind-template-version: v1 junk`, the prefix form yielded
+// "v1 junk" as the version token and the regex form yielded "v1".
 
 // parseTemplateVersion extracts the ORDERING key from a template marker:
 // "v11" → 11, "v9-pointer" → 9. Only the numeric generation orders — a

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -412,14 +412,34 @@ func runInitRefresh(cmd *cobra.Command, f *initFlags, cwd, docsPath string, clau
 	return nil
 }
 
-// templateDowngrade records one REFUSED workflow refresh: the file on disk
-// carries a newer `# logmind-template-version:` marker than this binary
-// bundles, so installWorkflowTemplates left it alone. Reported by both
-// callers (init refresh mode, doctor --fix) — never silent.
+// declineReason says WHY installWorkflowTemplates left an existing file
+// alone. One list with a reason, rather than one list per reason: two lists
+// that both mean "we declined to write this path" are two lists that will
+// disagree about whether a path is on them.
+type declineReason int
+
+const (
+	// declineDowngrade — the file carries a NEWER marker than this binary
+	// bundles (#286). Ours, but ahead of us.
+	declineDowngrade declineReason = iota
+	// declineUnmarked — no logmind marker at all. SPEC §1.1: the artifact
+	// belongs to the user and MUST NOT be overwritten.
+	declineUnmarked
+	// declineDisplaced — a marker exists but not on line 1 (#299). Neither
+	// clearly ours nor clearly theirs, so it is refused and named rather
+	// than guessed at.
+	declineDisplaced
+)
+
+// templateDowngrade records one REFUSED workflow refresh: installWorkflowTemplates
+// left the file on disk byte-for-byte alone. Reported by both callers (init
+// refresh mode, doctor --fix) — never silent.
 type templateDowngrade struct {
-	Path      string // rel path from repo root
-	Installed string // marker found on disk, e.g. "v11"
-	Bundled   string // marker this binary ships, e.g. "v4"
+	Path      string        // rel path from repo root
+	Installed string        // marker found on disk, e.g. "v11"; "" when there is none
+	Bundled   string        // marker this binary ships, e.g. "v4"
+	Reason    declineReason // why the write was refused
+	Line      int           // 1-based line the marker sat on; only meaningful for declineDisplaced
 }
 
 // installWorkflowTemplates copies internal/templates/github/*.yml.template
@@ -458,8 +478,27 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 		if !refresh {
 			continue
 		}
-		installedVer := extractTemplateVersion(string(existing))
-		bundledVer := extractTemplateVersion(body)
+		// OWNERSHIP FIRST (#299). Whether we may write this path at all is a
+		// separate question from whether its version is behind ours, and it
+		// is answered by the same extractor `doctor` reports from — so a file
+		// doctor calls the user's can no longer be one --fix overwrites.
+		installed := inserter.ExtractTemplateMarker(string(existing))
+		if !installed.Writable() {
+			reason := declineUnmarked
+			if installed.Ownership == inserter.MarkerDisplaced {
+				reason = declineDisplaced
+			}
+			declined = append(declined, templateDowngrade{
+				Path:      relativePath(repoRoot, target),
+				Installed: installed.Version,
+				Bundled:   inserter.ExtractTemplateMarker(body).Version,
+				Reason:    reason,
+				Line:      installed.Line,
+			})
+			continue
+		}
+		installedVer := installed.Version
+		bundledVer := inserter.ExtractTemplateMarker(body).Version
 		if installedVer != "" && bundledVer != "" && installedVer != bundledVer {
 			// ORDER, not inequality (#286). A released binary bundles OLDER
 			// markers than dev (`brew install logmind` → v1.2.0 → v4 while
@@ -478,6 +517,7 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 					Path:      relativePath(repoRoot, target),
 					Installed: installedVer,
 					Bundled:   bundledVer,
+					Reason:    declineDowngrade,
 				})
 				continue
 			}
@@ -500,18 +540,16 @@ func renderWorkflowTemplate(text string) string {
 	return strings.ReplaceAll(text, "__LOGMIND_VERSION__", version.Version)
 }
 
-// extractTemplateVersion reads the `# logmind-template-version: vN` line.
-// Returns "" when no marker is present (the user stripped it; treat as
-// customised).
-func extractTemplateVersion(text string) string {
-	for _, line := range strings.Split(text, "\n") {
-		const prefix = "# logmind-template-version:"
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
-		}
-	}
-	return ""
-}
+// extractTemplateVersion is GONE — see inserter.ExtractTemplateMarker (#299).
+//
+// It prefix-matched every line of the file, while internal/doctor matched an
+// anchored regex against line 1 only. A workflow whose marker sat on line 2
+// was markerless to the reporter and versioned to the writer, so `doctor`
+// printed "markerless" and `doctor --fix` then overwrote the file — the
+// component that DECIDED the rule was not the component that APPLIED it.
+// Both now call one extractor, which also settles a second disagreement the
+// two had: on `# logmind-template-version: v1 junk`, the prefix form yielded
+// "v1 junk" as the version token and the regex form yielded "v1".
 
 // parseTemplateVersion extracts the ORDERING key from a template marker:
 // "v11" → 11, "v9-pointer" → 9. Only the numeric generation orders — a

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -182,11 +182,22 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 	// A first-time init normally CREATES AGENTS.md, but a repo can already
 	// carry a block written by a newer binary (a partially-migrated fleet,
 	// #257) — so this surface reports the refusal too.
-	if msg, declined, err := inserter.EnsureAgentsMD(cwd); err == nil {
+	//
+	// unwritten counts the artifacts init WANTED and could not have. It is
+	// what stops the two summary lines at the bottom from claiming a success
+	// that did not happen (#306) — before it existed, an AGENTS.md or a
+	// workflow that refused to be written was a discarded error and a
+	// "logmind initialized successfully!".
+	unwritten := 0
+	msg, agentsDeclined, err := inserter.EnsureAgentsMD(cwd)
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "note: AGENTS.md was NOT written —", err)
+		unwritten++
+	} else {
 		if msg != "" {
 			fmt.Fprintln(out, msg)
 		}
-		reportAgentsBlockRefusal(cmd.ErrOrStderr(), declined)
+		reportAgentsBlockRefusal(cmd.ErrOrStderr(), agentsDeclined)
 	}
 	for _, agentName := range enabled {
 		filePath, err := inserter.CreateAgentFile(agentName, cwd)
@@ -202,20 +213,28 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 	}
 
-	// GitHub workflows.
+	// GitHub workflows. workflowsUnwritten is counted separately from the
+	// `unwritten` total above because the receipt reports a workflows RATIO,
+	// and an AGENTS.md that could not be written is not a workflow.
 	var installedWorkflows []string
+	workflowsUnwritten := 0
 	var dependabotChanged bool
 	if f.githubActions {
-		// Fresh install: refresh=false never overwrites, so the declined
-		// list is always empty here — only the refresh surfaces can hit a
-		// downgrade.
-		created, _, _, err := installWorkflowTemplates(cwd, false)
+		// Fresh install: refresh=false never overwrites, so no VERSION or
+		// OWNERSHIP decline can happen here — but a declineUnwritable can
+		// (#306), and it must be reported and counted rather than aborting
+		// the other templates.
+		created, _, declined, err := installWorkflowTemplates(cwd, false)
 		if err != nil {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: workflow install failed:", err)
+			unwritten++
 		}
 		for _, wf := range created {
 			fmt.Fprintln(out, "✓ Created", wf)
 		}
+		reportTemplateDowngrades(cmd.ErrOrStderr(), declined)
+		workflowsUnwritten = unwritableCount(declined)
+		unwritten += workflowsUnwritten
 		installedWorkflows = created
 
 		// .github/dependabot.yml — fresh install or merge. Keeps the
@@ -336,13 +355,28 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 	}
 
+	// THE SUMMARY MUST MATCH WHAT LANDED (#306). Both of these lines used to
+	// be unconditional, so a run that installed one of four workflows — or
+	// none — still said "successfully" and still listed `workflows` among the
+	// things it had written. The happy path is byte-identical to what it has
+	// always been; only a run with something unwritten reads differently, and
+	// it names the count so the notes on stderr can be found.
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "logmind initialized successfully!")
+	if unwritten > 0 {
+		fmt.Fprintf(out, "logmind initialized, but %d artifact(s) could NOT be written — see the notes on stderr.\n", unwritten)
+	} else {
+		fmt.Fprintln(out, "logmind initialized successfully!")
+	}
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Start logging decisions with:")
 	fmt.Fprintln(out, "  logmind log \"Your decision here\" -r \"why\" -a \"alternative\" -i \"implication\"")
 	fmt.Fprintln(out)
-	fmt.Fprintf(out, "ok initialized: docs/ .logmind/ workflows @v%s\n", version.Version)
+	if unwritten > 0 {
+		fmt.Fprintf(out, "ok initialized: docs/ .logmind/ workflows=%d/%d unwritten=%d @v%s\n",
+			len(installedWorkflows), len(installedWorkflows)+workflowsUnwritten, unwritten, version.Version)
+	} else {
+		fmt.Fprintf(out, "ok initialized: docs/ .logmind/ workflows @v%s\n", version.Version)
+	}
 	return nil
 }
 
@@ -430,6 +464,19 @@ const (
 	// clearly ours nor clearly theirs, so it is refused and named rather
 	// than guessed at.
 	declineDisplaced
+	// declineUnwritable — logmind wanted this file and could not have it
+	// (#306): a symlink at the destination, an unreadable existing file, an
+	// I/O failure. Not a judgement about the file's marker like the three
+	// above, but it lands on the SAME list for the reason the type comment
+	// gives — every one of them means "we did not write this path", and two
+	// lists that mean that are two lists that will disagree.
+	//
+	// It is on the list rather than being an early `return err` because a
+	// refusal on ONE template used to abandon the other three: with a symlink
+	// at check-decisions.yml (first alphabetically), `init` exited 0, said
+	// "logmind initialized successfully!", and never installed
+	// check-doc-links, regen-timeline or logmind-self-update at all.
+	declineUnwritable
 )
 
 // templateDowngrade records one REFUSED workflow refresh: installWorkflowTemplates
@@ -441,6 +488,7 @@ type templateDowngrade struct {
 	Bundled   string        // marker this binary ships, e.g. "v4"
 	Reason    declineReason // why the write was refused
 	Line      int           // 1-based line the marker sat on; only meaningful for declineDisplaced
+	Err       error         // the refusal itself; only set for declineUnwritable
 }
 
 // installWorkflowTemplates copies internal/templates/github/*.yml.template
@@ -453,6 +501,14 @@ type templateDowngrade struct {
 //
 // Returns (created, refreshed, declined, err). Each list is a slice of
 // relative paths from cwd; declined additionally names both markers.
+//
+// PER-TEMPLATE FAILURES DO NOT ABORT THE LOOP (#306). A refusal on one
+// artifact is recorded as a declineUnwritable entry and the remaining
+// templates are still installed; `err` is reserved for a failure that makes
+// EVERY template impossible (the workflows directory itself). The previous
+// shape returned `nil, nil, nil, err` from inside the loop, so a symlink at
+// check-decisions.yml — first alphabetically — silently cost the user the
+// other three workflows while `init` reported success.
 func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string, []templateDowngrade, error) {
 	workflowsDir := filepath.Join(repoRoot, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
@@ -478,13 +534,23 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 			// refuses instead (atomicio.RefuseSymlink) and makes its own
 			// parent directory.
 			if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
-				return nil, nil, nil, err
+				declined = append(declined, templateDowngrade{
+					Path:   relativePath(repoRoot, target),
+					Reason: declineUnwritable,
+					Err:    err,
+				})
+				continue
 			}
 			created = append(created, relativePath(repoRoot, target))
 			continue
 		}
 		if err != nil {
-			return nil, nil, nil, err
+			declined = append(declined, templateDowngrade{
+				Path:   relativePath(repoRoot, target),
+				Reason: declineUnwritable,
+				Err:    err,
+			})
+			continue
 		}
 		if !refresh {
 			continue
@@ -539,7 +605,14 @@ func installWorkflowTemplates(repoRoot string, refresh bool) ([]string, []string
 			// points at — a file logmind did not install and does not own.
 			// Refuse rather than guess, same as the create branch above.
 			if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
-				return nil, nil, nil, err
+				declined = append(declined, templateDowngrade{
+					Path:      relativePath(repoRoot, target),
+					Installed: installedVer,
+					Bundled:   bundledVer,
+					Reason:    declineUnwritable,
+					Err:       err,
+				})
+				continue
 			}
 			refreshed = append(refreshed, relativePath(repoRoot, target))
 			continue

--- a/internal/cli/init_refresh_flag_test.go
+++ b/internal/cli/init_refresh_flag_test.go
@@ -609,6 +609,287 @@ func TestInitRefresh_DoesNotClaimAllCurrentOverAFileItSkipped(t *testing.T) {
 	}
 }
 
+// TestInitRefresh_CreateWriteFailureDoesNotAbortTheRest pins the CREATE-arm
+// write failure at installWorkflowTemplatesMode's os.ReadFile ErrNotExist
+// branch (#306's create-write site, line ~694): a file that does not exist
+// yet, whose write to bring it into existence fails.
+//
+// Reached only via injection — there is no repository state that makes a
+// brand-new file's write fail on its own; a read-only target directory is
+// the same class of failure the two already-pinned write sites (RefuseSymlink,
+// force-write) use, and it is unavoidable for this site specifically because
+// the site exists only to handle "the write itself failed", which is
+// necessarily a filesystem condition rather than a content one.
+//
+// The directory is pre-created and chmod'd BEFORE `init` runs, so
+// installWorkflowTemplatesMode's own os.MkdirAll — which only needs to see
+// the directory already exists, not write into it — still succeeds, and
+// every template (the directory is empty) hits the CREATE branch rather than
+// a version-compare branch below it. A `return` at the write-failure site
+// would abandon every template after the first alphabetically before it was
+// ever attempted at all — the fresh-install analogue of
+// TestInitRefresh_EveryWriteFailureIsRecordedNotAborted.
+func TestInitRefresh_CreateWriteFailureDoesNotAbortTheRest(t *testing.T) {
+	dir := t.TempDir()
+	seedRepo(t, dir, "release")
+
+	wfDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(wfDir, 0o555); err != nil {
+		t.Skipf("cannot make the workflows directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(wfDir, 0o755) })
+	// Control: root ignores the mode bits, and CI sometimes runs as root.
+	if probe, err := os.CreateTemp(wfDir, "probe-*"); err == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("the read-only directory is still writable here (running as root?) — the probe cannot fail")
+	}
+
+	names := templates.ListWorkflowTemplates()
+	if len(names) < 2 {
+		t.Fatalf("setup: only %d workflow template(s) bundled — an abort at the first failure would be "+
+			"indistinguishable from a complete run", len(names))
+	}
+
+	out := runInitIn(t, dir, "--no-git")
+
+	var missing []string
+	for _, n := range names {
+		wf := strings.TrimSuffix(n, ".template")
+		if !strings.Contains(out, wf) {
+			missing = append(missing, wf)
+		}
+		if _, err := os.Stat(filepath.Join(wfDir, wf)); err == nil {
+			t.Errorf("%s exists despite its create-write having been made to fail", wf)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("%d of %d workflows that failed to be CREATED were never named: %v. The loop stopped "+
+			"at the first create failure instead of recording it and continuing:\n%s",
+			len(missing), len(names), missing, out)
+	}
+	if !strings.Contains(out, "could NOT be written") {
+		t.Errorf("`init` did not disclose that every workflow template failed to be created:\n%s", out)
+	}
+	if strings.Contains(out, "logmind initialized successfully!") {
+		t.Errorf("`init` claimed success while every workflow template failed to be created:\n%s", out)
+	}
+}
+
+// TestInitRefresh_ReadErrorDoesNotAbortTheRest pins the read-error branch at
+// installWorkflowTemplatesMode's ownership read (#306's read-error site,
+// line ~705): os.ReadFile fails with something other than ErrNotExist.
+//
+// A DIRECTORY in place of the target reaches this branch without touching
+// filesystem permissions at all: Lstat sees a non-symlink (RefuseSymlink
+// passes it through unchanged) and the subsequent os.ReadFile then fails
+// with "is a directory", which is not fs.ErrNotExist — landing on this arm
+// rather than the CREATE one. Portable (no root-skip needed) and reachable
+// without contrived permission bits, unlike the create-write and
+// refresh-write sites this PR also pins.
+func TestInitRefresh_ReadErrorDoesNotAbortTheRest(t *testing.T) {
+	dir := t.TempDir()
+	seedRepo(t, dir, "release")
+	runInitIn(t, dir, "--no-git")
+
+	names := templates.ListWorkflowTemplates()
+	if strings.TrimSuffix(names[0], ".template") != "check-decisions.yml" {
+		t.Fatalf("setup: expected check-decisions.yml to sort first, got %q — this test's ordering "+
+			"premise no longer holds", names[0])
+	}
+
+	// Force every OTHER workflow to need a rewrite, so "the rest were still
+	// processed" is a claim with something behind it.
+	if out, err := gitIn(dir, "branch", "-M", "release2"); err != nil {
+		t.Fatalf("rename the default branch: %v\n%s", err, out)
+	}
+
+	// The victim: a directory where a regular file belongs.
+	const victim = "check-decisions.yml"
+	victimPath := filepath.Join(dir, ".github", "workflows", victim)
+	if err := os.Remove(victimPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(victimPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// --refresh: a version-ordered refresh does not repair a stale
+	// scaffold-time trigger at all (see
+	// TestInitRefresh_RepairsAStaleScaffoldedTrigger) — only the
+	// force-render path does, so this is what actually gives the other
+	// three templates something to do.
+	out, execErr := tryInitIn(t, dir, "--no-git", "--refresh")
+
+	// 1. The failed read is named in the output.
+	if !strings.Contains(out, victim) {
+		t.Errorf("the workflow that could not be READ (%s) is not named in the output:\n%s", victim, out)
+	}
+	// 2. Every other workflow — all of which sort AFTER the victim — was
+	// still processed, not abandoned.
+	for _, n := range names[1:] {
+		wf := strings.TrimSuffix(n, ".template")
+		body := readWorkflow(t, dir, wf)
+		if strings.Contains(body, "branches: [release]\n") {
+			t.Errorf("%s still carries the stale trigger — the read error on %s (which sorts first) "+
+				"abandoned every template after it instead of recording the failure and continuing:\n%s",
+				wf, victim, out)
+		}
+	}
+	// 3. The directory planted as the victim was left exactly as found.
+	if fi, err := os.Stat(victimPath); err != nil || !fi.IsDir() {
+		t.Errorf("%s: the directory planted in place of the workflow was disturbed by the failed read (err %v)",
+			victim, err)
+	}
+	// 4. The shortfall is reported honestly: exit non-zero.
+	if execErr == nil {
+		t.Errorf("`init` exited 0 after failing to read %s:\n%s", victim, out)
+	}
+}
+
+// TestInitRefresh_DowngradeRefusalDoesNotAbortTheRest pins the downgrade
+// decline at installWorkflowTemplatesMode's version-order check (#306's
+// declineDowngrade site, line ~771) — the site the panel found matters most,
+// because it is not a failure-injection corner but the exact scenario the
+// code's own comment documents: a released binary bundling an OLDER
+// template than a repo it is scaffolding already carries (SPEC-documented,
+// #286).
+//
+// TestInitRefresh_DoesNotWidenOwnership already covers the DECISION (refuse,
+// don't downgrade) but not the LOOP: its "ahead" marker sits on
+// regen-timeline.yml, which sorts LAST among the four bundled templates, so
+// mutating that site's `continue` to `return` loses nothing in that test —
+// nothing comes after regen-timeline.yml. This test puts the ahead marker on
+// check-decisions.yml, which sorts FIRST, and forces every other template to
+// need re-creating, so a `return` at the decline site would abandon all
+// three of them — reproducing, end to end, the scenario the panel manually
+// verified against the built binary.
+func TestInitRefresh_DowngradeRefusalDoesNotAbortTheRest(t *testing.T) {
+	dir := t.TempDir()
+	seedRepo(t, dir, "release")
+	runInitIn(t, dir, "--no-git")
+
+	names := templates.ListWorkflowTemplates()
+	if strings.TrimSuffix(names[0], ".template") != "check-decisions.yml" {
+		t.Fatalf("setup: expected check-decisions.yml to sort first, got %q — this test's ordering "+
+			"premise no longer holds", names[0])
+	}
+
+	// The AHEAD marker — the scenario installWorkflowTemplatesMode's
+	// installedVer != bundledVer comment documents by name.
+	const ahead = "check-decisions.yml"
+	future := strings.Replace(readWorkflow(t, dir, ahead), "# logmind-template-version: v",
+		"# logmind-template-version: v99", 1)
+	if !strings.Contains(future, "# logmind-template-version: v99") {
+		t.Fatalf("setup: could not raise %s's marker", ahead)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".github", "workflows", ahead), []byte(future), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the other three, so this run's only way to bring them back is
+	// the CREATE branch reached AFTER the downgrade decline for `ahead` —
+	// exactly what the panel's manual repro forced.
+	var others []string
+	for _, n := range names[1:] {
+		wf := strings.TrimSuffix(n, ".template")
+		others = append(others, wf)
+		if err := os.Remove(filepath.Join(dir, ".github", "workflows", wf)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := runInitIn(t, dir, "--no-git")
+
+	if got := readWorkflow(t, dir, ahead); got != future {
+		t.Errorf("`init` downgraded %s from a NEWER template marker", ahead)
+	}
+	if !strings.Contains(out, "refusing to downgrade") {
+		t.Errorf("the newer marker on %s was not reported as refused:\n%s", ahead, out)
+	}
+	for _, wf := range others {
+		path := filepath.Join(dir, ".github", "workflows", wf)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s was never recreated — the downgrade refusal on %s (which sorts first) abandoned "+
+				"every template after it instead of recording the refusal and continuing:\n%s", wf, ahead, out)
+			continue
+		}
+		if !strings.Contains(out, "✓ Created .github/workflows/"+wf) {
+			t.Errorf("%s was recreated but not reported as created:\n%s", wf, out)
+		}
+	}
+}
+
+// TestInitRefresh_VersionOrderedWriteFailureDoesNotAbortTheRest pins the
+// version-ordered refresh write at installWorkflowTemplatesMode's
+// installedVer != bundledVer branch (#306's refresh-write site, line ~788)
+// — the ordinary "brew install bundles an older template than the repo
+// already has" shape, distinct from declineDowngrade's mirror image and
+// distinct from force-write (line ~814, already pinned), which only fires
+// under workflowForceRender.
+//
+// Two markers are rolled BACKWARDS — at both ends of the alphabetical list
+// — so a `return` at the write-failure site would abandon the second
+// (regen-timeline.yml) while only ever reporting the first
+// (check-decisions.yml).
+func TestInitRefresh_VersionOrderedWriteFailureDoesNotAbortTheRest(t *testing.T) {
+	dir := t.TempDir()
+	seedRepo(t, dir, "release")
+	runInitIn(t, dir, "--no-git")
+
+	rollBack := func(name string) string {
+		body := readWorkflow(t, dir, name)
+		marker := inserter.ExtractTemplateMarker(body)
+		if marker.Version == "" {
+			t.Fatalf("setup: %s carries no marker to roll back", name)
+		}
+		older := strings.Replace(body, "# logmind-template-version: "+marker.Version,
+			"# logmind-template-version: v1", 1)
+		if !strings.Contains(older, "# logmind-template-version: v1") {
+			t.Fatalf("setup: could not roll back %s's marker", name)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".github", "workflows", name), []byte(older), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return older
+	}
+	first := rollBack("check-decisions.yml") // sorts first
+	last := rollBack("regen-timeline.yml")   // sorts last
+
+	wfDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.Chmod(wfDir, 0o555); err != nil {
+		t.Skipf("cannot make the workflows directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(wfDir, 0o755) })
+	// Control: root ignores the mode bits, and CI sometimes runs as root.
+	if probe, err := os.CreateTemp(wfDir, "probe-*"); err == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("the read-only directory is still writable here (running as root?) — the probe cannot fail")
+	}
+
+	out, execErr := tryInitIn(t, dir, "--no-git")
+
+	for _, name := range []string{"check-decisions.yml", "regen-timeline.yml"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("%s's version-ordered refresh write failed but was never named in the output — "+
+				"the loop stopped at an earlier failure instead of recording it and continuing:\n%s", name, out)
+		}
+	}
+	if got := readWorkflow(t, dir, "check-decisions.yml"); got != first {
+		t.Errorf("check-decisions.yml changed despite its write failing")
+	}
+	if got := readWorkflow(t, dir, "regen-timeline.yml"); got != last {
+		t.Errorf("regen-timeline.yml changed despite its write failing")
+	}
+	if execErr == nil {
+		t.Errorf("`init` exited 0 after failing to refresh both rolled-back workflows:\n%s", out)
+	}
+}
+
 // TestShippedWorkflows_PrescribeCommandsThatExist is the CLASS guard behind
 // the flag above, and the one that would have caught this before it shipped.
 //

--- a/internal/cli/marker_overwrite_test.go
+++ b/internal/cli/marker_overwrite_test.go
@@ -1,0 +1,258 @@
+// marker_overwrite_test.go — logmind#297 and #299 at the level the user was
+// harmed: "my file lost its content".
+//
+// Both defects wrote something partial over the whole of a user-owned file.
+// #297: `self-update` handed a BLOCK BODY to a function whose first parameter
+// is a WHOLE FILE, then wrote the fragment that came back over AGENTS.md.
+// #299: `doctor` classified a workflow as markerless (SPEC §1.1 — the user's,
+// MUST NOT be overwritten) using a first-line-only extractor, while
+// `doctor --fix` re-classified it as versioned-and-stale using an any-line
+// extractor and overwrote it.
+//
+// The assertions here are on OUTCOMES — the bytes of a realistic file after
+// the real command ran — not on which arguments a helper received. An
+// argument assertion passes its own mutation and still goes green the day the
+// same fragment gets written by a different route.
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/inserter"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// runSelfUpdateCapture runs `self-update` in the current cwd and returns
+// (stdout, stderr).
+func runSelfUpdateCapture(t *testing.T) (string, string) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs([]string{"self-update"})
+	var out, errOut strings.Builder
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("self-update: %v\nstderr=%s", err, errOut.String())
+	}
+	return out.String(), errOut.String()
+}
+
+// TestSelfUpdate_PreservesAgentsMDOutsideBlock is #297's user symptom.
+//
+// An AGENTS.md with a STALE logmind block and repository prose both above and
+// below it. `self-update` must move the block forward and leave every other
+// byte alone. When the fragment-write ships, this file becomes the block body
+// alone and every sentinel below disappears.
+func TestSelfUpdate_PreservesAgentsMDOutsideBlock(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+
+		const above = "# AGENTS.md\n\nThis is the canonical instruction file for AI coding agents.\n\n"
+		const below = "\n\n## Project Overview\n\n**logmind** is a decision-logging CLI (Go).\n\n" +
+			"## Development Commands\n\n```bash\ngo build ./cmd/logmind\n```\n\n" +
+			"## Release infrastructure\n\nCross-repo writes are signed by the steward App.\n"
+
+		// A stale-but-refreshable block: the marker orders BEFORE the bundled
+		// one and carries the slim flavour, so the refresh path engages
+		// (rather than refusing, which would prove nothing about writing).
+		staleBlock := "\n<!-- logmind-block-version: v1-pointer -->\nSTALE BLOCK BODY\n"
+		original := above + "<!-- logmind-start -->" + staleBlock + "<!-- logmind-end -->" + below
+		writeRel(t, "AGENTS.md", original, 0o644)
+
+		runSelfUpdateCapture(t)
+
+		got := readRel(t, "AGENTS.md")
+
+		// SURVIVAL FIRST, so a failure names the harm the user reported
+		// ("my AGENTS.md lost its content") rather than a symptom of it.
+		for _, sentinel := range []string{
+			"This is the canonical instruction file for AI coding agents.",
+			"## Project Overview",
+			"**logmind** is a decision-logging CLI (Go).",
+			"go build ./cmd/logmind",
+			"## Release infrastructure",
+			"Cross-repo writes are signed by the steward App.",
+		} {
+			if !strings.Contains(got, sentinel) {
+				t.Errorf("self-update destroyed content outside the marker block: %q is gone", sentinel)
+			}
+		}
+
+		freshBody, ok := inserter.ExtractMarkerBlock(templates.AgentsSlimTemplate())
+		if !ok {
+			t.Fatal("bundled slim template carries no marker block")
+		}
+		if want := above + "<!-- logmind-start -->" + freshBody + "<!-- logmind-end -->" + below; got != want {
+			t.Errorf("self-update did not rewrite the block in place:\n got: %q\nwant: %q", got, want)
+		}
+
+		// Vacuity control LAST: if the block never moved forward, nothing was
+		// written and the survival assertions above proved nothing.
+		if strings.Contains(got, "STALE BLOCK BODY") {
+			t.Error("self-update did not refresh the stale block; the survival " +
+				"assertions above would prove nothing")
+		}
+	})
+}
+
+// TestSelfUpdate_LeavesMarkerlessAgentsMDContentIntact — SPEC §1.1 for the
+// self-update surface. An AGENTS.md the user wrote with no logmind block at
+// all gets the block ADDED (an insert preserves their content); what must
+// never happen is their prose being replaced.
+func TestSelfUpdate_LeavesMarkerlessAgentsMDContentIntact(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+
+		original := "# My own AGENTS.md\n\nI wrote every line of this myself.\n\n" +
+			"## House rules\n\nUSER_SENTINEL_ONE\n\n## More\n\nUSER_SENTINEL_TWO\n"
+		writeRel(t, "AGENTS.md", original, 0o644)
+
+		runSelfUpdateCapture(t)
+
+		got := readRel(t, "AGENTS.md")
+		for _, sentinel := range []string{
+			"I wrote every line of this myself.",
+			"## House rules",
+			"USER_SENTINEL_ONE",
+			"## More",
+			"USER_SENTINEL_TWO",
+		} {
+			if !strings.Contains(got, sentinel) {
+				t.Errorf("self-update destroyed user content: %q is gone", sentinel)
+			}
+		}
+	})
+}
+
+// plantDisplacedMarkerWorkflow writes the #299 reproduction: a workflow whose
+// `# logmind-template-version:` marker sits on line 2, under a header the
+// user added. Returns the rel path and the original bytes.
+func plantDisplacedMarkerWorkflow(t *testing.T) (string, string) {
+	t.Helper()
+	rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+	body := "# my org header — do not remove\n" +
+		"# logmind-template-version: v1\n" +
+		"name: check-decisions\n" +
+		"jobs: {}\n" +
+		"USER_SENTINEL_LINE\n"
+	writeRel(t, rel, body, 0o644)
+	return rel, body
+}
+
+// TestDoctorFix_LeavesDisplacedMarkerWorkflowAlone is #299's user symptom,
+// measured exactly as the issue measured it: doctor prints "markerless", and
+// then --fix must NOT overwrite the file it just called the user's.
+func TestDoctorFix_LeavesDisplacedMarkerWorkflowAlone(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel, before := plantDisplacedMarkerWorkflow(t)
+
+		_, stderr := runDoctorFixCmd(t)
+
+		if after := readRel(t, rel); after != before {
+			t.Errorf("doctor --fix overwrote a file it classified as the user's:\n got: %q\nwant: %q",
+				after, before)
+		}
+		// The refusal has to be visible and actionable: name the file, the
+		// marker, the line it is on, and both ways out.
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "left unchanged")
+		mustContain(t, stderr, "line 2")
+		mustContain(t, stderr, "not line 1")
+	})
+}
+
+// TestDoctorFix_LeavesUnmarkedWorkflowAlone — the plain SPEC §1.1 case: a
+// workflow with no logmind marker anywhere is the user's, and --fix must both
+// leave it alone AND say that it did.
+func TestDoctorFix_LeavesUnmarkedWorkflowAlone(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		before := "name: my own check-decisions\njobs: {}\nUSER_SENTINEL_LINE\n"
+		writeRel(t, rel, before, 0o644)
+
+		_, stderr := runDoctorFixCmd(t)
+
+		if after := readRel(t, rel); after != before {
+			t.Errorf("doctor --fix overwrote a markerless (user-owned) workflow:\n got: %q\nwant: %q",
+				after, before)
+		}
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "carries no `# logmind-template-version:` marker")
+		mustContain(t, stderr, "treats it as yours")
+	})
+}
+
+// TestDoctor_ReportsDisplacedMarkerRatherThanBareMarkerless — the reader's
+// half of #299. Reporting only "markerless" would hide that a marker IS
+// present, which is the one fact the user needs to move the file into either
+// camp deliberately.
+func TestDoctor_ReportsDisplacedMarkerRatherThanBareMarkerless(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		plantDisplacedMarkerWorkflow(t)
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline"})
+		var out, errOut strings.Builder
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		_ = root.Execute() // doctor exits non-zero on drift; the body is what matters
+
+		body := out.String()
+		mustContain(t, body, "check-decisions.yml")
+		mustContain(t, body, "on line 2, not line 1")
+	})
+}
+
+// TestDoctorFix_StillRefreshesAWorkflowItOwns is the CONTROL on every refusal
+// above: the strict first-line rule must not have turned --fix into a no-op.
+// A marker on line 1 is still ours, and still gets refreshed.
+func TestDoctorFix_StillRefreshesAWorkflowItOwns(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "# logmind-template-version: v1\n# ancient\n", 0o644)
+
+		runDoctorFixCmd(t)
+
+		want := inserter.ExtractTemplateMarker(
+			templates.Workflow("check-decisions.yml.template")).Version
+		got := inserter.ExtractTemplateMarker(readRel(t, rel))
+		if !got.Writable() || got.Version != want {
+			t.Errorf("a workflow logmind owns was not refreshed: got %+v; want version %q", got, want)
+		}
+	})
+}
+
+// TestSelfUpdate_HasNoSecondAgentsMDWriter guards the structural half of the
+// #297 fix. SPEC §1.1: "Exactly one automation owns any generated or copied
+// path. Two refreshers MUST NOT write the same path." The deleted loop was a
+// second refresher of AGENTS.md, and being unreachable is precisely why its
+// wrong-argument write survived untested — so the absence of a second writer
+// is the thing worth pinning, not the correctness of one that should not
+// exist.
+func TestSelfUpdate_HasNoSecondAgentsMDWriter(t *testing.T) {
+	src, err := os.ReadFile("self_update.go")
+	if err != nil {
+		t.Fatalf("read self_update.go: %v", err)
+	}
+	// Control: prove the probe can actually find a call in this file, so a
+	// pass means "absent", not "the search was wrong".
+	if !strings.Contains(string(src), "inserter.EnsureAgentsMD") {
+		t.Fatal("control failed: self_update.go no longer calls inserter.EnsureAgentsMD, " +
+			"so this file is not the one that owns the AGENTS.md refresh — re-point this test")
+	}
+	for _, banned := range []string{
+		"inserter.FindOutdatedMarkerBlocks",
+		"os.WriteFile(entry.Path",
+	} {
+		if strings.Contains(string(src), banned) {
+			t.Errorf("self-update grew a second AGENTS.md writer (%q); EnsureAgentsMD owns that path", banned)
+		}
+	}
+}

--- a/internal/cli/marker_overwrite_test.go
+++ b/internal/cli/marker_overwrite_test.go
@@ -4,7 +4,7 @@
 // Both defects wrote something partial over the whole of a user-owned file.
 // #297: `self-update` handed a BLOCK BODY to a function whose first parameter
 // is a WHOLE FILE, then wrote the fragment that came back over AGENTS.md.
-// #299: `doctor` classified a workflow as markerless (SPEC §1.1 — the user's,
+// #299: `doctor` classified a workflow as markerless (SPEC §5.2 — the user's,
 // MUST NOT be overwritten) using a first-line-only extractor, while
 // `doctor --fix` re-classified it as versioned-and-stale using an any-line
 // extractor and overwrote it.
@@ -16,10 +16,14 @@
 package cli
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -100,7 +104,7 @@ func TestSelfUpdate_PreservesAgentsMDOutsideBlock(t *testing.T) {
 	})
 }
 
-// TestSelfUpdate_LeavesMarkerlessAgentsMDContentIntact — SPEC §1.1 for the
+// TestSelfUpdate_LeavesMarkerlessAgentsMDContentIntact — SPEC §5.2 for the
 // self-update surface. An AGENTS.md the user wrote with no logmind block at
 // all gets the block ADDED (an insert preserves their content); what must
 // never happen is their prose being replaced.
@@ -167,7 +171,7 @@ func TestDoctorFix_LeavesDisplacedMarkerWorkflowAlone(t *testing.T) {
 	})
 }
 
-// TestDoctorFix_LeavesUnmarkedWorkflowAlone — the plain SPEC §1.1 case: a
+// TestDoctorFix_LeavesUnmarkedWorkflowAlone — the plain SPEC §5.2 case: a
 // workflow with no logmind marker anywhere is the user's, and --fix must both
 // leave it alone AND say that it did.
 func TestDoctorFix_LeavesUnmarkedWorkflowAlone(t *testing.T) {
@@ -317,74 +321,560 @@ func TestDoctorFix_StillRefreshesAWorkflowItOwns(t *testing.T) {
 	})
 }
 
-// TestSelfUpdate_HasNoSecondAgentsMDWriter guards the structural half of the
-// #297 fix. SPEC §1.1: "Exactly one automation owns any generated or copied
-// path. Two refreshers MUST NOT write the same path." The deleted loop was a
-// second refresher of AGENTS.md, and being unreachable is precisely why its
-// wrong-argument write survived untested — so the absence of a second writer
-// is the thing worth pinning, not the correctness of one that should not
-// exist.
-//
-// This started as a grep of exactly one file (self_update.go) for two exact
-// banned substrings ("inserter.FindOutdatedMarkerBlocks",
-// "os.WriteFile(entry.Path") — a second writer reintroduced under ANY OTHER
-// FILE, or under a differently-named variable in the same file, would have
-// passed it silently. Widened to scan every non-test .go source file under
-// internal/ (not just internal/cli) for the shape of a raw write to
-// AGENTS.md, allowlisting only internal/inserter/inserter.go — the one file
-// SPEC §1.1 permits to own that path (EnsureAgentsMD, RefreshMarkerBlockFile,
-// MigrateToAgentsMD's append). Every legitimate caller in this codebase
-// names the variable `agentsPath`; a second writer would either reuse that
-// convention (caught by the first alternative) or inline the path directly
-// (caught by the second).
-func TestSelfUpdate_HasNoSecondAgentsMDWriter(t *testing.T) {
-	// Control FIRST, on a synthetic fixture: prove the scanner actually
-	// flags the shape it exists to catch before trusting a clean result from
-	// the real tree below — an empty result from a broken scanner and an
-	// empty result from a clean tree look identical otherwise.
-	t.Run("control_detects_synthetic_second_writer", func(t *testing.T) {
-		dir := t.TempDir()
-		fixtures := map[string]string{
-			"by_convention.go": "package evil\n\nimport \"os\"\n\nfunc f(repoRoot string) {\n\tagentsPath := repoRoot + \"/AGENTS.md\"\n\tos.WriteFile(agentsPath, nil, 0o644)\n}\n",
-			"inlined.go":       "package evil\n\nimport (\"os\"; \"path/filepath\")\n\nfunc g(repoRoot string) {\n\tos.WriteFile(filepath.Join(repoRoot, \"AGENTS.md\"), nil, 0o644)\n}\n",
-		}
-		for name, body := range fixtures {
-			if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
-				t.Fatal(err)
-			}
-		}
-		got, err := findAgentsMDWriteViolations(dir)
-		if err != nil {
+// TestDoctorFix_RefusesDanglingWorkflowSymlink is the #306 live escape,
+// measured through the real command. os.ReadFile FOLLOWS a symlink, so a
+// DANGLING one at .github/workflows/check-decisions.yml returns fs.ErrNotExist
+// and the file reads as ABSENT — the same ENOENT-as-absent shape already fixed
+// in inserter.EnsureDependabot. installWorkflowTemplates then took its CREATE
+// branch and a bare os.WriteFile followed the link, landing the rendered
+// workflow wherever it pointed (a panel measured 6419 bytes written OUTSIDE
+// the repository) while --fix reported `workflows=1` as if it had installed
+// one. The refusal must be loud, and nothing may appear at the link target.
+func TestDoctorFix_RefusesDanglingWorkflowSymlink(t *testing.T) {
+	skipWithoutSymlinks(t)
+	outside := t.TempDir()
+	escapeTarget := filepath.Join(outside, "escaped-workflow.yml")
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if len(got) != len(fixtures) {
-			t.Fatalf("control: scanner found %d violation(s) in %d synthetic fixtures; "+
-				"want %d — the scanner itself is broken, so a clean result below proves nothing",
-				len(got), len(fixtures), len(fixtures))
+		if err := os.Symlink(escapeTarget, rel); err != nil {
+			t.Fatalf("plant dangling symlink: %v", err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--fix", "--offline"})
+		var out, errOut strings.Builder
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		err := root.Execute()
+
+		// THE HARM FIRST: nothing may exist outside the repository.
+		if _, statErr := os.Lstat(escapeTarget); statErr == nil {
+			body, _ := os.ReadFile(escapeTarget)
+			t.Fatalf("doctor --fix wrote %d bytes OUTSIDE the repo, through a dangling symlink, to %s",
+				len(body), escapeTarget)
+		}
+		// The link itself is untouched — refusing means leaving both the link
+		// and whatever it names exactly as found.
+		fi, lerr := os.Lstat(rel)
+		if lerr != nil || fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("the planted symlink at %s was replaced rather than refused (lstat err=%v)", rel, lerr)
+		}
+		// And the refusal is REPORTED, not silent — a silent no-op here reads
+		// to the user exactly like a successful install.
+		if err == nil {
+			t.Error("doctor --fix exited 0 on a workflow it could not write; the refusal was silent")
+		}
+		mustContain(t, errOut.String(), "symlink")
+	})
+}
+
+// TestDoctorFix_RefusesSymlinkedExistingWorkflow is the same escape through
+// installWorkflowTemplates' OTHER branch. A NON-dangling symlink reads fine
+// through os.ReadFile, so the file looks present and its (stale, line-1,
+// therefore logmind-owned) marker routes control to the REFRESH write — where
+// a bare os.WriteFile rewrites whatever the link points at. The dangling case
+// above never reaches this branch, so without this test the refresh write can
+// be reverted to a raw primitive and every behavioural assertion stays green.
+func TestDoctorFix_RefusesSymlinkedExistingWorkflow(t *testing.T) {
+	skipWithoutSymlinks(t)
+	outside := t.TempDir()
+	realTarget := filepath.Join(outside, "someone-elses-workflow.yml")
+	// Marker on line 1 (so it is "ours" and writable) but an old version (so
+	// the refresh branch engages), with user content underneath to detect a
+	// rewrite.
+	const userContent = "# logmind-template-version: v0-ANCIENT\nname: not ours\nUSER_SENTINEL_OUTSIDE\n"
+	if err := os.WriteFile(realTarget, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realTarget, rel); err != nil {
+			t.Fatalf("plant symlink: %v", err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--fix", "--offline"})
+		var out, errOut strings.Builder
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		err := root.Execute()
+
+		got, readErr := os.ReadFile(realTarget)
+		if readErr != nil {
+			t.Fatalf("the file outside the repo vanished: %v", readErr)
+		}
+		if string(got) != userContent {
+			t.Fatalf("doctor --fix wrote through the symlink and rewrote a file outside the repo:\n got: %q\nwant: %q",
+				string(got), userContent)
+		}
+		if err == nil {
+			t.Error("doctor --fix exited 0 on a workflow it could not write; the refusal was silent")
+		}
+		mustContain(t, errOut.String(), "symlink")
+
+		// VACUITY CONTROL: the refresh branch has to actually be the branch
+		// under test. A marker logmind does NOT own would be refused earlier,
+		// by the ownership gate, and would prove nothing about the write.
+		if m := inserter.ExtractTemplateMarker(userContent); !m.Writable() {
+			t.Fatalf("fixture marker is not writable (%+v) — control never reached the refresh write", m)
 		}
 	})
+}
 
-	violations, err := findAgentsMDWriteViolations("..") // internal/
-	if err != nil {
-		t.Fatalf("scan internal/ for a second AGENTS.md writer: %v", err)
+// TestResidualCause_NamesADistinctCausePerDriftValue is the #306 HIGH on the
+// residual note. residualProbes emits four drift values and they mean four
+// different things; the note must not attribute one row's cause to another.
+//
+// The specific regression: probePathResolution filed BOTH "cannot exec
+// --version" and "no version parsed" as drift="markerless", so `doctor --fix`
+// told a user whose PATH binary was merely unreadable that logmind "treats it
+// as yours and leaves it alone" — SPEC §5.2's OWNERSHIP verdict, applied to a
+// binary that has no ownership marker concept at all.
+func TestResidualCause_NamesADistinctCausePerDriftValue(t *testing.T) {
+	drifts := []string{"stale", "foreign", "markerless", "unreadable"}
+	cause := map[string]string{}
+	byText := map[string]string{}
+	for _, d := range drifts {
+		c := residualCause(d)
+		cause[d] = c
+		if prev, dup := byText[c]; dup {
+			t.Errorf("drift %q and drift %q report the IDENTICAL cause %q; one of them is wrong "+
+				"about what happened", prev, d, c)
+		}
+		byText[c] = d
 	}
-	for _, v := range violations {
-		t.Errorf("raw AGENTS.md write outside internal/inserter/inserter.go: %s — "+
-			"route this through inserter.EnsureAgentsMD / RefreshMarkerBlockFile instead", v)
+
+	// The ownership sentence belongs to "markerless" and to nothing else.
+	const ownership = "treats it as yours"
+	if !strings.Contains(cause["markerless"], ownership) {
+		t.Errorf("markerless no longer states the SPEC §5.2 ownership verdict: %q", cause["markerless"])
+	}
+	for _, d := range []string{"stale", "foreign", "unreadable"} {
+		if strings.Contains(cause[d], ownership) {
+			t.Errorf("drift %q claims SPEC §5.2 user ownership, which is only true of a markerless "+
+				"artifact: %q", d, cause[d])
+		}
+	}
+
+	// The citation itself, since one of these strings is user-facing stderr:
+	// both sentences live at SPEC.md §5.2, never in §1.1.
+	if strings.Contains(cause["markerless"], "§1.1") {
+		t.Errorf("markerless cites SPEC §1.1; the marker-ownership rule is §5.2's: %q", cause["markerless"])
+	}
+	mustContain(t, cause["markerless"], "§5.2")
+
+	// And "unreadable" says what actually happened.
+	mustContain(t, cause["unreadable"], "on PATH")
+	mustContain(t, cause["unreadable"], "--version")
+}
+
+// TestDoctorFix_UnreadablePathBinaryReportsItsOwnCause walks the whole route —
+// a real binary on PATH whose --version output carries no version, through the
+// real `doctor --fix` — because residualCause being right is only useful if
+// the drift value reaching it is right too. Before #306 this row arrived as
+// "markerless" and got the user-ownership sentence.
+func TestDoctorFix_UnreadablePathBinaryReportsItsOwnCause(t *testing.T) {
+	skipWithoutSymlinks(t) // shell-script fixture; same non-Windows condition
+	fakeDir := t.TempDir()
+	fake := filepath.Join(fakeDir, "logmind")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho some unrelated output\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// PREPEND rather than replace: doctor --fix shells out to git, which still
+	// has to resolve.
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		_, stderr := runDoctorFixCmd(t)
+
+		mustContain(t, stderr, "logmind on PATH")
+		mustContain(t, stderr, "--version")
+		if strings.Contains(stderr, `"logmind on PATH" still drifted — it carries no logmind marker`) {
+			t.Errorf("the PATH binary is reported as a markerless user-owned artifact; it is neither:\n%s", stderr)
+		}
+	})
+}
+
+// skipWithoutSymlinks skips on platforms where an unprivileged process cannot
+// create one (Windows), mirroring internal/inserter's helper of the same
+// purpose.
+func skipWithoutSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevation on Windows")
 	}
 }
 
-// agentsMDWriteViolationRe matches a WriteFile call whose target is built
-// from AGENTS.md — either the conventional `agentsPath` variable name every
-// legitimate caller in this codebase uses, or the "AGENTS.md" literal
-// inlined directly into the call.
-var agentsMDWriteViolationRe = regexp.MustCompile(`WriteFile\(\s*agentsPath\b|WriteFile\(\s*filepath\.Join\([^)]*"AGENTS\.md"`)
+// ---------------------------------------------------------------------------
+// The structural half of the #297 fix: nothing may write a managed path except
+// through the one primitive that owns it.
+// ---------------------------------------------------------------------------
 
-// findAgentsMDWriteViolations scans every non-test .go file under root for
-// agentsMDWriteViolationRe, skipping internal/inserter/inserter.go — the one
-// file SPEC §1.1 permits to write AGENTS.md.
-func findAgentsMDWriteViolations(root string) ([]string, error) {
-	var hits []string
+// TestWriteSurfaces_UseNoRawWritePrimitive is the rebuilt #297 second-writer
+// guard, and it is deliberately NOT a scan for the AGENTS.md PATH.
+//
+// SPEC §5.2: "Exactly one automation owns any generated or copied path. Two
+// refreshers MUST NOT write the same path." The deleted #297 loop was a second
+// refresher of AGENTS.md, and being unreachable is precisely why its
+// wrong-argument write survived untested — so the absence of a second writer is
+// the thing worth pinning, not the correctness of one that should not exist.
+//
+// WHY THE PATH IS THE WRONG THING TO SCAN FOR. Two earlier versions of this
+// guard matched on the target expression: first two exact banned substrings in
+// one file, then a regexp for `WriteFile(agentsPath` / `WriteFile(filepath.
+// Join(…"AGENTS.md"`. A review panel walked through both. The set of ways to
+// spell a path is unbounded, and every one of these compiles and passed:
+//
+//	os.WriteFile(entry.Path, []byte(entry.NewBody), 0o644)  // the literal #297 loop
+//	os.WriteFile(repoRoot+"/AGENTS.md", …)                  // concatenated literal
+//	p := filepath.Join(root, "AGENTS.md"); os.WriteFile(p, …) // renamed variable
+//	writeAgentsFile(agentsPath, …)                          // one-line wrapper
+//	…and anything at all under cmd/, which the old scan root never visited.
+//
+// The first of those five is the worst case for a path scan: it never names
+// AGENTS.md at all — it takes the path back OUT of the inserter API. And it is
+// invisible to a behavioural test too, which is why one is not the answer
+// here: after EnsureAgentsMD refreshes the block, FindOutdatedMarkerBlocks
+// reports nothing, so the restored loop is a no-op and every outcome assertion
+// above it stays green. Measured, not assumed — with the loop restored,
+// TestSelfUpdate_PreservesAgentsMDOutsideBlock passes.
+//
+// WHAT IS SCANNED INSTEAD. The write PRIMITIVE, which unlike a path is a
+// closed, enumerable set. Every one of those five evasions must ultimately
+// call one, so banning the primitive catches all five however the path is
+// spelled — and it generalises: the same guard is what would have caught the
+// live symlink escape at installWorkflowTemplates, where a bare os.WriteFile
+// followed a dangling symlink out of the repo (see
+// TestDoctorFix_RefusesDanglingWorkflowSymlink).
+//
+// KNOWN BOUNDARY, stated rather than implied: a second writer that took the
+// path from inserter.OutdatedMarkerEntry.Path AND routed it through
+// atomicio.WriteFile would satisfy this guard. Closing that needs either
+// interprocedural dataflow or the removal of the Path field, whose only
+// consumer is runAgentsUpdate in internal/cli/agents.go.
+func TestWriteSurfaces_UseNoRawWritePrimitive(t *testing.T) {
+	root := moduleRoot(t)
+
+	// SCOPE CONTROL FIRST. Evasion five was purely a scope failure — a
+	// perfectly good scanner pointed at internal/ alone, so a second writer
+	// under cmd/ was never read. Assert the walk actually reaches specific
+	// NAMED files before trusting a clean result, one per directory the guard
+	// claims to cover. Naming the files rather than counting them matters:
+	// the cheapest way to make this guard green is to drop a directory from
+	// writeSurfaceDirs, and a non-empty count would not notice.
+	scanned := map[string]bool{}
+	for _, dir := range writeSurfaceDirs {
+		files, err := goSourceFiles(filepath.Join(root, dir))
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+		for _, f := range files {
+			rel, relErr := filepath.Rel(root, f)
+			if relErr != nil {
+				t.Fatal(relErr)
+			}
+			scanned[filepath.ToSlash(rel)] = true
+		}
+	}
+	for _, sentinel := range []string{
+		"cmd/logmind/main.go",             // the binary's own package — evasion five's home
+		"internal/cli/self_update.go",     // where the #297 second writer lived
+		"internal/inserter/inserter.go",   // the owner of the AGENTS.md write primitive
+		"internal/inserter/dependabot.go", // a sibling installer found by a later sweep
+	} {
+		if !scanned[sentinel] {
+			t.Fatalf("scope control: %s was never read by the scan — the guard's coverage has "+
+				"shrunk, so a clean result below proves nothing about it", sentinel)
+		}
+	}
+
+	// DETECTION CONTROL. One synthetic fixture per evasion the panel found,
+	// including one in a nested subdirectory (proving the walk recurses) and
+	// one negative fixture that must NOT be flagged (proving the scanner
+	// discriminates rather than flagging every file it reads).
+	t.Run("control_detects_every_known_evasion", func(t *testing.T) {
+		dir := t.TempDir()
+		type fixture struct {
+			rel, body string
+			wantHit   bool
+		}
+		fixtures := []fixture{
+			{"evasion1_inserter_supplied_path.go", `package evil
+
+import (
+	"os"
+
+	"github.com/thrillmade/logmind/internal/inserter"
+)
+
+func f(cwd string) {
+	entries, _, _ := inserter.FindOutdatedMarkerBlocks(cwd)
+	for _, entry := range entries {
+		_ = os.WriteFile(entry.Path, []byte(entry.NewBody), 0o644)
+	}
+}
+`, true},
+			{"evasion2_concatenated_literal.go", `package evil
+
+import "os"
+
+func g(repoRoot string) { _ = os.WriteFile(repoRoot+"/AGENTS.md", nil, 0o644) }
+`, true},
+			{"evasion3_renamed_variable.go", `package evil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func h(repoRoot string) {
+	p := filepath.Join(repoRoot, "AGENTS.md")
+	_ = os.WriteFile(p, nil, 0o644)
+}
+`, true},
+			{"evasion4_helper_wrapper.go", `package evil
+
+import "os"
+
+func writeAgentsFile(path string, data []byte) error { return os.WriteFile(path, data, 0o644) }
+`, true},
+			{"nested/evasion5_under_a_subdirectory.go", `package nested
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func k(repoRoot string) {
+	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	_ = os.WriteFile(agentsPath, nil, 0o644)
+}
+`, true},
+			{"other_primitives.go", `package evil
+
+import "os"
+
+func m(path string) {
+	f, _ := os.Create(path)
+	_ = f
+	g, _ := os.OpenFile(path, os.O_WRONLY, 0o644)
+	_ = g
+}
+`, true},
+			// NEGATIVE control: the sanctioned route. A guard that flags this
+			// too would "pass" every fixture above while measuring nothing.
+			{"sanctioned_route.go", `package evil
+
+import (
+	"path/filepath"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
+)
+
+func n(repoRoot string) {
+	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	_ = atomicio.WriteFile(agentsPath, nil, 0o644)
+}
+`, false},
+			// NEGATIVE control: the primitive named in a comment and a string,
+			// never called. An AST scan must not confuse mention with use — a
+			// regexp over the bytes would flag this file and, by flagging the
+			// codebase's own explanatory comments, force the guard to be
+			// weakened until it stopped working.
+			{"mentions_only.go", `package evil
+
+// This function deliberately does not call os.WriteFile.
+func p() string { return "os.WriteFile" }
+`, false},
+		}
+		var wantHits []string
+		for _, fx := range fixtures {
+			full := filepath.Join(dir, fx.rel)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte(fx.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if fx.wantHit {
+				wantHits = append(wantHits, fx.rel)
+			}
+		}
+
+		got, err := findRawWritePrimitives(dir, []string{"."})
+		if err != nil {
+			t.Fatalf("scan fixtures: %v", err)
+		}
+		hitFiles := map[string]bool{}
+		for _, v := range got {
+			hitFiles[v.File] = true
+		}
+		for _, want := range wantHits {
+			if !hitFiles[filepath.ToSlash(want)] {
+				t.Errorf("control: %s was NOT flagged — this evasion would ship undetected", want)
+			}
+		}
+		for _, fx := range fixtures {
+			if !fx.wantHit && hitFiles[filepath.ToSlash(fx.rel)] {
+				t.Errorf("control: %s WAS flagged — the scanner does not discriminate, so a "+
+					"clean tree result would only mean the allowlist is doing the work", fx.rel)
+			}
+		}
+	})
+
+	// THE REAL TREE.
+	violations, err := findRawWritePrimitives(root, writeSurfaceDirs)
+	if err != nil {
+		t.Fatalf("scan the write surfaces: %v", err)
+	}
+	exercised := map[string]bool{}
+	for _, v := range violations {
+		if _, ok := rawWriteAllowlist[v.File]; ok {
+			exercised[v.File] = true
+			continue
+		}
+		t.Errorf("%s:%d calls %s directly — route it through atomicio.WriteFile (or an "+
+			"inserter primitive), which refuses a symlink at the destination and writes "+
+			"whole-file-or-nothing. If this path is one logmind already owns elsewhere, the "+
+			"call is a SECOND writer of it, which SPEC §5.2 forbids outright.",
+			v.File, v.Line, v.Call)
+	}
+
+	// STALENESS. An allowlist entry that no longer names a real violation is
+	// either a fix nobody deleted the exemption for, or a file that moved out
+	// from under it — and in the second case the exemption now covers nothing
+	// while the moved file goes unguarded. Either way it has to be noticed, so
+	// an unused entry fails rather than lingers.
+	for path, reason := range rawWriteAllowlist {
+		if !exercised[path] {
+			t.Errorf("allowlist entry %q (%s) matched no raw write — delete the entry if the "+
+				"call is gone, or update it if the file moved; a stale exemption widens this "+
+				"guard without anyone deciding to", path, reason)
+		}
+	}
+}
+
+// writeSurfaceDirs are the trees this guard covers: the command layer, the
+// artifact-installer package, and the binary's own main package. cmd/ is here
+// because its absence from the previous scan root was one of the five ways a
+// second writer got in.
+var writeSurfaceDirs = []string{
+	filepath.Join("internal", "cli"),
+	filepath.Join("internal", "inserter"),
+	"cmd",
+}
+
+// rawWriteAllowlist maps a REPO-RELATIVE PATH to the reason its raw write
+// primitive is permitted. Paths, not base names: a base-name key silently
+// exempts any future file that happens to share the name, which is the same
+// "matches more than it means" failure that let five second writers past the
+// previous version of this guard.
+//
+// Every entry is a standing finding, not an endorsement — and every entry is
+// checked for staleness below, so one whose violation is fixed, or whose file
+// moves, fails this test rather than quietly widening it.
+var rawWriteAllowlist = map[string]string{
+	// Opens a lock file for flock(2). No content is ever written through the
+	// descriptor, so there is no torn-write or symlink-follow exposure to fix.
+	"internal/cli/filelock_unix.go": "lock-file open, not a content write",
+
+	// FINDING, not a fix: os.WriteFile on a CI workflow pin path. Same
+	// ENOENT-as-absent / follow-the-symlink exposure as the two writes fixed
+	// in init.go on this branch. Owned by another in-flight lane (PR #313),
+	// so it is recorded here rather than routed around.
+	"internal/cli/agents.go": "workflow-pin write; raw primitive owned by PR #313's lane",
+
+	// FINDING, same as above: two raw hook writes, PR #313's lane.
+	"internal/cli/install_hook.go": "git-hook write; raw primitive owned by PR #313's lane",
+}
+
+// rawWriteViolation is one call to a banned primitive.
+type rawWriteViolation struct {
+	File string // repo-relative, slash-separated
+	Line int
+	Call string // e.g. "os.WriteFile"
+}
+
+// bannedWritePrimitives are the stdlib calls that write (or truncate) a file
+// at a path directly. Unlike a path expression, this set is CLOSED — which is
+// the whole reason the guard scans for it instead of for "AGENTS.md".
+//
+// os.Rename is absent deliberately: it is the second half of atomicio's own
+// temp-file-plus-rename, so banning it would ban the sanctioned route.
+var bannedWritePrimitives = map[string]map[string]bool{
+	"os":     {"WriteFile": true, "Create": true, "OpenFile": true, "Truncate": true},
+	"ioutil": {"WriteFile": true},
+}
+
+// findRawWritePrimitives parses every non-test .go file under root and returns
+// each CALL to a banned write primitive. Files whose base name is in allow are
+// skipped.
+//
+// AST, not regexp, and that is load-bearing rather than fastidious: this
+// codebase's comments discuss `os.WriteFile` constantly — describing exactly
+// the defect this guard pins — so a byte-level scan would flag its own
+// explanations, and the only way to make it green would be to weaken it.
+func findRawWritePrimitives(root string, dirs []string) ([]rawWriteViolation, error) {
+	var files []string
+	for _, dir := range dirs {
+		found, err := goSourceFiles(filepath.Join(root, dir))
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, found...)
+	}
+	var out []rawWriteViolation
+	fset := token.NewFileSet()
+	for _, path := range files {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+		rel = filepath.ToSlash(rel)
+		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if bannedWritePrimitives[pkg.Name][sel.Sel.Name] {
+				out = append(out, rawWriteViolation{
+					File: rel,
+					Line: fset.Position(sel.Pos()).Line,
+					Call: pkg.Name + "." + sel.Sel.Name,
+				})
+			}
+			return true
+		})
+	}
+	return out, nil
+}
+
+// goSourceFiles lists every non-test .go file under root, recursively.
+func goSourceFiles(root string) ([]string, error) {
+	var out []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -395,17 +885,30 @@ func findAgentsMDWriteViolations(root string) ([]string, error) {
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		if filepath.Base(path) == "inserter.go" && filepath.Base(filepath.Dir(path)) == "inserter" {
-			return nil
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if agentsMDWriteViolationRe.Match(data) {
-			hits = append(hits, path)
-		}
+		out = append(out, path)
 		return nil
 	})
-	return hits, err
+	return out, err
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod. Scanning from the module root — rather than from a relative
+// "..", which is how cmd/ came to be excluded — is what makes the guard's
+// coverage a property of the repository instead of of the test's location.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the test's working directory")
+		}
+		dir = parent
+	}
 }

--- a/internal/cli/marker_overwrite_test.go
+++ b/internal/cli/marker_overwrite_test.go
@@ -16,8 +16,10 @@
 package cli
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -187,6 +189,92 @@ func TestDoctorFix_LeavesUnmarkedWorkflowAlone(t *testing.T) {
 	})
 }
 
+// TestDoctorFix_UnmarkedWorkflowMessageNamesAWorkingRemedy is the #306 HIGH:
+// a panel found the declineUnmarked refusal told the user to make
+// `# logmind-template-version: <bundled>` the file's first line — but
+// installWorkflowTemplates only rewrites a file whose marker DIFFERS from
+// bundled, so pasting the CURRENT marker in by hand makes the file match on
+// the very next read and never refresh again, while doctor reports it
+// "current" forever. The remedy must be one that actually works
+// (delete-and-regenerate), and must NOT still offer the dead-end one.
+func TestDoctorFix_UnmarkedWorkflowMessageNamesAWorkingRemedy(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "jobs: {}\nUSER_SENTINEL\n", 0o644)
+
+		_, stderr := runDoctorFixCmd(t)
+
+		relSlash := filepath.ToSlash(rel)
+		mustContain(t, stderr, "delete "+relSlash)
+		mustContain(t, stderr, "logmind doctor --fix")
+		if strings.Contains(stderr, "make `# logmind-template-version:") {
+			t.Errorf("message still tells the user to paste the marker in by hand — that freezes "+
+				"the file at \"current\" without ever actually matching the bundled template:\n%s", stderr)
+		}
+	})
+}
+
+// TestDoctorFix_DeleteAndRerunRegeneratesUnmarkedWorkflow proves the remedy
+// TestDoctorFix_UnmarkedWorkflowMessageNamesAWorkingRemedy asserts the text
+// of actually works end to end: delete the refused file, re-run --fix, and
+// the file comes back as a real, current, working template — not the same
+// inert `jobs: {}` body the user started with.
+func TestDoctorFix_DeleteAndRerunRegeneratesUnmarkedWorkflow(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "jobs: {}\nUSER_SENTINEL\n", 0o644)
+		runDoctorFixCmd(t) // first pass: refused, file unchanged
+
+		if err := os.Remove(rel); err != nil {
+			t.Fatalf("remove refused file: %v", err)
+		}
+
+		runDoctorFixCmd(t) // second pass: file is gone -> CREATE branch, always writes
+
+		got := readRel(t, rel)
+		wantVersion := inserter.ExtractTemplateMarker(
+			templates.Workflow("check-decisions.yml.template")).Version
+		gotMarker := inserter.ExtractTemplateMarker(got)
+		if !gotMarker.Writable() || gotMarker.Version != wantVersion {
+			t.Errorf("delete-and-rerun did not regenerate the workflow: got %+v; want version %q",
+				gotMarker, wantVersion)
+		}
+		if strings.Contains(got, "USER_SENTINEL") || strings.Contains(got, "jobs: {}") {
+			t.Error("file still carries the old inert body — the remedy did not actually regenerate it")
+		}
+	})
+}
+
+// TestDoctorFix_ResidualNoteNamesOwnershipNotPathOrHook is the #306 LOW: the
+// residual note printed after --fix used one static sentence for every
+// still-drifted row — "(PATH/version, or a hand-written hook)" — which is
+// simply wrong for an unmarked WORKFLOW: it is neither PATH/version drift
+// (that's the on-PATH binary or a hook trailing the running version) nor a
+// hand-written git HOOK (a workflow has no such concept; "foreign" is
+// reserved for that). Before #306's ownership-first write refusal, this row
+// never reached the residual list at all — a markerless file was silently
+// overwritten into "current" instead, which is the very bug this branch
+// fixes — so the wrong attribution was invisible until the write refusal
+// made the row reachable.
+func TestDoctorFix_ResidualNoteNamesOwnershipNotPathOrHook(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		writeRel(t, rel, "jobs: {}\nUSER_SENTINEL\n", 0o644)
+
+		_, stderr := runDoctorFixCmd(t)
+
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "no logmind marker")
+		if strings.Contains(stderr, `"check-decisions.yml" still drifted — not auto-fixable by `+"`doctor --fix`"+` (PATH/version, or a hand-written hook)`) {
+			t.Errorf("residual note still blames PATH/version or a hand-written hook for a plain "+
+				"unmarked workflow, neither of which happened here:\n%s", stderr)
+		}
+	})
+}
+
 // TestDoctor_ReportsDisplacedMarkerRatherThanBareMarkerless — the reader's
 // half of #299. Reporting only "markerless" would hide that a marker IS
 // present, which is the one fact the user needs to move the file into either
@@ -236,23 +324,88 @@ func TestDoctorFix_StillRefreshesAWorkflowItOwns(t *testing.T) {
 // wrong-argument write survived untested — so the absence of a second writer
 // is the thing worth pinning, not the correctness of one that should not
 // exist.
+//
+// This started as a grep of exactly one file (self_update.go) for two exact
+// banned substrings ("inserter.FindOutdatedMarkerBlocks",
+// "os.WriteFile(entry.Path") — a second writer reintroduced under ANY OTHER
+// FILE, or under a differently-named variable in the same file, would have
+// passed it silently. Widened to scan every non-test .go source file under
+// internal/ (not just internal/cli) for the shape of a raw write to
+// AGENTS.md, allowlisting only internal/inserter/inserter.go — the one file
+// SPEC §1.1 permits to own that path (EnsureAgentsMD, RefreshMarkerBlockFile,
+// MigrateToAgentsMD's append). Every legitimate caller in this codebase
+// names the variable `agentsPath`; a second writer would either reuse that
+// convention (caught by the first alternative) or inline the path directly
+// (caught by the second).
 func TestSelfUpdate_HasNoSecondAgentsMDWriter(t *testing.T) {
-	src, err := os.ReadFile("self_update.go")
-	if err != nil {
-		t.Fatalf("read self_update.go: %v", err)
-	}
-	// Control: prove the probe can actually find a call in this file, so a
-	// pass means "absent", not "the search was wrong".
-	if !strings.Contains(string(src), "inserter.EnsureAgentsMD") {
-		t.Fatal("control failed: self_update.go no longer calls inserter.EnsureAgentsMD, " +
-			"so this file is not the one that owns the AGENTS.md refresh — re-point this test")
-	}
-	for _, banned := range []string{
-		"inserter.FindOutdatedMarkerBlocks",
-		"os.WriteFile(entry.Path",
-	} {
-		if strings.Contains(string(src), banned) {
-			t.Errorf("self-update grew a second AGENTS.md writer (%q); EnsureAgentsMD owns that path", banned)
+	// Control FIRST, on a synthetic fixture: prove the scanner actually
+	// flags the shape it exists to catch before trusting a clean result from
+	// the real tree below — an empty result from a broken scanner and an
+	// empty result from a clean tree look identical otherwise.
+	t.Run("control_detects_synthetic_second_writer", func(t *testing.T) {
+		dir := t.TempDir()
+		fixtures := map[string]string{
+			"by_convention.go": "package evil\n\nimport \"os\"\n\nfunc f(repoRoot string) {\n\tagentsPath := repoRoot + \"/AGENTS.md\"\n\tos.WriteFile(agentsPath, nil, 0o644)\n}\n",
+			"inlined.go":       "package evil\n\nimport (\"os\"; \"path/filepath\")\n\nfunc g(repoRoot string) {\n\tos.WriteFile(filepath.Join(repoRoot, \"AGENTS.md\"), nil, 0o644)\n}\n",
 		}
+		for name, body := range fixtures {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		got, err := findAgentsMDWriteViolations(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(fixtures) {
+			t.Fatalf("control: scanner found %d violation(s) in %d synthetic fixtures; "+
+				"want %d — the scanner itself is broken, so a clean result below proves nothing",
+				len(got), len(fixtures), len(fixtures))
+		}
+	})
+
+	violations, err := findAgentsMDWriteViolations("..") // internal/
+	if err != nil {
+		t.Fatalf("scan internal/ for a second AGENTS.md writer: %v", err)
 	}
+	for _, v := range violations {
+		t.Errorf("raw AGENTS.md write outside internal/inserter/inserter.go: %s — "+
+			"route this through inserter.EnsureAgentsMD / RefreshMarkerBlockFile instead", v)
+	}
+}
+
+// agentsMDWriteViolationRe matches a WriteFile call whose target is built
+// from AGENTS.md — either the conventional `agentsPath` variable name every
+// legitimate caller in this codebase uses, or the "AGENTS.md" literal
+// inlined directly into the call.
+var agentsMDWriteViolationRe = regexp.MustCompile(`WriteFile\(\s*agentsPath\b|WriteFile\(\s*filepath\.Join\([^)]*"AGENTS\.md"`)
+
+// findAgentsMDWriteViolations scans every non-test .go file under root for
+// agentsMDWriteViolationRe, skipping internal/inserter/inserter.go — the one
+// file SPEC §1.1 permits to write AGENTS.md.
+func findAgentsMDWriteViolations(root string) ([]string, error) {
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if filepath.Base(path) == "inserter.go" && filepath.Base(filepath.Dir(path)) == "inserter" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if agentsMDWriteViolationRe.Match(data) {
+			hits = append(hits, path)
+		}
+		return nil
+	})
+	return hits, err
 }

--- a/internal/cli/marker_overwrite_test.go
+++ b/internal/cli/marker_overwrite_test.go
@@ -16,17 +16,13 @@
 package cli
 
 import (
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/doctor"
 	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/templates"
 )
@@ -168,6 +164,24 @@ func TestDoctorFix_LeavesDisplacedMarkerWorkflowAlone(t *testing.T) {
 		mustContain(t, stderr, "left unchanged")
 		mustContain(t, stderr, "line 2")
 		mustContain(t, stderr, "not line 1")
+
+		// AND IT SAYS ONLY THAT (#306 HIGH 6). The residual note printed
+		// LATER IN THE SAME RUN used to contradict the refusal above outright:
+		// one file, one --fix, and both "its marker is on line 2, not line 1,
+		// so logmind cannot tell whether the file is yours or its own" and "it
+		// carries no logmind marker … so SPEC §5.2 treats it as yours". SPEC.md
+		// §5.2 hands the file to the user only when it carries "no marker at
+		// all", which is exactly what this file does not do. Asserting the
+		// first note alone left the second one unpinned, which is how it
+		// survived.
+		if strings.Contains(stderr, "carries no logmind marker") {
+			t.Errorf("doctor --fix says this file carries no logmind marker, having just reported "+
+				"the marker and the line it sits on:\n%s", stderr)
+		}
+		if strings.Contains(stderr, "treats it as yours") {
+			t.Errorf("doctor --fix claims SPEC §5.2 user ownership over a file carrying a logmind "+
+				"marker; §5.2 grants that only to an artifact carrying no marker at all:\n%s", stderr)
+		}
 	})
 }
 
@@ -441,28 +455,54 @@ func TestDoctorFix_RefusesSymlinkedExistingWorkflow(t *testing.T) {
 // as yours and leaves it alone" — SPEC §5.2's OWNERSHIP verdict, applied to a
 // binary that has no ownership marker concept at all.
 func TestResidualCause_NamesADistinctCausePerDriftValue(t *testing.T) {
-	drifts := []string{"stale", "foreign", "markerless", "unreadable"}
+	// "markerless+displaced" is a fifth CASE over four drift values: one
+	// verdict, two different facts, and only one of them is an ownership
+	// claim (#306 HIGH 6).
+	cases := map[string]doctor.WorkflowStatus{
+		"stale":      {Drift: "stale"},
+		"foreign":    {Drift: "foreign"},
+		"markerless": {Drift: "markerless"},
+		"displaced":  {Drift: "markerless", Displaced: true},
+		"unreadable": {Drift: "unreadable"},
+	}
 	cause := map[string]string{}
 	byText := map[string]string{}
-	for _, d := range drifts {
-		c := residualCause(d)
+	for _, d := range []string{"stale", "foreign", "markerless", "displaced", "unreadable"} {
+		c := residualCause(cases[d])
 		cause[d] = c
 		if prev, dup := byText[c]; dup {
-			t.Errorf("drift %q and drift %q report the IDENTICAL cause %q; one of them is wrong "+
+			t.Errorf("case %q and case %q report the IDENTICAL cause %q; one of them is wrong "+
 				"about what happened", prev, d, c)
 		}
 		byText[c] = d
 	}
+
+	// SPEC.md §5.2 gives the artifact to the user only when it carries "no
+	// marker at all". A marker on line 2 is not that, so the displaced case
+	// must NOT claim user ownership — saying it does contradicts, word for
+	// word, the declineDisplaced note printed for the same file in the same
+	// `doctor --fix` run.
+	if strings.Contains(cause["displaced"], "treats it as yours") {
+		t.Errorf("a DISPLACED marker is reported under SPEC §5.2's no-marker-at-all ownership rule, "+
+			"which does not cover it: %q", cause["displaced"])
+	}
+	if strings.Contains(cause["displaced"], "carries no logmind marker") {
+		t.Errorf("the displaced note says the file carries no marker; it carries one, on the wrong "+
+			"line, and that difference is the whole reason the file was refused: %q", cause["displaced"])
+	}
+	// And it says what IS true of it, in the same terms the write-side refusal
+	// uses, so the two notes read as one account rather than two.
+	mustContain(t, cause["displaced"], "not on line 1")
 
 	// The ownership sentence belongs to "markerless" and to nothing else.
 	const ownership = "treats it as yours"
 	if !strings.Contains(cause["markerless"], ownership) {
 		t.Errorf("markerless no longer states the SPEC §5.2 ownership verdict: %q", cause["markerless"])
 	}
-	for _, d := range []string{"stale", "foreign", "unreadable"} {
+	for _, d := range []string{"stale", "foreign", "unreadable", "displaced"} {
 		if strings.Contains(cause[d], ownership) {
-			t.Errorf("drift %q claims SPEC §5.2 user ownership, which is only true of a markerless "+
-				"artifact: %q", d, cause[d])
+			t.Errorf("case %q claims SPEC §5.2 user ownership, which is only true of an artifact "+
+				"carrying no marker at all: %q", d, cause[d])
 		}
 	}
 
@@ -506,6 +546,171 @@ func TestDoctorFix_UnreadablePathBinaryReportsItsOwnCause(t *testing.T) {
 	})
 }
 
+// TestInit_RefusedWorkflowDoesNotCostTheOtherThree is the #306 HIGH 4 user
+// symptom, measured on the artifacts that reached the disk.
+//
+// installWorkflowTemplates used to `return nil, nil, nil, err` from inside its
+// loop. check-decisions.yml sorts FIRST of the four bundled templates, so a
+// symlink there — a path the write correctly refuses — aborted the loop before
+// check-doc-links, logmind-self-update and regen-timeline were ever attempted.
+// `init` then exited 0, printed "logmind initialized successfully!" and a
+// receipt listing `workflows`, and a re-run reported "All workflow templates
+// already current." One refused artifact silently cost three unrelated ones.
+//
+// The assertion is on the FILES, not on the return value: a test on the
+// installer's error would pass while the user still lost three workflows.
+func TestInit_RefusedWorkflowDoesNotCostTheOtherThree(t *testing.T) {
+	skipWithoutSymlinks(t)
+	outside := t.TempDir()
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(outside, "escaped.yml"), rel); err != nil {
+			t.Fatalf("plant dangling symlink: %v", err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"init"})
+		var out, errOut strings.Builder
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		_ = root.Execute()
+		stdout, stderr := out.String(), errOut.String()
+
+		// THE HARM: the other three templates must be on disk.
+		for _, name := range []string{"check-doc-links.yml", "logmind-self-update.yml", "regen-timeline.yml"} {
+			p := filepath.Join(".github", "workflows", name)
+			if _, err := os.Stat(p); err != nil {
+				t.Errorf("%s was never installed — one refused artifact abandoned the rest (%v)", name, err)
+			}
+		}
+		// The refusal is still refused: nothing outside the repo, link intact.
+		if _, err := os.Stat(filepath.Join(outside, "escaped.yml")); err == nil {
+			t.Error("init wrote through the dangling symlink, outside the repository")
+		}
+		if fi, err := os.Lstat(rel); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("the planted symlink was replaced rather than refused (lstat err=%v)", err)
+		}
+
+		// AND THE SUMMARY TELLS THE TRUTH. Both lines used to be
+		// unconditional, which is what made the loss silent.
+		if strings.Contains(stdout, "logmind initialized successfully!") {
+			t.Errorf("init reported unqualified success having failed to write a workflow:\n%s", stdout)
+		}
+		if strings.Contains(stdout, "ok initialized: docs/ .logmind/ workflows @v") {
+			t.Errorf("the receipt lists `workflows` as written when one of them was not:\n%s", stdout)
+		}
+		mustContain(t, stdout, "could NOT be written")
+		mustContain(t, stdout, "workflows=3/4")
+		// And the path that did not land is NAMED, not merely counted.
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "symlink")
+	})
+}
+
+// TestInitRefresh_RefusedWorkflowIsNotReportedAsAllCurrent is the same defect
+// on init's OTHER surface. With the loop aborting, the refresh pass returned an
+// empty created/refreshed/declined triple, and the "all three lists are empty"
+// test for the reassuring line was therefore satisfied — so a repo that had
+// just failed to write a workflow was told every template was already current.
+func TestInitRefresh_RefusedWorkflowIsNotReportedAsAllCurrent(t *testing.T) {
+	skipWithoutSymlinks(t)
+	outside := t.TempDir()
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		runInitCapture(t, []string{"init"}) // first pass: fresh init
+		rel := filepath.Join(".github", "workflows", "check-decisions.yml")
+		if err := os.Remove(rel); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(outside, "escaped.yml"), rel); err != nil {
+			t.Fatalf("plant dangling symlink: %v", err)
+		}
+
+		stdout, stderr := runInitCapture(t, []string{"init"}) // second pass: refresh mode
+
+		if strings.Contains(stdout, "All workflow templates already current.") {
+			t.Errorf("refresh reported every template current over a workflow it could not write:\n%s", stdout)
+		}
+		mustContain(t, stderr, "check-decisions.yml")
+		mustContain(t, stderr, "was NOT written")
+	})
+}
+
+// TestSelfUpdate_ReportsARefusedAgentsMDRefresh is #306 HIGH 5.
+//
+// `if …, err := inserter.EnsureAgentsMD(cwd); err == nil {` had no else, so a
+// refused AGENTS.md write was discarded whole: self-update printed
+// "✓ logmind templates are up to date." over a block that was still stale,
+// exited 0, and said nothing on stderr. The error became reachable on this very
+// branch, when the AGENTS.md write learned to refuse a symlink — the fix made
+// the failure possible and then dropped it.
+//
+// Measured through the real command, on the three things the user can see:
+// the block on disk, stdout, and the exit code.
+func TestSelfUpdate_ReportsARefusedAgentsMDRefresh(t *testing.T) {
+	skipWithoutSymlinks(t)
+	outside := t.TempDir()
+	target := filepath.Join(outside, "AGENTS.md")
+
+	withTempCwd(t, func(_ string) {
+		gitInitCwd(t)
+		// Init first so the hooks and .claude/settings.json this command also
+		// refreshes are already current. Without that they report changes of
+		// their own, `updated` goes true, and the stdout assertions below pass
+		// for the wrong reason.
+		runInitCapture(t, []string{"init"})
+
+		// The same stale-but-REFRESHABLE block shape
+		// TestSelfUpdate_PreservesAgentsMDOutsideBlock uses: the marker orders
+		// before the bundled one and carries the slim flavour, so the refresh
+		// genuinely engages. An unrecognised marker would be refused by
+		// planBlockRefresh before any write was attempted, and would prove
+		// nothing about a discarded write error.
+		stale := "# AGENTS.md\n\nUSER_SENTINEL_OUTSIDE\n\n" +
+			"<!-- logmind-start -->\n<!-- logmind-block-version: v1-pointer -->\nSTALE BLOCK BODY\n<!-- logmind-end -->\n"
+		if err := os.WriteFile(target, []byte(stale), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove("AGENTS.md"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, "AGENTS.md"); err != nil {
+			t.Fatalf("plant symlink: %v", err)
+		}
+
+		root := NewRootCmd()
+		root.SetArgs([]string{"self-update"})
+		var out, errOut strings.Builder
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		err := root.Execute()
+		stdout, stderr := out.String(), errOut.String()
+
+		// The refusal held — the file outside the repo is untouched.
+		if got := readRel(t, target); got != stale {
+			t.Fatalf("self-update wrote through the symlink to a file outside the repo")
+		}
+		// And it was REPORTED rather than dropped.
+		if strings.Contains(stdout, "✓ logmind templates are up to date.") {
+			t.Errorf("self-update called a stale, unrefreshed block up to date:\n%s", stdout)
+		}
+		if strings.Contains(stdout, "ok self-update applied") {
+			t.Errorf("self-update issued its applied receipt for a refresh that failed:\n%s", stdout)
+		}
+		if err == nil {
+			t.Error("self-update exited 0 having failed to refresh the block; the failure was silent")
+		}
+		mustContain(t, stderr, "AGENTS.md")
+		mustContain(t, stderr, "symlink")
+	})
+}
+
 // skipWithoutSymlinks skips on platforms where an unprivileged process cannot
 // create one (Windows), mirroring internal/inserter's helper of the same
 // purpose.
@@ -513,402 +718,5 @@ func skipWithoutSymlinks(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation requires elevation on Windows")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// The structural half of the #297 fix: nothing may write a managed path except
-// through the one primitive that owns it.
-// ---------------------------------------------------------------------------
-
-// TestWriteSurfaces_UseNoRawWritePrimitive is the rebuilt #297 second-writer
-// guard, and it is deliberately NOT a scan for the AGENTS.md PATH.
-//
-// SPEC §5.2: "Exactly one automation owns any generated or copied path. Two
-// refreshers MUST NOT write the same path." The deleted #297 loop was a second
-// refresher of AGENTS.md, and being unreachable is precisely why its
-// wrong-argument write survived untested — so the absence of a second writer is
-// the thing worth pinning, not the correctness of one that should not exist.
-//
-// WHY THE PATH IS THE WRONG THING TO SCAN FOR. Two earlier versions of this
-// guard matched on the target expression: first two exact banned substrings in
-// one file, then a regexp for `WriteFile(agentsPath` / `WriteFile(filepath.
-// Join(…"AGENTS.md"`. A review panel walked through both. The set of ways to
-// spell a path is unbounded, and every one of these compiles and passed:
-//
-//	os.WriteFile(entry.Path, []byte(entry.NewBody), 0o644)  // the literal #297 loop
-//	os.WriteFile(repoRoot+"/AGENTS.md", …)                  // concatenated literal
-//	p := filepath.Join(root, "AGENTS.md"); os.WriteFile(p, …) // renamed variable
-//	writeAgentsFile(agentsPath, …)                          // one-line wrapper
-//	…and anything at all under cmd/, which the old scan root never visited.
-//
-// The first of those five is the worst case for a path scan: it never names
-// AGENTS.md at all — it takes the path back OUT of the inserter API. And it is
-// invisible to a behavioural test too, which is why one is not the answer
-// here: after EnsureAgentsMD refreshes the block, FindOutdatedMarkerBlocks
-// reports nothing, so the restored loop is a no-op and every outcome assertion
-// above it stays green. Measured, not assumed — with the loop restored,
-// TestSelfUpdate_PreservesAgentsMDOutsideBlock passes.
-//
-// WHAT IS SCANNED INSTEAD. The write PRIMITIVE, which unlike a path is a
-// closed, enumerable set. Every one of those five evasions must ultimately
-// call one, so banning the primitive catches all five however the path is
-// spelled — and it generalises: the same guard is what would have caught the
-// live symlink escape at installWorkflowTemplates, where a bare os.WriteFile
-// followed a dangling symlink out of the repo (see
-// TestDoctorFix_RefusesDanglingWorkflowSymlink).
-//
-// KNOWN BOUNDARY, stated rather than implied: a second writer that took the
-// path from inserter.OutdatedMarkerEntry.Path AND routed it through
-// atomicio.WriteFile would satisfy this guard. Closing that needs either
-// interprocedural dataflow or the removal of the Path field, whose only
-// consumer is runAgentsUpdate in internal/cli/agents.go.
-func TestWriteSurfaces_UseNoRawWritePrimitive(t *testing.T) {
-	root := moduleRoot(t)
-
-	// SCOPE CONTROL FIRST. Evasion five was purely a scope failure — a
-	// perfectly good scanner pointed at internal/ alone, so a second writer
-	// under cmd/ was never read. Assert the walk actually reaches specific
-	// NAMED files before trusting a clean result, one per directory the guard
-	// claims to cover. Naming the files rather than counting them matters:
-	// the cheapest way to make this guard green is to drop a directory from
-	// writeSurfaceDirs, and a non-empty count would not notice.
-	scanned := map[string]bool{}
-	for _, dir := range writeSurfaceDirs {
-		files, err := goSourceFiles(filepath.Join(root, dir))
-		if err != nil {
-			t.Fatalf("walk %s: %v", dir, err)
-		}
-		for _, f := range files {
-			rel, relErr := filepath.Rel(root, f)
-			if relErr != nil {
-				t.Fatal(relErr)
-			}
-			scanned[filepath.ToSlash(rel)] = true
-		}
-	}
-	for _, sentinel := range []string{
-		"cmd/logmind/main.go",             // the binary's own package — evasion five's home
-		"internal/cli/self_update.go",     // where the #297 second writer lived
-		"internal/inserter/inserter.go",   // the owner of the AGENTS.md write primitive
-		"internal/inserter/dependabot.go", // a sibling installer found by a later sweep
-	} {
-		if !scanned[sentinel] {
-			t.Fatalf("scope control: %s was never read by the scan — the guard's coverage has "+
-				"shrunk, so a clean result below proves nothing about it", sentinel)
-		}
-	}
-
-	// DETECTION CONTROL. One synthetic fixture per evasion the panel found,
-	// including one in a nested subdirectory (proving the walk recurses) and
-	// one negative fixture that must NOT be flagged (proving the scanner
-	// discriminates rather than flagging every file it reads).
-	t.Run("control_detects_every_known_evasion", func(t *testing.T) {
-		dir := t.TempDir()
-		type fixture struct {
-			rel, body string
-			wantHit   bool
-		}
-		fixtures := []fixture{
-			{"evasion1_inserter_supplied_path.go", `package evil
-
-import (
-	"os"
-
-	"github.com/thrillmade/logmind/internal/inserter"
-)
-
-func f(cwd string) {
-	entries, _, _ := inserter.FindOutdatedMarkerBlocks(cwd)
-	for _, entry := range entries {
-		_ = os.WriteFile(entry.Path, []byte(entry.NewBody), 0o644)
-	}
-}
-`, true},
-			{"evasion2_concatenated_literal.go", `package evil
-
-import "os"
-
-func g(repoRoot string) { _ = os.WriteFile(repoRoot+"/AGENTS.md", nil, 0o644) }
-`, true},
-			{"evasion3_renamed_variable.go", `package evil
-
-import (
-	"os"
-	"path/filepath"
-)
-
-func h(repoRoot string) {
-	p := filepath.Join(repoRoot, "AGENTS.md")
-	_ = os.WriteFile(p, nil, 0o644)
-}
-`, true},
-			{"evasion4_helper_wrapper.go", `package evil
-
-import "os"
-
-func writeAgentsFile(path string, data []byte) error { return os.WriteFile(path, data, 0o644) }
-`, true},
-			{"nested/evasion5_under_a_subdirectory.go", `package nested
-
-import (
-	"os"
-	"path/filepath"
-)
-
-func k(repoRoot string) {
-	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
-	_ = os.WriteFile(agentsPath, nil, 0o644)
-}
-`, true},
-			{"other_primitives.go", `package evil
-
-import "os"
-
-func m(path string) {
-	f, _ := os.Create(path)
-	_ = f
-	g, _ := os.OpenFile(path, os.O_WRONLY, 0o644)
-	_ = g
-}
-`, true},
-			// NEGATIVE control: the sanctioned route. A guard that flags this
-			// too would "pass" every fixture above while measuring nothing.
-			{"sanctioned_route.go", `package evil
-
-import (
-	"path/filepath"
-
-	"github.com/thrillmade/logmind/internal/atomicio"
-)
-
-func n(repoRoot string) {
-	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
-	_ = atomicio.WriteFile(agentsPath, nil, 0o644)
-}
-`, false},
-			// NEGATIVE control: the primitive named in a comment and a string,
-			// never called. An AST scan must not confuse mention with use — a
-			// regexp over the bytes would flag this file and, by flagging the
-			// codebase's own explanatory comments, force the guard to be
-			// weakened until it stopped working.
-			{"mentions_only.go", `package evil
-
-// This function deliberately does not call os.WriteFile.
-func p() string { return "os.WriteFile" }
-`, false},
-		}
-		var wantHits []string
-		for _, fx := range fixtures {
-			full := filepath.Join(dir, fx.rel)
-			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(full, []byte(fx.body), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			if fx.wantHit {
-				wantHits = append(wantHits, fx.rel)
-			}
-		}
-
-		got, err := findRawWritePrimitives(dir, []string{"."})
-		if err != nil {
-			t.Fatalf("scan fixtures: %v", err)
-		}
-		hitFiles := map[string]bool{}
-		for _, v := range got {
-			hitFiles[v.File] = true
-		}
-		for _, want := range wantHits {
-			if !hitFiles[filepath.ToSlash(want)] {
-				t.Errorf("control: %s was NOT flagged — this evasion would ship undetected", want)
-			}
-		}
-		for _, fx := range fixtures {
-			if !fx.wantHit && hitFiles[filepath.ToSlash(fx.rel)] {
-				t.Errorf("control: %s WAS flagged — the scanner does not discriminate, so a "+
-					"clean tree result would only mean the allowlist is doing the work", fx.rel)
-			}
-		}
-	})
-
-	// THE REAL TREE.
-	violations, err := findRawWritePrimitives(root, writeSurfaceDirs)
-	if err != nil {
-		t.Fatalf("scan the write surfaces: %v", err)
-	}
-	exercised := map[string]bool{}
-	for _, v := range violations {
-		if _, ok := rawWriteAllowlist[v.File]; ok {
-			exercised[v.File] = true
-			continue
-		}
-		t.Errorf("%s:%d calls %s directly — route it through atomicio.WriteFile (or an "+
-			"inserter primitive), which refuses a symlink at the destination and writes "+
-			"whole-file-or-nothing. If this path is one logmind already owns elsewhere, the "+
-			"call is a SECOND writer of it, which SPEC §5.2 forbids outright.",
-			v.File, v.Line, v.Call)
-	}
-
-	// STALENESS. An allowlist entry that no longer names a real violation is
-	// either a fix nobody deleted the exemption for, or a file that moved out
-	// from under it — and in the second case the exemption now covers nothing
-	// while the moved file goes unguarded. Either way it has to be noticed, so
-	// an unused entry fails rather than lingers.
-	for path, reason := range rawWriteAllowlist {
-		if !exercised[path] {
-			t.Errorf("allowlist entry %q (%s) matched no raw write — delete the entry if the "+
-				"call is gone, or update it if the file moved; a stale exemption widens this "+
-				"guard without anyone deciding to", path, reason)
-		}
-	}
-}
-
-// writeSurfaceDirs are the trees this guard covers: the command layer, the
-// artifact-installer package, and the binary's own main package. cmd/ is here
-// because its absence from the previous scan root was one of the five ways a
-// second writer got in.
-var writeSurfaceDirs = []string{
-	filepath.Join("internal", "cli"),
-	filepath.Join("internal", "inserter"),
-	"cmd",
-}
-
-// rawWriteAllowlist maps a REPO-RELATIVE PATH to the reason its raw write
-// primitive is permitted. Paths, not base names: a base-name key silently
-// exempts any future file that happens to share the name, which is the same
-// "matches more than it means" failure that let five second writers past the
-// previous version of this guard.
-//
-// Every entry is a standing finding, not an endorsement — and every entry is
-// checked for staleness below, so one whose violation is fixed, or whose file
-// moves, fails this test rather than quietly widening it.
-var rawWriteAllowlist = map[string]string{
-	// Opens a lock file for flock(2). No content is ever written through the
-	// descriptor, so there is no torn-write or symlink-follow exposure to fix.
-	"internal/cli/filelock_unix.go": "lock-file open, not a content write",
-
-	// FINDING, not a fix: os.WriteFile on a CI workflow pin path. Same
-	// ENOENT-as-absent / follow-the-symlink exposure as the two writes fixed
-	// in init.go on this branch. Owned by another in-flight lane (PR #313),
-	// so it is recorded here rather than routed around.
-	"internal/cli/agents.go": "workflow-pin write; raw primitive owned by PR #313's lane",
-
-	// FINDING, same as above: two raw hook writes, PR #313's lane.
-	"internal/cli/install_hook.go": "git-hook write; raw primitive owned by PR #313's lane",
-}
-
-// rawWriteViolation is one call to a banned primitive.
-type rawWriteViolation struct {
-	File string // repo-relative, slash-separated
-	Line int
-	Call string // e.g. "os.WriteFile"
-}
-
-// bannedWritePrimitives are the stdlib calls that write (or truncate) a file
-// at a path directly. Unlike a path expression, this set is CLOSED — which is
-// the whole reason the guard scans for it instead of for "AGENTS.md".
-//
-// os.Rename is absent deliberately: it is the second half of atomicio's own
-// temp-file-plus-rename, so banning it would ban the sanctioned route.
-var bannedWritePrimitives = map[string]map[string]bool{
-	"os":     {"WriteFile": true, "Create": true, "OpenFile": true, "Truncate": true},
-	"ioutil": {"WriteFile": true},
-}
-
-// findRawWritePrimitives parses every non-test .go file under root and returns
-// each CALL to a banned write primitive. Files whose base name is in allow are
-// skipped.
-//
-// AST, not regexp, and that is load-bearing rather than fastidious: this
-// codebase's comments discuss `os.WriteFile` constantly — describing exactly
-// the defect this guard pins — so a byte-level scan would flag its own
-// explanations, and the only way to make it green would be to weaken it.
-func findRawWritePrimitives(root string, dirs []string) ([]rawWriteViolation, error) {
-	var files []string
-	for _, dir := range dirs {
-		found, err := goSourceFiles(filepath.Join(root, dir))
-		if err != nil {
-			return nil, err
-		}
-		files = append(files, found...)
-	}
-	var out []rawWriteViolation
-	fset := token.NewFileSet()
-	for _, path := range files {
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return nil, err
-		}
-		rel = filepath.ToSlash(rel)
-		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
-		}
-		ast.Inspect(f, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			pkg, ok := sel.X.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			if bannedWritePrimitives[pkg.Name][sel.Sel.Name] {
-				out = append(out, rawWriteViolation{
-					File: rel,
-					Line: fset.Position(sel.Pos()).Line,
-					Call: pkg.Name + "." + sel.Sel.Name,
-				})
-			}
-			return true
-		})
-	}
-	return out, nil
-}
-
-// goSourceFiles lists every non-test .go file under root, recursively.
-func goSourceFiles(root string) ([]string, error) {
-	var out []string
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		out = append(out, path)
-		return nil
-	})
-	return out, err
-}
-
-// moduleRoot walks up from the test's working directory to the directory
-// holding go.mod. Scanning from the module root — rather than from a relative
-// "..", which is how cmd/ came to be excluded — is what makes the guard's
-// coverage a property of the repository instead of of the test's location.
-func moduleRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("no go.mod found above the test's working directory")
-		}
-		dir = parent
 	}
 }

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -157,11 +157,23 @@ func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 			// SPEC §1.1: "An artifact carrying no marker at all belongs to
 			// the user and MUST NOT be overwritten." Saying so is what makes
 			// the refusal auditable rather than a silent no-op.
+			//
+			// The remedy is delete-and-regenerate, NOT "paste the bundled
+			// marker in yourself": installWorkflowTemplates only rewrites a
+			// file whose installed marker DIFFERS from the bundled one (the
+			// `installedVer != bundledVer` guard below) — pasting the
+			// CURRENT marker makes the file match on the very next read, so
+			// it is filed "current" forever and never refreshed again, no
+			// matter what the rest of the file says. Deleting the file
+			// routes the next `--fix`/`init` through the CREATE branch
+			// instead, which always writes — verified end to end for #306.
 			fmt.Fprintf(stderr,
 				"note: %s left unchanged — it carries no `# logmind-template-version:` marker, "+
 					"so logmind treats it as yours and will not overwrite it. To hand it back to "+
-					"logmind, make `# logmind-template-version: %s` its first line.\n",
-				d.Path, d.Bundled)
+					"logmind, delete %s and re-run `logmind doctor --fix` (or `logmind init`) to "+
+					"regenerate it from the bundled template — pasting the marker in by hand would "+
+					"make the file look current forever without actually matching it.\n",
+				d.Path, d.Path)
 		case declineDisplaced:
 			fmt.Fprintf(stderr,
 				"note: %s left unchanged — its `# logmind-template-version: %s` marker is on line %d, "+

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -181,6 +181,19 @@ func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 					"not overwrite it. Move the marker to line 1 to let logmind refresh it, or delete "+
 					"the marker to keep the file yours.\n",
 				d.Path, d.Installed, d.Line)
+		case declineUnwritable:
+			// Not a judgement about the file — logmind wanted it and could not
+			// have it. Distinguished from the three refusals above because the
+			// remedy is different in kind: those ask the user to decide who
+			// owns the file, this one says the write itself could not happen.
+			// Every other template in the same pass was still installed (#306),
+			// which is why this reads "was NOT written" rather than "left
+			// unchanged": the run continued, and the user has to know that this
+			// one path did not come with it.
+			fmt.Fprintf(stderr,
+				"note: %s was NOT written — %v. The other workflow templates in this run were "+
+					"installed; re-run once this path is writable.\n",
+				d.Path, d.Err)
 		default:
 			fmt.Fprintf(stderr,
 				"note: %s left unchanged — installed template %s is NEWER than the %s this binary bundles; "+
@@ -188,6 +201,22 @@ func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 				d.Path, d.Installed, d.Bundled)
 		}
 	}
+}
+
+// unwritableCount counts the declines that are FAILURES rather than ownership
+// judgements. declineUnmarked / declineDisplaced / declineDowngrade are stable,
+// legitimate repository states a surface may finish successfully on; a path
+// logmind could not write at all is not, and every surface has to be able to
+// tell the two apart — that is what lets a refusal continue the run without
+// letting the run claim it succeeded (#306).
+func unwritableCount(declined []templateDowngrade) int {
+	n := 0
+	for _, d := range declined {
+		if d.Reason == declineUnwritable {
+			n++
+		}
+	}
+	return n
 }
 
 // reportAgentsBlockRefusal writes the one stderr line for a refused

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -147,12 +147,34 @@ func applyRefresh(cwd string, opts refreshOpts) (refreshResult, error) {
 // Shape follows SPEC §3.4's rule for the analogous fail-open case ("Failing
 // open MUST NOT be silent... MUST say so on stderr, naming what it looked
 // for and what it found"): name the file, both markers, and the direction.
+// Three refusals, three remedies — so three messages. A single "left
+// unchanged" line would tell a user whose file is AHEAD of the binary to go
+// take ownership of it, and a user whose file is THEIRS to go upgrade.
 func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 	for _, d := range declined {
-		fmt.Fprintf(stderr,
-			"note: %s left unchanged — installed template %s is NEWER than the %s this binary bundles; "+
-				"refusing to downgrade. Upgrade logmind to move it forward.\n",
-			d.Path, d.Installed, d.Bundled)
+		switch d.Reason {
+		case declineUnmarked:
+			// SPEC §1.1: "An artifact carrying no marker at all belongs to
+			// the user and MUST NOT be overwritten." Saying so is what makes
+			// the refusal auditable rather than a silent no-op.
+			fmt.Fprintf(stderr,
+				"note: %s left unchanged — it carries no `# logmind-template-version:` marker, "+
+					"so logmind treats it as yours and will not overwrite it. To hand it back to "+
+					"logmind, make `# logmind-template-version: %s` its first line.\n",
+				d.Path, d.Bundled)
+		case declineDisplaced:
+			fmt.Fprintf(stderr,
+				"note: %s left unchanged — its `# logmind-template-version: %s` marker is on line %d, "+
+					"not line 1, so logmind cannot tell whether the file is yours or its own and will "+
+					"not overwrite it. Move the marker to line 1 to let logmind refresh it, or delete "+
+					"the marker to keep the file yours.\n",
+				d.Path, d.Installed, d.Line)
+		default:
+			fmt.Fprintf(stderr,
+				"note: %s left unchanged — installed template %s is NEWER than the %s this binary bundles; "+
+					"refusing to downgrade. Upgrade logmind to move it forward.\n",
+				d.Path, d.Installed, d.Bundled)
+		}
 	}
 }
 

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -154,7 +154,7 @@ func reportTemplateDowngrades(stderr io.Writer, declined []templateDowngrade) {
 	for _, d := range declined {
 		switch d.Reason {
 		case declineUnmarked:
-			// SPEC §1.1: "An artifact carrying no marker at all belongs to
+			// SPEC §5.2: "An artifact carrying no marker at all belongs to
 			// the user and MUST NOT be overwritten." Saying so is what makes
 			// the refusal auditable rather than a silent no-op.
 			//

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -71,8 +71,21 @@ func runSelfUpdate(cmd *cobra.Command) error {
 
 	updated := false
 	blockRefused := false
+	blockFailed := false
 
-	if msg, declined, err := inserter.EnsureAgentsMD(cwd); err == nil {
+	// THE ERROR IS NOT OPTIONAL (#306). This used to read
+	// `if …, err := inserter.EnsureAgentsMD(cwd); err == nil {` with no else,
+	// which was survivable only while the error was unreachable. Teaching the
+	// AGENTS.md write to refuse a symlink at its destination made it reachable,
+	// and the discarded branch then printed "✓ logmind templates are up to
+	// date." over a block that was still stale, exited 0, and never showed the
+	// refusal at all — the worst of the three outcomes, because it is the one
+	// that stops the user from looking.
+	msg, declined, err := inserter.EnsureAgentsMD(cwd)
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "error: self-update: AGENTS.md logmind block was NOT refreshed —", err)
+		blockFailed = true
+	} else {
 		if msg != "" {
 			fmt.Fprintln(out, msg)
 			updated = true
@@ -140,14 +153,28 @@ func runSelfUpdate(cmd *cobra.Command) error {
 	}
 
 	if !updated {
-		if blockRefused {
+		switch {
+		case blockFailed:
+			// Neither "up to date" nor "left unchanged": the refresh was
+			// attempted and FAILED, and the block on disk is still whatever it
+			// was — stale, most likely, since that is why the write was tried.
+			fmt.Fprintln(out, "! AGENTS.md logmind block could NOT be refreshed — see the error on stderr.")
+		case blockRefused:
 			// "up to date" would contradict the note on stderr — this repo's
 			// block is one this binary can't move forward, not one it just
 			// verified (#267).
 			fmt.Fprintln(out, "! AGENTS.md logmind block left unchanged — see the note on stderr.")
-		} else {
+		default:
 			fmt.Fprintln(out, "✓ logmind templates are up to date.")
 		}
+	}
+	if blockFailed {
+		// `ok self-update applied` is a receipt for work that happened. Exit
+		// non-zero as well: the self-update workflow runs this unattended, and
+		// a zero exit is the difference between a repo whose stale block gets
+		// noticed and one where it never does.
+		fmt.Fprintln(out, "ok self-update incomplete")
+		return ErrSilent
 	}
 	fmt.Fprintln(out, "ok self-update applied")
 	return nil

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -90,7 +90,7 @@ func runSelfUpdate(cmd *cobra.Command) error {
 	// AGENTS.md a second time in the same command. FindOutdatedMarkerBlocks
 	// only ever reports AGENTS.md, and EnsureAgentsMD above has already
 	// refreshed it against the same classifier (planBlockRefresh) — so the
-	// loop was pure duplication, which SPEC §1.1 forbids outright ("Exactly
+	// loop was pure duplication, which SPEC §5.2 forbids outright ("Exactly
 	// one automation owns any generated or copied path. Two refreshers MUST
 	// NOT write the same path"). Being unreachable is also why nothing caught
 	// that it passed the BLOCK BODY where the WHOLE FILE belonged and wrote
@@ -98,8 +98,17 @@ func runSelfUpdate(cmd *cobra.Command) error {
 	//
 	// Deleting the duplicate is the fix, not repairing its arguments: the
 	// second writer had no work of its own to do, and a dead write path is
-	// exactly where an untested defect survives. EnsureAgentsMD is the single
-	// owner of this path, and it reports through `msg` above.
+	// exactly where an untested defect survives.
+	//
+	// Precisely what is single here, since "EnsureAgentsMD is the single owner
+	// of this path" overstated it: AGENTS.md's bytes have exactly one WRITE
+	// PRIMITIVE, inserter.RefreshMarkerBlockFile, which owns the read, requires
+	// the markers to be present, and writes the whole file back. Two commands
+	// route through it — this one via inserter.EnsureAgentsMD, and `logmind
+	// agents update --apply` via runAgentsUpdate — which is one owner reached
+	// from two surfaces, not two refreshers. What SPEC §5.2 forbids is the
+	// second REFRESHER, and within this command the call above is the only one.
+	// EnsureAgentsMD reports through `msg`.
 
 	// Refresh local hooks to match the running binary's body.
 	if _, err := os.Stat(filepath.Join(cwd, ".git")); err == nil {

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -84,22 +84,22 @@ func runSelfUpdate(cmd *cobra.Command) error {
 		blockRefused = declined != nil
 	}
 
-	// Refresh per-agent stubs by detecting drift and rewriting affected
-	// files. The inserter package's FindOutdatedMarkerBlocks +
-	// MigrateToAgentsMD pipeline already covers this; we call them here
-	// in best-effort mode. Its refusal is dropped deliberately: it can only
-	// concern the same AGENTS.md EnsureAgentsMD just reported on above.
-	if entries, _, err := inserter.FindOutdatedMarkerBlocks(cwd); err == nil {
-		for _, entry := range entries {
-			refreshed := inserter.ReplaceMarkerBlock(entry.OldBody, entry.NewBody)
-			if err := os.WriteFile(entry.Path, []byte(refreshed), 0o644); err == nil {
-				if rel, err := filepath.Rel(cwd, entry.Path); err == nil {
-					fmt.Fprintln(out, "✓ Refreshed marker block in", rel)
-					updated = true
-				}
-			}
-		}
-	}
+	// NOTE — there is deliberately no second AGENTS.md refresher here (#297).
+	//
+	// A FindOutdatedMarkerBlocks loop used to sit at this point, writing
+	// AGENTS.md a second time in the same command. FindOutdatedMarkerBlocks
+	// only ever reports AGENTS.md, and EnsureAgentsMD above has already
+	// refreshed it against the same classifier (planBlockRefresh) — so the
+	// loop was pure duplication, which SPEC §1.1 forbids outright ("Exactly
+	// one automation owns any generated or copied path. Two refreshers MUST
+	// NOT write the same path"). Being unreachable is also why nothing caught
+	// that it passed the BLOCK BODY where the WHOLE FILE belonged and wrote
+	// the resulting fragment over the user's entire AGENTS.md.
+	//
+	// Deleting the duplicate is the fix, not repairing its arguments: the
+	// second writer had no work of its own to do, and a dead write path is
+	// exactly where an untested defect survives. EnsureAgentsMD is the single
+	// owner of this path, and it reports through `msg` above.
 
 	// Refresh local hooks to match the running binary's body.
 	if _, err := os.Stat(filepath.Join(cwd, ".git")); err == nil {

--- a/internal/cli/template_downgrade_test.go
+++ b/internal/cli/template_downgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/templates"
 )
 
@@ -91,7 +92,7 @@ func TestParseTemplateVersion_Ordering(t *testing.T) {
 // this binary ships for one workflow template.
 func bundledTemplateVersion(t *testing.T, name string) string {
 	t.Helper()
-	v := extractTemplateVersion(templates.Workflow(name + ".template"))
+	v := inserter.ExtractTemplateMarker(templates.Workflow(name + ".template")).Version
 	if v == "" {
 		t.Fatalf("bundled %s carries no template-version marker", name)
 	}
@@ -166,7 +167,7 @@ func TestInstallWorkflowTemplates_StillUpgrades(t *testing.T) {
 			t.Errorf("declined = %+v; want none on an upgrade", declined)
 		}
 		want := bundledTemplateVersion(t, "check-decisions.yml")
-		if got := extractTemplateVersion(readRel(t, rel)); got != want {
+		if got := inserter.ExtractTemplateMarker(readRel(t, rel)).Version; got != want {
 			t.Errorf("marker after refresh = %q; want %q", got, want)
 		}
 		found := false
@@ -197,7 +198,7 @@ func TestInstallWorkflowTemplates_UnparseableMarkerStillRefreshes(t *testing.T) 
 			t.Errorf("declined = %+v; want none for an unparseable marker", declined)
 		}
 		want := bundledTemplateVersion(t, "check-decisions.yml")
-		if got := extractTemplateVersion(readRel(t, rel)); got != want {
+		if got := inserter.ExtractTemplateMarker(readRel(t, rel)).Version; got != want {
 			t.Errorf("marker after refresh = %q; want %q (unparseable must not pin)", got, want)
 		}
 	})

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -122,6 +122,22 @@ type WorkflowStatus struct {
 	Marker        *string `json:"marker"`
 	BundledMarker *string `json:"bundled_marker"`
 	Drift         string  `json:"drift"`
+
+	// Displaced is true when a marker IS present but not on line 1 (#299).
+	// The VERDICT for that file is "markerless" — the writer refuses to touch
+	// it — but the REASON is not the one a bare markerless file has, and SPEC
+	// §5.2 grants user ownership only to "an artifact carrying no marker at
+	// all". Without this, `doctor --fix` printed both "its marker is on line 2,
+	// not line 1, so logmind cannot tell whether the file is yours or its own"
+	// and "it carries no logmind marker … so SPEC §5.2 treats it as yours" for
+	// the same file in the same run.
+	//
+	// Deliberately NOT serialized: the JSON field names here are a cross-repo
+	// contract (clud-bug, agent-skills parse this shape), and this is an
+	// explanation for a stderr note, not a verdict a consumer branches on.
+	// One owner for the fact — probeWorkflow computes it, callers read it,
+	// nobody re-derives it by sniffing the prose in Marker.
+	Displaced bool `json:"-"`
 }
 
 // ToolStatus aggregates per-tool fields (currently just `logmind`;
@@ -630,7 +646,8 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 	// matches the existing "markerless (pre-v0.6.10)" / "foreign … left
 	// alone" rows rather than inventing a drift value consumers don't parse.
 	display := owned
-	if found.Ownership == inserter.MarkerDisplaced {
+	displaced := found.Ownership == inserter.MarkerDisplaced
+	if displaced {
 		v := fmt.Sprintf("%s on line %d, not line 1", found.Version, found.Line)
 		display = &v
 	}
@@ -638,6 +655,7 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 	return WorkflowStatus{
 		Name: name, Installed: true, Marker: display,
 		BundledMarker: bundled, Drift: classifyMarker(owned, bundled),
+		Displaced: displaced,
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -614,7 +614,7 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 
 	// `owned` is what the DRIFT VERDICT is computed from, and it is non-nil
 	// only when the file is ours to refresh. classifyMarker's nil case is the
-	// SPEC §1.1 "belongs to the user" verdict, so routing anything the writer
+	// SPEC §5.2 "belongs to the user" verdict, so routing anything the writer
 	// would refuse through nil is what keeps the reader's answer identical to
 	// the writer's — the disagreement between them WAS #299.
 	var owned *string
@@ -908,8 +908,18 @@ func probeClaudePreToolUseHook(projectRoot string) WorkflowStatus {
 //     can act on it without invoking `which -a`.
 //   - drift="missing"   when no logmind found on PATH (merge driver
 //     shell-outs will fail).
-//   - drift="markerless" when the PATH binary exists but its
-//     --version is unreadable / unparseable.
+//   - drift="unreadable" when the PATH binary exists but its
+//     --version cannot be executed or cannot be parsed.
+//
+// "unreadable" is deliberately NOT "markerless" (#306). Everywhere else in
+// this file "markerless" carries SPEC §5.2's OWNERSHIP verdict — "an artifact
+// carrying no marker at all belongs to the user and MUST NOT be overwritten"
+// — and callers act on it as such: `doctor --fix` refuses to write the path,
+// and the residual note tells the user logmind is leaving their file alone. A
+// binary on PATH is not a user-owned markerless artifact and has no marker
+// concept at all; what happened is that logmind could not read its version.
+// Reusing the ownership token for it made --fix report a true fact ("still
+// drifted") with a false cause.
 //
 // Errors are best-effort: every failure path produces a status row
 // (no panics). This is the v0.6.16 carry-forward that bubbles up
@@ -942,7 +952,7 @@ func probePathResolution() WorkflowStatus {
 		marker := fmt.Sprintf("%s (cannot exec --version)", pathBin)
 		return WorkflowStatus{
 			Name: "logmind on PATH", Installed: true,
-			Marker: &marker, BundledMarker: &running, Drift: "markerless",
+			Marker: &marker, BundledMarker: &running, Drift: "unreadable",
 		}
 	}
 	text := strings.TrimSpace(string(out))
@@ -951,7 +961,7 @@ func probePathResolution() WorkflowStatus {
 		marker := fmt.Sprintf("%s (no version parsed from %q)", pathBin, text)
 		return WorkflowStatus{
 			Name: "logmind on PATH", Installed: true,
-			Marker: &marker, BundledMarker: &running, Drift: "markerless",
+			Marker: &marker, BundledMarker: &running, Drift: "unreadable",
 		}
 	}
 	pathVer := strings.TrimRight(m[1], ",")
@@ -993,6 +1003,8 @@ func formatDrift(drift string) string {
 		return "current"
 	case "markerless":
 		return "markerless"
+	case "unreadable":
+		return "version unreadable"
 	case "missing":
 		return "—"
 	case "foreign":

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -89,8 +89,14 @@ var LogmindWorkflows = []string{
 }
 
 // Marker regexes match Python's compiled patterns at the source.
+// The `# logmind-template-version:` extractor deliberately does NOT live
+// here. doctor READS that marker and internal/cli WRITES against it, and two
+// copies of the rule meant a file could be markerless to the reader and
+// versioned to the writer at the same time (#299) — so `doctor --fix`
+// overwrote a file `doctor` had just called the user's. Both sides now call
+// inserter.ExtractTemplateMarker, the same way both already order generations
+// through inserter.ParseMarkerGeneration (#294).
 var (
-	logmindMarkerRe       = regexp.MustCompile(`^# logmind-template-version:\s*(\S+)`)
 	logmindBlockVersionRe = regexp.MustCompile(`<!--\s*logmind-block-version:\s*(\S+)\s*-->`)
 	// logmindVersionLineRe parses the version out of a PATH binary's
 	// `--version` output. It anchors on the REAL versionLine format emitted
@@ -549,20 +555,15 @@ func classifyLogmindDrift(workflows []WorkflowStatus) string {
 
 func bundledLogmindMarker(workflowName string) *string {
 	body := templates.Workflow(workflowName + ".template")
-	first := firstLine(body)
-	m := logmindMarkerRe.FindStringSubmatch(first)
-	if len(m) < 2 {
+	marker := inserter.ExtractTemplateMarker(body)
+	if !marker.Writable() {
+		// A template WE ship whose marker isn't on line 1 is a build defect,
+		// not a repo state — report "no bundled marker" rather than compare
+		// against a token the writer would refuse to act on.
 		return nil
 	}
-	v := m[1]
+	v := marker.Version
 	return &v
-}
-
-func firstLine(s string) string {
-	if idx := strings.Index(s, "\n"); idx >= 0 {
-		return s[:idx]
-	}
-	return s
 }
 
 func readWorkflow(projectRoot, name string) (string, bool) {
@@ -609,16 +610,34 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 	if !ok {
 		return WorkflowStatus{Name: name, Installed: false, Marker: nil, BundledMarker: bundled, Drift: "missing"}
 	}
-	first := firstLine(content)
-	m := logmindMarkerRe.FindStringSubmatch(first)
-	var marker *string
-	if len(m) >= 2 {
-		v := m[1]
-		marker = &v
+	found := inserter.ExtractTemplateMarker(content)
+
+	// `owned` is what the DRIFT VERDICT is computed from, and it is non-nil
+	// only when the file is ours to refresh. classifyMarker's nil case is the
+	// SPEC §1.1 "belongs to the user" verdict, so routing anything the writer
+	// would refuse through nil is what keeps the reader's answer identical to
+	// the writer's — the disagreement between them WAS #299.
+	var owned *string
+	if found.Writable() {
+		v := found.Version
+		owned = &v
 	}
+
+	// `display` may say more than the verdict does. A displaced marker is
+	// "markerless" as a verdict, but reporting only that would hide the fact
+	// that a marker IS present — the one thing the user needs in order to
+	// move the file deliberately into either camp. Prose in the marker column
+	// matches the existing "markerless (pre-v0.6.10)" / "foreign … left
+	// alone" rows rather than inventing a drift value consumers don't parse.
+	display := owned
+	if found.Ownership == inserter.MarkerDisplaced {
+		v := fmt.Sprintf("%s on line %d, not line 1", found.Version, found.Line)
+		display = &v
+	}
+
 	return WorkflowStatus{
-		Name: name, Installed: true, Marker: marker,
-		BundledMarker: bundled, Drift: classifyMarker(marker, bundled),
+		Name: name, Installed: true, Marker: display,
+		BundledMarker: bundled, Drift: classifyMarker(owned, bundled),
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -88,8 +88,14 @@ var LogmindWorkflows = []string{
 }
 
 // Marker regexes match Python's compiled patterns at the source.
+// The `# logmind-template-version:` extractor deliberately does NOT live
+// here. doctor READS that marker and internal/cli WRITES against it, and two
+// copies of the rule meant a file could be markerless to the reader and
+// versioned to the writer at the same time (#299) — so `doctor --fix`
+// overwrote a file `doctor` had just called the user's. Both sides now call
+// inserter.ExtractTemplateMarker, the same way both already order generations
+// through inserter.ParseMarkerGeneration (#294).
 var (
-	logmindMarkerRe       = regexp.MustCompile(`^# logmind-template-version:\s*(\S+)`)
 	logmindBlockVersionRe = regexp.MustCompile(`<!--\s*logmind-block-version:\s*(\S+)\s*-->`)
 	// logmindVersionLineRe parses the version out of a PATH binary's
 	// `--version` output. It anchors on the REAL versionLine format emitted
@@ -482,20 +488,15 @@ func classifyLogmindDrift(workflows []WorkflowStatus) string {
 
 func bundledLogmindMarker(workflowName string) *string {
 	body := templates.Workflow(workflowName + ".template")
-	first := firstLine(body)
-	m := logmindMarkerRe.FindStringSubmatch(first)
-	if len(m) < 2 {
+	marker := inserter.ExtractTemplateMarker(body)
+	if !marker.Writable() {
+		// A template WE ship whose marker isn't on line 1 is a build defect,
+		// not a repo state — report "no bundled marker" rather than compare
+		// against a token the writer would refuse to act on.
 		return nil
 	}
-	v := m[1]
+	v := marker.Version
 	return &v
-}
-
-func firstLine(s string) string {
-	if idx := strings.Index(s, "\n"); idx >= 0 {
-		return s[:idx]
-	}
-	return s
 }
 
 func readWorkflow(projectRoot, name string) (string, bool) {
@@ -542,16 +543,34 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 	if !ok {
 		return WorkflowStatus{Name: name, Installed: false, Marker: nil, BundledMarker: bundled, Drift: "missing"}
 	}
-	first := firstLine(content)
-	m := logmindMarkerRe.FindStringSubmatch(first)
-	var marker *string
-	if len(m) >= 2 {
-		v := m[1]
-		marker = &v
+	found := inserter.ExtractTemplateMarker(content)
+
+	// `owned` is what the DRIFT VERDICT is computed from, and it is non-nil
+	// only when the file is ours to refresh. classifyMarker's nil case is the
+	// SPEC §1.1 "belongs to the user" verdict, so routing anything the writer
+	// would refuse through nil is what keeps the reader's answer identical to
+	// the writer's — the disagreement between them WAS #299.
+	var owned *string
+	if found.Writable() {
+		v := found.Version
+		owned = &v
 	}
+
+	// `display` may say more than the verdict does. A displaced marker is
+	// "markerless" as a verdict, but reporting only that would hide the fact
+	// that a marker IS present — the one thing the user needs in order to
+	// move the file deliberately into either camp. Prose in the marker column
+	// matches the existing "markerless (pre-v0.6.10)" / "foreign … left
+	// alone" rows rather than inventing a drift value consumers don't parse.
+	display := owned
+	if found.Ownership == inserter.MarkerDisplaced {
+		v := fmt.Sprintf("%s on line %d, not line 1", found.Version, found.Line)
+		display = &v
+	}
+
 	return WorkflowStatus{
-		Name: name, Installed: true, Marker: marker,
-		BundledMarker: bundled, Drift: classifyMarker(marker, bundled),
+		Name: name, Installed: true, Marker: display,
+		BundledMarker: bundled, Drift: classifyMarker(owned, bundled),
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -413,9 +413,9 @@ func TestProbePathResolution_MatchingVersionIsCurrent(t *testing.T) {
 // TestProbePathResolution_RealVersionFormatNotMarkerless is the direct #214
 // regression: a PATH binary whose `--version` prints the genuine
 // `logmind <ver> (spec <ver>)` line (root.go's versionLine) MUST classify as
-// current/stale — never markerless. The pre-fix regex (`version\s+(\S+)`)
-// found no "version" token in that line, so a real on-PATH Go logmind was
-// always mis-labeled markerless and the PATH-drift row went blind.
+// current/stale — never the unparseable fallback. The pre-fix regex
+// (`version\s+(\S+)`) found no "version" token in that line, so a real
+// on-PATH Go logmind was always mis-labeled and the PATH-drift row went blind.
 func TestProbePathResolution_RealVersionFormatNotMarkerless(t *testing.T) {
 	tmp := t.TempDir()
 	fake := filepath.Join(tmp, "logmind")
@@ -430,8 +430,8 @@ func TestProbePathResolution_RealVersionFormatNotMarkerless(t *testing.T) {
 	_ = os.Setenv("PATH", tmp)
 
 	row := probePathResolution()
-	if row.Drift == "markerless" {
-		t.Fatalf("Drift = markerless on a real `logmind <ver> (spec <ver>)` line; #214 regressed (marker=%v)", row.Marker)
+	if row.Drift == "unreadable" {
+		t.Fatalf("Drift = unreadable on a real `logmind <ver> (spec <ver>)` line; #214 regressed (marker=%v)", row.Marker)
 	}
 	if row.Drift != "stale" {
 		t.Errorf("Drift = %q; want stale (9.9.9-onpath != running %s)", row.Drift, version.Version)
@@ -444,8 +444,9 @@ func TestProbePathResolution_RealVersionFormatNotMarkerless(t *testing.T) {
 // TestProbePathResolution_LegacyClickVersionClassified is the dual-review
 // follow-up to #214: a stale PYTHON (Click) binary on PATH prints
 // `logmind, version X`. The re-anchored regex must still parse it and
-// classify it stale/DRIFT — not silently degrade it to markerless, which
-// would blind the drift row to exactly the stale binary it exists to catch.
+// classify it stale/DRIFT — not silently degrade it to the unparseable
+// fallback, which would blind the drift row to exactly the stale binary it
+// exists to catch.
 func TestProbePathResolution_LegacyClickVersionClassified(t *testing.T) {
 	tmp := t.TempDir()
 	fake := filepath.Join(tmp, "logmind")
@@ -458,8 +459,8 @@ func TestProbePathResolution_LegacyClickVersionClassified(t *testing.T) {
 	_ = os.Setenv("PATH", tmp)
 
 	row := probePathResolution()
-	if row.Drift == "markerless" {
-		t.Fatalf("Drift = markerless on legacy Click `logmind, version 0.6.16`; a stale Python binary must be classified, not blinded (marker=%v)", row.Marker)
+	if row.Drift == "unreadable" {
+		t.Fatalf("Drift = unreadable on legacy Click `logmind, version 0.6.16`; a stale Python binary must be classified, not blinded (marker=%v)", row.Marker)
 	}
 	if row.Drift != "stale" {
 		t.Errorf("Drift = %q; want stale (0.6.16 != running %s)", row.Drift, version.Version)
@@ -469,7 +470,15 @@ func TestProbePathResolution_LegacyClickVersionClassified(t *testing.T) {
 	}
 }
 
-func TestProbePathResolution_MarkerlessOnGarbageVersion(t *testing.T) {
+// TestProbePathResolution_UnreadableOnGarbageVersion — #306: a PATH binary
+// whose output carries no parseable version is "unreadable", NOT "markerless".
+// "markerless" is SPEC §5.2's OWNERSHIP verdict ("an artifact carrying no
+// marker at all belongs to the user and MUST NOT be overwritten") and callers
+// act on it as such — `doctor --fix` refuses to write the path and the
+// residual note tells the user logmind is leaving their file alone. A binary
+// on PATH is not a user-owned markerless artifact; reusing the ownership token
+// for it made --fix state a true drift with a false cause.
+func TestProbePathResolution_UnreadableOnGarbageVersion(t *testing.T) {
 	tmp := t.TempDir()
 	fake := filepath.Join(tmp, "logmind")
 	// Output that doesn't include the `version ` token at all so the
@@ -483,8 +492,12 @@ func TestProbePathResolution_MarkerlessOnGarbageVersion(t *testing.T) {
 	_ = os.Setenv("PATH", tmp)
 
 	row := probePathResolution()
-	if row.Drift != "markerless" {
-		t.Errorf("Drift = %q; want markerless", row.Drift)
+	if row.Drift != "unreadable" {
+		t.Errorf("Drift = %q; want unreadable", row.Drift)
+	}
+	if row.Drift == "markerless" {
+		t.Error("Drift = markerless: an unreadable PATH binary is being reported under SPEC §5.2's " +
+			"user-ownership verdict, which is a different fact about a different kind of artifact")
 	}
 }
 

--- a/internal/inserter/dependabot.go
+++ b/internal/inserter/dependabot.go
@@ -43,6 +43,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/templates"
 )
 
@@ -106,10 +107,15 @@ func EnsureDependabot(repoRoot string) (DependabotResult, error) {
 		// Fresh install — write the bundled template verbatim. mkdir
 		// the parent so `.github` is created when the repo is brand
 		// new (logmind init can run before .github exists).
-		if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
-			return DependabotUnchanged, fmt.Errorf("mkdir .github: %w", mkErr)
-		}
-		if wErr := os.WriteFile(path, []byte(templates.DependabotTemplate()), 0o644); wErr != nil {
+		// os.ReadFile follows a symlink, so a DANGLING symlink at path
+		// (pointing at a target that doesn't exist) also returns
+		// fs.ErrNotExist here — the file looks "absent" when it is really a
+		// link elsewhere. A bare os.WriteFile would then follow that same
+		// link and create the write target wherever it points, possibly
+		// outside the repo. atomicio.WriteFile refuses instead
+		// (atomicio.RefuseSymlink, #300) and makes its own parent directory,
+		// so the explicit MkdirAll this replaced is no longer needed.
+		if wErr := atomicio.WriteFile(path, []byte(templates.DependabotTemplate()), 0o644); wErr != nil {
 			return DependabotUnchanged, fmt.Errorf("write dependabot.yml: %w", wErr)
 		}
 		return DependabotCreated, nil
@@ -151,7 +157,11 @@ func EnsureDependabot(repoRoot string) (DependabotResult, error) {
 		// we don't want to corrupt the file.
 		return DependabotUnchanged, nil
 	}
-	if err := os.WriteFile(path, []byte(merged), 0o644); err != nil {
+	// path was read successfully above (existing, string(data)), so this is
+	// a whole-file overwrite of a file the user may have reached through a
+	// symlink — atomicio.WriteFile refuses that (atomicio.RefuseSymlink,
+	// #300) rather than silently writing the merged body through the link.
+	if err := atomicio.WriteFile(path, []byte(merged), 0o644); err != nil {
 		return DependabotUnchanged, fmt.Errorf("write dependabot.yml: %w", err)
 	}
 	return DependabotMerged, nil

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -162,24 +162,72 @@ func ExtractMarkerBlock(content string) (string, bool) {
 	return content[blockStart:end], true
 }
 
-// ReplaceMarkerBlock swaps the body between the existing markers,
+// ErrNoMarkerBlock is returned by RefreshMarkerBlockFile when the file on
+// disk carries no well-formed logmind marker block. It is a REFUSAL, not a
+// failure to write: a file with no block is not logmind's to rewrite (SPEC
+// §1.1 — "An artifact carrying no marker at all belongs to the user and MUST
+// NOT be overwritten"), so the bytes are left exactly as found.
+var ErrNoMarkerBlock = errors.New("no logmind marker block")
+
+// RefreshMarkerBlockFile is THE write primitive for the marker block: the
+// only exported way to move an installed block forward. It reads the file,
+// refuses unless the file itself carries a well-formed block, and writes back
+// the surgically-rewritten WHOLE file.
+//
+// It exists because the two-string signature it replaces could not be called
+// wrong in a way the compiler or the runtime would notice. `ReplaceMarkerBlock(
+// content, newBody)` took a whole file and a fragment as the same type, and
+// returned its first argument unchanged when the markers were missing — so
+// handing it a block body where a file belonged produced a fragment, silently,
+// which `self-update` then wrote over the user's entire AGENTS.md (#297).
+// Owning the read and the write here means a caller never holds a string that
+// it could pass to the wrong parameter: there is no parameter to get wrong.
+//
+// The refusal is the second half of the same guarantee. `replaceMarkerBlock`
+// returns its input when the markers are absent, which is the correct pure
+// behaviour and a catastrophic write behaviour — "unchanged" is only safe if
+// nobody writes it. This function turns that case into ErrNoMarkerBlock and
+// writes nothing at all.
+//
+// Uses os.WriteFile (not atomicio) deliberately: it replaces an os.WriteFile
+// call on the same path, and os.WriteFile FOLLOWS a symlink where a
+// write-rename would replace it with a regular file — SPEC §1.1 requires a
+// refresh to preserve the link. Hardening the durability of this write is a
+// separate change from fixing what it writes.
+func RefreshMarkerBlockFile(path, newBlockBody string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	if _, ok := ExtractMarkerBlock(content); !ok {
+		return fmt.Errorf("%s: %w", path, ErrNoMarkerBlock)
+	}
+	return os.WriteFile(path, []byte(replaceMarkerBlock(content, newBlockBody)), 0o644)
+}
+
+// replaceMarkerBlock swaps the body between the existing markers,
 // preserving everything else byte-for-byte. Returns content unchanged
 // when either marker is absent OR when the markers are out of order
 // (end appears before start — malformed input, never a legitimate state).
 // Mirrors ExtractMarkerBlock's `end < start` guard so the two primitives
 // share the same well-formedness contract.
 //
+// UNEXPORTED on purpose (#297). "Returns its input unchanged" is a safe
+// contract for a pure function and a data-loss contract for anything that
+// writes the result, so the function that can produce a fragment is not
+// reachable from outside this package; RefreshMarkerBlockFile is, and it
+// checks first. Callers outside the package have no way to express the
+// mistake because they have no way to name this function.
+//
 // This is the SURGICAL REWRITE primitive. Marker-block round-trip
 // invariant (proved in the package test):
 //
 //	old, _ := ExtractMarkerBlock(c0)
-//	c1 := ReplaceMarkerBlock(c0, "FOO")
-//	c2 := ReplaceMarkerBlock(c1, old)
+//	c1 := replaceMarkerBlock(c0, "FOO")
+//	c2 := replaceMarkerBlock(c1, old)
 //	c0 == c2 byte-for-byte
-//
-// Used by both `agents update --apply` (rewriting stale blocks) and
-// the `ensure_agents_md` silent-refresh path.
-func ReplaceMarkerBlock(content, newBlockBody string) string {
+func replaceMarkerBlock(content, newBlockBody string) string {
 	start := strings.Index(content, startMarker)
 	end := strings.Index(content, endMarker)
 	if start == -1 || end == -1 || end < start {
@@ -398,8 +446,12 @@ func EnsureAgentsMD(repoRoot string) (string, *AgentsBlockRefusal, error) {
 	}
 	templateBlock, tok := ExtractMarkerBlock(plan.Template)
 	if tok && strings.TrimSpace(installedBlock) != strings.TrimSpace(templateBlock) {
-		refreshed := ReplaceMarkerBlock(content, templateBlock)
-		if err := os.WriteFile(agentsPath, []byte(refreshed), 0o644); err != nil {
+		// Routed through the one write primitive rather than doing its own
+		// read/replace/write — EnsureAgentsMD is the SINGLE refresher of this
+		// path (SPEC §1.1: "Exactly one automation owns any generated or
+		// copied path. Two refreshers MUST NOT write the same path"), and it
+		// gets the markers-required refusal for free.
+		if err := RefreshMarkerBlockFile(agentsPath, templateBlock); err != nil {
 			return "", nil, err
 		}
 		return "Refreshed AGENTS.md logmind block to current template", nil, nil
@@ -433,14 +485,22 @@ func agentsMDTemplate() string {
 // OutdatedMarkerEntry records one stale AGENTS.md block:
 //
 //	Path = absolute path to AGENTS.md
-//	OldBody = body currently in the file
 //	NewBody = body the template wants installed
 //
 // Returned by FindOutdatedMarkerBlocks; consumed by
-// `agents update [--apply]`.
+// `agents update [--apply]`, which feeds Path+NewBody straight into
+// RefreshMarkerBlockFile.
+//
+// There is deliberately NO OldBody field (#297). It carried the block body
+// currently on disk, had no consumer but one — `self-update` passed it as the
+// WHOLE-FILE argument of ReplaceMarkerBlock and wrote the fragment that came
+// back over the user's entire AGENTS.md — and its presence is what made that
+// call look plausible: a struct that hands you a path and a body next to each
+// other invites writing the body to the path. Detection needs only "which file
+// is stale, and what should be in it"; anything that needs the current bytes
+// reads the file.
 type OutdatedMarkerEntry struct {
 	Path    string
-	OldBody string
 	NewBody string
 }
 
@@ -496,7 +556,7 @@ func FindOutdatedMarkerBlocks(repoRoot string) ([]OutdatedMarkerEntry, *AgentsBl
 		return nil, nil, nil
 	}
 	return []OutdatedMarkerEntry{{
-		Path: agentsPath, OldBody: installed, NewBody: fresh,
+		Path: agentsPath, NewBody: fresh,
 	}}, nil, nil
 }
 
@@ -677,6 +737,89 @@ func parseBlockMarker(marker string) (int, string, bool) {
 		return 0, "", false
 	}
 	return n, suffix, true
+}
+
+// templateMarkerRE matches the `# logmind-template-version: vN` line an
+// installed workflow template carries. Anchored at `^` and applied to LINE 1
+// ONLY — see ExtractTemplateMarker for why that anchor is the ownership test
+// rather than an implementation detail.
+var templateMarkerRE = regexp.MustCompile(`^# logmind-template-version:\s*(\S+)`)
+
+// MarkerOwnership answers the only question a write path may ask about an
+// installed artifact: is this file logmind's to overwrite?
+type MarkerOwnership int
+
+const (
+	// MarkerOwned — the logmind marker is on line 1. logmind installed this
+	// file and MAY refresh it (subject to the ordering guard, #286).
+	MarkerOwned MarkerOwnership = iota
+	// MarkerAbsent — no logmind marker anywhere. SPEC §1.1: "An artifact
+	// carrying no marker at all belongs to the user and MUST NOT be
+	// overwritten."
+	MarkerAbsent
+	// MarkerDisplaced — a marker exists, but not on line 1. Neither clearly
+	// ours nor clearly the user's, so it is refused and reported rather than
+	// guessed at — the same "unknown means refuse, never guess" rule #267 and
+	// #286 landed on.
+	MarkerDisplaced
+)
+
+// TemplateMarker is the result of reading an installed artifact's
+// template-version marker.
+type TemplateMarker struct {
+	Ownership MarkerOwnership
+	Version   string // the marker token, e.g. "v5"; "" when MarkerAbsent
+	Line      int    // 1-based line the marker was found on; 0 when MarkerAbsent
+}
+
+// Writable reports whether a refresh path may overwrite this artifact.
+// Only MarkerOwned qualifies.
+func (m TemplateMarker) Writable() bool { return m.Ownership == MarkerOwned }
+
+// ExtractTemplateMarker is the SINGLE OWNER of "does this file carry a
+// logmind template-version marker, and is it ours". Every reader and every
+// writer routes through it.
+//
+// It replaces two extractors that disagreed (#299): doctor matched an
+// anchored regex against LINE 1 ONLY, while init's extractTemplateVersion
+// prefix-matched EVERY line. A file whose marker sat on line 2 was therefore
+// "markerless" to the component that REPORTED and versioned-and-stale to the
+// component that WROTE — so `doctor --fix` overwrote a file it had just told
+// the user was theirs. Which extractor was right did not matter to that bug;
+// that there were two of them did.
+//
+// FIRST LINE ONLY is the surviving semantics, and not merely because it is
+// the stricter of the two:
+//
+//   - It matches what logmind WRITES. Every bundled template in
+//     internal/templates/github carries the marker as its first byte, so
+//     "marker on line 1" is exactly the set of files logmind produced. An
+//     ownership test should recognise our own output, not a superset of it.
+//   - Any-line makes ownership a substring search, and a substring search
+//     over a user's file CLAIMS it. A workflow that quotes the marker in a
+//     heredoc, a comment, or an echoed setup step would be adopted — and
+//     then overwritten — because it mentioned us. Permissiveness on the read
+//     side is not neutral when the write side is destructive.
+//   - It leaves the user a deliberate way to take a file back: move the
+//     marker, or drop it. Under any-line, disowning a file requires finding
+//     and deleting every occurrence.
+//
+// The cost is that a marker displaced by a hand-added header stops being
+// recognised. That cost is paid explicitly rather than silently: displacement
+// is its own state (MarkerDisplaced), every write path refuses it, and the
+// refusal is reported — never collapsed into "markerless" and acted on.
+func ExtractTemplateMarker(text string) TemplateMarker {
+	for i, line := range strings.Split(text, "\n") {
+		m := templateMarkerRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if i == 0 {
+			return TemplateMarker{Ownership: MarkerOwned, Version: m[1], Line: 1}
+		}
+		return TemplateMarker{Ownership: MarkerDisplaced, Version: m[1], Line: i + 1}
+	}
+	return TemplateMarker{Ownership: MarkerAbsent}
 }
 
 // OutdatedPinEntry records one stale workflow pin:

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -165,7 +165,7 @@ func ExtractMarkerBlock(content string) (string, bool) {
 // ErrNoMarkerBlock is returned by RefreshMarkerBlockFile when the file on
 // disk carries no well-formed logmind marker block. It is a REFUSAL, not a
 // failure to write: a file with no block is not logmind's to rewrite (SPEC
-// §1.1 — "An artifact carrying no marker at all belongs to the user and MUST
+// §5.2 — "An artifact carrying no marker at all belongs to the user and MUST
 // NOT be overwritten"), so the bytes are left exactly as found.
 var ErrNoMarkerBlock = errors.New("no logmind marker block")
 
@@ -463,7 +463,7 @@ func EnsureAgentsMD(repoRoot string) (string, *AgentsBlockRefusal, error) {
 	if tok && strings.TrimSpace(installedBlock) != strings.TrimSpace(templateBlock) {
 		// Routed through the one write primitive rather than doing its own
 		// read/replace/write — EnsureAgentsMD is the SINGLE refresher of this
-		// path (SPEC §1.1: "Exactly one automation owns any generated or
+		// path (SPEC §5.2: "Exactly one automation owns any generated or
 		// copied path. Two refreshers MUST NOT write the same path"), and it
 		// gets the markers-required refusal for free.
 		if err := RefreshMarkerBlockFile(agentsPath, templateBlock); err != nil {
@@ -768,7 +768,7 @@ const (
 	// MarkerOwned — the logmind marker is on line 1. logmind installed this
 	// file and MAY refresh it (subject to the ordering guard, #286).
 	MarkerOwned MarkerOwnership = iota
-	// MarkerAbsent — no logmind marker anywhere. SPEC §1.1: "An artifact
+	// MarkerAbsent — no logmind marker anywhere. SPEC §5.2: "An artifact
 	// carrying no marker at all belongs to the user and MUST NOT be
 	// overwritten."
 	MarkerAbsent

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -189,11 +189,16 @@ var ErrNoMarkerBlock = errors.New("no logmind marker block")
 // nobody writes it. This function turns that case into ErrNoMarkerBlock and
 // writes nothing at all.
 //
-// Uses os.WriteFile (not atomicio) deliberately: it replaces an os.WriteFile
-// call on the same path, and os.WriteFile FOLLOWS a symlink where a
-// write-rename would replace it with a regular file — SPEC §1.1 requires a
-// refresh to preserve the link. Hardening the durability of this write is a
-// separate change from fixing what it writes.
+// Routed through atomicio.WriteFile rather than a bare os.WriteFile: this
+// was the one write in the package that still used the truncate+write
+// two-syscall form, on the file SPEC §1.1 names as the artifact a repo
+// reads project instructions from. (An earlier version of this comment
+// claimed SPEC §1.1 required preserving a symlink here; it does not — the
+// symlink-preservation rule is §5.2's, scoped to catalog-subscribed items,
+// not to AGENTS.md.) atomicio.WriteFile also refuses to write through a
+// symlink at path (atomicio.RefuseSymlink, #300) — a bare os.WriteFile
+// FOLLOWS a symlink, which for a dangling one at agentsPath means creating
+// a file wherever it points, possibly outside the repo.
 func RefreshMarkerBlockFile(path, newBlockBody string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -203,7 +208,7 @@ func RefreshMarkerBlockFile(path, newBlockBody string) error {
 	if _, ok := ExtractMarkerBlock(content); !ok {
 		return fmt.Errorf("%s: %w", path, ErrNoMarkerBlock)
 	}
-	return os.WriteFile(path, []byte(replaceMarkerBlock(content, newBlockBody)), 0o644)
+	return atomicio.WriteFile(path, []byte(replaceMarkerBlock(content, newBlockBody)), 0o644)
 }
 
 // replaceMarkerBlock swaps the body between the existing markers,
@@ -324,11 +329,14 @@ func CreateAgentFile(agentName, repoRoot string) (string, error) {
 		return "", nil
 	}
 	filePath := filepath.Join(repoRoot, filepath.FromSlash(a.FilePattern))
-	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
-		return "", err
-	}
 	body := agentTemplate(agentName)
-	if err := os.WriteFile(filePath, []byte(body), 0o644); err != nil {
+	// atomicio.WriteFile makes its own parent directory, and — unlike the
+	// bare os.WriteFile this replaced — refuses (atomicio.RefuseSymlink,
+	// #300) rather than silently writing through a symlink at filePath (a
+	// per-agent path like CLAUDE.md or .cursorrules); no ReadFile precedes
+	// this call, so a dangling symlink here was never even caught by an
+	// ErrNotExist check.
+	if err := atomicio.WriteFile(filePath, []byte(body), 0o644); err != nil {
 		return "", err
 	}
 	return filePath, nil
@@ -412,7 +420,14 @@ func EnsureAgentsMD(repoRoot string) (string, *AgentsBlockRefusal, error) {
 
 	data, err := os.ReadFile(agentsPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		if err := os.WriteFile(agentsPath, []byte(agentsMDTemplate()), 0o644); err != nil {
+		// os.ReadFile follows a symlink, so a DANGLING symlink at agentsPath
+		// (pointing at a target that doesn't exist) also returns
+		// fs.ErrNotExist here — the file looks "absent" when it is really a
+		// link somewhere outside the repo. A bare os.WriteFile would then
+		// follow that same link and create the write target wherever it
+		// points. atomicio.WriteFile refuses instead (atomicio.RefuseSymlink,
+		// #300), the same as every other AGENTS.md write in this file.
+		if err := atomicio.WriteFile(agentsPath, []byte(agentsMDTemplate()), 0o644); err != nil {
 			return "", nil, err
 		}
 		return "Created AGENTS.md (canonical agent instructions)", nil, nil
@@ -952,7 +967,13 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 					a.Display, filepath.Base(filePath)))
 		}
 
-		if err := os.WriteFile(filePath, []byte(templates.Stub()), 0o644); err != nil {
+		// filePath resolved and read successfully above (fileExists +
+		// os.ReadFile both followed it), so this is a per-agent artifact the
+		// user owns, potentially reached through a symlink — atomicio.WriteFile
+		// over the bare os.WriteFile this replaced so a symlinked CLAUDE.md /
+		// .cursorrules / etc. is refused (atomicio.RefuseSymlink, #300) instead
+		// of silently written through.
+		if err := atomicio.WriteFile(filePath, []byte(templates.Stub()), 0o644); err != nil {
 			return messages, declined, err
 		}
 		messages = append(messages,
@@ -967,7 +988,7 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 		// Match Python: existing.rstrip() + "\n\n" + "\n".join(appended).
 		body := strings.TrimRight(string(existing), " \t\n\r") +
 			"\n\n" + strings.Join(appendedBlocks, "\n")
-		if err := os.WriteFile(agentsPath, []byte(body), 0o644); err != nil {
+		if err := atomicio.WriteFile(agentsPath, []byte(body), 0o644); err != nil {
 			return messages, declined, err
 		}
 	}

--- a/internal/inserter/inserter_test.go
+++ b/internal/inserter/inserter_test.go
@@ -37,15 +37,15 @@ func TestReplaceMarkerBlock_RoundTrip(t *testing.T) {
 			}
 			// Replace with garbage.
 			garbageBody := "\n!! WRECK !!\n"
-			wrecked := ReplaceMarkerBlock(tc.content, garbageBody)
+			wrecked := replaceMarkerBlock(tc.content, garbageBody)
 			if !strings.Contains(wrecked, garbageBody) {
-				t.Fatalf("ReplaceMarkerBlock didn't insert garbage body")
+				t.Fatalf("replaceMarkerBlock didn't insert garbage body")
 			}
 			if wrecked == tc.content {
-				t.Fatalf("ReplaceMarkerBlock didn't change content")
+				t.Fatalf("replaceMarkerBlock didn't change content")
 			}
 			// Restore.
-			restored := ReplaceMarkerBlock(wrecked, orig)
+			restored := replaceMarkerBlock(wrecked, orig)
 			if restored != tc.content {
 				t.Fatalf("round-trip drift:\n--- want ---\n%s\n--- got ---\n%s",
 					tc.content, restored)
@@ -63,7 +63,7 @@ func TestReplaceMarkerBlock_PreservesOuterBytes(t *testing.T) {
 	body := startMarker + "\nold body\n" + endMarker
 	c0 := above + body + below
 
-	c1 := ReplaceMarkerBlock(c0, "\nNEW BODY OF DIFFERENT LENGTH\n")
+	c1 := replaceMarkerBlock(c0, "\nNEW BODY OF DIFFERENT LENGTH\n")
 	if !strings.HasPrefix(c1, above) {
 		t.Fatalf("prefix bytes were modified:\n--- want ---\n%q\n--- got ---\n%q",
 			above, c1[:len(above)])
@@ -79,7 +79,7 @@ func TestReplaceMarkerBlock_PreservesOuterBytes(t *testing.T) {
 // the file format drifts.
 func TestReplaceMarkerBlock_NoMarkers(t *testing.T) {
 	in := "# Plain markdown\n\nNo markers here.\n"
-	out := ReplaceMarkerBlock(in, "NEW")
+	out := replaceMarkerBlock(in, "NEW")
 	if out != in {
 		t.Fatalf("input was mutated despite missing markers:\n--- want ---\n%q\n--- got ---\n%q",
 			in, out)
@@ -300,7 +300,7 @@ func TestEnsureAgentsMD_FullBlockRefreshesFullNotSlim(t *testing.T) {
 	dir := t.TempDir()
 	agentsPath := filepath.Join(dir, "AGENTS.md")
 	// A stale v6 full block: correct FULL marker flavour, differing bytes.
-	staleFull := ReplaceMarkerBlock(templates.AgentsTemplate(),
+	staleFull := replaceMarkerBlock(templates.AgentsTemplate(),
 		"\n<!-- logmind-block-version: v6 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nstale full body\n")
 	if err := os.WriteFile(agentsPath, []byte(staleFull), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
@@ -572,7 +572,7 @@ func TestFindOutdatedMarkerBlocks_CurrentNoop(t *testing.T) {
 func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	dir := t.TempDir()
 	driftedBody := "\n<!-- logmind-block-version: v8-pointer -->\nDIFFERENT CONTENT BUT SAME VERSION\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsSlimTemplate(), driftedBody)
+	wrecked := replaceMarkerBlock(templates.AgentsSlimTemplate(), driftedBody)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -583,8 +583,18 @@ func TestFindOutdatedMarkerBlocks_DriftedDetected(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("expected 1 outdated entry; got %d", len(out))
 	}
-	if !strings.Contains(out[0].OldBody, "DIFFERENT CONTENT") {
-		t.Errorf("OldBody = %q; want to contain DIFFERENT CONTENT", out[0].OldBody)
+	// The entry names WHICH file is stale and WHAT belongs in it. It
+	// deliberately no longer carries the body currently on disk (#297): that
+	// field's only consumer passed it where a whole file belonged. Assert the
+	// replacement body instead — it is what the write path actually installs.
+	// Derived from the template, never restated: a marker bump must not need
+	// this assertion re-pointed.
+	wantBody, _ := ExtractMarkerBlock(templates.AgentsSlimTemplate())
+	if out[0].NewBody != wantBody {
+		t.Errorf("NewBody = %q; want the current slim block body %q", out[0].NewBody, wantBody)
+	}
+	if filepath.Base(out[0].Path) != "AGENTS.md" {
+		t.Errorf("Path = %q; want AGENTS.md", out[0].Path)
 	}
 }
 
@@ -657,7 +667,7 @@ func TestFindOutdatedMarkerBlocks_OldFullRefreshesToCurrent(t *testing.T) {
 	// Synthesize a v5-shaped block body. The byte content differs from
 	// the current template, so the drift compare must fire.
 	v5Body := "\n<!-- logmind-block-version: v5 -->\n## Decision Logging (logmind)\nold v5 body\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsTemplate(), v5Body)
+	wrecked := replaceMarkerBlock(templates.AgentsTemplate(), v5Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -693,7 +703,7 @@ func TestFindOutdatedMarkerBlocks_PriorFullRefreshesToCurrent(t *testing.T) {
 	dir := t.TempDir()
 	// Synthesize a v6-shaped full block body (older marker, differing bytes).
 	v6Body := "\n<!-- logmind-block-version: v6 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nold v6 body without the branch-summary convention\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsTemplate(), v6Body)
+	wrecked := replaceMarkerBlock(templates.AgentsTemplate(), v6Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -734,7 +744,7 @@ func TestFindOutdatedMarkerBlocks_V7RefreshesToV8(t *testing.T) {
 	// Synthesize a v7-shaped full block body (older marker, pre-enforcement
 	// prose, differing bytes).
 	v7Body := "\n<!-- logmind-block-version: v7 -->\n## Decision Logging (logmind) — REQUIRED for substantive commits\nold v7 body: the commit-msg hook only warns\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsTemplate(), v7Body)
+	wrecked := replaceMarkerBlock(templates.AgentsTemplate(), v7Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -772,7 +782,7 @@ func TestFindOutdatedMarkerBlocks_V7RefreshesToV8(t *testing.T) {
 func TestFindOutdatedMarkerBlocks_OldSlimRefreshesToCurrent(t *testing.T) {
 	dir := t.TempDir()
 	v7Body := "\n<!-- logmind-block-version: v7-pointer -->\n## Decision logging — `logmind log` is the commit primitive\nold v7 body\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsSlimTemplate(), v7Body)
+	wrecked := replaceMarkerBlock(templates.AgentsSlimTemplate(), v7Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -800,7 +810,7 @@ func TestFindOutdatedMarkerBlocks_OldSlimRefreshesToCurrent(t *testing.T) {
 func TestFindOutdatedMarkerBlocks_V8PointerRefreshesToV9Pointer(t *testing.T) {
 	dir := t.TempDir()
 	v8Body := "\n<!-- logmind-block-version: v8-pointer -->\n## Decision logging — `logmind log` is the commit primitive\nold v8-pointer body: the commit-msg hook only warns\n"
-	wrecked := ReplaceMarkerBlock(templates.AgentsSlimTemplate(), v8Body)
+	wrecked := replaceMarkerBlock(templates.AgentsSlimTemplate(), v8Body)
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(wrecked), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -826,17 +836,17 @@ func TestFindOutdatedMarkerBlocks_V8PointerRefreshesToV9Pointer(t *testing.T) {
 
 // TestReplaceMarkerBlock_InvertedMarkers — when end marker appears
 // BEFORE start marker (malformed input), the function MUST return
-// content unchanged. Without this guard, ReplaceMarkerBlock would
+// content unchanged. Without this guard, replaceMarkerBlock would
 // silently corrupt by duplicating the inter-marker region.
 //
 // Flagged by clud-bug-review on PR #118 — ExtractMarkerBlock already
-// had this guard; ReplaceMarkerBlock did not. Pinned by this test.
+// had this guard; replaceMarkerBlock did not. Pinned by this test.
 func TestReplaceMarkerBlock_InvertedMarkers(t *testing.T) {
 	// End marker appears BEFORE start marker — corrupt file shape.
 	content := "PREFIX\n<!-- /logmind-block-version -->\nMIDDLE\n<!-- logmind-block-version: v8-pointer -->\nSUFFIX"
-	got := ReplaceMarkerBlock(content, "WOULD-OVERWRITE")
+	got := replaceMarkerBlock(content, "WOULD-OVERWRITE")
 	if got != content {
-		t.Errorf("ReplaceMarkerBlock on inverted markers must return content unchanged.\nWant: %q\nGot:  %q", content, got)
+		t.Errorf("replaceMarkerBlock on inverted markers must return content unchanged.\nWant: %q\nGot:  %q", content, got)
 	}
 }
 

--- a/internal/inserter/marker_overwrite_test.go
+++ b/internal/inserter/marker_overwrite_test.go
@@ -1,0 +1,250 @@
+// marker_overwrite_test.go — logmind#297: a partial write must never land on
+// a whole user-owned artifact.
+//
+// The defect these pin: `self-update` called ReplaceMarkerBlock(entry.OldBody,
+// entry.NewBody) — a BLOCK BODY where the WHOLE FILE belonged — and wrote the
+// result over AGENTS.md. ReplaceMarkerBlock returns its first argument
+// unchanged when it finds no markers, and a block body never contains the
+// markers that bracket it, so the "refresh" wrote the fragment over the file:
+// project overview, development commands, every line the repository wrote
+// itself, gone.
+//
+// These tests deliberately do NOT assert what arguments anything is called
+// with. An argument test passes its own mutation and still goes green the day
+// the bug ships again; the invariant that actually protects the user is that
+// the bytes outside the marker block survive the write.
+package inserter
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// realisticAgentsMD builds an AGENTS.md shaped like one a repository actually
+// carries: prose ABOVE the logmind block and prose BELOW it, with the block in
+// the middle. Both halves are what #297 destroyed.
+func realisticAgentsMD(t *testing.T, blockBody string) string {
+	t.Helper()
+	const above = "# AGENTS.md\n\nThis is the canonical instruction file for AI coding agents.\n\n"
+	const below = "\n\n## Project Overview\n\nlogmind is a decision-logging CLI.\n\n" +
+		"## Development Commands\n\n```bash\ngo build ./cmd/logmind\n```\n\n" +
+		"## clud-bug — Claude PR review\n\nReviews are automated.\n"
+	return above + startMarker + blockBody + endMarker + below
+}
+
+// TestRefreshMarkerBlockFile_PreservesBytesOutsideBlock is the #297 invariant
+// at the level the user was harmed: after a refresh, every byte above and
+// below the marker block is exactly what it was.
+func TestRefreshMarkerBlockFile_PreservesBytesOutsideBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+
+	staleBody := "\n<!-- logmind-block-version: v1-pointer -->\nSTALE BLOCK BODY\n"
+	original := realisticAgentsMD(t, staleBody)
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	freshBody, ok := ExtractMarkerBlock(templates.AgentsSlimTemplate())
+	if !ok {
+		t.Fatal("the bundled slim template carries no marker block")
+	}
+	if err := RefreshMarkerBlockFile(path, freshBody); err != nil {
+		t.Fatalf("RefreshMarkerBlockFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(data)
+
+	// The whole file must still be a whole file — this is the assertion that
+	// goes red when a fragment is written over it.
+	want := realisticAgentsMD(t, freshBody)
+	if got != want {
+		t.Fatalf("refresh did not rewrite the block in place:\n got: %q\nwant: %q", got, want)
+	}
+
+	// Named sentinels, so a failure says WHICH half was lost rather than
+	// dumping two large strings.
+	for _, sentinel := range []string{
+		"This is the canonical instruction file for AI coding agents.", // above
+		"## Project Overview",            // below
+		"go build ./cmd/logmind",         // below
+		"## clud-bug — Claude PR review", // below
+	} {
+		if !strings.Contains(got, sentinel) {
+			t.Errorf("content outside the marker block was destroyed: %q is gone", sentinel)
+		}
+	}
+	if strings.Contains(got, "STALE BLOCK BODY") {
+		t.Error("the stale block body survived; the refresh did not happen")
+	}
+}
+
+// TestRefreshMarkerBlockFile_RefusesMarkerlessFile is SPEC §1.1's rule made
+// executable: "An artifact carrying no marker at all belongs to the user and
+// MUST NOT be overwritten." The bytes must be identical afterwards, and the
+// caller must get an error rather than a silent no-op.
+func TestRefreshMarkerBlockFile_RefusesMarkerlessFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+
+	// No logmind markers anywhere — entirely the user's file.
+	original := "# My own AGENTS.md\n\nI wrote every line of this myself.\n\nUSER_SENTINEL\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := RefreshMarkerBlockFile(path, "SOME NEW BODY")
+	if !errors.Is(err, ErrNoMarkerBlock) {
+		t.Fatalf("RefreshMarkerBlockFile err = %v; want ErrNoMarkerBlock", err)
+	}
+	// The error has to name the file — a refusal the user cannot locate is
+	// not a report (SPEC §3.4).
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("refusal %q does not name the file %q", err, path)
+	}
+
+	data, err2 := os.ReadFile(path)
+	if err2 != nil {
+		t.Fatalf("read back: %v", err2)
+	}
+	if string(data) != original {
+		t.Fatalf("a markerless file was modified:\n got: %q\nwant: %q", string(data), original)
+	}
+}
+
+// TestRefreshMarkerBlockFile_RefusesInvertedMarkers — end-before-start is
+// malformed, never a legitimate state. replaceMarkerBlock returns such input
+// unchanged, which is safe only if nobody writes the result; the file path
+// must refuse it outright rather than rewrite the file with itself.
+func TestRefreshMarkerBlockFile_RefusesInvertedMarkers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+
+	original := "head\n" + endMarker + "\ninverted\n" + startMarker + "\ntail\nUSER_SENTINEL\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := RefreshMarkerBlockFile(path, "NEW BODY"); !errors.Is(err, ErrNoMarkerBlock) {
+		t.Fatalf("RefreshMarkerBlockFile err = %v; want ErrNoMarkerBlock", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("a malformed file was modified:\n got: %q\nwant: %q", string(data), original)
+	}
+}
+
+// TestExtractTemplateMarker_OwnershipStates pins the three-way answer #299
+// turned on. The two extractors it replaced could not both be right, and the
+// bug was that they were consulted separately.
+func TestExtractTemplateMarker_OwnershipStates(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		text    string
+		want    MarkerOwnership
+		version string
+		line    int
+	}{
+		{
+			name:    "marker on line 1 is ours",
+			text:    "# logmind-template-version: v5\nname: check-decisions\n",
+			want:    MarkerOwned,
+			version: "v5",
+			line:    1,
+		},
+		{
+			name: "no marker anywhere belongs to the user",
+			text: "name: my own workflow\njobs: {}\n",
+			want: MarkerAbsent,
+		},
+		{
+			// The #299 reproduction. Under the deleted any-line extractor this
+			// was "versioned"; under doctor's it was "markerless". It is now
+			// neither — it is displaced, and every write path refuses it.
+			name:    "marker on line 2 is displaced",
+			text:    "# my org header — do not remove\n# logmind-template-version: v1\nname: x\n",
+			want:    MarkerDisplaced,
+			version: "v1",
+			line:    2,
+		},
+		{
+			name:    "marker far down the file is still displaced",
+			text:    "a\nb\nc\n# logmind-template-version: v9\n",
+			want:    MarkerDisplaced,
+			version: "v9",
+			line:    4,
+		},
+		{
+			// Indented is not line-1-anchored: the regex is anchored at ^, so
+			// leading whitespace makes it not ours. A user's YAML comment
+			// nested inside a block must never claim the file for logmind.
+			name: "indented marker is not ours",
+			text: "  # logmind-template-version: v5\nname: x\n",
+			want: MarkerAbsent,
+		},
+		{
+			// The version token is the first non-space run, not the rest of
+			// the line — the deleted prefix extractor returned "v1 junk" here
+			// and doctor's regex returned "v1". One answer now.
+			name:    "trailing junk is not part of the version",
+			text:    "# logmind-template-version: v1 junk here\n",
+			want:    MarkerOwned,
+			version: "v1",
+			line:    1,
+		},
+		{
+			name:    "CRLF line endings do not leak into the token",
+			text:    "# logmind-template-version: v5\r\nname: x\r\n",
+			want:    MarkerOwned,
+			version: "v5",
+			line:    1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractTemplateMarker(tc.text)
+			if got.Ownership != tc.want {
+				t.Errorf("Ownership = %v; want %v", got.Ownership, tc.want)
+			}
+			if got.Version != tc.version {
+				t.Errorf("Version = %q; want %q", got.Version, tc.version)
+			}
+			if got.Line != tc.line {
+				t.Errorf("Line = %d; want %d", got.Line, tc.line)
+			}
+			if want := tc.want == MarkerOwned; got.Writable() != want {
+				t.Errorf("Writable() = %v; want %v", got.Writable(), want)
+			}
+		})
+	}
+}
+
+// TestExtractTemplateMarker_BundledTemplatesAreOwned is the control on the
+// strict semantics: first-line-only is only the right rule if it recognises
+// everything logmind actually writes. If a template ever grows a header above
+// its marker, this fails loudly instead of that template silently becoming
+// un-refreshable in every repo that has it.
+func TestExtractTemplateMarker_BundledTemplatesAreOwned(t *testing.T) {
+	names := templates.ListWorkflowTemplates()
+	if len(names) == 0 {
+		t.Fatal("no bundled workflow templates found — this control proves nothing")
+	}
+	for _, name := range names {
+		got := ExtractTemplateMarker(templates.Workflow(name))
+		if !got.Writable() {
+			t.Errorf("bundled %s is not recognised as logmind's own: %+v "+
+				"(its `# logmind-template-version:` marker must be line 1)", name, got)
+		}
+	}
+}

--- a/internal/inserter/marker_overwrite_test.go
+++ b/internal/inserter/marker_overwrite_test.go
@@ -88,7 +88,7 @@ func TestRefreshMarkerBlockFile_PreservesBytesOutsideBlock(t *testing.T) {
 	}
 }
 
-// TestRefreshMarkerBlockFile_RefusesMarkerlessFile is SPEC §1.1's rule made
+// TestRefreshMarkerBlockFile_RefusesMarkerlessFile is SPEC §5.2's rule made
 // executable: "An artifact carrying no marker at all belongs to the user and
 // MUST NOT be overwritten." The bytes must be identical afterwards, and the
 // caller must get an error rather than a silent no-op.

--- a/internal/inserter/symlink_write_test.go
+++ b/internal/inserter/symlink_write_test.go
@@ -272,3 +272,85 @@ func TestMigrateToAgentsMD_RefusesSymlinkedAGENTSMD(t *testing.T) {
 		t.Errorf("migrate wrote through the AGENTS.md symlink:\n got: %q\nwant: %q", string(got), current)
 	}
 }
+
+// TestEnsureDependabot_RefusesDanglingSymlink is dependabot.go's create
+// branch — the same ENOENT-as-absent shape as EnsureAgentsMD's create
+// branch above, missed by both the original panel report and the first
+// #306 sweep because dependabot.go sits in this package but wasn't among
+// the five inserter.go call sites already fixed. .github/dependabot.yml is
+// a dangling symlink; os.ReadFile returns fs.ErrNotExist, the file looks
+// "absent", and a bare os.WriteFile would create the bundled template
+// wherever the link points.
+func TestEnsureDependabot_RefusesDanglingSymlink(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	escapeTarget := filepath.Join(outside, "escaped-dependabot.yml")
+
+	githubDir := filepath.Join(repoRoot, ".github")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatalf("mkdir .github: %v", err)
+	}
+	dependabotPath := filepath.Join(githubDir, "dependabot.yml")
+	if err := os.Symlink(escapeTarget, dependabotPath); err != nil {
+		t.Fatalf("plant dangling symlink: %v", err)
+	}
+
+	_, err := EnsureDependabot(repoRoot)
+
+	if err == nil {
+		t.Fatal("EnsureDependabot did not error on a dangling dependabot.yml symlink; " +
+			"the write either silently followed the link or silently no-opped")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	assertNotCreated(t, escapeTarget)
+	assertStillDanglingSymlink(t, dependabotPath, escapeTarget)
+}
+
+// TestEnsureDependabot_RefusesSymlinkedExistingFile is dependabot.go's
+// merge branch: a NON-dangling symlink at .github/dependabot.yml, pointing
+// at a real file elsewhere that already has content but no github-actions
+// ecosystem entry — os.ReadFile follows the link and succeeds, so this
+// reaches appendGithubActionsEntry and the write that follows, which must
+// refuse rather than merge the entry through the link into a file this
+// tool does not own.
+func TestEnsureDependabot_RefusesSymlinkedExistingFile(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	realTarget := filepath.Join(outside, "real-dependabot.yml")
+	const userContent = "version: 2\nupdates:\n  - package-ecosystem: \"gomod\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n"
+	if err := os.WriteFile(realTarget, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("seed real target: %v", err)
+	}
+
+	githubDir := filepath.Join(repoRoot, ".github")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatalf("mkdir .github: %v", err)
+	}
+	dependabotPath := filepath.Join(githubDir, "dependabot.yml")
+	if err := os.Symlink(realTarget, dependabotPath); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	_, err := EnsureDependabot(repoRoot)
+
+	if err == nil {
+		t.Fatal("EnsureDependabot did not error on a symlinked dependabot.yml")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	got, readErr := os.ReadFile(realTarget)
+	if readErr != nil {
+		t.Fatalf("real target vanished: %v", readErr)
+	}
+	if string(got) != userContent {
+		t.Errorf("EnsureDependabot wrote through the symlink and modified user content:\n got: %q\nwant: %q",
+			string(got), userContent)
+	}
+}

--- a/internal/inserter/symlink_write_test.go
+++ b/internal/inserter/symlink_write_test.go
@@ -1,0 +1,274 @@
+// symlink_write_test.go — the arbitrary-write half of the marker-block-
+// overwrite class this branch is named for. A panel on #300 found that its
+// symlink audit covered os.Create and os.OpenFile but never os.WriteFile —
+// which FOLLOWS a symlink at the destination. os.ReadFile does too, so a
+// DANGLING symlink at a path this package treats as "the user's instruction
+// file" makes the missing-file check (errors.Is(err, fs.ErrNotExist)) true,
+// the caller concludes the file is simply absent, and the WriteFile that
+// follows creates the write body wherever the link points — possibly
+// outside the repository entirely.
+//
+// Every write site in this file now goes through atomicio.WriteFile, which
+// (as of #300) refuses outright when the destination already exists as a
+// symlink, dangling or not (atomicio.RefuseSymlink). These tests plant that
+// exact symlink and run the REAL exported entry points — EnsureAgentsMD,
+// CreateAgentFile, MigrateToAgentsMD — asserting on what a user would
+// actually observe: the file outside the repo was never created, the link
+// itself is untouched, and the error surfaced is legible (not a generic I/O
+// failure).
+package inserter
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// skipOnWindows mirrors atomicio's own test skip: unprivileged symlink
+// creation is unreliable on Windows CI runners.
+func skipSymlinkTestsOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+}
+
+// assertNotCreated fails the test if path exists at all (regular file,
+// directory, or otherwise) — the escape-hatch write must never land.
+func assertNotCreated(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err == nil {
+		t.Errorf("write escaped the repo: %s was created", path)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("unexpected error statting %s: %v", path, err)
+	}
+}
+
+// assertStillDanglingSymlink fails unless path is still exactly the
+// symlink it started as — RefuseSymlink's contract is to leave BOTH the
+// link and whatever it points to untouched, not to clean up the link on
+// its way out.
+func assertStillDanglingSymlink(t *testing.T, path, wantTarget string) {
+	t.Helper()
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("symlink at %s is gone: %v", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s was replaced with a non-symlink (mode %v)", path, fi.Mode())
+	}
+	got, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Readlink(%s): %v", path, err)
+	}
+	if got != wantTarget {
+		t.Errorf("symlink target changed: got %q, want %q", got, wantTarget)
+	}
+}
+
+// TestEnsureAgentsMD_RefusesDanglingAGENTSMDSymlink is the panel's exact
+// reproduction: AGENTS.md is a symlink to a path that does not exist.
+// os.ReadFile(agentsPath) returns fs.ErrNotExist — indistinguishable, to a
+// caller that only checks errors.Is(err, fs.ErrNotExist), from AGENTS.md
+// simply never having been created. The pre-#306-fix code took that branch
+// straight into a bare os.WriteFile(agentsPath, ...), which opens(2) THROUGH
+// the symlink and creates the target file wherever it points — outside
+// repoRoot, in this test.
+func TestEnsureAgentsMD_RefusesDanglingAGENTSMDSymlink(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	escapeTarget := filepath.Join(outside, "escaped-agents.md")
+	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+
+	if err := os.Symlink(escapeTarget, agentsPath); err != nil {
+		t.Fatalf("plant dangling symlink: %v", err)
+	}
+
+	_, _, err := EnsureAgentsMD(repoRoot)
+
+	if err == nil {
+		t.Fatal("EnsureAgentsMD did not error on a dangling AGENTS.md symlink; " +
+			"the write either silently followed the link or silently no-opped")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+
+	// The harm: nothing gets created outside the repo the link pointed at.
+	assertNotCreated(t, escapeTarget)
+	// The refusal: the link itself is left exactly as planted, not replaced
+	// with a regular file — a caller re-running after removing the link
+	// still sees the same dangling link, not a half-fixed state.
+	assertStillDanglingSymlink(t, agentsPath, escapeTarget)
+}
+
+// TestCreateAgentFile_RefusesDanglingSymlink covers the per-agent path
+// (CLAUDE.md, .cursorrules, ...): CreateAgentFile has no ReadFile/ErrNotExist
+// check at all — it went straight to os.WriteFile pre-fix, so a dangling
+// symlink here was never even caught by the "is it missing" branch other
+// sites had; the vulnerability was the same, just with one less step.
+func TestCreateAgentFile_RefusesDanglingSymlink(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	escapeTarget := filepath.Join(outside, "escaped-claude.md")
+	claudePath := filepath.Join(repoRoot, "CLAUDE.md")
+
+	if err := os.Symlink(escapeTarget, claudePath); err != nil {
+		t.Fatalf("plant dangling symlink: %v", err)
+	}
+
+	_, err := CreateAgentFile("claude", repoRoot)
+
+	if err == nil {
+		t.Fatal("CreateAgentFile did not error on a dangling CLAUDE.md symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	assertNotCreated(t, escapeTarget)
+	assertStillDanglingSymlink(t, claudePath, escapeTarget)
+}
+
+// TestMigrateToAgentsMD_RefusesSymlinkedPerAgentFile covers the stub-replace
+// write inside `agents migrate`: the per-agent file (.cursorrules here) is
+// NOT dangling — it resolves to a real file elsewhere with real user
+// content, which os.ReadFile follows and reads successfully before the
+// write. A bare os.WriteFile at that point writes the stub THROUGH the
+// link, silently replacing content in a file this tool never created and
+// does not own; atomicio.WriteFile refuses instead.
+func TestMigrateToAgentsMD_RefusesSymlinkedPerAgentFile(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	// AGENTS.md needs to be a plain, up-to-date file so the leading
+	// EnsureAgentsMD(repoRoot) call inside MigrateToAgentsMD no-ops instead
+	// of erroring for an unrelated reason.
+	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(agentsMDTemplate()), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	outside := t.TempDir()
+	realTarget := filepath.Join(outside, "real-cursorrules")
+	const userContent = "# my own cursor rules\n\nUSER_SENTINEL_UNTOUCHED\n"
+	if err := os.WriteFile(realTarget, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("seed real target: %v", err)
+	}
+	cursorPath := filepath.Join(repoRoot, ".cursorrules")
+	if err := os.Symlink(realTarget, cursorPath); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	_, _, err := MigrateToAgentsMD(repoRoot)
+
+	if err == nil {
+		t.Fatal("MigrateToAgentsMD did not error on a symlinked .cursorrules")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	// The harm: the real file the link points at keeps the user's content —
+	// it must NOT have been silently replaced with the stub.
+	got, readErr := os.ReadFile(realTarget)
+	if readErr != nil {
+		t.Fatalf("real target vanished: %v", readErr)
+	}
+	if string(got) != userContent {
+		t.Errorf("migrate wrote through the symlink and clobbered user content:\n got: %q\nwant: %q",
+			string(got), userContent)
+	}
+}
+
+// TestRefreshMarkerBlockFile_RefusesSymlinkedTarget is ruling 3 of #306: THE
+// write primitive for the marker block routes through atomicio.WriteFile
+// rather than a bare os.WriteFile. The target here is a non-dangling
+// symlink to a real file that already carries a well-formed marker block —
+// ReadFile + ExtractMarkerBlock both follow the link and succeed, so this
+// reaches the write call, which must refuse rather than silently rewrite
+// the block through the link.
+func TestRefreshMarkerBlockFile_RefusesSymlinkedTarget(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	outside := t.TempDir()
+	realTarget := filepath.Join(outside, "real-agents.md")
+	const original = "before\n<!-- logmind-start -->\nOLD BODY\n<!-- logmind-end -->\nafter\n"
+	if err := os.WriteFile(realTarget, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed real target: %v", err)
+	}
+
+	repoRoot := t.TempDir()
+	linkedPath := filepath.Join(repoRoot, "AGENTS.md")
+	if err := os.Symlink(realTarget, linkedPath); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	err := RefreshMarkerBlockFile(linkedPath, "NEW BODY")
+
+	if err == nil {
+		t.Fatal("RefreshMarkerBlockFile did not error on a symlinked target")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	got, readErr := os.ReadFile(realTarget)
+	if readErr != nil {
+		t.Fatalf("real target vanished: %v", readErr)
+	}
+	if string(got) != original {
+		t.Errorf("RefreshMarkerBlockFile wrote through the symlink:\n got: %q\nwant: %q",
+			string(got), original)
+	}
+}
+
+// TestMigrateToAgentsMD_RefusesSymlinkedAGENTSMD covers the SECOND write
+// site inside MigrateToAgentsMD (the append of migrated per-agent content
+// into AGENTS.md) as distinct from the stub-replace site covered above.
+// AGENTS.md is a symlink to a real, already-current file, so the leading
+// EnsureAgentsMD(repoRoot) call no-ops (no diff to refresh) rather than
+// erroring for an unrelated reason — the append write further down is what
+// this test exercises.
+func TestMigrateToAgentsMD_RefusesSymlinkedAGENTSMD(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	repoRoot := t.TempDir()
+	outside := t.TempDir()
+	realAgents := filepath.Join(outside, "real-AGENTS.md")
+	current := agentsMDTemplate()
+	if err := os.WriteFile(realAgents, []byte(current), 0o644); err != nil {
+		t.Fatalf("seed real AGENTS.md: %v", err)
+	}
+	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	if err := os.Symlink(realAgents, agentsPath); err != nil {
+		t.Fatalf("plant AGENTS.md symlink: %v", err)
+	}
+
+	// A plain (non-symlinked) per-agent file with real content, so its own
+	// stub-replace succeeds and populates appendedBlocks — otherwise
+	// MigrateToAgentsMD never reaches the append write at all.
+	cursorPath := filepath.Join(repoRoot, ".cursorrules")
+	if err := os.WriteFile(cursorPath, []byte("# my cursor rules\n\nSOME_CONTENT\n"), 0o644); err != nil {
+		t.Fatalf("seed .cursorrules: %v", err)
+	}
+
+	_, _, err := MigrateToAgentsMD(repoRoot)
+
+	if err == nil {
+		t.Fatal("MigrateToAgentsMD did not error on a symlinked AGENTS.md")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	got, readErr := os.ReadFile(realAgents)
+	if readErr != nil {
+		t.Fatalf("real AGENTS.md vanished: %v", readErr)
+	}
+	if string(got) != current {
+		t.Errorf("migrate wrote through the AGENTS.md symlink:\n got: %q\nwant: %q", string(got), current)
+	}
+}


### PR DESCRIPTION
Closes #297. Closes #299.

Two issues, one class: **a partial write landing on a whole artifact the user owns**, against SPEC line 1101 — *"An artifact carrying no marker at all belongs to the user and MUST NOT be overwritten."*

- **#297** — `self_update.go` passed `entry.OldBody` (a block body) where `ReplaceMarkerBlock`'s first parameter is the **whole file**, then wrote the result over all of `AGENTS.md`.
- **#299** — `doctor` read the template marker from **line 1 only**; `init` scanned **every line**. A marker displaced to line 2 was markerless to one and versioned to the other, and `doctor --fix` then overwrote the file it had misjudged.

## The shape: remove the ability to express the bug

Not "fix the argument" — three changes so it can't be typed:

1. **`ReplaceMarkerBlock` is unexported.** "Returns its input unchanged when markers are absent" is a safe contract for a pure function and a data-loss contract for anything that writes the result.
2. **`inserter.RefreshMarkerBlockFile(path, newBody) error`** is the only exported way to rewrite a block. It owns the read, so there is no whole-file parameter left to get wrong, and it refuses with `ErrNoMarkerBlock` — writing nothing — when the file carries no well-formed block.
3. **`OutdatedMarkerEntry.OldBody` deleted.** A struct handing you a path and a body side by side is what made the wrong call look plausible.

The #297 call site was then **deleted, not repaired**: `FindOutdatedMarkerBlocks` only ever reported `AGENTS.md`, which `EnsureAgentsMD` had already refreshed through the same classifier — a second refresher of one path, against SPEC §5.2 *"Two refreshers MUST NOT write the same path."* Being unreachable is exactly why its wrong-argument write survived untested.

## One extractor: first-line-only

`cli.extractTemplateVersion` and `doctor.logmindMarkerRe` are both deleted; `inserter.ExtractTemplateMarker` is the single owner. First-line-only wins because **any-line makes ownership a substring search, and a substring search over a user's file claims it** — a workflow merely quoting the marker inside a heredoc would be adopted, then overwritten. All four bundled templates carry the marker at byte 0, pinned by a test.

Displacement is now its own state (`MarkerDisplaced`), refused by every writer and reported — never collapsed into "markerless" and acted on.

## Mutations — 4 applied, 4 compiled, 4 died

| | mutation | result |
|---|---|---|
| M1 | drop the `ErrNoMarkerBlock` guard | markerless + inverted-marker tests RED |
| M2 | re-introduce the #297 shape | byte-survival test RED, showing the file replaced by the fragment |
| M3 | any-line semantics | displaced-marker test RED — file overwritten, no note |
| M4 | disable the ownership gate | displaced RED (bytes lost); unmarked RED (note missing) |

Sources restored from private copies, never `git checkout`; SHA-256 re-verified identical.

## Tests assert outcomes, not arguments

A realistic `AGENTS.md` with prose above *and* below a stale block survives `self-update` byte-for-byte; a markerless file's bytes are unchanged and the user gets a located error naming the marker, the line, and both ways out. Vacuity control included. Live-binary re-check of both original repros passes.

`go build` / `go vet` / `gofmt -l .` clean; `go test ./...` exit 0.

## Found beyond the issues

- A **third** extractor disagreement nobody reported: on `# logmind-template-version: v1 junk`, the prefix form returned `"v1 junk"`, the regex form `"v1"`. Pinned by a test.
- Genuinely markerless workflows were never byte-overwritten — the old `installedVer != ""` check blocked it by accident. Only the *displaced* case lost bytes.
- The symlink exposure this section previously listed as a follow-up is **done here**: `RefreshMarkerBlockFile` — and every other write in `internal/inserter` and the two workflow writes in `internal/cli/init.go` — now routes through `atomicio.WriteFile`, which refuses a symlink at the destination instead of following it.

## Round 2 — four panel findings

1. **The second-writer guard was rebuilt around the write PRIMITIVE, not the path.** The previous version matched `WriteFile(agentsPath` / `WriteFile(filepath.Join(…"AGENTS.md"` and scanned `internal/` only; a panel got five second writers past it, including the literal #297 loop. The set of ways to spell a path is unbounded — the set of write primitives is not. `TestWriteSurfaces_UseNoRawWritePrimitive` parses the AST of every non-test `.go` file under `cmd/`, `internal/cli/` and `internal/inserter/` and fails on any direct `os.WriteFile` / `Create` / `OpenFile` / `Truncate`, with a named allowlist. All five evasions now compile and go red. A behavioural test cannot cover this class and one is not claimed: with the #297 loop restored, `FindOutdatedMarkerBlocks` reports nothing after `EnsureAgentsMD` has run, so the loop is a no-op and every outcome assertion stays green — measured, not assumed.
2. **A live symlink escape in `installWorkflowTemplates`.** Both its create and refresh branches used a bare `os.WriteFile`; a dangling symlink at `.github/workflows/check-decisions.yml` made `doctor --fix` write 6419 bytes outside the repository while reporting `workflows=1`. Both branches now route through `atomicio.WriteFile`, with a regression per branch driven through the real `doctor --fix`.
3. **`residualCause` reported a true drift with a false cause.** `probePathResolution` filed both "cannot exec `--version`" and "no version parsed" as `drift="markerless"` — SPEC §5.2's *ownership* verdict — so `--fix` told users their PATH binary "belongs to you and was left alone". Those two cases are now `drift="unreadable"` and get their own sentence.
4. **17 misattributed SPEC citations corrected.** Both quoted sentences — *"Exactly one automation owns any generated or copied path"* and *"An artifact carrying no marker at all belongs to the user"* — live at `SPEC.md:1097` and `:1101`, inside **§5.2**, never in §1.1. One of the wrong citations was user-facing stderr. Verified against the live SPEC, not against another comment.

**Round 2 mutations — 7 applied, 7 compiled, 7 died** (each init.go branch reverted separately; the drift token; the `residualCause` branch; the citation; the guard's own scope and its discrimination control). Restored from private copies, never `git checkout`; all 161 files re-verified byte-identical.
