### PR TITLE
fix(claudehook): report engine skew — the harness gate's genuinely silent failure

### DIFF
--- a/docs/decisions-branches/fix__harness-gate-absence.md
+++ b/docs/decisions-branches/fix__harness-gate-absence.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-claudehook-report-engine-skew-which-is-the-harness-gate-s-ge -->
+- **2026-08-15** — claudehook: report engine skew, which is the harness gate's genuinely silent failure
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:00 - claudehook: report engine skew, which is the harness gate's genuinely silent failure
+
+**Reasoning:** The issue's premise turned out to be partly wrong, and measuring it changed the fix. Driving real headless Claude Code sessions with live PreToolUse hooks and reading the resulting transcripts showed that a missing binary is already loud: the shell's command-not-found exits nonzero and non-two, which the harness records as a non-blocking error carrying both the stderr and the full command string. Adding a command -v guard would make it worse, because to stay fail-open the guard must exit zero, and exit zero with stderr is the one combination that reaches nobody. The verifiably silent case is engine skew, where a logmind on PATH answers guard-commit but is not the binary that installed the entry: it exits zero and says nothing.
+
+**Alternatives considered:** Prefix the command with a binary existence check as the issue proposed. Rejected on the measurement above: it addresses the case that already reports itself and silences it. Skew is worse on this layer than on the git layer because the settings file is cloned with the repository while git hooks are not, so a fresh clone can carry an entry no local binary matches.
+
+**Implications:**
+- The canonical command string is unchanged; only its comment, which previously argued there was no behavioural gain, now records what was measured. Skew is detected from the marker read inside the binary rather than through the shell, so there is no portability branch and no unknown-flag breakage, and it routes through the git layer's existing notice primitive rather than growing a second copy. The notice goes to stderr and, on the allow path, as a systemMessage the harness displays. Known blind spots: an entry living in user-level settings, and an unrelated binary named logmind. The old test asserting the guard's absence is replaced by one that runs the command under an empty PATH and pins loud, fail-open, and named; a mutation that adds the guard and updates the expected string passes the shape test and is caught only by the behavioural one.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -175,7 +175,22 @@ auto-fix in the `check-doc-links` workflow).
   (`internal/guardcommit` + `internal/claudehook`); escape hatches are
   `[skip-logmind]`, `LOGMIND_ALLOW_GIT_COMMIT=1`, and
   `git.enforce_commits: false`. The git layer signals a block via exit
-  65 and fails open on any other error.
+  65 and fails open on any other error; the harness layer signals a block
+  via exit 2 (the only code Claude Code treats as blocking) and fails open
+  on every other.
+  **Both layers report their own absence, by different means** — §3.4's
+  "failing open MUST NOT be silent" applies to each, and what reaches a
+  human differs per layer. The git hook prints a stderr notice on every
+  no-decision exit, and carries its installed-by version to the engine in
+  `LOGMIND_HOOK_VERSION`. The harness hook cannot do either: it is one line
+  run through whatever shell the OS gives Claude Code, where `command -v`
+  and inline `VAR=x cmd` are not portable. Instead a missing binary
+  announces itself through the shell's own exit 127 — which Claude Code
+  surfaces as a non-blocking hook error carrying the command string and its
+  version marker, whereas an exit-0 hook's stderr is surfaced to nobody —
+  and engine skew is reported from inside the binary, which reads the
+  installed marker back out of `.claude/settings.json` and emits a
+  `systemMessage`. Both layers share one skew decision (`engineSkewNotice`).
   **§3.4 requires the local hatches and forbids them at the CI gate** —
   "the gate has no self-service escape, and MUST NOT be given one". The
   shipped `check-decisions` template violates this today and the gate is

--- a/internal/claudehook/claudehook.go
+++ b/internal/claudehook/claudehook.go
@@ -74,12 +74,38 @@ func SettingsPath(repoRoot string) string {
 // user's shell, which varies by OS) — giving doctor's drift probe the
 // exact same marker-extraction contract the git hooks already use.
 //
-// Deliberately NOT prefixed with a `command -v logmind` guard: the
-// command must stay a single cross-platform line, and a missing logmind
-// binary already produces a non-2 "command not found" exit — which is
-// the correct fail-open behavior for a PreToolUse hook (only exit code 2
-// blocks the tool call). Adding our own existence check would only
-// introduce a platform-specific branch for no behavioral gain.
+// Deliberately NOT prefixed with a `command -v logmind` guard, and the
+// reason is now stronger than "no behavioral gain" (issue #298, SPEC
+// §3.4's "Failing open MUST NOT be silent"): the bare name is the LOUD
+// shape here, and the guard would be the silent one.
+//
+// Measured against Claude Code 2.1.233, driving a real headless session
+// with this exact command string and no `logmind` on PATH: the shell
+// exits 127, the Bash tool call still runs (fail-open holds — only exit
+// 2 blocks), and Claude Code records a `hook_non_blocking_error`
+// attachment carrying both `/bin/sh: logmind: command not found` AND
+// this whole command string, version marker included. That names what
+// it looked for, what it found, and which logmind installed the entry
+// — §3.4's three requirements — and it reaches a human.
+//
+// A `command -v logmind >/dev/null || { echo ... >&2; exit 0; }` guard
+// would have to exit 0 to stay fail-open, and an exit-0 PreToolUse
+// hook's stderr is surfaced to NO ONE (same measurement: it produces a
+// bare `hook_success` attachment). The "obvious" fix therefore trades a
+// notice a human sees for one nobody does — on top of the
+// cross-platform problem, since the command runs through bash on POSIX
+// but PowerShell on Windows without Git Bash, where `command -v` is not
+// syntax at all.
+//
+// What the bare name genuinely cannot catch is a logmind that IS on
+// PATH and answers `guard-commit`, but is not the one that wrote this
+// entry: that exits 0 and says nothing. Nothing on this line can fix
+// that, and nothing on this line has to — the engine reports it from
+// the inside, reading the marker above back out of settings.json. See
+// harnessHookVersion in internal/cli/guard_commit.go.
+//
+// TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud pins the measured
+// behaviour rather than the shape of the string.
 func CanonicalCommand() string {
 	return "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + version.Version
 }

--- a/internal/claudehook/claudehook_test.go
+++ b/internal/claudehook/claudehook_test.go
@@ -1,6 +1,7 @@
 package claudehook
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -22,8 +23,78 @@ func TestCanonicalCommand_Shape(t *testing.T) {
 	if got != want {
 		t.Fatalf("CanonicalCommand() = %q; want %q", got, want)
 	}
-	if strings.Contains(got, "command -v") {
-		t.Errorf("CanonicalCommand() must NOT contain a `command -v logmind` guard (must stay cross-platform + fail-open on missing binary); got %q", got)
+}
+
+// TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud replaces an older
+// assertion that the command string "must NOT contain `command -v`". That
+// assertion pinned a SHAPE, and a shape assertion is passed by any rewrite
+// that keeps the shape while destroying the behaviour — including the one
+// that matters here: appending `|| true`, or wrapping the call in an
+// existence check that exits 0, both keep `command -v` absent and both make
+// the vanished gate silent.
+//
+// What is pinned instead is the outcome measured against Claude Code 2.1.233
+// with a real PreToolUse hook and no `logmind` on PATH. Two exit-code facts
+// carry the whole contract, and they pull in opposite directions:
+//
+//   - exit 2 is the ONLY code that blocks the tool call, so anything else is
+//     fail-open. §3.4: "a missing, stale or crashing engine MUST allow."
+//   - exit 0 is the only code whose stderr reaches NOBODY (it yields a bare
+//     `hook_success` attachment). A non-zero, non-2 exit yields a
+//     `hook_non_blocking_error` attachment carrying the stderr and the
+//     command string, which is what a human actually sees. §3.4: "Failing
+//     open MUST NOT be silent."
+//
+// So the missing-binary path must land strictly between the two — non-zero
+// AND non-2 — with something on stderr that names what was looked for. That
+// is exactly what a bare command name does for free, via the shell's own
+// exit 127; the test exists to catch the day someone "improves" it.
+func TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no POSIX sh; the harness runs CanonicalCommand under the user's shell on Windows")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not on PATH; skipping shell-exec test")
+	}
+
+	// An empty directory as the ENTIRE PATH: no logmind, by construction.
+	emptyPath := t.TempDir()
+
+	// Control: the probe can observe a run that DOES find the binary. Without
+	// this, a test that only ever sees "not found" cannot tell a real absence
+	// from a broken harness — see the stub's argv check in the sibling test.
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "logmind"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("write stub logmind: %v", err)
+	}
+	var control bytes.Buffer
+	ctl := exec.Command(sh, "-c", CanonicalCommand())
+	ctl.Env = []string{"PATH=" + stubDir}
+	ctl.Stderr = &control
+	if err := ctl.Run(); err != nil {
+		t.Fatalf("control run (logmind present) failed: %v; stderr=%q", err, control.String())
+	}
+	if control.Len() != 0 {
+		t.Fatalf("control run wrote stderr %q; want silence when the binary IS present", control.String())
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.Command(sh, "-c", CanonicalCommand())
+	cmd.Env = []string{"PATH=" + emptyPath}
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+
+	code := cmd.ProcessState.ExitCode()
+	if err == nil || code == 0 {
+		t.Fatalf("exit code = %d (err=%v); want non-zero — an exit-0 PreToolUse hook's stderr reaches nobody, so a gate that vanished this way would be silent (SPEC §3.4)", code, err)
+	}
+	if code == 2 {
+		t.Fatalf("exit code = 2; that BLOCKS the tool call — a missing logmind must never stop a user working (SPEC §3.4 fail-open)")
+	}
+	if !strings.Contains(stderr.String(), "logmind") {
+		t.Errorf("stderr = %q; want it to name what was looked for (SPEC §3.4: \"naming what it looked for and what it found\")", stderr.String())
 	}
 }
 

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
@@ -181,7 +182,7 @@ func runGuardCommit(
 ) (exitCode int, err error) {
 	switch layer {
 	case "harness":
-		return guardCommitHarness(stdin, stderr, repoRootFlag, thresholdFlag, thresholdExplicit), nil
+		return guardCommitHarness(stdin, stdout, stderr, repoRootFlag, thresholdFlag, thresholdExplicit), nil
 	case "git-hook":
 		if msgFile == "" {
 			// Pure CLI-usage error, independent of any repo/config state.
@@ -279,7 +280,11 @@ type harnessPayload struct {
 // SUBDIRECTORY of the repo), falling back to --repo-root then the process
 // cwd. resolveRepoAndConfig then resolves that to the git toplevel so both
 // config AND every git op use the correct base directory.
-func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, thresholdFlag int, thresholdExplicit bool) int {
+//
+// stdout carries exactly one thing and only when there is something to say:
+// the §3.4 engine-skew notice, as a PreToolUse hook-output JSON object (see
+// writeHarnessNotice). Every ordinary allow still prints nothing at all.
+func guardCommitHarness(stdin io.Reader, stdout, stderr io.Writer, repoRootFlag string, thresholdFlag int, thresholdExplicit bool) int {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return 0 // fail open: couldn't even read the payload
@@ -371,13 +376,99 @@ func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, 
 		return 0 // the repo off-ramp: git.enforce_commits: false
 	}
 
+	// §3.4's skew report for THIS layer (issue #298). Same primitive, same
+	// wording and same major-only boundary as the git-hook layer's
+	// (engineSkewNotice); only the handshake channel differs — see
+	// harnessHookVersion for why this layer reads the marker instead of an
+	// environment variable. Placed after the enforce_commits off-ramp for the
+	// git layer's reason: a repo that turned local enforcement off does not
+	// get nagged about which binary would have enforced it.
+	skew := engineSkewNotice(harnessHookVersion(repoRoot))
+	if skew != "" {
+		fmt.Fprintln(stderr, skew)
+	}
+
 	subject := extractSubjectHint(payload.ToolInput.Command)
 	d := guardcommit.Evaluate(repoRoot, subject, threshold, guardcommit.WorkingTreeUnion)
 	if d.Allow {
+		// The allow path exits 0, and an exit-0 hook's stderr reaches nobody
+		// (see writeHarnessNotice) — so the notice has to go out the one
+		// channel that does. On the block path below it rides the exit-2
+		// stderr the harness already surfaces, so no second copy is needed.
+		writeHarnessNotice(stdout, skew)
 		return 0
 	}
 	fmt.Fprintln(stderr, d.Reason)
 	return 2
+}
+
+// harnessHookVersion returns the version of logmind that installed this
+// repo's PreToolUse guard entry, or "" when there is no entry, no marker, or
+// no readable .claude/settings.json.
+//
+// The git-hook layer gets the same fact handed to it in LOGMIND_HOOK_VERSION,
+// set inline around the invocation by its own shell body. This layer cannot
+// do that: its whole invocation is a SINGLE line run through whatever shell
+// the OS hands Claude Code (bash on POSIX; PowerShell on Windows without Git
+// Bash), and `VAR=x cmd` is POSIX-only syntax. A `--hook-version` flag is
+// worse still, for the reason spelled out on hookVersionEnv: an engine that
+// predates the flag would error out, turning "the gate ran against an older
+// engine" into "the gate did not run".
+//
+// So the handshake reads the marker where the installer already wrote it —
+// the `# logmind-hook-version:` suffix on the command string in
+// .claude/settings.json (claudehook.CanonicalCommand). Moving the check
+// inside the binary makes portability a non-issue, and the marker is a
+// stronger source than an env var besides: it is the byte the installer
+// actually left behind, not something the environment can assert.
+//
+// Its one blind spot, stated rather than hidden: an entry installed into the
+// USER-level ~/.claude/settings.json instead of the repo's leaves nothing to
+// read here, and the notice stays silent. That degrades the same way a
+// missing LOGMIND_HOOK_VERSION does on the git layer.
+func harnessHookVersion(repoRoot string) string {
+	return claudehook.Inspect(repoRoot).Version
+}
+
+// harnessNotice is the PreToolUse hook-output JSON shape guard-commit writes
+// on stdout to put a line in front of a human. `systemMessage` is Claude
+// Code's documented "display a message to the user" field, and it is the ONLY
+// field emitted: `hookSpecificOutput.permissionDecision` would move the
+// allow/block decision, and a report about the gate's own integrity must
+// never be able to do that.
+type harnessNotice struct {
+	SystemMessage string `json:"systemMessage"`
+}
+
+// writeHarnessNotice emits notice as a hook-output JSON object on stdout, or
+// does nothing when notice is empty.
+//
+// Why stdout-JSON and not stderr, when §3.4 says stderr and the git layer
+// uses it: measured against Claude Code 2.1.233, a PreToolUse hook that exits
+// 0 has its stderr recorded in the transcript and surfaced to NO ONE — it
+// produces a `hook_success` attachment and nothing else. Only two things a
+// PreToolUse hook can do reach a human without blocking the tool call: exit
+// non-zero-and-non-2 (a `hook_non_blocking_error` attachment carrying the
+// stderr), or print `{"systemMessage": ...}` on stdout (a
+// `hook_system_message` attachment). The first misreports a gate that ran and
+// allowed as a hook that failed, and it is already how the MISSING-binary
+// case announces itself (the shell's own exit 127) — so this layer takes the
+// second. The stderr copy still goes out alongside, both because §3.4 asks
+// for it and because it is what the block path (exit 2, where stderr IS
+// surfaced) carries.
+//
+// A notice must never be able to break the gate it reports on: a marshal
+// failure of this fixed two-field shape is impossible, and if it somehow
+// happened, dropping the notice is the correct outcome, not a crash.
+func writeHarnessNotice(stdout io.Writer, notice string) {
+	if notice == "" {
+		return
+	}
+	b, err := json.Marshal(harnessNotice{SystemMessage: notice})
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(stdout, string(b))
 }
 
 // guardCommitGitHook implements the --layer git-hook evaluation: resolve
@@ -451,25 +542,32 @@ func guardCommitGitHook(repoRootFlag, msgFile string, thresholdFlag int, thresho
 // able to break a gate that was working.
 const hookVersionEnv = "LOGMIND_HOOK_VERSION"
 
-// reportEngineSkew writes the §3.4 skew notice to stderr when the logmind
-// that installed the calling hook (hookVer) and the logmind now running as
-// its engine disagree on MAJOR version. Advisory only — it NEVER touches the
-// allow/block decision or the exit code, because a skewed engine has still
-// evaluated the change and its answer stands.
+// engineSkewNotice returns the §3.4 skew notice — one line, no trailing
+// newline — when the logmind that installed the calling hook (hookVer) and
+// the logmind now running as its engine disagree on MAJOR version, and ""
+// when they don't. It is the single owner of that message and of the decision
+// to send it: BOTH hook layers route through it (git-hook via
+// reportEngineSkew, harness via writeHarnessNotice), because two copies of
+// "when is the gate skewed" are two copies that will disagree, and a layer
+// whose copy quietly says "never" is a gate that stopped reporting its own
+// absence — the exact failure §3.4 names.
 //
-// Never routed through qout: like a block reason, this is a report about the
-// gate's own integrity, and §3.4 keeps those off stdout and out of reach of a
-// quiet flag. The caller only reaches this after the git.enforce_commits
-// off-ramp, so a repo that deliberately turned local enforcement off does not
-// get nagged about which binary would have enforced it.
+// The layers differ only in where they GET hookVer (an environment variable
+// on the git side, the installed settings.json marker on the harness side —
+// see harnessHookVersion) and in which channel actually reaches a human on
+// each (see writeHarnessNotice). Neither difference belongs in this function.
+//
+// Advisory in the strictest sense: nothing here touches the allow/block
+// decision or the exit code, because a skewed engine has still evaluated the
+// change and its answer stands.
 //
 // Major is the reporting boundary, not exact equality — see
 // version.SameMajor's doc comment for why (a per-patch notice would print on
 // every commit in every un-refreshed repo, and `logmind doctor` already
 // reports minor/patch hook staleness on demand).
-func reportEngineSkew(stderr io.Writer, hookVer string) {
+func engineSkewNotice(hookVer string) string {
 	if hookVer == "" || version.SameMajor(hookVer, version.Version) {
-		return
+		return ""
 	}
 	// os.Executable is what the hook actually resolved off PATH — "what it
 	// found", in §3.4's terms. Degrade to the bare name rather than dropping
@@ -478,9 +576,23 @@ func reportEngineSkew(stderr io.Writer, hookVer string) {
 	if err != nil || engine == "" {
 		engine = "logmind"
 	}
-	fmt.Fprintf(stderr,
-		"logmind: commit gate ran a DIFFERENT logmind than the one that installed this hook — hook installed by logmind %s, engine answering PATH is logmind %s (%s). Enforcement may differ across that boundary; refresh with `logmind doctor --fix`.\n",
+	return fmt.Sprintf(
+		"logmind: commit gate ran a DIFFERENT logmind than the one that installed this hook — hook installed by logmind %s, engine answering PATH is logmind %s (%s). Enforcement may differ across that boundary; refresh with `logmind doctor --fix`.",
 		hookVer, version.Version, engine)
+}
+
+// reportEngineSkew writes engineSkewNotice's verdict to the git-hook layer's
+// stderr.
+//
+// Never routed through qout: like a block reason, this is a report about the
+// gate's own integrity, and §3.4 keeps those off stdout and out of reach of a
+// quiet flag. The caller only reaches this after the git.enforce_commits
+// off-ramp, so a repo that deliberately turned local enforcement off does not
+// get nagged about which binary would have enforced it.
+func reportEngineSkew(stderr io.Writer, hookVer string) {
+	if notice := engineSkewNotice(hookVer); notice != "" {
+		fmt.Fprintln(stderr, notice)
+	}
 }
 
 // exGitHookBlock is the git-hook layer's distinctive block exit code —

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -884,4 +886,210 @@ func writeMsgFile(t *testing.T, repo, subject string) string {
 		t.Fatalf("write msg file: %v", err)
 	}
 	return path
+}
+
+// --- the harness layer's engine-skew handshake (issue #298) ---------------
+//
+// #270 gave the git layer the §3.4 report; the harness layer never got one, so
+// half the rule shipped. The harness layer's hole is the WIDER of the two,
+// because .claude/settings.json is ordinary repo content that travels with
+// `git clone` — a fresh clone arrives carrying a guard entry written by
+// whatever logmind the last committer had, to be run by whatever logmind the
+// cloner has. That is §3.4's "fleet mid-migration" by construction.
+//
+// It cannot use the git layer's LOGMIND_HOOK_VERSION channel: the harness
+// invocation is a single line run through whatever shell the OS hands Claude
+// Code, and `VAR=x cmd` is POSIX-only syntax. It reads the installer's own
+// marker out of settings.json instead, and routes the verdict through the same
+// engineSkewNotice both layers share.
+
+// installHarnessGuardWithVersion installs the REAL PreToolUse guard entry
+// (claudehook's own installer, not a hand-rolled imitation) and then rewrites
+// its `# logmind-hook-version:` marker to hookVer, or strips the marker
+// entirely when hookVer is "".
+//
+// Going through the installer is the point: it pins that the engine reads the
+// marker the installer actually WRITES. A hand-built fixture would keep
+// passing after a change to CanonicalCommand's marker placement that left
+// every real repo unreadable.
+func installHarnessGuardWithVersion(t *testing.T, repo, hookVer string) {
+	t.Helper()
+	if _, err := claudehook.EnsurePreToolUseGuard(repo); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	path := claudehook.SettingsPath(repo)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	installed := hooks.HookVersionPrefix + version.Version
+	if !strings.Contains(string(data), installed) {
+		t.Fatalf("installer wrote no %q marker; fixture is stale:\n%s", installed, data)
+	}
+	replacement := hooks.HookVersionPrefix + hookVer
+	if hookVer == "" {
+		replacement = ""
+	}
+	out := strings.Replace(string(data), installed, replacement, 1)
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		t.Fatalf("rewrite settings.json: %v", err)
+	}
+}
+
+// The load-bearing one. A repo whose guard entry was installed by a 1.x
+// logmind, evaluated by this 2.x engine: the commit is still allowed (the gate
+// ran and said yes), AND the skew reaches a human.
+//
+// "Reaches a human" is asserted on the channel that actually does so. Measured
+// against Claude Code 2.1.233 with a live PreToolUse hook: an exit-0 hook's
+// stderr produces a bare `hook_success` attachment and is shown to nobody,
+// while a `{"systemMessage": ...}` object on stdout produces a dedicated
+// `hook_system_message` attachment — Claude Code's documented "display a
+// message to the user" field. A stderr-only notice here would satisfy §3.4's
+// letter and be invisible in practice, which is the failure §3.4 exists to
+// stop.
+func TestRunGuardCommit_Harness_ReportsMajorEngineSkewToTheUser(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	if err := os.WriteFile(filepath.Join(repo, "small.go"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil — a skew notice must never change the decision", exitCode, err)
+	}
+
+	// stdout must be exactly one hook-output JSON object Claude Code can
+	// parse. Decoding into a map (not a struct) is deliberate: it lets the
+	// test see EVERY key, so a future field that could move the allow/block
+	// decision cannot be added here unnoticed.
+	var out map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not a hook-output JSON object: %v\nstdout = %q", err, stdout.String())
+	}
+	msg, ok := out["systemMessage"].(string)
+	if !ok {
+		t.Fatalf("stdout carries no systemMessage; got %q", stdout.String())
+	}
+	for _, must := range []string{"DIFFERENT logmind", "1.2.0", version.Version} {
+		if !strings.Contains(msg, must) {
+			t.Errorf("systemMessage missing %q; got %q", must, msg)
+		}
+	}
+	if len(out) != 1 {
+		t.Errorf("hook output carries %d keys (%v); want systemMessage ALONE — a permissionDecision or continue field here would let a report about the gate move the gate", len(out), out)
+	}
+	// §3.4 asks for stderr too, and the block path relies on it.
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; want the notice there as well (SPEC §3.4)", stderr.String())
+	}
+}
+
+// A skew notice must not be able to rescue — or to cause — a block.
+func TestRunGuardCommit_Harness_SkewNoticeLeavesTheBlockIntact(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(25)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if exitCode != 2 || err != nil {
+		t.Fatalf("exitCode=%d err=%v; want 2,nil (the block still stands under skew)", exitCode, err)
+	}
+	// Exit 2 IS surfaced, stderr and all — so the notice rides it, and nothing
+	// goes to stdout, where a JSON body next to a block would be two answers to
+	// one question.
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; want the skew notice alongside the block reason", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Errorf("stderr = %q; want the block reason too", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q; want empty on the block path", stdout.String())
+	}
+}
+
+// The noise floor, plus the two ways this layer legitimately knows nothing: no
+// guard entry installed in the repo at all, and an entry carrying no marker (a
+// pre-marker install). Both must stay silent rather than guess.
+func TestRunGuardCommit_Harness_SkewNoticeStaysSilentWhenItShould(t *testing.T) {
+	sameMajor := "2.99.99"
+	if !version.SameMajor(sameMajor, version.Version) {
+		t.Fatalf("fixture is stale: %q is no longer the same major as %q", sameMajor, version.Version)
+	}
+	for name, install := range map[string]func(t *testing.T, repo string){
+		"no settings.json at all": func(*testing.T, string) {},
+		"entry without a marker":  func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, "") },
+		"same major":              func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, sameMajor) },
+		"unparseable":             func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, "not-a-version") },
+		"exactly this version":    func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, version.Version) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := initRepo(t)
+			install(t, repo)
+			if err := os.WriteFile(filepath.Join(repo, "small.go"), []byte("x\n"), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+				strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+			if err != nil || exitCode != 0 {
+				t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q; want empty — an ordinary allow must print nothing", stdout.String())
+			}
+			if strings.Contains(stderr.String(), "DIFFERENT logmind") {
+				t.Errorf("skew notice fired for %s; stderr = %q", name, stderr.String())
+			}
+		})
+	}
+}
+
+// git.enforce_commits:false is the repo saying it does not want local
+// interception. Nagging it about which binary would have intercepted is noise
+// it explicitly opted out of — same placement as the git layer's.
+func TestRunGuardCommit_Harness_SkewNoticeRespectsTheEnforceOffRamp(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	writeGuardCommitConfig(t, repo, "git:\n  enforce_commits: false\n")
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(25)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+	}
+	if stdout.Len() != 0 || strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stdout=%q stderr=%q; want silence under enforce_commits:false", stdout.String(), stderr.String())
+	}
+}
+
+// The frequency pin. A PreToolUse hook fires on EVERY Bash tool call; a notice
+// attached to all of them is a notice nobody reads. It must ride only the
+// calls the gate actually judges — the git-commit ones.
+func TestRunGuardCommit_Harness_SkewNoticeOnlyRidesGitCommits(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `ls -la`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("stdout=%q stderr=%q; want silence on a non-commit Bash call", stdout.String(), stderr.String())
+	}
 }


### PR DESCRIPTION
Closes #298.

**The issue's premise is partly wrong, and measuring it changed the fix.**

I drove real headless `claude -p` sessions (Claude Code 2.1.233) with live PreToolUse hooks and read the resulting transcripts. Control: a `SessionStart` hook from the same `--settings` file fired, proving the file loaded; a file-write side effect proved the PreToolUse hook ran even when the stream showed nothing.

| hook behaviour | tool call | transcript attachment | reaches a human |
|---|---|---|---|
| exit 0, stderr written | runs | `hook_success` (stderr recorded) | **no** |
| exit 0, `{"systemMessage":…}` on stdout | runs | `hook_system_message` | **yes** |
| exit ≠0, ≠2 (incl. shell's 127) | runs | `hook_non_blocking_error` — stderr **plus the command string** | **yes** |
| exit 2 | blocked | — | violates fail-open |

Running the **exact current command** with an absent binary produced `hook_non_blocking_error: "/bin/sh: zzlogmindzz: command not found"`, carrying the command and its version marker. **The missing-binary case is already loud.**

And the proposed `command -v` guard makes it *worse*: to stay fail-open the guard must `exit 0`, and exit-0-with-stderr is the one combination in that table that reaches nobody.

## What is actually silent: engine skew

A `logmind` on PATH that answers `guard-commit` but is **not** the binary that installed the entry — exits 0, says nothing. Worse on this layer than on the git layer: `.claude/settings.json` is cloned with the repository, git hooks are not, so a fresh clone can carry an entry no local binary matches.

`CanonicalCommand()` is unchanged — only its comment, which previously argued there was no behavioural gain and now records what was measured. Skew is detected via `claudehook.Inspect(repoRoot).Version`, reading the marker from inside the binary rather than through the shell: no portability branch, no unknown-flag breakage. It routes through the git layer's existing notice primitive (extracted to `engineSkewNotice`) rather than growing a second copy.

The notice goes to stderr **and**, on the allow path, as `{"systemMessage":…}` on stdout — the one channel measured to reach a human without blocking.

**Cost, stated:** blind when the entry lives in user-level settings; no notice for an unrelated binary named `logmind`.

## `claudehook_test.go:26`

The old assertion (*"must NOT contain a `command -v logmind` guard"*) is replaced by `TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud`, which runs the real command under an empty-dir PATH — with a stub-present control run — and pins exit ≠0 (loud), exit ≠2 (fail-open), and stderr naming `logmind`.

## Mutations — 7 applied, 7 compiled, 7 died

Including **M5**: add the `command -v … exit 0` guard *and* update the expected string. The shape test **passed**; only the behavioural test caught it. That is the case for replacing a substring assertion with a behavioural one.

Sources restored from private copies, SHA-256 byte-identical each time.

`go build` / `go vet` / `gofmt -l .` clean; `go test ./...` all ok. E2E through the built binary: exit 0, stderr notice, systemMessage JSON.