### PR TITLE
fix(test): one helper creates every test repository, so the maintenance race can't be reintroduced a file at a time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ records the "why" behind changes via `logmind log`, and keeps the derived
 `docs/timeline.md` + `docs/file-structure.md` in sync as agent-readable
 context. One leg of the thrillmade SkDD toolchain (with clud-bug = review,
 agent-skills = catalog). Entry point `cmd/logmind/main.go`; code under
-`internal/`. See [docs/plan.md](docs/plan.md) for architecture + roadmap.
+`internal/`. See [docs/plan.md](docs/plan.md) for architecture, and
+[docs/roadmap.md](docs/roadmap.md) for what ships next and in what order.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ tests, release workflow).
 ## Documentation
 
 - **[Install](docs/install.md)** - Full install matrix (brew, curl, go install, manual, legacy Python)
-- **[Plan & Architecture](docs/plan.md)** - Vision, approach, and technical details
+- **[Architecture](docs/plan.md)** - Vision, approach, and technical details
+- **[Roadmap](docs/roadmap.md)** - What ships next, in what order, and why
 - **[AI Agent Files](docs/ai-agent-files.md)** - How logmind integrates with AI instruction files
 - **[First Decision Example](docs/first-decision-example.md)** - What the initial decision looks like
 
@@ -304,7 +305,8 @@ tests, release workflow).
 - **AI-friendly:** Recent decisions + file structure = complete context
 - **Automatic:** Commits and pushes on every log
 
-See [docs/plan.md](docs/plan.md) for complete architecture and roadmap.
+See [docs/plan.md](docs/plan.md) for the architecture and
+[docs/roadmap.md](docs/roadmap.md) for the roadmap.
 
 ## Legacy install (Python, frozen at v0.6.16)
 

--- a/docs/decisions-branches/docs__roadmap-as-source.md
+++ b/docs/decisions-branches/docs__roadmap-as-source.md
@@ -1,0 +1,61 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-14-make-docs-roadmap-md-the-source-of-truth-for-sequencing -->
+- **2026-08-14** — Make docs/roadmap.md the source of truth for sequencing
+<!-- logmind-entry-end -->
+
+## 2026-08-14 17:02 - Make docs/roadmap.md the source of truth for sequencing
+
+**Reasoning:** The roadmap lived in a scratchpad HTML file that the artifact was published from. That file was wiped twice today by session restarts, taking the only copy of the sequencing with it — the published page survived but could not be updated, so it drifted to showing 26 issues and a superseded critical path while the real count was 31 and the critical path had changed to #288. A roadmap that cannot survive a restart is not a source of truth. It now lives in the repository, versioned and reviewable, and the artifact renders FROM it rather than being it.
+
+**Alternatives considered:** Keep the roadmap inside docs/plan.md. Rejected on half-life: plan.md is architecture and changes yearly; the release board changed six times in one day. Fusing them is exactly why plan.md spent weeks describing a derived_docs.mode config gate that had already been deleted.
+
+**Implications:**
+- One owner per fact, stated in both files: if a date, count, issue number or ordering appears in both, roadmap.md is right and plan.md is stale. plan.md is retitled from 'Plan & Architecture' to 'Architecture' to stop implying it owns sequencing. Every number in roadmap.md carries the command that produced it, and every claimed zero carries a control proving the probe finds a non-zero when one exists — including the load-bearing one that regen bot commits have a null author.login, so a login-keyed probe reports zero on every PR and looks clean. All seven SPEC citations verified LIVE against blob cd64e5c; check-links passes.
+
+---
+
+## 2026-08-14 21:24 - Correct seven defects an adversarial panel found in the roadmap
+
+**Reasoning:** The file whose entire purpose is being accurate had seven. Two drove what gets built next. FIRST: it said the steward App was on no ruleset bypass list and called that the tightest constraint on the tag — measured now, there are two active rulesets not three, reporulez-default 18292242 returns 404, and both survivors carry Integration:3951953 which IS skdd-steward. Their updated_at is 2026-08-07T17:1x, a week before that commit, so it was likely never true when written. I had verified the bypass was granted and said so out loud, then wrote the opposite into the file from older survey text. SECOND: 'seven success runs, the single push event failed' — actually 503 runs, 15 on push, 13 of them green. The conclusion survived, the evidence did not, and an auditor who finds thirteen greens discounts the section that is right.
+
+**Alternatives considered:** Fix the two critical ones and file the rest. Rejected: five of the seven are the file describing a state that is not the current one, which is the single failure mode it exists to avoid. A roadmap that is 70% accurate is worse than none, because it is trusted.
+
+**Implications:**
+- The #288 section is rewritten around what is actually unresolved: the bypass is granted, the push has still never landed a commit, and the reason is not a refusal — 13 green push runs with 0 commits means the job finds the docs current and exits before pushing. The one failure, on 0aa9049, predates the bypass by six days, so the original diagnosis was right when filed and the remedy has since been applied. skdd was misread across two branches: main has no workflows at all, dev carries check-decisions v4, and the earlier 'already on v11, migrating is a no-op' would have dropped a repo that genuinely needs migrating. One-owner-per-fact was claimed and not achieved — AGENTS.md, README twice and docs/spec.md all still pointed at plan.md for the roadmap, so all four are repointed. #243 carried its own ordering table that reversed this file's, recreating the two-owners defect one revision after the split; its body is rewritten to point here. Four pre-existing issues were unplaced and now are. The verified date was impossible — 2026-08-07 against a SHA created 2026-08-14.
+
+---
+
+## 2026-08-15 09:18 - roadmap: state the command, not the answer, for every fact git already owns
+
+**Reasoning:** This file went stale twice, the second time during the adversarial panel that was checking it, which blocked it. The cause was structural rather than careless: the file copied SHAs, commit counts, ahead-counts and open-PR counts that git and gh already own, and a hand-kept second copy reads as true until one quietly is not. That is the one-owner-per-fact rule the file exists to enforce, and it was not being applied to the file itself. The State section and the landed-commits table now carry the commands that produce those numbers instead of the numbers.
+
+**Alternatives considered:** Correct the numbers a third time and keep the shape. Rejected because the failure repeats on a timescale shorter than the review that catches it. The nine findings the panel raised were almost all instances of one defect wearing nine faces, and correcting instances leaves the tenth to be found by a reader who trusts it.
+
+**Implications:**
+- Numbers that survive are load-bearing for a judgment rather than descriptive of the moment, and each is stamped with the date it was measured and the command that measures it again. Also corrected in this pass, all re-measured against live gh: the protocol bot-commit share is 43 of 109 on the last ten merged pull requests rather than 42 of 98, there are two push failures rather than one, skdd carries regen-timeline at v11 rather than nothing, check-decisions has no push trigger at all, and agent-skills 207 is merged.
+
+---
+
+## 2026-08-15 13:53 - roadmap: make each shown command reproduce its own number, and drop a claim that was false when written
+
+**Reasoning:** The re-panel blocked on two defects. Both gh api calls over a pull request commit list omitted --paginate, so the command printed beside the number answered a different question than the number: PR 75 carries 63 commits over three pages, and without the flag gh returns only the first, which counts 15 against a stated 30. A command shown to make a number self-verifying is worse than no command when it does not reproduce it. Separately, the file asserted that issue 244 still contradicted Ruling 12 in its body. That body was corrected on 2026-08-01, two weeks before the claim was written, and I had verified it myself earlier in the same session and left the stale sentence standing.
+
+**Alternatives considered:** Drop the commands and keep only the prose numbers. Rejected because the command is the whole mechanism by which this file avoids the staleness that blocked it twice; the answer is to make the commands correct rather than to remove the check. Also rejected: leaving the 244 paragraph as a harmless overstatement, since a roadmap that invents remaining work is exactly as misleading as one that hides it.
+
+**Implications:**
+- Both aggregate and single-PR probes now carry --paginate, and re-running them yields 109 commits with 43 from the regen bot, a 39.4 percent share, matching what the file states. The control confirms the probe distinguishes bot from human rather than matching everything.
+
+---
+
+## 2026-08-15 14:12 - roadmap: remove the branch-tip pin from the header — the file's own rule, broken in the file's own header
+
+**Reasoning:** The fourth review found the verification header naming the dev and main tips it was checked against, two paragraphs above the rule forbidding exactly that. Worse, the pin was already wrong when written: the commit introducing it is timestamped three minutes after PR 302 moved dev past the SHA it names. A rule stated and then broken in the same document teaches readers the rule is decorative.
+
+**Alternatives considered:** Update the header to the current tip. Rejected for the fourth time on the same grounds: any branch tip written into this file is wrong within hours, and the previous three corrections all proved it. The SPEC blob pin stays because a blob hash is immutable and cannot rot; a branch tip is a moving reference that this file may not own.
+
+**Implications:**
+- The header now pins only the SPEC blob and tells the reader to run git rev-parse for the tips. The absence is documented rather than silent, so the next person does not helpfully add it back. A grep for a dev or main tip in the file returns nothing, controlled against the two immutable commit references in the historical sections, which are allowed and still present.
+
+---
+

--- a/docs/decisions-branches/fix__harness-gate-absence.md
+++ b/docs/decisions-branches/fix__harness-gate-absence.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-claudehook-report-engine-skew-which-is-the-harness-gate-s-ge -->
+- **2026-08-15** — claudehook: report engine skew, which is the harness gate's genuinely silent failure
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:00 - claudehook: report engine skew, which is the harness gate's genuinely silent failure
+
+**Reasoning:** The issue's premise turned out to be partly wrong, and measuring it changed the fix. Driving real headless Claude Code sessions with live PreToolUse hooks and reading the resulting transcripts showed that a missing binary is already loud: the shell's command-not-found exits nonzero and non-two, which the harness records as a non-blocking error carrying both the stderr and the full command string. Adding a command -v guard would make it worse, because to stay fail-open the guard must exit zero, and exit zero with stderr is the one combination that reaches nobody. The verifiably silent case is engine skew, where a logmind on PATH answers guard-commit but is not the binary that installed the entry: it exits zero and says nothing.
+
+**Alternatives considered:** Prefix the command with a binary existence check as the issue proposed. Rejected on the measurement above: it addresses the case that already reports itself and silences it. Skew is worse on this layer than on the git layer because the settings file is cloned with the repository while git hooks are not, so a fresh clone can carry an entry no local binary matches.
+
+**Implications:**
+- The canonical command string is unchanged; only its comment, which previously argued there was no behavioural gain, now records what was measured. Skew is detected from the marker read inside the binary rather than through the shell, so there is no portability branch and no unknown-flag breakage, and it routes through the git layer's existing notice primitive rather than growing a second copy. The notice goes to stderr and, on the allow path, as a systemMessage the harness displays. Known blind spots: an entry living in user-level settings, and an unrelated binary named logmind. The old test asserting the guard's absence is replaced by one that runs the command under an empty PATH and pins loud, fail-open, and named; a mutation that adds the guard and updates the expected string passes the shape test and is caught only by the behavioural one.
+
+---
+

--- a/docs/decisions-branches/fix__ignore-patterns-merge.md
+++ b/docs/decisions-branches/fix__ignore-patterns-merge.md
@@ -1,0 +1,31 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-tree-union-the-ignore-sources-instead-of-letting-config-repl -->
+- **2026-08-15** — tree: union the ignore sources instead of letting config replace the defaults
+<!-- logmind-entry-end -->
+
+## 2026-08-15 09:08 - tree: union the ignore sources instead of letting config replace the defaults
+
+**Reasoning:** Setting a single file_structure.ignore_patterns entry replaced the built-in list wholesale, so a repo that ignored one temp file suddenly rendered node_modules, .venv and dist into its file structure. Measured against real binaries on a scratch repo whose config sets only *.tmp: before, the tree carried .venv, dist and node_modules at 535 bytes; after, 405 bytes with only .logmind and docs. The four consumers all funnel through tree.ResolveRules, so the merge lands in one function rather than at four call sites.
+
+**Alternatives considered:** Resolve overlapping patterns by letting any matching negation win, wherever it sits in the merged list. That is what this branch shipped first, and an adversarial panel blocked it: inside a single .gitignore reading `!important.log` then `*.log`, real git answers `.gitignore:2:*.log` — ignored, last match wins — while negation-wins answered not-ignored. The divergence was far broader than the cross-source case that justified it, and it left config no way to re-exclude what .gitignore had negated. The evidence originally offered for it was real but misdiagnosed: a repo with no config did receive DefaultConfig's sixteen patterns at the config source's position, so positional resolution did let a re-appended dist override a !dist. The defect was the mis-ranked defaults, not the positional rule.
+
+**Implications:**
+- The built-in defaults become a source of their own, config.DefaultIgnorePatterns, and DefaultConfig leaves FileStructure.IgnorePatterns nil — so a non-empty value there means the user's config.yml set the key and nothing else can, which makes the mis-ranking unrepresentable rather than corrected. Resolution is then strictly positional, defaults then gitignore then config then extras, last match wins, per SPEC §1.4 and git alike.
+- dedup keeps the last occurrence of a repeated rule rather than the first: under last-match-wins, dropping the later copy moves a decision earlier and changes verdicts, which `*.log` / `!important.log` / `*.log` demonstrates against git.
+- Seven fixtures are now compared against `git check-ignore` directly rather than against hand-written expectations; the oracle needs two invocations because `-v` redefines the exit code as "a pattern matched", so a path re-included by a trailing negation still exits 0.
+- DefaultMap renders DefaultIgnorePatterns instead of keeping a second hand-maintained copy, so what `logmind config list` prints and what `config set` writes back come from one owner. The remaining #304 gap is unchanged and still filed separately: `config set` materialises the defaults into the user file, and under positional resolution that materialised copy now ranks as config — correct per §1.4, but a reason to fix #304 rather than to live with it.
+
+---
+
+## 2026-08-15 13:54 - tree: give the built-in ignore defaults their own source, then resolve positionally like git
+
+**Reasoning:** The panel refuted the negation-wins resolution I approved a round earlier. Its justification covered only collisions across sources, but the implementation applied everywhere, so a single gitignore containing a negation followed by a broader pattern disagreed with git itself. Real git ignores important.log given bang-important.log then star-dot-log, because the last matching rule wins; logmind did not. The actual defect was never that positional resolution is wrong. It is that DefaultConfig seeded the ignore list, so a repository with no config file still reached the resolver carrying sixteen patterns wearing the config source's identity, in last position, where any positional rule mis-ranks them.
+
+**Alternatives considered:** Keep negation-wins and document the divergence for users. Rejected: it diverges from git in cases the justification never covered, leaves config no way to re-exclude what gitignore negated, and asks every reader to learn a second set of ignore semantics. Also rejected: a wasSet sentinel alongside the seeded defaults, because it leaves a third state that can still be mis-ranked. Unseeding removes the state rather than detecting it.
+
+**Implications:**
+- Verified against git check-ignore as an oracle across seven fixtures, all agreeing, including the three orderings of a negation among broader patterns. The oracle itself needed care: check-ignore -v exits zero whenever any pattern matched, including a path a trailing negation re-included, so reading its exit code as the verdict inverts every negation row and would have agreed with a broken resolver. Fifteen mutations, all compiled, all died; one from the previous round had survived because ResolveRules' variadic extras had no production caller and no test at all. Dedup now keeps the last occurrence rather than the first, which is verdict-preserving under last-match-wins where keep-first is not.
+
+---
+

--- a/docs/decisions-branches/fix__test-repo-maintenance.md
+++ b/docs/decisions-branches/fix__test-repo-maintenance.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-testgit-one-helper-creates-every-test-repository-so-the-main -->
+- **2026-08-15** — testgit: one helper creates every test repository, so the maintenance race cannot be reintroduced a file at a time
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:01 - testgit: one helper creates every test repository, so the maintenance race cannot be reintroduced a file at a time
+
+**Reasoning:** Git commit calls run_auto_maintenance, gated by maintenance.auto rather than gc.auto, and the spawned process daemonises and is still writing into the object store when a test returns, so TempDir cleanup fails with directory not empty. It surfaces as a cleanup error on whichever test loses the race, which is why it looked like a different bug each time. Four files carried the fix inline and the rest did not. Reproduced independently on this machine before writing the test: five of five commits spawned git maintenance with gc.auto alone, zero of five with both keys.
+
+**Alternatives considered:** Paste the two config lines into each remaining file. Rejected: that is the arrangement that already failed once, since the next person adding a test repository has nothing telling them the lines exist. A leaf package depending only on os, exec and testing means any package can import it without a cycle, so there is no reason left to hand-roll one.
+
+**Implications:**
+- The issue counted fourteen exposed files; the sweep found eight genuinely unguarded initialisations, several of the listed files being false positives that already routed through a guarded helper or never touched real git. It also found three exposures the issue did not list at all: two clone destinations and one bare push remote, none of which inherit configuration from the repository they came from. Cloning is the gap a file-by-file audit misses, because the search term is init. Green count went from 880 to 882, the two additions being the helper's own tests, one reading the keys back and one capturing trace output across five commits to assert zero spawns.
+
+---
+

--- a/docs/decisions-branches/fix__test-repo-maintenance.md
+++ b/docs/decisions-branches/fix__test-repo-maintenance.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-15 14:26 - testgit: close the last unguarded committing test repo, so the sweep claim is true
+
+**Reasoning:** The panel found the claim that one helper creates every test repository was false while tree_rootlabel_test.go still ran its own init, config, commit and worktree add with no suppression. It predates this branch and the diff never touched it, which is exactly why a completeness claim needs its own check rather than inheriting the diff's. Re-swept afterwards: of the seven remaining files matching a crude init probe, none call git commit, and only a commit triggers run_auto_maintenance, so none can lose the race. The control confirms the probe finds real git-exec files rather than matching nothing.
+
+**Alternatives considered:** File it as a follow-up and merge with the hole open, which is what the panel proposed. Rejected: the entire point of this change is that the race cannot be reintroduced a file at a time, and shipping a known unguarded committing repo alongside that claim makes the claim the thing people trust instead of the code.
+
+**Implications:**
+- This one file keeps its local run helper rather than adopting testgit.InitRepo, because it also needs git worktree add against the same handle; it calls DisableMaintenance directly instead, which is the shared primitive both wrappers use.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -184,7 +184,22 @@ auto-fix in the `check-doc-links` workflow).
   (`internal/guardcommit` + `internal/claudehook`); escape hatches are
   `[skip-logmind]`, `LOGMIND_ALLOW_GIT_COMMIT=1`, and
   `git.enforce_commits: false`. The git layer signals a block via exit
-  65 and fails open on any other error.
+  65 and fails open on any other error; the harness layer signals a block
+  via exit 2 (the only code Claude Code treats as blocking) and fails open
+  on every other.
+  **Both layers report their own absence, by different means** — §3.4's
+  "failing open MUST NOT be silent" applies to each, and what reaches a
+  human differs per layer. The git hook prints a stderr notice on every
+  no-decision exit, and carries its installed-by version to the engine in
+  `LOGMIND_HOOK_VERSION`. The harness hook cannot do either: it is one line
+  run through whatever shell the OS gives Claude Code, where `command -v`
+  and inline `VAR=x cmd` are not portable. Instead a missing binary
+  announces itself through the shell's own exit 127 — which Claude Code
+  surfaces as a non-blocking hook error carrying the command string and its
+  version marker, whereas an exit-0 hook's stderr is surfaced to nobody —
+  and engine skew is reported from inside the binary, which reads the
+  installed marker back out of `.claude/settings.json` and emits a
+  `systemMessage`. Both layers share one skew decision (`engineSkewNotice`).
   **§3.4 requires the local hatches and forbids them at the CI gate** —
   "the gate has no self-service escape, and MUST NOT be given one". The
   shipped `check-decisions` template violates this today and the gate is

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,4 +1,13 @@
-# logmind: Plan & Architecture
+# logmind: Architecture
+
+> **Sequencing lives in [roadmap.md](roadmap.md), not here.** This document is
+> the durable half — what logmind is, how the enforcement layers fit together,
+> and why the load-bearing calls were made. It changes yearly. The release
+> board changes weekly, and fusing the two is what let the combined document
+> describe a config gate for weeks after that gate was deleted.
+>
+> One owner per fact: if a date, a count, an issue number or an ordering appears
+> in both files, `roadmap.md` is right and this one is stale.
 
 ## Vision
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,330 @@
+# logmind — roadmap to v2.0.0
+
+> **This file is the source of truth for sequencing.** The roadmap artifact
+> renders from it.
+>
+> [#243](https://github.com/thrillmade/logmind/issues/243) is the tracking
+> thread and points here. It carried its own ordering table until 2026-08-14,
+> which meant two orderings of record — the exact defect this split was made to
+> remove, recreated one revision later. That table is gone; if the two ever
+> disagree again, this file is right.
+>
+> Architecture lives in [plan.md](plan.md) — that changes yearly,
+> this changes weekly, and fusing them is why the old combined document went
+> stale.
+>
+> **Every number here was measured, with the command shown.** Nothing is carried
+> from memory or from an issue body. A claimed zero is stated with the control
+> that proves the probe finds a non-zero when one exists.
+
+**Verified 2026-08-15** against the live SPEC at `thrillmade/protocol` blob
+`cd64e5c` (1,475 lines, Sections 0–8, no appendices) — an immutable blob, so
+that pin cannot rot.
+
+This line used to name the `dev` and `main` SHAs it was checked against. Those
+are gone, and their absence is the point: the pin was stale three minutes before
+the commit that introduced it, which is the fourth recurrence of the defect this
+file exists to prevent — in the file's own header, two paragraphs above the rule
+forbidding it. A branch tip is not a fact this file may own. Run
+`git rev-parse --short origin/dev origin/main` instead.
+
+---
+
+## State
+
+**This file does not carry SHAs, counts, or "N ahead".** Two revisions tried and
+both were stale within hours — once *during* the review that checked them. Git
+already owns those facts, and a hand-kept second copy reads as true until one
+quietly isn't. That is the same one-owner-per-fact rule this file was created to
+enforce, applied to itself.
+
+Run these instead:
+
+```sh
+git fetch origin --prune
+git log --oneline origin/main..origin/dev          # what is on dev, not yet on main
+gh issue list --state open --limit 60              # open issues
+gh pr list --state open                            # open pull requests
+gh release list --limit 1                          # what `brew install` gives
+```
+
+The one durable fact worth stating: **everything built since June is unreleased.**
+The released binary predates the commit gate, the harness guard, the zero-conflict
+invariant and the `areas:` declaration — so `brew install` does not get any of
+them until the tag.
+
+### How work is verified
+
+`dev` deliberately has **no CI** — of the two workflows, only
+`check-derived-docs` (`regen-timeline.yml`) carries a `push: branches: [main]`
+trigger. `check-decisions` has **no push trigger at all**; it runs only on
+`pull_request`. The bar is a **local adversarial panel** per change, plus the
+full suite run against integrated `dev`. Pull requests into `dev` still get
+CI on their own merge-ref (both workflows' `pull_request` trigger carries no
+`branches:` filter); what the panel and the local suite cover is the
+*integrated* result, which PR-level CI never sees.
+
+---
+
+## Landed on `dev`, not yet on `main`
+
+```sh
+git log --oneline origin/main..origin/dev
+```
+
+Those issues stay **open** until `dev` reaches `main` — `closes #N` only fires on
+the default branch. That is expected, not drift.
+
+---
+
+## Blocked on a person
+
+### #288 — the bypass is granted; it has never been exercised
+
+**Not a blocker on the tag.** An earlier revision of this file said the steward
+App was on no bypass list and called that "the tightest constraint on the tag."
+**That was wrong**, and the correction matters more than the original claim.
+
+```
+$ gh api repos/thrillmade/logmind/rulesets --jq '.[]|"\(.id) \(.name)"'
+18502737 org-baseline
+16898453 org-default-protection
+
+$ gh api repos/thrillmade/logmind/rulesets/18502737 \
+    --jq '[.bypass_actors[]|"\(.actor_type):\(.actor_id)"]'
+["OrganizationAdmin:null", "Integration:3951953"]
+
+$ gh api /apps/skdd-steward --jq .id
+3951953
+```
+
+Two active rulesets, not three — `reporulez-default` (18292242) returns **404**
+here and no longer covers this repository. Both survivors carry
+`Integration:3951953`, which is `skdd-steward`. Their `updated_at` is
+**2026-08-07T17:1x**.
+
+### What is actually unresolved
+
+The push has still never landed a commit, and the reason is *not* a refusal.
+**Measured 2026-08-15** against `logmind / check-derived-docs`
+(`.github/workflows/regen-timeline.yml`, workflow id `277546816`):
+
+```sh
+$ git log origin/main --format='%s' | grep -c '^chore: regen derived docs$'
+0
+$ gh api repos/thrillmade/protocol/pulls/75/commits --paginate \
+    --jq '[.[] | select(.commit.author.name == "logmind-auto-regen[bot]")] | length'
+30
+# --paginate is load-bearing: PR#75 has 63 commits over 3 pages and `gh api`
+# returns only the first without it, which answers 15.
+$ gh api "repos/thrillmade/logmind/actions/workflows/277546816/runs?per_page=100&event=push" \
+    --paginate --jq '.workflow_runs[] | .conclusion' | sort | uniq -c
+     13 success
+      2 failure
+```
+
+| probe | result |
+|---|---|
+| regen commits on `main`, by exact subject line | **0** |
+| control — same probe, protocol PR#75 bot commits | **30** |
+| `push`-event runs of `regen-timeline` | **15** |
+| `push` runs that **succeeded** | **13** |
+| `push` runs that **failed** | **2** |
+
+Thirteen green push runs and zero commits means the job runs, finds the derived
+docs already current, and exits 0 on that path — it never reaches the push at
+all. **Both** `push` failures carry the GH013 `Changes must be made through a
+pull request` refusal: `fcf7268` (**2026-07-25**) and `0aa9049`
+(**2026-08-01**), each dated *before* the bypass was added
+(**2026-08-07**). So the original diagnosis was correct when filed and the
+remedy has since been applied.
+
+**The bypass is therefore untested, not missing.** It gets exercised the first
+time `main` receives a merge that leaves a derived doc stale — which is the
+`dev` → `main` merge at the tag, not something to manufacture beforehand.
+
+> **A caution this file has already earned.** An earlier revision reported
+> "seven `success` runs, and the single `push` event failed." The real figures
+> are 15 push runs and 13 successes. The conclusion — that the green column
+> never described `regen-on-main` — survived, but the evidence for it did not,
+> and an auditor who finds thirteen greens discounts the section that is right.
+> Every count in this file names the command that produced it for exactly this
+> reason.
+
+### Awaiting protocol rulings
+
+| issue | question | blocks |
+|---|---|---|
+| protocol#77 | who owns the §1.2 per-tool redirect files | skdd#6 scope |
+| protocol#89 | is `!pattern` valid in `file_structure.ignore_patterns` | the fix shape for #269 |
+| protocol#90 | §7.3's example declares 3 areas for logmind; we implement 5 | what the tag bakes in |
+| protocol#93 | §3.4 requires non-empty reasoning; §3.1 says an entry without it is well-formed | nothing — gate follows §3.4 today |
+
+### #241 — pre-tag by Ruling 12, but unbuildable as written
+
+Underspecified — the setup surface itself has open questions (profile
+vocabulary, whether the limit-watch is tooled or purely behavioural). It is
+**no longer blocked on missing skills**: agent-skills#207 (merged
+2026-08-15) shipped both `session-heartbeat` and `unattended-operation`,
+implementing agent-skills#173 and #174. Those two tracking issues remain
+open on GitHub — that is bookkeeping, not a build blocker; the skills exist
+in the catalog today.
+
+---
+
+## The order
+
+Gate integrity came first because **#257 is a distribution mechanism**: anything
+wrong in the binary, hooks or templates when it ships is pushed to every consumer
+repo and must then be fixed twice.
+
+### 1 — Gate integrity ✅ on `dev`
+
+#278 · #260 · #284 · #286 · #285 · #267 · #270. All landed.
+
+### 2 — Prerequisites for the fleet migration
+
+Each is a hard gate on #257, not a parallel cleanup. **#257 itself is
+post-tag, not pre-tag** — `setup-logmind` installs from `/releases/latest`,
+and the released v1.2.0 answers `logmind check-decisions --base` with
+`Error: unknown flag: --base` (ruling recorded in #243). The fleet cannot
+take the new gate template until v2.0.0 exists, so this whole cluster —
+including #288 below and #265+#257 in §4 — runs after the tag by
+construction, even though it is numbered ahead of "§3 — Remaining pre-tag
+work" in this list: numbering here is dependency order, not calendar order
+across the tag boundary.
+
+| | why it blocks |
+|---|---|
+| **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
+| **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
+| **template v12** | the shipped `regen-timeline` template pushes with a raw `LOGMIND_AUTO_REGEN_PAT`; logmind's own copy mints a `skdd-steward[bot]` token via `create-github-app-token@v3`. Shipping as-is deploys the credential path logmind abandoned. Also fix the action-pin regression — the template pins `setup-logmind@v1.0.0` while five repos run `@v1.0.1`. |
+
+### 3 — Remaining pre-tag work
+
+**#261** — gate logic inline on `pull_request` (§6.3). *Reordered:* originally
+ahead of the gate cluster; doing it after means relocating a **correct**
+evaluation rather than a wrong one. Its remedy restructures `regen-timeline.yml`,
+so that file moves twice regardless of what else we do.
+
+**#269** — `ignore_patterns` replaces the 16 built-in defaults instead of merging.
+§1.4 line 202 says the three sources are **merged**, so this is a spec violation,
+not a wart. Fix shape depends on protocol#89.
+
+**#259** — the derived-doc restore does not refuse while a merge, rebase,
+cherry-pick or revert is in progress. Restoring mid-conflict discards the
+resolution someone is part-way through, and the restore paths run automatically.
+
+**#266** — `logmind config set` has no refusal for gate settings. §1.6's point is
+that some keys are humans-only; an agent that can lower `commit_line_threshold`
+to unblock itself has bought exactly what §3.4's gate exists to prevent.
+
+**#244** — branch→issue binding plus comment-back on merge. Pre-tag by **Ruling
+12**, not by defect: nothing in current behaviour is wrong, the feature simply
+does not exist. Recorded here rather than in §5 so the ruling stays visible.
+Its body no longer contradicts the ruling: it was corrected 2026-08-01 and now
+opens "Pre-tag — in v2.0.0 scope by Ruling 12." Nothing to do.
+
+**#241** — `logmind auto`. Also pre-tag by Ruling 12. It previously needed two
+skills that did not exist; those shipped in agent-skills#207 (merged
+2026-08-15). What remains is #241's own underspecification — see above.
+
+**#279** — the site's `--version` example is one line; §7.3 requires two, and the
+tag-time flip would not have added the `areas:` line. **Built and on `dev`**
+(#302). The issue stays open until `dev` reaches `main`, per the rule above.
+The panel verified it by building the site in both states rather than reading
+the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
+
+### 4 — #265 + #257, together (post-tag — see §2)
+
+One fleet move, per standing constraint. #265 collapses the decision layout —
+main is a branch like any other, no cap, no archive, `rotateDecisions` deleted
+rather than ported — and adds `docs/timeline-archive.md` as a **third** derived
+file that every restore path and `check-derived-docs` must learn. All of them
+name two today.
+
+**#277 rides here too.** It reports `check-derived-docs` enforcing the opposite
+of §3.3 — regenerating from the branch's own sources and failing on the diff, so
+it demands the branch commit exactly what §3.3 forbids. logmind's own copy and
+its shipped `v11` template are **already correct**; the defect is a stale
+installed copy in the consumer repos. So it is a #257 payload, not code to write
+here, and it closes when the fleet takes the current template.
+
+### 5 — After the tag
+
+#263 (§6.7 pre-push gate, wholly new scope) · #251 · #271 · #280 · #210 · #217 ·
+#258 · #268 · #273 · #274 · #283.
+
+---
+
+## The fleet, measured
+
+Read from each repository's **installed** file, not inferred from what this repo
+ships.
+
+| repo | `check-decisions` | `regen-timeline` | pushes to PR branch |
+|---|---|---|---|
+| protocol | `v2` | `v4` | **yes** |
+| clud-bug | `v2` | `v4` | **yes** |
+| clud-bug-app | `v2` | `v4` | **yes** |
+| agent-skills | `v2` | `v4` | **yes** |
+| reporulez | *unversioned* | *unmarked* | no |
+| skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
+
+**logmind ships** `check-decisions` at **`v5`** and `regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
+v4" is not one number.
+
+Two corrections to #257's original inventory:
+
+- **reporulez is structurally unreachable by refresh.** `installWorkflowTemplates`
+  guards on `installedVer != ""`, so a file with no `# logmind-template-version`
+  marker is skipped **forever**. It needs hand-replacement or it is silently left
+  behind.
+- **skdd was misread, and the misreading mixed two branches.** Its `main` has no
+  `.github/workflows` at all (404); its `dev` carries `check-decisions` at **v4**,
+  added 2026-08-01. An earlier revision of this file said "already on v11, so
+  migrating it is a no-op" — that was wrong in both halves, and it would have
+  removed a repository from the migration list that genuinely needs migrating.
+  Its clean `check-derived-docs` history is still no validation: green because
+  neither derived doc exists on any skdd branch.
+
+### The cost of not migrating
+
+`thrillmade/protocol`, last 10 **merged** pull requests by creation date
+(#92, #88, #85, #84, #83, #80, #76, #75, #70, #69) — **measured 2026-08-15**:
+
+```sh
+$ gh api "repos/thrillmade/protocol/pulls?state=closed&sort=created&direction=desc&per_page=30" \
+    --jq '[.[] | select(.merged_at != null)] | .[0:10] | .[].number'
+$ for pr in 92 88 85 84 83 80 76 75 70 69; do
+    gh api "repos/thrillmade/protocol/pulls/$pr/commits" --paginate \
+      --jq '[.[] | .commit.author.name]'
+  done
+# 109 commits total, 43 with .commit.author.name == "logmind-auto-regen[bot]"
+```
+
+**109 commits, 43 of them `logmind-auto-regen[bot]` — 39%.** PR#75 alone
+carries 30, every subject byte-identical (`chore: regen derived docs`); its 63
+commits alternate human/bot 1:1 for the first 60, confirmed by commit order.
+PR#70 contains a *human* commit titled `[skip-logmind] chore: regen derived docs` —
+someone hand-running the regeneration to pre-empt the bot.
+
+It has already produced one governance failure: **protocol#75, the SPEC 2.0
+rewrite itself, merged over a red required `check-derived-docs` via admin
+bypass.** A repository where every push needs a rebase is one where people start
+bypassing gates.
+
+> **Method note, load-bearing.** Those bot commits have `.author.login == null` —
+> no linked account. A probe keyed on `.author.login` reports **zero on every
+> pull request** and looks like a clean result. Identity must be read from
+> `.commit.author.name`.
+
+---
+
+## Pre-tag checklist
+
+1. `dev` → `main`, which closes #264, #278, #260, #284, #285, #286, #267, #270.
+2. Run `release.yml` with `dry_run=true`.
+3. **Separately** re-confirm the homebrew-tap ruleset bypass — the dry run skips
+   that push, so it never exercises the identity that failed with GH013.
+4. Tag. That is the CEO's action, not the lane's.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,4 +33,5 @@ logmind's own templates install.
 review's output but performs none, and declaring a version is a §7.3
 obligation rather than an implementation of §7.
 
-See [docs/plan.md](plan.md) for architecture and the forward roadmap.
+See [docs/plan.md](plan.md) for architecture and [docs/roadmap.md](roadmap.md)
+for the forward roadmap.

--- a/internal/claudehook/claudehook.go
+++ b/internal/claudehook/claudehook.go
@@ -74,12 +74,38 @@ func SettingsPath(repoRoot string) string {
 // user's shell, which varies by OS) — giving doctor's drift probe the
 // exact same marker-extraction contract the git hooks already use.
 //
-// Deliberately NOT prefixed with a `command -v logmind` guard: the
-// command must stay a single cross-platform line, and a missing logmind
-// binary already produces a non-2 "command not found" exit — which is
-// the correct fail-open behavior for a PreToolUse hook (only exit code 2
-// blocks the tool call). Adding our own existence check would only
-// introduce a platform-specific branch for no behavioral gain.
+// Deliberately NOT prefixed with a `command -v logmind` guard, and the
+// reason is now stronger than "no behavioral gain" (issue #298, SPEC
+// §3.4's "Failing open MUST NOT be silent"): the bare name is the LOUD
+// shape here, and the guard would be the silent one.
+//
+// Measured against Claude Code 2.1.233, driving a real headless session
+// with this exact command string and no `logmind` on PATH: the shell
+// exits 127, the Bash tool call still runs (fail-open holds — only exit
+// 2 blocks), and Claude Code records a `hook_non_blocking_error`
+// attachment carrying both `/bin/sh: logmind: command not found` AND
+// this whole command string, version marker included. That names what
+// it looked for, what it found, and which logmind installed the entry
+// — §3.4's three requirements — and it reaches a human.
+//
+// A `command -v logmind >/dev/null || { echo ... >&2; exit 0; }` guard
+// would have to exit 0 to stay fail-open, and an exit-0 PreToolUse
+// hook's stderr is surfaced to NO ONE (same measurement: it produces a
+// bare `hook_success` attachment). The "obvious" fix therefore trades a
+// notice a human sees for one nobody does — on top of the
+// cross-platform problem, since the command runs through bash on POSIX
+// but PowerShell on Windows without Git Bash, where `command -v` is not
+// syntax at all.
+//
+// What the bare name genuinely cannot catch is a logmind that IS on
+// PATH and answers `guard-commit`, but is not the one that wrote this
+// entry: that exits 0 and says nothing. Nothing on this line can fix
+// that, and nothing on this line has to — the engine reports it from
+// the inside, reading the marker above back out of settings.json. See
+// harnessHookVersion in internal/cli/guard_commit.go.
+//
+// TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud pins the measured
+// behaviour rather than the shape of the string.
 func CanonicalCommand() string {
 	return "logmind guard-commit --layer harness " + hooks.HookVersionPrefix + version.Version
 }

--- a/internal/claudehook/claudehook_test.go
+++ b/internal/claudehook/claudehook_test.go
@@ -1,6 +1,7 @@
 package claudehook
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -22,8 +23,78 @@ func TestCanonicalCommand_Shape(t *testing.T) {
 	if got != want {
 		t.Fatalf("CanonicalCommand() = %q; want %q", got, want)
 	}
-	if strings.Contains(got, "command -v") {
-		t.Errorf("CanonicalCommand() must NOT contain a `command -v logmind` guard (must stay cross-platform + fail-open on missing binary); got %q", got)
+}
+
+// TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud replaces an older
+// assertion that the command string "must NOT contain `command -v`". That
+// assertion pinned a SHAPE, and a shape assertion is passed by any rewrite
+// that keeps the shape while destroying the behaviour — including the one
+// that matters here: appending `|| true`, or wrapping the call in an
+// existence check that exits 0, both keep `command -v` absent and both make
+// the vanished gate silent.
+//
+// What is pinned instead is the outcome measured against Claude Code 2.1.233
+// with a real PreToolUse hook and no `logmind` on PATH. Two exit-code facts
+// carry the whole contract, and they pull in opposite directions:
+//
+//   - exit 2 is the ONLY code that blocks the tool call, so anything else is
+//     fail-open. §3.4: "a missing, stale or crashing engine MUST allow."
+//   - exit 0 is the only code whose stderr reaches NOBODY (it yields a bare
+//     `hook_success` attachment). A non-zero, non-2 exit yields a
+//     `hook_non_blocking_error` attachment carrying the stderr and the
+//     command string, which is what a human actually sees. §3.4: "Failing
+//     open MUST NOT be silent."
+//
+// So the missing-binary path must land strictly between the two — non-zero
+// AND non-2 — with something on stderr that names what was looked for. That
+// is exactly what a bare command name does for free, via the shell's own
+// exit 127; the test exists to catch the day someone "improves" it.
+func TestCanonicalCommand_MissingBinaryIsFailOpenAndLoud(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no POSIX sh; the harness runs CanonicalCommand under the user's shell on Windows")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not on PATH; skipping shell-exec test")
+	}
+
+	// An empty directory as the ENTIRE PATH: no logmind, by construction.
+	emptyPath := t.TempDir()
+
+	// Control: the probe can observe a run that DOES find the binary. Without
+	// this, a test that only ever sees "not found" cannot tell a real absence
+	// from a broken harness — see the stub's argv check in the sibling test.
+	stubDir := t.TempDir()
+	stub := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "logmind"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("write stub logmind: %v", err)
+	}
+	var control bytes.Buffer
+	ctl := exec.Command(sh, "-c", CanonicalCommand())
+	ctl.Env = []string{"PATH=" + stubDir}
+	ctl.Stderr = &control
+	if err := ctl.Run(); err != nil {
+		t.Fatalf("control run (logmind present) failed: %v; stderr=%q", err, control.String())
+	}
+	if control.Len() != 0 {
+		t.Fatalf("control run wrote stderr %q; want silence when the binary IS present", control.String())
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.Command(sh, "-c", CanonicalCommand())
+	cmd.Env = []string{"PATH=" + emptyPath}
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+
+	code := cmd.ProcessState.ExitCode()
+	if err == nil || code == 0 {
+		t.Fatalf("exit code = %d (err=%v); want non-zero — an exit-0 PreToolUse hook's stderr reaches nobody, so a gate that vanished this way would be silent (SPEC §3.4)", code, err)
+	}
+	if code == 2 {
+		t.Fatalf("exit code = 2; that BLOCKS the tool call — a missing logmind must never stop a user working (SPEC §3.4 fail-open)")
+	}
+	if !strings.Contains(stderr.String(), "logmind") {
+		t.Errorf("stderr = %q; want it to name what was looked for (SPEC §3.4: \"naming what it looked for and what it found\")", stderr.String())
 	}
 }
 

--- a/internal/cli/guard_commit.go
+++ b/internal/cli/guard_commit.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
@@ -181,7 +182,7 @@ func runGuardCommit(
 ) (exitCode int, err error) {
 	switch layer {
 	case "harness":
-		return guardCommitHarness(stdin, stderr, repoRootFlag, thresholdFlag, thresholdExplicit), nil
+		return guardCommitHarness(stdin, stdout, stderr, repoRootFlag, thresholdFlag, thresholdExplicit), nil
 	case "git-hook":
 		if msgFile == "" {
 			// Pure CLI-usage error, independent of any repo/config state.
@@ -279,7 +280,11 @@ type harnessPayload struct {
 // SUBDIRECTORY of the repo), falling back to --repo-root then the process
 // cwd. resolveRepoAndConfig then resolves that to the git toplevel so both
 // config AND every git op use the correct base directory.
-func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, thresholdFlag int, thresholdExplicit bool) int {
+//
+// stdout carries exactly one thing and only when there is something to say:
+// the §3.4 engine-skew notice, as a PreToolUse hook-output JSON object (see
+// writeHarnessNotice). Every ordinary allow still prints nothing at all.
+func guardCommitHarness(stdin io.Reader, stdout, stderr io.Writer, repoRootFlag string, thresholdFlag int, thresholdExplicit bool) int {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return 0 // fail open: couldn't even read the payload
@@ -371,13 +376,99 @@ func guardCommitHarness(stdin io.Reader, stderr io.Writer, repoRootFlag string, 
 		return 0 // the repo off-ramp: git.enforce_commits: false
 	}
 
+	// §3.4's skew report for THIS layer (issue #298). Same primitive, same
+	// wording and same major-only boundary as the git-hook layer's
+	// (engineSkewNotice); only the handshake channel differs — see
+	// harnessHookVersion for why this layer reads the marker instead of an
+	// environment variable. Placed after the enforce_commits off-ramp for the
+	// git layer's reason: a repo that turned local enforcement off does not
+	// get nagged about which binary would have enforced it.
+	skew := engineSkewNotice(harnessHookVersion(repoRoot))
+	if skew != "" {
+		fmt.Fprintln(stderr, skew)
+	}
+
 	subject := extractSubjectHint(payload.ToolInput.Command)
 	d := guardcommit.Evaluate(repoRoot, subject, threshold, guardcommit.WorkingTreeUnion)
 	if d.Allow {
+		// The allow path exits 0, and an exit-0 hook's stderr reaches nobody
+		// (see writeHarnessNotice) — so the notice has to go out the one
+		// channel that does. On the block path below it rides the exit-2
+		// stderr the harness already surfaces, so no second copy is needed.
+		writeHarnessNotice(stdout, skew)
 		return 0
 	}
 	fmt.Fprintln(stderr, d.Reason)
 	return 2
+}
+
+// harnessHookVersion returns the version of logmind that installed this
+// repo's PreToolUse guard entry, or "" when there is no entry, no marker, or
+// no readable .claude/settings.json.
+//
+// The git-hook layer gets the same fact handed to it in LOGMIND_HOOK_VERSION,
+// set inline around the invocation by its own shell body. This layer cannot
+// do that: its whole invocation is a SINGLE line run through whatever shell
+// the OS hands Claude Code (bash on POSIX; PowerShell on Windows without Git
+// Bash), and `VAR=x cmd` is POSIX-only syntax. A `--hook-version` flag is
+// worse still, for the reason spelled out on hookVersionEnv: an engine that
+// predates the flag would error out, turning "the gate ran against an older
+// engine" into "the gate did not run".
+//
+// So the handshake reads the marker where the installer already wrote it —
+// the `# logmind-hook-version:` suffix on the command string in
+// .claude/settings.json (claudehook.CanonicalCommand). Moving the check
+// inside the binary makes portability a non-issue, and the marker is a
+// stronger source than an env var besides: it is the byte the installer
+// actually left behind, not something the environment can assert.
+//
+// Its one blind spot, stated rather than hidden: an entry installed into the
+// USER-level ~/.claude/settings.json instead of the repo's leaves nothing to
+// read here, and the notice stays silent. That degrades the same way a
+// missing LOGMIND_HOOK_VERSION does on the git layer.
+func harnessHookVersion(repoRoot string) string {
+	return claudehook.Inspect(repoRoot).Version
+}
+
+// harnessNotice is the PreToolUse hook-output JSON shape guard-commit writes
+// on stdout to put a line in front of a human. `systemMessage` is Claude
+// Code's documented "display a message to the user" field, and it is the ONLY
+// field emitted: `hookSpecificOutput.permissionDecision` would move the
+// allow/block decision, and a report about the gate's own integrity must
+// never be able to do that.
+type harnessNotice struct {
+	SystemMessage string `json:"systemMessage"`
+}
+
+// writeHarnessNotice emits notice as a hook-output JSON object on stdout, or
+// does nothing when notice is empty.
+//
+// Why stdout-JSON and not stderr, when §3.4 says stderr and the git layer
+// uses it: measured against Claude Code 2.1.233, a PreToolUse hook that exits
+// 0 has its stderr recorded in the transcript and surfaced to NO ONE — it
+// produces a `hook_success` attachment and nothing else. Only two things a
+// PreToolUse hook can do reach a human without blocking the tool call: exit
+// non-zero-and-non-2 (a `hook_non_blocking_error` attachment carrying the
+// stderr), or print `{"systemMessage": ...}` on stdout (a
+// `hook_system_message` attachment). The first misreports a gate that ran and
+// allowed as a hook that failed, and it is already how the MISSING-binary
+// case announces itself (the shell's own exit 127) — so this layer takes the
+// second. The stderr copy still goes out alongside, both because §3.4 asks
+// for it and because it is what the block path (exit 2, where stderr IS
+// surfaced) carries.
+//
+// A notice must never be able to break the gate it reports on: a marshal
+// failure of this fixed two-field shape is impossible, and if it somehow
+// happened, dropping the notice is the correct outcome, not a crash.
+func writeHarnessNotice(stdout io.Writer, notice string) {
+	if notice == "" {
+		return
+	}
+	b, err := json.Marshal(harnessNotice{SystemMessage: notice})
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(stdout, string(b))
 }
 
 // guardCommitGitHook implements the --layer git-hook evaluation: resolve
@@ -451,25 +542,32 @@ func guardCommitGitHook(repoRootFlag, msgFile string, thresholdFlag int, thresho
 // able to break a gate that was working.
 const hookVersionEnv = "LOGMIND_HOOK_VERSION"
 
-// reportEngineSkew writes the §3.4 skew notice to stderr when the logmind
-// that installed the calling hook (hookVer) and the logmind now running as
-// its engine disagree on MAJOR version. Advisory only — it NEVER touches the
-// allow/block decision or the exit code, because a skewed engine has still
-// evaluated the change and its answer stands.
+// engineSkewNotice returns the §3.4 skew notice — one line, no trailing
+// newline — when the logmind that installed the calling hook (hookVer) and
+// the logmind now running as its engine disagree on MAJOR version, and ""
+// when they don't. It is the single owner of that message and of the decision
+// to send it: BOTH hook layers route through it (git-hook via
+// reportEngineSkew, harness via writeHarnessNotice), because two copies of
+// "when is the gate skewed" are two copies that will disagree, and a layer
+// whose copy quietly says "never" is a gate that stopped reporting its own
+// absence — the exact failure §3.4 names.
 //
-// Never routed through qout: like a block reason, this is a report about the
-// gate's own integrity, and §3.4 keeps those off stdout and out of reach of a
-// quiet flag. The caller only reaches this after the git.enforce_commits
-// off-ramp, so a repo that deliberately turned local enforcement off does not
-// get nagged about which binary would have enforced it.
+// The layers differ only in where they GET hookVer (an environment variable
+// on the git side, the installed settings.json marker on the harness side —
+// see harnessHookVersion) and in which channel actually reaches a human on
+// each (see writeHarnessNotice). Neither difference belongs in this function.
+//
+// Advisory in the strictest sense: nothing here touches the allow/block
+// decision or the exit code, because a skewed engine has still evaluated the
+// change and its answer stands.
 //
 // Major is the reporting boundary, not exact equality — see
 // version.SameMajor's doc comment for why (a per-patch notice would print on
 // every commit in every un-refreshed repo, and `logmind doctor` already
 // reports minor/patch hook staleness on demand).
-func reportEngineSkew(stderr io.Writer, hookVer string) {
+func engineSkewNotice(hookVer string) string {
 	if hookVer == "" || version.SameMajor(hookVer, version.Version) {
-		return
+		return ""
 	}
 	// os.Executable is what the hook actually resolved off PATH — "what it
 	// found", in §3.4's terms. Degrade to the bare name rather than dropping
@@ -478,9 +576,23 @@ func reportEngineSkew(stderr io.Writer, hookVer string) {
 	if err != nil || engine == "" {
 		engine = "logmind"
 	}
-	fmt.Fprintf(stderr,
-		"logmind: commit gate ran a DIFFERENT logmind than the one that installed this hook — hook installed by logmind %s, engine answering PATH is logmind %s (%s). Enforcement may differ across that boundary; refresh with `logmind doctor --fix`.\n",
+	return fmt.Sprintf(
+		"logmind: commit gate ran a DIFFERENT logmind than the one that installed this hook — hook installed by logmind %s, engine answering PATH is logmind %s (%s). Enforcement may differ across that boundary; refresh with `logmind doctor --fix`.",
 		hookVer, version.Version, engine)
+}
+
+// reportEngineSkew writes engineSkewNotice's verdict to the git-hook layer's
+// stderr.
+//
+// Never routed through qout: like a block reason, this is a report about the
+// gate's own integrity, and §3.4 keeps those off stdout and out of reach of a
+// quiet flag. The caller only reaches this after the git.enforce_commits
+// off-ramp, so a repo that deliberately turned local enforcement off does not
+// get nagged about which binary would have enforced it.
+func reportEngineSkew(stderr io.Writer, hookVer string) {
+	if notice := engineSkewNotice(hookVer); notice != "" {
+		fmt.Fprintln(stderr, notice)
+	}
 }
 
 // exGitHookBlock is the git-hook layer's distinctive block exit code —

--- a/internal/cli/guard_commit_test.go
+++ b/internal/cli/guard_commit_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -884,4 +886,210 @@ func writeMsgFile(t *testing.T, repo, subject string) string {
 		t.Fatalf("write msg file: %v", err)
 	}
 	return path
+}
+
+// --- the harness layer's engine-skew handshake (issue #298) ---------------
+//
+// #270 gave the git layer the §3.4 report; the harness layer never got one, so
+// half the rule shipped. The harness layer's hole is the WIDER of the two,
+// because .claude/settings.json is ordinary repo content that travels with
+// `git clone` — a fresh clone arrives carrying a guard entry written by
+// whatever logmind the last committer had, to be run by whatever logmind the
+// cloner has. That is §3.4's "fleet mid-migration" by construction.
+//
+// It cannot use the git layer's LOGMIND_HOOK_VERSION channel: the harness
+// invocation is a single line run through whatever shell the OS hands Claude
+// Code, and `VAR=x cmd` is POSIX-only syntax. It reads the installer's own
+// marker out of settings.json instead, and routes the verdict through the same
+// engineSkewNotice both layers share.
+
+// installHarnessGuardWithVersion installs the REAL PreToolUse guard entry
+// (claudehook's own installer, not a hand-rolled imitation) and then rewrites
+// its `# logmind-hook-version:` marker to hookVer, or strips the marker
+// entirely when hookVer is "".
+//
+// Going through the installer is the point: it pins that the engine reads the
+// marker the installer actually WRITES. A hand-built fixture would keep
+// passing after a change to CanonicalCommand's marker placement that left
+// every real repo unreadable.
+func installHarnessGuardWithVersion(t *testing.T, repo, hookVer string) {
+	t.Helper()
+	if _, err := claudehook.EnsurePreToolUseGuard(repo); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	path := claudehook.SettingsPath(repo)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	installed := hooks.HookVersionPrefix + version.Version
+	if !strings.Contains(string(data), installed) {
+		t.Fatalf("installer wrote no %q marker; fixture is stale:\n%s", installed, data)
+	}
+	replacement := hooks.HookVersionPrefix + hookVer
+	if hookVer == "" {
+		replacement = ""
+	}
+	out := strings.Replace(string(data), installed, replacement, 1)
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		t.Fatalf("rewrite settings.json: %v", err)
+	}
+}
+
+// The load-bearing one. A repo whose guard entry was installed by a 1.x
+// logmind, evaluated by this 2.x engine: the commit is still allowed (the gate
+// ran and said yes), AND the skew reaches a human.
+//
+// "Reaches a human" is asserted on the channel that actually does so. Measured
+// against Claude Code 2.1.233 with a live PreToolUse hook: an exit-0 hook's
+// stderr produces a bare `hook_success` attachment and is shown to nobody,
+// while a `{"systemMessage": ...}` object on stdout produces a dedicated
+// `hook_system_message` attachment — Claude Code's documented "display a
+// message to the user" field. A stderr-only notice here would satisfy §3.4's
+// letter and be invisible in practice, which is the failure §3.4 exists to
+// stop.
+func TestRunGuardCommit_Harness_ReportsMajorEngineSkewToTheUser(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	if err := os.WriteFile(filepath.Join(repo, "small.go"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil — a skew notice must never change the decision", exitCode, err)
+	}
+
+	// stdout must be exactly one hook-output JSON object Claude Code can
+	// parse. Decoding into a map (not a struct) is deliberate: it lets the
+	// test see EVERY key, so a future field that could move the allow/block
+	// decision cannot be added here unnoticed.
+	var out map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not a hook-output JSON object: %v\nstdout = %q", err, stdout.String())
+	}
+	msg, ok := out["systemMessage"].(string)
+	if !ok {
+		t.Fatalf("stdout carries no systemMessage; got %q", stdout.String())
+	}
+	for _, must := range []string{"DIFFERENT logmind", "1.2.0", version.Version} {
+		if !strings.Contains(msg, must) {
+			t.Errorf("systemMessage missing %q; got %q", must, msg)
+		}
+	}
+	if len(out) != 1 {
+		t.Errorf("hook output carries %d keys (%v); want systemMessage ALONE — a permissionDecision or continue field here would let a report about the gate move the gate", len(out), out)
+	}
+	// §3.4 asks for stderr too, and the block path relies on it.
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; want the notice there as well (SPEC §3.4)", stderr.String())
+	}
+}
+
+// A skew notice must not be able to rescue — or to cause — a block.
+func TestRunGuardCommit_Harness_SkewNoticeLeavesTheBlockIntact(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(25)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if exitCode != 2 || err != nil {
+		t.Fatalf("exitCode=%d err=%v; want 2,nil (the block still stands under skew)", exitCode, err)
+	}
+	// Exit 2 IS surfaced, stderr and all — so the notice rides it, and nothing
+	// goes to stdout, where a JSON body next to a block would be two answers to
+	// one question.
+	if !strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stderr = %q; want the skew notice alongside the block reason", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "logmind log") {
+		t.Errorf("stderr = %q; want the block reason too", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q; want empty on the block path", stdout.String())
+	}
+}
+
+// The noise floor, plus the two ways this layer legitimately knows nothing: no
+// guard entry installed in the repo at all, and an entry carrying no marker (a
+// pre-marker install). Both must stay silent rather than guess.
+func TestRunGuardCommit_Harness_SkewNoticeStaysSilentWhenItShould(t *testing.T) {
+	sameMajor := "2.99.99"
+	if !version.SameMajor(sameMajor, version.Version) {
+		t.Fatalf("fixture is stale: %q is no longer the same major as %q", sameMajor, version.Version)
+	}
+	for name, install := range map[string]func(t *testing.T, repo string){
+		"no settings.json at all": func(*testing.T, string) {},
+		"entry without a marker":  func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, "") },
+		"same major":              func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, sameMajor) },
+		"unparseable":             func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, "not-a-version") },
+		"exactly this version":    func(t *testing.T, repo string) { installHarnessGuardWithVersion(t, repo, version.Version) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := initRepo(t)
+			install(t, repo)
+			if err := os.WriteFile(filepath.Join(repo, "small.go"), []byte("x\n"), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+				strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+			if err != nil || exitCode != 0 {
+				t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q; want empty — an ordinary allow must print nothing", stdout.String())
+			}
+			if strings.Contains(stderr.String(), "DIFFERENT logmind") {
+				t.Errorf("skew notice fired for %s; stderr = %q", name, stderr.String())
+			}
+		})
+	}
+}
+
+// git.enforce_commits:false is the repo saying it does not want local
+// interception. Nagging it about which binary would have intercepted is noise
+// it explicitly opted out of — same placement as the git layer's.
+func TestRunGuardCommit_Harness_SkewNoticeRespectsTheEnforceOffRamp(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+	writeGuardCommitConfig(t, repo, "git:\n  enforce_commits: false\n")
+	if err := os.WriteFile(filepath.Join(repo, "big.go"), []byte(bigLines(25)), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `git commit -m x`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+	}
+	if stdout.Len() != 0 || strings.Contains(stderr.String(), "DIFFERENT logmind") {
+		t.Errorf("stdout=%q stderr=%q; want silence under enforce_commits:false", stdout.String(), stderr.String())
+	}
+}
+
+// The frequency pin. A PreToolUse hook fires on EVERY Bash tool call; a notice
+// attached to all of them is a notice nobody reads. It must ride only the
+// calls the gate actually judges — the git-commit ones.
+func TestRunGuardCommit_Harness_SkewNoticeOnlyRidesGitCommits(t *testing.T) {
+	repo := initRepo(t)
+	installHarnessGuardWithVersion(t, repo, "1.2.0")
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := runGuardCommit(repo, "harness", "", 20, true, false,
+		strings.NewReader(harnessJSON(t, "Bash", `ls -la`, repo)), &stdout, &stderr)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("exitCode=%d err=%v; want 0,nil", exitCode, err)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("stdout=%q stderr=%q; want silence on a non-commit Bash call", stdout.String(), stderr.String())
+	}
 }

--- a/internal/cli/install_hook_test.go
+++ b/internal/cli/install_hook_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // TestInstallHook_NotARepo asserts the "not a git repository" output
@@ -185,8 +187,8 @@ func initRepo(t *testing.T) string {
 		t.Skip("git not on PATH; skipping integration test")
 	}
 	dir := t.TempDir()
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
 		{"config", "user.email", "t@t.com"},
 		{"config", "user.name", "t"},
 	} {

--- a/internal/cli/log_concurrency_test.go
+++ b/internal/cli/log_concurrency_test.go
@@ -48,6 +48,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // TestLogConcurrent_NoCrashes_NoLostDecisions is the mandatory
@@ -301,18 +303,14 @@ func newConcurrencyTestRepo(t *testing.T, binPath string) string {
 	t.Helper()
 	repo := t.TempDir()
 
-	runGitCmd(t, repo, "init", "-q", "-b", "main")
+	// testgit.InitRepo disables git's background maintenance in the new
+	// repo (see its package doc) — this suite is the most exposed of any
+	// to issue #271's race, since it drives many concurrent commits into
+	// one repo.
+	testgit.InitRepo(t, repo, "-q", "-b", "main")
 	runGitCmd(t, repo, "config", "user.email", "test@test.com")
 	runGitCmd(t, repo, "config", "user.name", "test")
 	runGitCmd(t, repo, "config", "commit.gpgsign", "false")
-	// Both keys — see initLogTestGitRepo (log_test.go) for the full write-up
-	// and the GIT_TRACE2 evidence. Short version: `git commit` spawns
-	// `git maintenance run --auto`, gated by maintenance.auto and NOT by
-	// gc.auto; the spawned process can daemonize and is still writing into
-	// .git/objects when t.TempDir() cleanup runs. This suite is the most
-	// exposed of any — it drives many concurrent commits into one repo.
-	runGitCmd(t, repo, "config", "gc.auto", "0")
-	runGitCmd(t, repo, "config", "maintenance.auto", "false")
 
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test repo\n"), 0o644); err != nil {
 		t.Fatalf("seed README.md: %v", err)

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/thrillmade/logmind/internal/gitcli"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // signalOnSubstr is a thread-safe io.Writer that closes `fired` the first time
@@ -63,6 +64,11 @@ func (w *signalOnSubstr) String() string {
 // Used by the log tests that need branch resolution + commit.
 func initLogTestGitRepo(t *testing.T, dir string) {
 	t.Helper()
+	// testgit.InitRepo disables git's background maintenance in the new
+	// repo — see the package doc there for why (issue #271: a spawned
+	// `git maintenance` process can outlive a test and race
+	// t.TempDir()'s RemoveAll).
+	testgit.InitRepo(t, dir, "--initial-branch=main")
 	mustGit := func(args ...string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
@@ -70,36 +76,9 @@ func initLogTestGitRepo(t *testing.T, dir string) {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
 	}
-	mustGit("init", "--initial-branch=main")
 	mustGit("config", "user.email", "test@example.com")
 	mustGit("config", "user.name", "Test")
 	mustGit("config", "commit.gpgsign", "false")
-	// Suppress git's background maintenance in throwaway test repos.
-	//
-	// The symptom: `t.TempDir() RemoveAll cleanup: unlinkat .../.git/objects:
-	// directory not empty` — a CLEANUP error, not an assertion failure,
-	// landing on whichever test lost the race. It reddened four PRs across
-	// ubuntu and macOS cells while every test passed locally.
-	//
-	// BOTH keys are required, and gc.auto alone is NOT enough — that was a
-	// first fix attempt that shipped and did not work. `git commit` calls
-	// run_auto_maintenance() unconditionally, and the spawn gate for it is
-	// `maintenance.auto` (default true), a SEPARATE key from `gc.auto`.
-	// Verified with GIT_TRACE2_EVENT on git 2.39.5: with gc.auto=0 alone,
-	// `git commit` still spawned `git maintenance` on 5 of 5 commits; adding
-	// maintenance.auto=false took it to 0 of 5, and removing it again in the
-	// same repo restored 5 of 5.
-	//
-	// That spawned maintenance can daemonize (maintenance.autoDetach, default
-	// true) into a grandchild outside git's process tree, which is why the
-	// race is load-dependent and never reproduces locally — unloaded, it
-	// finishes in single-digit milliseconds.
-	//
-	// This is NOT a logmind defect: every exec.Command in non-test code is
-	// paired with a blocking Run/Output/CombinedOutput, and there are zero
-	// bare .Start() calls, so no logmind command outlives itself.
-	mustGit("config", "gc.auto", "0")
-	mustGit("config", "maintenance.auto", "false")
 }
 
 // scaffoldDocs drives `logmind init --no-git` against the current cwd
@@ -553,14 +532,7 @@ func TestLog_PushesToBareRemote(t *testing.T) {
 		// `git push` inside `logmind log` has a destination.
 		remote := filepath.Join(t.TempDir(), "bare.git")
 		branch := strings.TrimSpace(runGitOut(t, d, "rev-parse", "--abbrev-ref", "HEAD"))
-		for _, args := range [][]string{
-			{"init", "--bare", "-q", remote},
-		} {
-			cmd := exec.Command("git", args...)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("git %v: %v\n%s", args, err, out)
-			}
-		}
+		testgit.InitRepo(t, remote, "--bare", "-q")
 		runGitIn(t, d, "remote", "add", "origin", remote)
 		runGitIn(t, d, "push", "-u", "-q", "origin", branch)
 

--- a/internal/cli/pulse_test.go
+++ b/internal/cli/pulse_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // neutralizePathProbe points PATH at a directory containing ONLY a `git`
@@ -654,10 +655,9 @@ func initClonePairScaffolded(t *testing.T) (origin, repo string) {
 	commitAll(t, origin, "scaffold")
 
 	repo = filepath.Join(t.TempDir(), "repo")
-	cmd := exec.Command("git", "clone", "-q", origin, repo)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git clone: %v\n%s", err, out)
-	}
+	// A clone does NOT inherit origin's gc.auto/maintenance.auto (local,
+	// per-repo config `git clone` doesn't copy) — see testgit's package doc.
+	testgit.CloneRepo(t, repo, "-q", origin)
 	runGitIn(t, repo, "config", "user.email", "test@example.com")
 	runGitIn(t, repo, "config", "user.name", "Test")
 	runGitIn(t, repo, "config", "commit.gpgsign", "false")

--- a/internal/cli/rebase_test.go
+++ b/internal/cli/rebase_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // TestRebaseNotARepo: rebase outside a git repo errors out cleanly.
@@ -31,14 +33,10 @@ func gitInit(t *testing.T) string {
 		t.Skip("git not on PATH")
 	}
 	dir := t.TempDir()
+	testgit.InitRepo(t, dir, "-q", "-b", "main")
 	cmds := [][]string{
-		{"git", "init", "-q", "-b", "main"},
 		{"git", "config", "user.email", "test@example.com"},
 		{"git", "config", "user.name", "Test"},
-		// Both keys — see initLogTestGitRepo (log_test.go). maintenance.auto is
-		// the actual spawn gate; gc.auto alone does not suppress it.
-		{"git", "config", "gc.auto", "0"},
-		{"git", "config", "maintenance.auto", "false"},
 		{"git", "commit", "--allow-empty", "-q", "-m", "initial"},
 	}
 	for _, c := range cmds {
@@ -142,8 +140,8 @@ func TestRebaseSuccessNoPush(t *testing.T) {
 	// as origin. After cloning the upstream main has 1 commit; we add
 	// one more on the local feature branch.
 	remote := filepath.Join(t.TempDir(), "bare.git")
+	testgit.CloneRepo(t, remote, "--bare", "-q", cwd)
 	for _, c := range [][]string{
-		{"git", "clone", "--bare", "-q", cwd, remote},
 		{"git", "-C", cwd, "remote", "add", "origin", remote},
 		{"git", "-C", cwd, "fetch", "-q", "origin"},
 		{"git", "-C", cwd, "checkout", "-q", "-b", "feat/x"},

--- a/internal/cli/refresh_test.go
+++ b/internal/cli/refresh_test.go
@@ -9,14 +9,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // gitInitCwd runs `git init` (+ identity) in the current working dir so
 // merge-driver config and hook installation have a real repo to act on.
 func gitInitCwd(t *testing.T) {
 	t.Helper()
+	testgit.InitRepo(t, "")
 	for _, args := range [][]string{
-		{"init"},
 		{"config", "user.email", "t@example.com"},
 		{"config", "user.name", "logmind-test"},
 	} {

--- a/internal/cli/skill_push_test.go
+++ b/internal/cli/skill_push_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/thrillmade/logmind/internal/skill"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // initGitRepo runs the minimal git plumbing to make the repo at root
@@ -39,14 +40,10 @@ func initGitRepo(t *testing.T, root string) {
 			t.Fatalf("git %v: %v (%s)", args, err, out)
 		}
 	}
-	runGit("init", "-q", "-b", "main")
+	testgit.InitRepo(t, root, "-q", "-b", "main")
 	runGit("config", "user.email", "test@example.com")
 	runGit("config", "user.name", "Test")
 	runGit("config", "commit.gpgsign", "false")
-	// Both keys — see initLogTestGitRepo (log_test.go). maintenance.auto is
-	// the actual spawn gate; gc.auto alone does not suppress it.
-	runGit("config", "gc.auto", "0")
-	runGit("config", "maintenance.auto", "false")
 	runGit("remote", "add", "origin", "https://github.com/thrillmade/logmind.git")
 	// Seed a commit so HEAD exists.
 	dummy := filepath.Join(root, ".seed")

--- a/internal/cli/warp_test.go
+++ b/internal/cli/warp_test.go
@@ -31,6 +31,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // initClonePair builds a real origin/repo pair on the local filesystem: origin
@@ -52,10 +54,10 @@ func initClonePair(t *testing.T) (origin, repo string) {
 	commitAll(t, origin, "init")
 
 	repo = filepath.Join(t.TempDir(), "repo")
-	cmd := exec.Command("git", "clone", "-q", origin, repo)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git clone: %v\n%s", err, out)
-	}
+	// A clone does NOT inherit origin's gc.auto/maintenance.auto — those are
+	// local, per-repo config that `git clone` doesn't copy — so the clone
+	// needs testgit's fix applied again, independently (see its package doc).
+	testgit.CloneRepo(t, repo, "-q", origin)
 	runGitIn(t, repo, "config", "user.email", "test@example.com")
 	runGitIn(t, repo, "config", "user.name", "Test")
 	runGitIn(t, repo, "config", "commit.gpgsign", "false")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,7 +131,26 @@ type DecisionsConfig struct {
 
 // FileStructureConfig mirrors the `file_structure:` section.
 type FileStructureConfig struct {
-	AutoUpdate     bool     `yaml:"auto_update"`
+	AutoUpdate bool `yaml:"auto_update"`
+	// IgnorePatterns is the CONFIG pattern source of SPEC §1.4 — the THIRD
+	// of three, never the effective set, and never the defaults.
+	//
+	// DefaultConfig deliberately leaves this nil. That is the whole point:
+	// nil means "this repository configured nothing", a non-empty slice means
+	// "the user's config.yml set this key", and there is no third state to
+	// get wrong. Seeding it with the built-in defaults (which DefaultConfig
+	// used to do) made those two indistinguishable by the time the value
+	// reached tree.ResolveRules — sixteen built-in patterns arriving wearing
+	// the config source's identity, at the config source's POSITION. §1.4
+	// resolves positionally (last match wins, as git does), so mis-ranked
+	// defaults silently outranked a `.gitignore` `!dist` the repository had
+	// written on purpose. Unseeding makes that state unrepresentable rather
+	// than merely corrected.
+	//
+	// The built-in defaults are DefaultIgnorePatterns() — source 1, kept
+	// distinct. The three-way merge happens once, in tree.ResolveRules,
+	// which every consumer routes through. Read this field directly to
+	// decide what to ignore and you reopen #269.
 	IgnorePatterns []string `yaml:"ignore_patterns"`
 	// RootLabel overrides the file-structure tree's root line. Default ""
 	// = the checkout directory's basename (today's behavior); a fixed
@@ -195,8 +214,50 @@ func ResolveSpecFile(repoRoot string, cfg Config) (path string, ok bool) {
 	return joined, true
 }
 
+// DefaultIgnorePatterns returns the built-in ignore patterns — SPEC §1.4's
+// FIRST pattern source, and the SPEC §1.2.1 "MUST include at least" list.
+//
+// This is the one owner of that fact. DefaultMap (the `config list` / `config
+// set` surface) renders it, and tree.ResolveRules seeds the merge with it;
+// neither keeps a second copy. It is deliberately NOT part of DefaultConfig's
+// FileStructure.IgnorePatterns, which is the CONFIG source only — see that
+// field's doc comment for why conflating the two was the #269/#303 defect.
+//
+// Returns a fresh slice per call so a caller that appends cannot scribble on
+// the built-ins for every other caller in the process.
+//
+// Patterns are written WITHOUT the SPEC prose's trailing "/": internal/tree's
+// matcher does a literal filepath.Match against the whole relative path, each
+// path component, and the basename, and §1.4 says so itself — "a trailing
+// slash therefore matches nothing, so patterns are written without one".
+func DefaultIgnorePatterns() []string {
+	return []string{
+		"__pycache__",
+		".git",
+		"node_modules",
+		"venv",
+		".venv",
+		"env",
+		".env",
+		"*.pyc",
+		".pytest_cache",
+		".mypy_cache",
+		"dist",
+		"build",
+		"*.egg-info",
+		".next",
+		".turbo",
+		".DS_Store",
+	}
+}
+
 // DefaultConfig returns a fresh Config populated with the same values
 // hard-coded into Python's DEFAULT_CONFIG (core/config.py:14-67).
+//
+// One deliberate departure: FileStructure.IgnorePatterns is nil rather than
+// the built-in list. See that field's doc comment — the field is §1.4's
+// config source, and the defaults are their own source
+// (DefaultIgnorePatterns).
 func DefaultConfig() Config {
 	return Config{
 		Git: GitConfig{
@@ -213,34 +274,13 @@ func DefaultConfig() Config {
 		},
 		FileStructure: FileStructureConfig{
 			AutoUpdate: true,
-			IgnorePatterns: []string{
-				"__pycache__",
-				".git",
-				"node_modules",
-				"venv",
-				".venv",
-				"env",
-				".env",
-				"*.pyc",
-				".pytest_cache",
-				".mypy_cache",
-				"dist",
-				"build",
-				"*.egg-info",
-				// SPEC §1.2.1's default list MUST also include these three
-				// (.next/, .turbo/, .DS_Store) — added without the SPEC
-				// prose's trailing "/" because internal/tree's matcher
-				// (patternSetMatches) does a literal filepath.Match against
-				// the basename/path component; every OTHER default pattern
-				// here is already written without a trailing slash for the
-				// same reason (a literal ".next/" would never match the
-				// directory component ".next" and so would silently ignore
-				// nothing).
-				".next",
-				".turbo",
-				".DS_Store",
-			},
-			RootLabel: "",
+			// IgnorePatterns is left NIL on purpose — see the field's doc
+			// comment. The built-in defaults are DefaultIgnorePatterns(),
+			// a source of their own; putting them here would hand
+			// tree.ResolveRules sixteen patterns wearing the config
+			// source's identity and position.
+			IgnorePatterns: nil,
+			RootLabel:      "",
 		},
 		// Context.Repomap default false → `logmind context` emits today's
 		// two-doc payload byte-for-byte. NOT added to DefaultMap (below); the
@@ -353,23 +393,15 @@ func DefaultMap() *OrderedMap {
 
 	fileStructure := NewOrderedMap()
 	fileStructure.Set("auto_update", true)
-	patterns := []any{
-		"__pycache__",
-		".git",
-		"node_modules",
-		"venv",
-		".venv",
-		"env",
-		".env",
-		"*.pyc",
-		".pytest_cache",
-		".mypy_cache",
-		"dist",
-		"build",
-		"*.egg-info",
-		".next",
-		".turbo",
-		".DS_Store",
+	// Derived from DefaultIgnorePatterns rather than hand-copied: the two
+	// lists used to be maintained separately, so `config list` could report
+	// one set while the tree walk used another. `config set` writes this
+	// merged map straight back out, so what `config list` shows and what
+	// `config set` would persist come from the same source by construction.
+	defaults := DefaultIgnorePatterns()
+	patterns := make([]any, 0, len(defaults))
+	for _, p := range defaults {
+		patterns = append(patterns, p)
 	}
 	fileStructure.Set("ignore_patterns", patterns)
 	root.Set("file_structure", fileStructure)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,16 @@ func TestDefaultConfig(t *testing.T) {
 	if !c.FileStructure.AutoUpdate {
 		t.Errorf("FileStructure.AutoUpdate = false; want true")
 	}
+	// FileStructure.IgnorePatterns is SPEC §1.4's CONFIG source, and a
+	// default Config has configured nothing — so it MUST be empty. It used
+	// to be seeded with the built-in defaults, which made "the user set
+	// this" and "nobody set this" indistinguishable downstream; §1.4
+	// resolves positionally, so defaults wearing the config source's
+	// position outranked a `.gitignore` negation (#303). The built-ins now
+	// live in DefaultIgnorePatterns and are pinned just below.
+	if len(c.FileStructure.IgnorePatterns) != 0 {
+		t.Errorf("FileStructure.IgnorePatterns = %q; want empty — it is §1.4's config source, and DefaultConfig configures nothing", c.FileStructure.IgnorePatterns)
+	}
 	wantPatterns := []string{
 		"__pycache__", ".git", "node_modules", "venv", ".venv",
 		"env", ".env", "*.pyc", ".pytest_cache", ".mypy_cache",
@@ -37,8 +47,8 @@ func TestDefaultConfig(t *testing.T) {
 		// SPEC §1.2.1 additions: .next/, .turbo/, .DS_Store.
 		".next", ".turbo", ".DS_Store",
 	}
-	if !reflect.DeepEqual(c.FileStructure.IgnorePatterns, wantPatterns) {
-		t.Errorf("FileStructure.IgnorePatterns =\n  %q\nwant\n  %q", c.FileStructure.IgnorePatterns, wantPatterns)
+	if !reflect.DeepEqual(DefaultIgnorePatterns(), wantPatterns) {
+		t.Errorf("DefaultIgnorePatterns() =\n  %q\nwant\n  %q", DefaultIgnorePatterns(), wantPatterns)
 	}
 	if !c.Agents["claude"] || !c.Agents["cursor"] {
 		t.Errorf("Agents claude/cursor should be true by default: %v", c.Agents)
@@ -55,35 +65,60 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
-// TestDefaultConfig_IgnorePatterns_IncludesSpecRequiredDefaults pins the
+// TestDefaultIgnorePatterns_IncludesSpecRequiredDefaults pins the
 // MINOR fix: SPEC §1.2.1 states the default file_structure.ignore_patterns
 // "MUST include at least" .git/, node_modules/, venv/, __pycache__/,
 // .next/, dist/, build/, .turbo/, *.pyc, .DS_Store. .next/.turbo/.DS_Store
 // were missing entirely. (Checked here without the SPEC prose's trailing
-// "/" — see the doc comment on DefaultConfig's IgnorePatterns literal for
-// why: internal/tree's matcher does a literal component match, and every
-// sibling default pattern already omits the trailing slash for the same
-// reason.)
-func TestDefaultConfig_IgnorePatterns_IncludesSpecRequiredDefaults(t *testing.T) {
-	got := DefaultConfig().FileStructure.IgnorePatterns
+// "/" — see the doc comment on DefaultIgnorePatterns for why: internal/tree's
+// matcher does a literal component match, and §1.4 says a trailing slash
+// matches nothing.)
+func TestDefaultIgnorePatterns_IncludesSpecRequiredDefaults(t *testing.T) {
+	got := DefaultIgnorePatterns()
 	set := map[string]bool{}
 	for _, p := range got {
 		set[p] = true
 	}
-	for _, want := range []string{".next", ".turbo", ".DS_Store"} {
+	for _, want := range []string{
+		"__pycache__", ".git", "node_modules", "venv",
+		"dist", "build", "*.pyc", ".next", ".turbo", ".DS_Store",
+	} {
 		if !set[want] {
-			t.Errorf("DefaultConfig().FileStructure.IgnorePatterns = %q; missing SPEC §1.2.1-required default %q", got, want)
+			t.Errorf("DefaultIgnorePatterns() = %q; missing SPEC §1.2.1-required default %q", got, want)
 		}
 	}
 }
 
-// TestDefaultMap_IgnorePatterns_MatchesDefaultConfig guards against the
-// two hand-maintained pattern lists (DefaultConfig's typed slice and
-// DefaultMap's `config list`/get/set-facing []any slice) drifting apart —
-// `logmind config list` must show the same ignore_patterns file-structure
-// tree generation actually uses.
-func TestDefaultMap_IgnorePatterns_MatchesDefaultConfig(t *testing.T) {
-	typed := DefaultConfig().FileStructure.IgnorePatterns
+// TestDefaultIgnorePatterns_ReturnsAFreshSlice pins that callers cannot
+// scribble on the built-ins for the rest of the process. tree.ResolveRules
+// appends .gitignore and config rules onto this slice; sharing a backing
+// array would let one repository's patterns leak into the next.
+func TestDefaultIgnorePatterns_ReturnsAFreshSlice(t *testing.T) {
+	first := DefaultIgnorePatterns()
+	first[0] = "clobbered"
+	first = append(first, "appended")
+	second := DefaultIgnorePatterns()
+	if second[0] == "clobbered" {
+		t.Errorf("DefaultIgnorePatterns()[0] = %q; a previous caller's write leaked", second[0])
+	}
+	for _, p := range second {
+		if p == "appended" {
+			t.Errorf("DefaultIgnorePatterns() = %q; a previous caller's append leaked", second)
+		}
+	}
+}
+
+// TestDefaultMap_IgnorePatterns_MatchesDefaultIgnorePatterns guards the
+// `config list` / `config set` round trip (#304): DefaultMap is what
+// `logmind config list` prints AND what `config set` writes back, so the
+// list it shows must be exactly the one the tree walk seeds itself with.
+//
+// The two lists used to be hand-maintained separately and could drift;
+// DefaultMap now renders DefaultIgnorePatterns, so this test additionally
+// pins that the derivation stays a derivation — reintroduce a literal here
+// and the entries can silently diverge again.
+func TestDefaultMap_IgnorePatterns_MatchesDefaultIgnorePatterns(t *testing.T) {
+	typed := DefaultIgnorePatterns()
 	fileStructure, ok := DefaultMap().Get("file_structure")
 	if !ok {
 		t.Fatal("DefaultMap() has no file_structure key")

--- a/internal/config/timeline_test.go
+++ b/internal/config/timeline_test.go
@@ -41,10 +41,19 @@ func TestFileStructureRootLabel_DefaultAndRoundTrip(t *testing.T) {
 	if cfg.FileStructure.RootLabel != "my-repo" {
 		t.Errorf("RootLabel = %q; want my-repo", cfg.FileStructure.RootLabel)
 	}
-	// Leafwise deep-merge: setting root_label must NOT wipe the default
-	// ignore_patterns (regression guard for the typed-config merge).
-	if len(cfg.FileStructure.IgnorePatterns) == 0 {
-		t.Errorf("ignore_patterns lost when only root_label was set")
+	// Leafwise deep-merge: setting root_label must not disturb its sibling
+	// key. IgnorePatterns is §1.4's CONFIG source and this config sets no
+	// patterns, so the correct value is EMPTY — a non-empty one here would
+	// mean sixteen built-in defaults had been smuggled into the config
+	// source, which is exactly the mis-ranking #303 fixed.
+	//
+	// That the defaults still apply to the walk is a claim about rendered
+	// output, so it is pinned where it is observable — see
+	// TestFileStructure_RootLabelOnlyConfigKeepsEveryDefault in
+	// internal/tree (internal/config cannot import internal/tree; tree
+	// imports config).
+	if len(cfg.FileStructure.IgnorePatterns) != 0 {
+		t.Errorf("ignore_patterns = %q after setting only root_label; want empty — the built-in defaults are DefaultIgnorePatterns, not the config source", cfg.FileStructure.IgnorePatterns)
 	}
 }
 

--- a/internal/gitattr/gitattr_test.go
+++ b/internal/gitattr/gitattr_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 var update = flag.Bool("update", false, "regenerate testdata/*.golden files from current Go output")
@@ -163,13 +165,7 @@ func TestConfigureMergeDrivers_SetsKeys(t *testing.T) {
 		t.Skip("git not on PATH; skipping ConfigureMergeDrivers test")
 	}
 	dir := t.TempDir()
-	for _, args := range [][]string{{"init", "-q"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-	}
+	testgit.InitRepo(t, dir, "-q")
 	if !ConfigureMergeDrivers(dir) {
 		t.Fatalf("ConfigureMergeDrivers returned false on fresh repo")
 	}

--- a/internal/gitcli/gitcli_push_test.go
+++ b/internal/gitcli/gitcli_push_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // bareRemote creates a `git init --bare` repo under t.TempDir() and
@@ -18,10 +20,7 @@ func bareRemote(t *testing.T) string {
 		t.Skip("git not on PATH; skipping push integration test")
 	}
 	dir := t.TempDir()
-	cmd := exec.Command("git", "init", "--bare", "-q", dir)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init --bare: %v\n%s", err, out)
-	}
+	testgit.InitRepo(t, dir, "--bare", "-q")
 	return dir
 }
 

--- a/internal/gitcli/gitcli_remote_test.go
+++ b/internal/gitcli/gitcli_remote_test.go
@@ -3,6 +3,8 @@ package gitcli
 import (
 	"os/exec"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 func TestRemoteRepoName(t *testing.T) {
@@ -22,7 +24,7 @@ func TestRemoteRepoName(t *testing.T) {
 				t.Fatalf("git %v: %v\n%s", args, err, out)
 			}
 		}
-		git("init")
+		testgit.InitRepo(t, dir)
 		git("remote", "add", "origin", url)
 		if got := RemoteRepoName(dir); got != "logmind" {
 			t.Errorf("RemoteRepoName(%q) = %q; want logmind", url, got)
@@ -31,11 +33,7 @@ func TestRemoteRepoName(t *testing.T) {
 
 	// No origin remote → "" (resolveRootLabel falls back to the basename).
 	dir := t.TempDir()
-	cmd := exec.Command("git", "init")
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, out)
-	}
+	testgit.InitRepo(t, dir)
 	if got := RemoteRepoName(dir); got != "" {
 		t.Errorf("no-origin RemoteRepoName = %q; want empty", got)
 	}

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // initRepo creates a fresh git repo at t.TempDir(), commits an initial
@@ -20,8 +22,8 @@ func initRepo(t *testing.T) string {
 		t.Skip("git not on PATH; skipping integration test")
 	}
 	dir := t.TempDir()
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "test"},
 	} {

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thrillmade/logmind/internal/agents"
 	"github.com/thrillmade/logmind/internal/gitcli"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // initRepo creates a fresh git repo at t.TempDir(), commits an initial
@@ -23,8 +24,8 @@ func initRepo(t *testing.T) string {
 		t.Skip("git not on PATH; skipping integration test")
 	}
 	dir := t.TempDir()
+	testgit.InitRepo(t, dir, "-q")
 	for _, args := range [][]string{
-		{"init", "-q"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "test"},
 	} {

--- a/internal/hooks/commit_msg_enforce_test.go
+++ b/internal/hooks/commit_msg_enforce_test.go
@@ -18,6 +18,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 func TestCommitMsgHook_RealGitCommit_EnforcesAndCarveOuts(t *testing.T) {
@@ -263,6 +265,11 @@ func newEnforcingRepo(t *testing.T, binDir string) string {
 	t.Helper()
 	dir := t.TempDir()
 	runGitIn(t, dir, binDir, nil, "init", "-q")
+	// Disable background maintenance — see testgit's package doc (issue
+	// #271). `git config` needs no special PATH/env, so this can go
+	// straight through testgit rather than this file's binDir-aware
+	// runGitIn wrapper.
+	testgit.DisableMaintenance(t, dir)
 	runGitIn(t, dir, binDir, nil, "config", "user.email", "t@t.com")
 	runGitIn(t, dir, binDir, nil, "config", "user.name", "t")
 	if _, err := InstallCommitMsg(dir); err != nil {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // update mirrors the snapshot pattern from internal/cli — `make
@@ -928,7 +930,7 @@ func initRealGitRepo(t *testing.T) string {
 	// `origin/main`), so leaving it ambient makes them pass locally and fail
 	// in CI with `fatal: invalid reference: main`. internal/cli's helpers
 	// already pin it the same way.
-	gitIn(t, dir, "init", "-q", "--initial-branch=main")
+	testgit.InitRepo(t, dir, "-q", "--initial-branch=main")
 	gitIn(t, dir, "config", "user.email", "test@example.com")
 	gitIn(t, dir, "config", "user.name", "Test")
 	gitIn(t, dir, "config", "commit.gpgsign", "false")

--- a/internal/testgit/testgit.go
+++ b/internal/testgit/testgit.go
@@ -1,0 +1,97 @@
+// Package testgit is the single place every test in this module creates a
+// real git repository. Route every `git init` / `git clone` a test needs
+// through InitRepo / CloneRepo (or, when a repo is built some other way,
+// call DisableMaintenance directly) so the repo can never end up missing
+// the two config keys below.
+//
+// # Why this exists
+//
+// `git commit` (and merge/rebase/fetch/receive-pack) unconditionally calls
+// run_auto_maintenance(), gated by `maintenance.auto` (default true) — a
+// SEPARATE key from `gc.auto`. The spawned `git maintenance` process can
+// daemonize (`maintenance.autoDetach`, default true) into a grandchild
+// outside git's process tree, and is still writing into `.git/objects`
+// when a test returns. That makes `t.TempDir()`'s RemoveAll fail with
+// "directory not empty" — a CLEANUP error, not an assertion failure,
+// landing on whichever test happens to lose the race. Because the spawned
+// process finishes in single-digit milliseconds when the machine isn't
+// loaded, this never reproduces locally; it only shows up as a flake on a
+// busy CI runner.
+//
+// Measured with GIT_TRACE2_EVENT on git 2.39.5, same repository, 5 commits:
+//
+//	gc.auto=0 alone                    -> 5 of 5 commits still spawned `git maintenance`
+//	gc.auto=0 + maintenance.auto=false -> 0 of 5
+//	fix removed again                  -> 5 of 5
+//
+// See logmind issue #271 for the incident history: this reddened four pull
+// requests across ubuntu and macOS while passing locally every time, and
+// took three attempts to land because the first two fixed only the
+// helpers already found rather than enumerating every repo-creating test.
+// A `git clone` does NOT inherit these keys from its source (gc.auto and
+// maintenance.auto are local, per-repo config that `git clone` does not
+// copy), so a clone destination needs the same treatment even when the
+// repo it was cloned from already called InitRepo.
+package testgit
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// InitRepo runs `git init <args...>` in dir and immediately disables
+// background maintenance in the new repo. Works for bare repos too:
+// `InitRepo(t, dir, "--bare", "-q")`.
+//
+// dir is created first if it doesn't already exist — callers commonly
+// name a not-yet-created path (e.g. filepath.Join(t.TempDir(),
+// "bare.git")) and expect `git init` to create it, same as plain
+// `git init <dir>` would.
+//
+// Pass dir == "" to init in the test's current working directory (e.g.
+// inside withTempCwd) rather than a directory named by path.
+func InitRepo(t testing.TB, dir string, args ...string) {
+	t.Helper()
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	run(t, dir, append([]string{"init"}, args...)...)
+	DisableMaintenance(t, dir)
+}
+
+// CloneRepo runs `git clone <args...> <dst>` and immediately disables
+// background maintenance in the new clone at dst. args is everything
+// that goes between `clone` and the destination — flags plus the source,
+// e.g. CloneRepo(t, dst, "--bare", "-q", src).
+func CloneRepo(t testing.TB, dst string, args ...string) {
+	t.Helper()
+	full := append([]string{"clone"}, args...)
+	full = append(full, dst)
+	run(t, "", full...)
+	DisableMaintenance(t, dst)
+}
+
+// DisableMaintenance sets gc.auto=0 and maintenance.auto=false on the
+// repo at dir. Call this directly — instead of InitRepo/CloneRepo — when
+// a test builds its repo some other way this package doesn't wrap: a
+// `git init --bare` remote that later receives pushes, a clone made by
+// hand, or any repo-creating command this package has no wrapper for
+// yet. BOTH keys are required; gc.auto alone does not suppress the spawn
+// (see package doc).
+func DisableMaintenance(t testing.TB, dir string) {
+	t.Helper()
+	run(t, dir, "config", "gc.auto", "0")
+	run(t, dir, "config", "maintenance.auto", "false")
+}
+
+func run(t testing.TB, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v (dir=%q): %v\n%s", args, dir, err, out)
+	}
+}

--- a/internal/testgit/testgit_test.go
+++ b/internal/testgit/testgit_test.go
@@ -1,0 +1,119 @@
+package testgit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitRepo_SetsBothMaintenanceKeys pins the exact config InitRepo
+// writes, read back from the repo it built (not asserted against
+// InitRepo's own source). A regression that drops one of the two keys
+// from DisableMaintenance still compiles and still "creates a repo" —
+// this is the check that would actually notice.
+func TestInitRepo_SetsBothMaintenanceKeys(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	InitRepo(t, dir, "-q")
+
+	for _, tc := range []struct{ key, want string }{
+		{"gc.auto", "0"},
+		{"maintenance.auto", "false"},
+	} {
+		cmd := exec.Command("git", "config", "--get", tc.key)
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git config --get %s: %v", tc.key, err)
+		}
+		if got := strings.TrimSpace(string(out)); got != tc.want {
+			t.Errorf("%s = %q; want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestInitRepo_SuppressesMaintenanceSpawn pins the fix at the level the
+// bug actually appears: not "the config keys are set" but "the spawn
+// that races t.TempDir() cleanup does not happen". It runs 5 real
+// commits in a repo InitRepo built, each under its own
+// GIT_TRACE2_EVENT log, and asserts `git maintenance` is never among the
+// child processes git spawns.
+//
+// This is the exact methodology and repo state issue #271 measured
+// with on git 2.39.5 (same result reproduced here as a control before
+// this test was written: gc.auto=0 alone left `git maintenance`
+// spawning on 5 of 5 commits; gc.auto=0 + maintenance.auto=false took
+// it to 0 of 5). A helper that regresses to gc.auto-only would make
+// THIS test fail while TestInitRepo_SetsBothMaintenanceKeys above would
+// need to check the right key to catch the same regression — this one
+// catches it regardless of which key is missing, because it looks at
+// git's actual behavior instead of at config state.
+func TestInitRepo_SuppressesMaintenanceSpawn(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	InitRepo(t, dir, "-q", "--initial-branch=main")
+	run(t, dir, "config", "user.email", "test@example.com")
+	run(t, dir, "config", "user.name", "Test")
+	run(t, dir, "config", "commit.gpgsign", "false")
+
+	traceDir := t.TempDir()
+	const commits = 5
+	spawns := 0
+	for i := 0; i < commits; i++ {
+		tracePath := filepath.Join(traceDir, fmt.Sprintf("trace-%d.jsonl", i))
+		cmd := exec.Command("git", "commit", "--allow-empty", "-q", "-m", fmt.Sprintf("c%d", i))
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_TRACE2_EVENT="+tracePath)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git commit #%d: %v\n%s", i, err, out)
+		}
+		data, err := os.ReadFile(tracePath)
+		if err != nil {
+			t.Fatalf("read trace2 event log for commit #%d: %v", i, err)
+		}
+		spawns += countMaintenanceSpawns(t, data)
+	}
+
+	if spawns != 0 {
+		t.Fatalf("git maintenance spawned %d time(s) across %d commits in a repo built by InitRepo; want 0 (gc.auto=0 + maintenance.auto=false should suppress every spawn — see package doc)", spawns, commits)
+	}
+}
+
+// countMaintenanceSpawns scans a GIT_TRACE2_EVENT JSONL log for
+// child_start events whose argv names `maintenance` as a git subcommand
+// (covers both the `git maintenance ...` and the resolved
+// `.../git-core/git maintenance ...` argv shapes git's trace2 emits).
+func countMaintenanceSpawns(t testing.TB, trace []byte) int {
+	t.Helper()
+	n := 0
+	for _, line := range strings.Split(string(trace), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Event string   `json:"event"`
+			Argv  []string `json:"argv"`
+		}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue // trace2 emits event shapes this struct doesn't model; skip them
+		}
+		if ev.Event != "child_start" {
+			continue
+		}
+		for _, a := range ev.Argv {
+			if a == "maintenance" {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}

--- a/internal/tree/gitignore_differential_test.go
+++ b/internal/tree/gitignore_differential_test.go
@@ -1,0 +1,275 @@
+package tree
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Differential tests against real git.
+//
+// SPEC §1.4 says a `!pattern` "re-includes a path an earlier pattern
+// excluded" — positional last-match-wins, which is git's own rule inside a
+// .gitignore. Prose can be read two ways; `git check-ignore -v` cannot. It is
+// the strongest oracle available for this behaviour, so the .gitignore source
+// is compared against it directly rather than against our own expectations.
+//
+// SCOPE: the oracle covers §1.4's SECOND source only. git knows nothing about
+// logmind's built-in defaults or file_structure.ignore_patterns, so these
+// fixtures resolve `readGitignoreRules` alone. The three-way merge is pinned
+// on rendered output in ignore_merge_test.go. Every fixture also uses
+// top-level paths, where a path and its basename coincide, so the comparison
+// isolates RESOLUTION rather than re-testing glob matching.
+//
+// The repos are hermetic: GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM are pointed
+// at /dev/null so a developer's ~/.gitignore or core.excludesFile cannot
+// change the verdict. Nothing is staged — `git check-ignore` reads the
+// exclude rules, and leaving the index empty keeps it that way.
+
+// runGit runs git in repoRoot with global/system config neutralised and
+// returns stdout plus the exit code. A code other than the caller's expected
+// set is a harness failure, not a verdict.
+func runGit(t *testing.T, repoRoot string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.Output()
+	if err == nil {
+		return string(out), 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if code := exitErr.ExitCode(); code == 1 {
+			return string(out), code
+		}
+		t.Fatalf("git %v in %s: exit %d (stderr: %s)", args, repoRoot, exitErr.ExitCode(), exitErr.Stderr)
+	}
+	t.Fatalf("git %v in %s: %v", args, repoRoot, err)
+	return "", -1
+}
+
+// gitCheckIgnore reports whether real git considers path ignored in repoRoot,
+// plus the "<file>:<line>:<pattern>" attribution.
+//
+// The verdict and the attribution come from SEPARATE invocations on purpose.
+// `git check-ignore -v` changes what the exit code means: it becomes "some
+// pattern MATCHED", so a path re-included by a trailing `!important.log`
+// still exits 0 while printing `.gitignore:2:!important.log`. Reading that as
+// "ignored" inverts every negation case in the table — which is precisely the
+// behaviour under test, so the oracle would have agreed with a broken
+// resolver. Measured on git 2.39.5:
+//
+//	$ printf '*.log\n!important.log\n' > .gitignore
+//	$ git check-ignore -v important.log ; echo $?
+//	.gitignore:2:!important.log	important.log
+//	0
+//	$ git check-ignore important.log ; echo $?
+//	1
+//
+// So: plain run for the verdict (0 = ignored, 1 = not), -v run for the
+// attribution only, which is diagnostic and never consulted for truth.
+func gitCheckIgnore(t *testing.T, repoRoot, path string) (bool, string) {
+	t.Helper()
+	_, code := runGit(t, repoRoot, "check-ignore", "--no-index", path)
+	verbose, _ := runGit(t, repoRoot, "check-ignore", "-v", "--no-index", path)
+	return code == 0, strings.TrimSpace(verbose)
+}
+
+// gitignoreRepo creates a hermetic git repo whose .gitignore holds body, and
+// materialises each path in files so the fixture is a real working tree.
+func gitignoreRepo(t *testing.T, body string, files ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		full := filepath.Join(root, f)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s: %v (%s)", root, err, out)
+	}
+	return root
+}
+
+// TestGitignoreResolution_AgreesWithGitCheckIgnore is the differential. Each
+// fixture's verdict comes from `git check-ignore -v`, never from a hand-written
+// expectation, so a divergence shows up as disagreement rather than as a test
+// that was quietly written to match whatever we shipped.
+//
+// wantIgnored is carried alongside purely as a control on the ORACLE: if git
+// stopped answering (wrong flags, a stray global excludes file, a harness bug
+// swallowing an exit code) every case would silently collapse to one verdict
+// and the differential would pass while comparing nothing. The table holds
+// both polarities and asserts git produced each.
+func TestGitignoreResolution_AgreesWithGitCheckIgnore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; the differential oracle is unavailable")
+	}
+
+	cases := []struct {
+		name string
+		body string
+		path string
+		// wantIgnored is what git MUST say — a control on the oracle, not
+		// the assertion under test (that one compares git to logmind).
+		wantIgnored bool
+	}{
+		{
+			// The case the adversarial panel blocked #303 on. The negation
+			// sits EARLIER than *.log, so it re-includes nothing: git
+			// attributes the verdict to `.gitignore:2:*.log`.
+			name:        "negation_before_the_pattern_loses",
+			body:        "!important.log\n*.log\n",
+			path:        "important.log",
+			wantIgnored: true,
+		},
+		{
+			// Same two lines, swapped. Now the negation is last and wins.
+			// Together with the case above this pins that ORDER, not the
+			// mere presence of a negation, decides.
+			name:        "negation_after_the_pattern_wins",
+			body:        "*.log\n!important.log\n",
+			path:        "important.log",
+			wantIgnored: false,
+		},
+		{
+			// A pattern repeated after its own negation. This is the case
+			// that makes first-seen deduplication wrong: drop line 3 as a
+			// duplicate of line 1 and `!important.log` becomes last,
+			// flipping the verdict away from git's.
+			name:        "pattern_repeated_after_its_negation",
+			body:        "*.log\n!important.log\n*.log\n",
+			path:        "important.log",
+			wantIgnored: true,
+		},
+		{
+			// A directory logmind also ships as a built-in default, so the
+			// repository re-including it is the real-world escape hatch —
+			// and the .gitignore source alone must already agree with git.
+			name:        "directory_reincluded_by_a_later_negation",
+			body:        "dist\n!dist\n",
+			path:        "dist",
+			wantIgnored: false,
+		},
+		{
+			// The same two lines the other way round: a negation that an
+			// exclusion follows does not survive.
+			name:        "directory_reexcluded_by_a_later_pattern",
+			body:        "!dist\ndist\n",
+			path:        "dist",
+			wantIgnored: true,
+		},
+		{
+			// Control: an ordinary single-rule exclusion, no negation
+			// anywhere. Establishes the fixture harness reaches a verdict
+			// at all before the ordering cases are believed.
+			name:        "plain_exclusion_no_negation",
+			body:        "node_modules\n",
+			path:        "node_modules",
+			wantIgnored: true,
+		},
+		{
+			// Control: a path no rule mentions. Proves the oracle can
+			// return "not ignored" for reasons other than a negation.
+			name:        "unmatched_path",
+			body:        "node_modules\n",
+			path:        "README.md",
+			wantIgnored: false,
+		},
+	}
+
+	sawIgnored, sawNotIgnored := false, false
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := gitignoreRepo(t, tc.body, tc.path)
+
+			gitIgnored, attribution := gitCheckIgnore(t, root, tc.path)
+			if gitIgnored != tc.wantIgnored {
+				t.Fatalf("ORACLE CONTROL FAILED: git check-ignore says ignored=%v for %q under %q; the fixture expected %v. Fix the harness before reading the comparison below (attribution: %q)",
+					gitIgnored, tc.path, tc.body, tc.wantIgnored, attribution)
+			}
+
+			rules, err := readGitignoreRules(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logmindIgnored := IgnoreRules(rules).Matches(tc.path, tc.path)
+
+			if logmindIgnored != gitIgnored {
+				t.Errorf("DIVERGENCE from git for %q under .gitignore %q:\n  git       ignored=%v (%s)\n  logmind   ignored=%v\n  rules     %+v",
+					tc.path, tc.body, gitIgnored, attribution, logmindIgnored, rules)
+			}
+		})
+		if tc.wantIgnored {
+			sawIgnored = true
+		} else {
+			sawNotIgnored = true
+		}
+	}
+
+	if !sawIgnored || !sawNotIgnored {
+		t.Errorf("the differential table is one-sided (sawIgnored=%v sawNotIgnored=%v); it cannot distinguish a working comparison from a stuck one", sawIgnored, sawNotIgnored)
+	}
+}
+
+// TestGitignoreResolution_DedupKeepsTheLastOccurrence pins the reason dedup
+// keeps the last copy of a repeated rule rather than the first.
+//
+// ResolveRules deduplicates so the defaults and a config that repeats them do
+// not grow the list without bound. Under last-match-wins, dropping the LATER
+// copy moves a rule earlier and changes verdicts; dropping the earlier one
+// cannot, because the surviving copy sits where the original decision was
+// made. This is the same fixture as the differential's
+// "pattern_repeated_after_its_negation" case, run through the full merge so
+// the property is pinned where dedup actually runs.
+func TestGitignoreResolution_DedupKeepsTheLastOccurrence(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n!important.log\n*.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rules, err := ResolveRules(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rules.Matches("important.log", "important.log") {
+		t.Errorf("important.log survived; want ignored — the trailing *.log is the last match, and dedup must not have dropped it in favour of the leading copy:\n%+v", rules)
+	}
+	// The surviving copy must be the LAST one, i.e. positioned after the
+	// negation. Assert the list shape too, so a resolver that got the right
+	// answer for the wrong reason still fails.
+	negateAt, lastLogAt := -1, -1
+	for i, r := range rules {
+		if r.Pattern == "important.log" && r.Negate {
+			negateAt = i
+		}
+		if r.Pattern == "*.log" && !r.Negate {
+			lastLogAt = i
+		}
+	}
+	if negateAt == -1 || lastLogAt == -1 {
+		t.Fatalf("expected both rules to survive dedup; got %+v", rules)
+	}
+	if lastLogAt < negateAt {
+		t.Errorf("*.log is at %d, before !important.log at %d; dedup kept the FIRST occurrence and moved the decision earlier:\n%+v", lastLogAt, negateAt, rules)
+	}
+}

--- a/internal/tree/ignore_merge_test.go
+++ b/internal/tree/ignore_merge_test.go
@@ -1,0 +1,341 @@
+package tree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The SPEC §1.4 contract these tests pin:
+//
+//	Patterns come from three sources, merged: the built-in defaults, the
+//	repository's .gitignore with leading and trailing "/" trimmed, and
+//	file_structure.ignore_patterns from config. A !pattern re-includes a
+//	path an earlier pattern excluded.
+//
+// Every assertion here is on the RENDERED file-structure document, not on
+// ResolveRules' return value — the bug in #269 was invisible at the helper
+// level (ResolveRules faithfully merged whatever it was handed; the config
+// loader had already thrown the defaults away) and only showed up as
+// node_modules/ appearing in docs/file-structure.md.
+
+// namedRepo lays out a fixture under a fixed "myrepo" directory so the
+// rendered root line is deterministic (same trick as TestFileStructureTemplate).
+func namedRepo(t *testing.T, layout map[string]string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "myrepo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, body := range layout {
+		full := filepath.Join(root, rel)
+		if strings.HasSuffix(rel, "/") {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// writeIgnoreConfig drops a .logmind/config.yml whose only setting is
+// file_structure.ignore_patterns — the shape a repository that wants one
+// extra pattern would hand-write.
+func writeIgnoreConfig(t *testing.T, root string, patterns ...string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("file_structure:\n  ignore_patterns:\n")
+	for _, p := range patterns {
+		b.WriteString("    - \"" + p + "\"\n")
+	}
+	dir := filepath.Join(root, ".logmind")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustGenerate(t *testing.T, root string) string {
+	t.Helper()
+	got, err := GenerateFileStructure(root, -1)
+	if err != nil {
+		t.Fatalf("GenerateFileStructure: %v", err)
+	}
+	return got
+}
+
+// mustHide fails when any of `names` survives into the rendered tree.
+func mustHide(t *testing.T, got string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		if strings.Contains(got, n) {
+			t.Errorf("rendered tree still contains %q (should be ignored):\n%s", n, got)
+		}
+	}
+}
+
+// mustShow fails when any of `names` is missing from the rendered tree.
+func mustShow(t *testing.T, got string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		if !strings.Contains(got, n) {
+			t.Errorf("rendered tree is missing %q (should be kept):\n%s", n, got)
+		}
+	}
+}
+
+// TestFileStructure_ConfigPatternsMergeWithDefaults is the #269 regression:
+// a repository that sets ONE ignore pattern used to lose all sixteen
+// built-in defaults, because config.LoadPath unmarshals YAML over
+// DefaultConfig() and yaml.Unmarshal REPLACES a slice rather than appending.
+// node_modules/, dist/ and the rest then flooded docs/file-structure.md.
+func TestFileStructure_ConfigPatternsMergeWithDefaults(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"node_modules/lib.js": "n",
+		"dist/bundle.js":      "d",
+		".venv/pyvenv.cfg":    "v",
+		"scratch.tmp":         "s",
+		"docs/readme.md":      "r",
+	})
+	writeIgnoreConfig(t, root, "*.tmp")
+
+	got := mustGenerate(t, root)
+	// The custom pattern still applies...
+	mustHide(t, got, "scratch.tmp")
+	// ...and so do the built-in defaults it used to displace.
+	mustHide(t, got, "node_modules", "dist", ".venv")
+	// Control: the fixture really was walked.
+	mustShow(t, got, "docs", "readme.md")
+}
+
+// TestFileStructure_ConfigNegationReincludesDefault covers the escape hatch
+// that makes an unconditional merge safe: a repository that genuinely wants
+// dist/ on its map says so with "!dist". Without this, merging the defaults
+// in would remove capability from every repo that had opted out by listing
+// its own patterns.
+func TestFileStructure_ConfigNegationReincludesDefault(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"dist/bundle.js":      "d",
+		"node_modules/lib.js": "n",
+		"docs/readme.md":      "r",
+	})
+	writeIgnoreConfig(t, root, "!dist")
+
+	got := mustGenerate(t, root)
+	mustShow(t, got, "dist", "bundle.js")
+	// Negating one default must not disturb the others.
+	mustHide(t, got, "node_modules")
+}
+
+// TestFileStructure_GitignoreSourceHonoured pins the second of §1.4's three
+// sources, including the leading- and trailing-"/" trim: ".gitignore" entries
+// are written "/coverage/" and "reports/", and both forms must ignore.
+func TestFileStructure_GitignoreSourceHonoured(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"coverage/index.html": "c",
+		"reports/out.xml":     "x",
+		"docs/readme.md":      "r",
+		".gitignore":          "# comment\n\n/coverage/\nreports/\n",
+	})
+
+	got := mustGenerate(t, root)
+	mustHide(t, got, "coverage", "reports")
+	mustShow(t, got, "docs", "readme.md")
+}
+
+// TestFileStructure_GitignoreNegationReincludesDefault covers a negation
+// arriving from the second source: ".gitignore" re-includes a path the
+// built-in defaults excluded.
+//
+// This is the case that killed positional resolution the first time, and it
+// passes now for a structural reason rather than because negation cheats.
+// The repository configures NOTHING. It used to still hand ResolveRules the
+// sixteen built-in defaults as the CONFIG source, because DefaultConfig
+// seeded FileStructure.IgnorePatterns — so that re-appended `dist` sat at
+// position 3, AFTER the `!dist` here at position 2, and a positional
+// resolver correctly-but-uselessly let it win. The defaults are now their
+// own source (config.DefaultIgnorePatterns, seeded first by ResolveRules)
+// and the config source is empty for a repository that configured nothing,
+// so `!dist` is the last rule matching dist and nothing follows it.
+//
+// Change ResolveRules to seed from config.DefaultConfig().FileStructure
+// .IgnorePatterns again and this goes red.
+func TestFileStructure_GitignoreNegationReincludesDefault(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"dist/bundle.js":      "d",
+		"node_modules/lib.js": "n",
+		".gitignore":          "!dist\n",
+	})
+
+	got := mustGenerate(t, root)
+	mustShow(t, got, "dist", "bundle.js")
+	mustHide(t, got, "node_modules")
+}
+
+// TestFileStructure_NegationSurvivesACustomConfig pins the two sources
+// interacting: the negation comes from .gitignore, the extra pattern from
+// config, and both must land. Drop either source from the merge and one
+// half of this goes red.
+func TestFileStructure_NegationSurvivesACustomConfig(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"dist/bundle.js":      "d",
+		"node_modules/lib.js": "n",
+		"scratch.tmp":         "s",
+		"docs/readme.md":      "r",
+		".gitignore":          "!dist\n",
+	})
+	writeIgnoreConfig(t, root, "*.tmp")
+
+	got := mustGenerate(t, root)
+	mustShow(t, got, "dist", "bundle.js")
+	mustHide(t, got, "node_modules", "scratch.tmp")
+	mustShow(t, got, "docs")
+}
+
+// TestFileStructure_ConfigReExcludesWhatGitignoreNegated pins the capability
+// positional resolution buys, and that negation-wins resolution could not
+// express at all: config is §1.4's LAST source, so a repository whose
+// .gitignore re-includes dist/ can still keep it off its own map by naming it
+// in file_structure.ignore_patterns.
+//
+// Under the negation-wins rule this PR replaced, the `!dist` won from
+// wherever it sat and this was unreachable — there was no way to overrule a
+// .gitignore negation from config.
+func TestFileStructure_ConfigReExcludesWhatGitignoreNegated(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"dist/bundle.js": "d",
+		"docs/readme.md": "r",
+		".gitignore":     "!dist\n",
+	})
+	writeIgnoreConfig(t, root, "dist")
+
+	got := mustGenerate(t, root)
+	mustHide(t, got, "dist", "bundle.js")
+	mustShow(t, got, "docs", "readme.md")
+}
+
+// TestFileStructure_RootLabelOnlyConfigKeepsEveryDefault is the rendered-
+// output half of internal/config's TestFileStructureRootLabel_DefaultAndRoundTrip.
+//
+// A config that sets only root_label must not cost the repository the
+// built-in defaults. That used to be checked by asserting the typed config's
+// IgnorePatterns was non-empty — but the defaults no longer live there
+// (they are config.DefaultIgnorePatterns, seeded by ResolveRules), so the
+// claim is only observable here, on the document a user actually reads.
+// internal/config cannot make it: tree imports config, not the reverse.
+func TestFileStructure_RootLabelOnlyConfigKeepsEveryDefault(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"node_modules/lib.js": "n",
+		"dist/bundle.js":      "d",
+		".venv/pyvenv.cfg":    "v",
+		"docs/readme.md":      "r",
+	})
+	dir := filepath.Join(root, ".logmind")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte("file_structure:\n  root_label: myrepo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := mustGenerate(t, root)
+	mustHide(t, got, "node_modules", "dist", ".venv")
+	mustShow(t, got, "docs", "readme.md")
+}
+
+// TestResolveRules_ExtrasApplyAndRankLast covers ResolveRules' variadic
+// `extras`, the ad-hoc fourth source kept for parity with Python's
+// `extra_ignore` on generate_tree.
+//
+// It had no test and no production caller, so dropping it entirely from the
+// merge went unnoticed — found by mutating the append away and watching the
+// suite stay green. Position matters now, so this pins both halves: an extra
+// ignores, and an extra ranks AFTER config, so it can re-exclude what a
+// config `!pattern` re-included.
+func TestResolveRules_ExtrasApplyAndRankLast(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"vendored/lib.js": "v",
+		"dist/bundle.js":  "d",
+		"docs/readme.md":  "r",
+	})
+
+	// An extra excludes a path no other source mentions.
+	rules, err := ResolveRules(root, nil, "vendored")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := RenderWithLabel(root, rules, -1, "myrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustHide(t, got, "vendored", "lib.js")
+	mustShow(t, got, "docs", "readme.md")
+
+	// Config re-includes dist; the extra, ranking after it, takes it back.
+	rules, err = ResolveRules(root, []string{"!dist"}, "dist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = RenderWithLabel(root, rules, -1, "myrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustHide(t, got, "dist", "bundle.js")
+
+	// Control: without the extra, the config negation stands — so the
+	// assertion above is about the extra's POSITION, not about dist being
+	// hidden by the built-in default all along.
+	rules, err = ResolveRules(root, []string{"!dist"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = RenderWithLabel(root, rules, -1, "myrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustShow(t, got, "dist", "bundle.js")
+}
+
+// TestFileStructure_NoConfigHidesEveryDefault is the byte-parity guard for
+// the fleet: docs/file-structure.md sits behind a byte comparison in CI, so
+// a repository with no config and no .gitignore must render exactly what it
+// rendered before the merge landed. The fixture holds one entry per built-in
+// default; only docs/ and keep.txt may survive.
+func TestFileStructure_NoConfigHidesEveryDefault(t *testing.T) {
+	root := namedRepo(t, map[string]string{
+		"__pycache__/m.pyc":      "p",
+		".git/HEAD":              "h",
+		"node_modules/lib.js":    "n",
+		"venv/pyvenv.cfg":        "v",
+		".venv/pyvenv.cfg":       "v",
+		"env/pyvenv.cfg":         "v",
+		".env":                   "SECRET=1",
+		"stale.pyc":              "p",
+		".pytest_cache/CACHEDIR": "c",
+		".mypy_cache/cache.json": "c",
+		"dist/bundle.js":         "d",
+		"build/out.o":            "o",
+		"logmind.egg-info/PKG":   "e",
+		".next/build-manifest":   "b",
+		".turbo/cookies":         "c",
+		".DS_Store":              "d",
+		"docs/readme.md":         "r",
+		"keep.txt":               "k",
+	})
+
+	got := mustGenerate(t, root)
+	const wantTree = "```\nmyrepo\n├── docs\n│   └── readme.md\n└── keep.txt\n```\n"
+	if !strings.Contains(got, wantTree) {
+		t.Errorf("rendered tree changed for a repo with no config:\n=== got ===\n%s\n=== want tree ===\n%s", got, wantTree)
+	}
+}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -7,19 +7,25 @@
 // trees come from the Go walker so consuming repos get identical
 // output regardless of host OS.
 //
-// The renderer respects three pattern sources, merged in this order:
+// The renderer respects SPEC §1.4's three pattern sources, merged in
+// that section's order:
 //
 //  1. logmind built-in defaults (DEFAULT_IGNORES in tree_gen.py)
 //  2. patterns from the repo's .gitignore (with leading-"/" and
-//     trailing-"/" trimmed; `!negate` lines are routed to the negate
-//     bucket)
-//  3. any extra patterns the caller supplies (e.g. config.yml's
-//     file_structure.ignore_patterns)
+//     trailing-"/" trimmed)
+//  3. file_structure.ignore_patterns from .logmind/config.yml, plus any
+//     extras the caller supplies
+//
+// The merge is unconditional — a repository that names one pattern of
+// its own keeps the built-in sixteen (#269). `!pattern` is honoured in
+// every source, which is what keeps that from being a one-way door: a
+// project that genuinely wants dist/ on its map writes `!dist`.
 //
 // Pattern matching is path-aware: a pattern like `site/.next` matches
 // any path that traverses through site/.next, not just basenames.
-// Negation (`!keep.log`) re-includes a path that would otherwise be
-// ignored — gitignore precedence rules.
+// Resolution is POSITIONAL — the last rule in the merged list that
+// matches decides, exactly as git does within a .gitignore — see
+// IgnoreRules.Matches.
 package tree
 
 import (
@@ -55,20 +61,26 @@ const fileStructureTemplateTail = "\n```\n" +
 	"`logmind file-structure --write docs/file-structure.md --max-depth N` or\n" +
 	"`logmind tree --max-depth 0` for the full tree._\n"
 
-// IgnoreRules holds compiled ignore + negate patterns.
+// Rule is one pattern from one of §1.4's three sources. Negate marks a
+// `!pattern` entry, which re-includes a path an EARLIER rule excluded —
+// "earlier" being load-bearing, since resolution is positional.
+type Rule struct {
+	Pattern string
+	Negate  bool
+}
+
+// IgnoreRules is the merged pattern list in §1.4 source order — defaults,
+// then .gitignore, then config. One ordered list rather than separate
+// ignore/negate buckets so that `!` is parsed in exactly one place and no
+// rule can be filed under the wrong source. ORDER IS THE SEMANTICS here:
+// Matches resolves by position, so reordering this slice changes verdicts.
 //
 // Patterns are stored as raw strings; matching happens at the leaf via
-// filepath.Match. Per pattern we test three targets per item:
+// filepath.Match. Per rule we test three targets per item:
 //  1. full repo-relative path (e.g. "site/.next/cache")
 //  2. each path component individually
 //  3. the basename
-//
-// First match wins for ignore-vs-negate (negate beats ignore — matches
-// gitignore precedence).
-type IgnoreRules struct {
-	Ignore []string
-	Negate []string
-}
+type IgnoreRules []Rule
 
 // Matches reports whether the path should be excluded.
 //
@@ -76,24 +88,54 @@ type IgnoreRules struct {
 // basename is the path's last component (extracted once by the caller
 // since it's reused across pattern tests).
 //
-// Mirrors Python IgnoreRules.matches (tree_gen.py:47-59).
+// Resolution is POSITIONAL LAST-MATCH-WINS: the last rule in the merged list
+// that matches decides, and a `!pattern` only re-includes what a rule BEFORE
+// it excluded. That is §1.4 as written — "a !pattern re-includes a path an
+// earlier pattern excluded" — and it is what git does. Inside one .gitignore,
+//
+//	!important.log
+//	*.log
+//
+// git reports `.gitignore:2:*.log` for important.log: ignored, because the
+// negation sits earlier. Any rule that lets a negation win from anywhere in
+// the list disagrees with git on that file, and leaves config with no way to
+// re-exclude what .gitignore negated.
+//
+// This is only correct because the sources are RANKED CORRECTLY, and that
+// depends on the built-in defaults being a source of their own
+// (config.DefaultIgnorePatterns, seeded first by ResolveRules) rather than
+// arriving as the config source. When DefaultConfig still seeded
+// FileStructure.IgnorePatterns, a repository with no config file at all
+// handed ResolveRules sixteen built-in patterns at the CONFIG source's
+// position — so a positional resolver let that third-position `dist` outrank
+// a `.gitignore` `!dist` the repository had written on purpose. The defect
+// was the mis-ranked defaults, not the positional rule; see
+// config.FileStructureConfig.IgnorePatterns.
+//
+// The whole list is scanned rather than short-circuiting on the first match:
+// under last-match-wins the LAST matching rule is the answer, so an early
+// match tells us nothing.
 func (r IgnoreRules) Matches(relPath, basename string) bool {
-	if !patternSetMatches(r.Ignore, relPath, basename) {
+	if len(r) == 0 {
 		return false
 	}
-	// Ignore matched — check negation override.
-	if patternSetMatches(r.Negate, relPath, basename) {
-		return false
+	var components []string
+	if relPath != "" {
+		components = strings.Split(relPath, "/")
 	}
-	return true
+	ignored := false
+	for _, rule := range r {
+		if !rule.matches(relPath, basename, components) {
+			continue
+		}
+		ignored = !rule.Negate
+	}
+	return ignored
 }
 
-// patternSetMatches tests every pattern in `patterns` against the full
-// relative path, each path component, and the basename. Returns true
-// on the first match.
-//
-// Empty pattern set always returns false (matches Python's
-// `if not patterns: return False` short-circuit).
+// matches tests the rule's pattern against the full relative path, the
+// basename, and each path component. `components` is relPath pre-split by
+// the caller, since it is reused across every rule in the list.
 //
 // IMPORTANT: filepath.Match has subtly different semantics from
 // Python's fnmatch.fnmatchcase — Go's `*` does NOT match `/`, Python's
@@ -103,53 +145,73 @@ func (r IgnoreRules) Matches(relPath, basename string) bool {
 // a slash (`site/.next`). The mismatch would only surface on an
 // unusual pattern like `*foo*/bar` which doesn't appear in real use.
 // Worth noting if a future config.yml adds patterns that cross slashes.
-func patternSetMatches(patterns []string, relPath, basename string) bool {
-	if len(patterns) == 0 {
-		return false
+func (rule Rule) matches(relPath, basename string, components []string) bool {
+	if ok, _ := filepath.Match(rule.Pattern, relPath); ok {
+		return true
 	}
-	var components []string
-	if relPath != "" {
-		components = strings.Split(relPath, "/")
+	if ok, _ := filepath.Match(rule.Pattern, basename); ok {
+		return true
 	}
-	for _, pat := range patterns {
-		if ok, _ := filepath.Match(pat, relPath); ok {
+	for _, comp := range components {
+		if ok, _ := filepath.Match(rule.Pattern, comp); ok {
 			return true
-		}
-		if ok, _ := filepath.Match(pat, basename); ok {
-			return true
-		}
-		for _, comp := range components {
-			if ok, _ := filepath.Match(pat, comp); ok {
-				return true
-			}
 		}
 	}
 	return false
 }
 
-// readGitignorePatterns returns (ignore, negate) lists from
-// `<repoRoot>/.gitignore`. Strips comments, blank lines, leading "/"
-// and trailing "/". `!pattern` entries are routed to negate.
+// parseRules converts raw pattern strings into Rules, in order. A leading
+// "!" marks a negation and is stripped.
+//
+// §1.4 introduces `!pattern` right after listing the three sources without
+// naming one, so it is honoured in ALL of them — the config source included.
+// That is the superset reading (protocol#89 is still open on whether the
+// config source qualifies): if `!` is later restricted to .gitignore, a
+// config `!dist` degrades to an unmatched literal, whereas shipping without
+// it strands every repository that needs to see a default-ignored directory.
+//
+// The leading-/trailing-"/" trim is NOT applied here — §1.4 scopes it to the
+// .gitignore source, and states plainly that a trailing slash matches
+// nothing, so patterns are written without one.
+func parseRules(patterns []string) []Rule {
+	rules := make([]Rule, 0, len(patterns))
+	for _, p := range patterns {
+		negate := strings.HasPrefix(p, "!")
+		if negate {
+			p = p[1:]
+		}
+		if p == "" {
+			continue
+		}
+		rules = append(rules, Rule{Pattern: p, Negate: negate})
+	}
+	return rules
+}
+
+// readGitignoreRules returns the rules from `<repoRoot>/.gitignore` in file
+// order. Strips comments, blank lines, leading "/" and trailing "/" —
+// §1.4's trim, which this source and only this source gets.
 //
 // Mirrors Python _read_gitignore_patterns (tree_gen.py:80-109). Not a
 // complete gitignore parser — anchored patterns / recursive globs are
 // out of scope. Good enough to suppress obvious build-cache noise.
-func readGitignorePatterns(repoRoot string) (ignore, negate []string, err error) {
+func readGitignoreRules(repoRoot string) ([]Rule, error) {
 	path := filepath.Join(repoRoot, ".gitignore")
 	data, readErr := os.ReadFile(path)
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
-			return nil, nil, nil
+			return nil, nil
 		}
-		return nil, nil, readErr
+		return nil, readErr
 	}
+	var rules []Rule
 	for _, raw := range strings.Split(string(data), "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		isNegate := strings.HasPrefix(line, "!")
-		if isNegate {
+		negate := strings.HasPrefix(line, "!")
+		if negate {
 			line = line[1:]
 		}
 		line = strings.TrimPrefix(line, "/")
@@ -157,49 +219,75 @@ func readGitignorePatterns(repoRoot string) (ignore, negate []string, err error)
 		if line == "" {
 			continue
 		}
-		if isNegate {
-			negate = append(negate, line)
-		} else {
-			ignore = append(ignore, line)
-		}
-	}
-	return ignore, negate, nil
-}
-
-// ResolveRules merges built-in defaults + .gitignore patterns + caller
-// extras into an IgnoreRules ready for Render.
-//
-// `defaults` should be config.DefaultConfig().FileStructure.IgnorePatterns
-// (or the user-overridden equivalent). `extras` is for ad-hoc additions
-// the caller wants on top — currently unused by the CLI but kept for
-// parity with Python's `extra_ignore` parameter on generate_tree.
-//
-// Stable de-dup preserves first-seen order.
-func ResolveRules(repoRoot string, defaults []string, extras ...string) (IgnoreRules, error) {
-	combined := append([]string{}, defaults...)
-	gi, neg, err := readGitignorePatterns(repoRoot)
-	if err != nil {
-		return IgnoreRules{}, err
-	}
-	combined = append(combined, gi...)
-	combined = append(combined, extras...)
-
-	rules := IgnoreRules{
-		Ignore: dedup(combined),
-		Negate: dedup(neg),
+		rules = append(rules, Rule{Pattern: line, Negate: negate})
 	}
 	return rules, nil
 }
 
-func dedup(in []string) []string {
-	seen := make(map[string]struct{}, len(in))
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if _, ok := seen[s]; ok {
+// ResolveRules merges §1.4's three pattern sources into the ordered rule
+// list Render and repomap walk with. It is the ONE place the merge happens,
+// so every consumer of file_structure.ignore_patterns gets the same answer:
+//
+//  1. the built-in defaults, unconditionally — a repository that names one
+//     pattern of its own keeps the other sixteen. Before #269 they arrived
+//     as this function's first argument, so a config that set the key at all
+//     replaced them (yaml.Unmarshal overwrites a slice, it does not append)
+//     and node_modules/, dist/ and .venv/ reappeared in the generated map.
+//     They now come from config.DefaultIgnorePatterns — their OWN source,
+//     not a copy that DefaultConfig smuggled into the config field. That
+//     distinction is what makes positional resolution safe: with the
+//     defaults ranked first, a `.gitignore` `!dist` in a repository that
+//     configured nothing has nothing after it to override the re-inclusion.
+//  2. the repository's .gitignore, leading/trailing "/" trimmed.
+//  3. configPatterns — file_structure.ignore_patterns as loaded from
+//     .logmind/config.yml — then any caller extras. `extras` is for ad-hoc
+//     additions on top, kept for parity with Python's `extra_ignore`
+//     parameter on generate_tree.
+//
+// Sources are concatenated in §1.4's order and resolved positionally: the
+// LAST matching rule decides (see Matches). So a later source can both
+// re-include what an earlier one excluded and re-exclude what an earlier one
+// negated, which is what §1.4's "an earlier pattern" means and what git does.
+func ResolveRules(repoRoot string, configPatterns []string, extras ...string) (IgnoreRules, error) {
+	rules := parseRules(config.DefaultIgnorePatterns())
+	gitignore, err := readGitignoreRules(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	rules = append(rules, gitignore...)
+	rules = append(rules, parseRules(configPatterns)...)
+	rules = append(rules, parseRules(extras)...)
+	return dedup(rules), nil
+}
+
+// dedup drops repeated rules — same pattern AND same polarity, so `dist`
+// and `!dist` both survive. It keeps the LAST occurrence, not the first.
+//
+// That is not a style choice, it is what makes dedup verdict-preserving
+// under last-match-wins. Only the last rule matching a path decides, so
+// deleting an EARLIER exact duplicate can never change any verdict: the
+// later copy is still there, in the same place, and every rule after it is
+// untouched. Keeping the first instead would move a rule earlier in the
+// list and change answers — a .gitignore reading
+//
+//	*.log
+//	!important.log
+//	*.log
+//
+// resolves important.log as ignored (git agrees: last line wins), but
+// first-seen dedup drops the third line and leaves `!important.log` last,
+// flipping the verdict. Keep-last has no such case.
+func dedup(in []Rule) IgnoreRules {
+	lastAt := make(map[Rule]int, len(in))
+	for i, rule := range in {
+		lastAt[rule] = i
+	}
+	out := make(IgnoreRules, 0, len(in))
+	for i, rule := range in {
+		if lastAt[rule] != i {
 			continue
 		}
-		seen[s] = struct{}{}
-		out = append(out, s)
+		out = append(out, rule)
 	}
 	return out
 }
@@ -220,9 +308,9 @@ func dedup(in []string) []string {
 // sentinel (-1) to mean unbounded; the CLI wires this internally. A
 // positive maxDepth truncates the tree at that depth (root = depth 0).
 //
-// rules.Negate patterns re-include previously-matched paths; rules.Ignore
-// excludes them. Both are matched against the entry's repo-relative
-// posix path (e.g. "site/.next/cache").
+// The last rule matching an entry decides: a negating one re-includes it,
+// a plain one excludes it. Both are matched against the entry's
+// repo-relative posix path (e.g. "site/.next/cache").
 func Render(rootPath string, rules IgnoreRules, maxDepth int) (string, error) {
 	return RenderWithLabel(rootPath, rules, maxDepth, "")
 }
@@ -355,9 +443,11 @@ func relPosix(repoRoot, full string) string {
 // repoRoot defaults to "." when empty.
 // maxDepth=-1 → unbounded; 0 → root-only; positive → truncate.
 //
-// The function loads `<repoRoot>/.logmind/config.yml` for the
-// ignore_patterns override (falls back to built-in defaults when
-// config is missing — matches Python's load_config fallback).
+// The function loads `<repoRoot>/.logmind/config.yml` for the config
+// pattern source, which ResolveRules merges ON TOP of the built-in
+// defaults and .gitignore rather than in place of them (§1.4). A missing
+// or unparseable config degrades to the defaults alone — matches Python's
+// load_config fallback.
 func GenerateFileStructure(repoRoot string, maxDepth int) (string, error) {
 	if repoRoot == "" {
 		repoRoot = "."

--- a/internal/tree/tree_rootlabel_test.go
+++ b/internal/tree/tree_rootlabel_test.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"github.com/thrillmade/logmind/internal/testgit"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,11 @@ func TestResolveRootLabel_WorktreeMatchesMainCheckout(t *testing.T) {
 	run(main, "init", "-q")
 	run(main, "config", "user.email", "test@test.com")
 	run(main, "config", "user.name", "test")
+	// This test commits, so it needs the same background-maintenance
+	// suppression every other test repo gets (#271). It builds its repo
+	// through a local `run` helper rather than testgit.InitRepo because it
+	// also needs `git worktree add` against the same handle.
+	testgit.DisableMaintenance(t, main)
 	mustWriteTree(t, filepath.Join(main, "README.md"), "hello\n")
 	run(main, "add", "README.md")
 	run(main, "commit", "-q", "-m", "init")

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -86,7 +87,7 @@ func TestRenderIgnoreDefault(t *testing.T) {
 		"__pycache__/foo.py": "p",
 		"node_modules/lib":   "n",
 	})
-	rules := IgnoreRules{Ignore: []string{"__pycache__", "node_modules"}}
+	rules := IgnoreRules{{Pattern: "__pycache__"}, {Pattern: "node_modules"}}
 	got, err := Render(root, rules, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +107,7 @@ func TestRenderIgnoreGlob(t *testing.T) {
 		"sub/x.pyc": "p",
 		"sub/x.py":  "p",
 	})
-	rules := IgnoreRules{Ignore: []string{"*.pyc"}}
+	rules := IgnoreRules{{Pattern: "*.pyc"}}
 	got, err := Render(root, rules, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +128,7 @@ func TestRenderIgnorePathPattern(t *testing.T) {
 		"other/.next/keep":   "k",
 	})
 	// Path-shaped ignore: site/.next should match only under site/.
-	rules := IgnoreRules{Ignore: []string{"site/.next"}}
+	rules := IgnoreRules{{Pattern: "site/.next"}}
 	got, err := Render(root, rules, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -147,8 +148,8 @@ func TestRenderNegate(t *testing.T) {
 		"keep.log": "k",
 	})
 	rules := IgnoreRules{
-		Ignore: []string{"*.log"},
-		Negate: []string{"keep.log"},
+		{Pattern: "*.log"},
+		{Pattern: "keep.log", Negate: true},
 	}
 	got, err := Render(root, rules, -1)
 	if err != nil {
@@ -196,8 +197,16 @@ func TestRenderMaxDepthZeroRootOnly(t *testing.T) {
 	}
 }
 
-// TestReadGitignorePatterns exercises the gitignore parser's trim logic.
-func TestReadGitignorePatterns(t *testing.T) {
+// TestReadGitignoreRules exercises the gitignore parser's trim logic, and
+// that it hands rules back in FILE order.
+//
+// File order is not bookkeeping — under last-match-wins a negation's
+// position relative to its neighbours IS the answer, so the second half of
+// this test resolves the parsed rules both ways round and asserts the two
+// verdicts differ. Assert the ordering in prose only and the claim survives
+// any resolver, including one that ignores order entirely (which is what
+// shipped before #303).
+func TestReadGitignoreRules(t *testing.T) {
 	dir := t.TempDir()
 	body := "# comment\n" +
 		"\n" +
@@ -209,30 +218,34 @@ func TestReadGitignorePatterns(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ig, neg, err := readGitignorePatterns(dir)
+	got, err := readGitignoreRules(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantIg := []string{"__pycache__", "foo", "*.log", "bare"}
-	wantNeg := []string{"keep.log"}
-	if !equalStrings(ig, wantIg) {
-		t.Errorf("ignore = %v; want %v", ig, wantIg)
+	want := []Rule{
+		{Pattern: "__pycache__"},
+		{Pattern: "foo"},
+		{Pattern: "*.log"},
+		{Pattern: "keep.log", Negate: true},
+		{Pattern: "bare"},
 	}
-	if !equalStrings(neg, wantNeg) {
-		t.Errorf("negate = %v; want %v", neg, wantNeg)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("rules = %v; want %v", got, want)
 	}
-}
 
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+	// As parsed: `*.log` then `!keep.log`. The negation is LAST, so
+	// keep.log is re-included.
+	if IgnoreRules(got).Matches("keep.log", "keep.log") {
+		t.Errorf("keep.log is ignored with the negation last; want re-included")
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+	// Swap those two neighbours and nothing else. Now `*.log` is last, so
+	// the same file is ignored. Equal verdicts here would mean position
+	// carries no meaning.
+	swapped := append([]Rule(nil), got...)
+	swapped[2], swapped[3] = swapped[3], swapped[2]
+	if !IgnoreRules(swapped).Matches("keep.log", "keep.log") {
+		t.Errorf("keep.log is re-included with the negation moved EARLIER than *.log; want ignored — resolution is not positional")
 	}
-	return true
 }
 
 // TestFileStructureTemplate pins the template head + tail bytes so


### PR DESCRIPTION
Closes #271.

`git commit` calls `run_auto_maintenance()`, gated by **`maintenance.auto`** — a separate key from `gc.auto`. The spawned process daemonises (`maintenance.autoDetach`) and is still writing into `.git/objects` when a test returns, so `t.TempDir()` cleanup fails with `directory not empty`. It surfaces as a *cleanup* error on whichever test loses the race, which is why it looked like a different bug every time.

Reproduced independently on this machine before writing the test, git 2.39.5 with `GIT_TRACE2_EVENT`:

| config | `git maintenance` spawns / 5 commits |
|---|---|
| `gc.auto=0` only | **5** |
| `gc.auto=0` + `maintenance.auto=false` | **0** |

## One helper, not fourteen copies

New leaf package `internal/testgit` — `InitRepo`, `CloneRepo`, and the shared `DisableMaintenance` primitive. It depends only on `os`, `os/exec`, `testing`, so any package can import it with zero cycle risk, and there is no longer a reason to hand-roll one. The four files that already carried the fix inline are deduplicated onto it.

Routed through it: **15 files** across `internal/cli`, `internal/gitcli`, `internal/guardcommit`, `internal/hooks`, `internal/gitattr`.

## The issue's file count was wrong in both directions

- It listed **14** exposed files. The sweep found **8** genuinely unguarded initialisations — several listed files were false positives that already routed through a guarded helper or never touch real git (`--no-git` only).
- It **missed three exposures entirely**: two clone destinations (`warp_test.go`, `pulse_test.go`) and a bare push remote (`log_test.go`). None inherit config from the repository they came from. Cloning is precisely the gap a file-by-file audit misses, because the search term everyone reaches for is `init`.

Grep patterns controlled against known hits before trusting their misses; `internal/skill/push_test.go`'s `clone` references confirmed mocked, not real `exec.Command`.

## Mutation

Removed `maintenance.auto=false` from `DisableMaintenance`. **Compiled**, both new tests went red — the spawn test reporting **5 of 5** commits spawning `git maintenance`, matching the issue's own measurement. Restored from a private scratchpad copy (not `git checkout`), verified byte-identical by `md5`.

## Regression tests

`TestInitRepo_SetsBothMaintenanceKeys` reads the config back via `git config --get`; `TestInitRepo_SuppressesMaintenanceSpawn` captures real `GIT_TRACE2_EVENT` across 5 commits and asserts zero spawns — validated against a hand-built control repo reproducing the 5-of-5 vs 0-of-5 numbers before being written.

## Green count

**880 PASS / 0 FAIL / 1 SKIP** on pristine `origin/dev` → **882 / 0 / 1** after. The +2 are exactly the new `testgit` tests. `go build` / `go vet` / `gofmt -l .` clean before and after.

`go test ./internal/cli/ -count=3` → **ok, 618.8s, 0 failures** (needed `-timeout=30m`; 3× a ~230–300s suite exceeds Go's 10-minute default regardless of this change).

One implementation note: `InitRepo` `MkdirAll`s its target first — several call sites relied on `git init <dir>` creating the directory, which broke when first routed through the helper. Caught by the full-suite run.