### PR TITLE
docs(orchestrator-app): the steward bypasses in every org repo, not only the tap

### DIFF
--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-15 15:15 - orchestrator-app: rulesets aggregate, so the org-level bypass alone does not decide exemption
+
+**Reasoning:** My previous correction replaced one over-claim with another. It was right that the steward bypasses two organisation-level rulesets applying to every repository, and wrong to conclude that a direct push is therefore exempt anywhere. Bypass is evaluated per ruleset and rulesets aggregate, so a repository that additionally carries its own pull-request rule without naming the steward still blocks it. Seven do. The original sentence I called false was true under its natural reading: the tap is the only repository whose own ruleset names the steward.
+
+**Alternatives considered:** Revert to the original sentence. Rejected, because it was true but incomplete in a way that mattered: read alongside the risk paragraph it produced a materially wrong picture of blast radius. The fix is to state the aggregation rule that makes both facts consistent, not to choose between them.
+
+**Implications:**
+- The load-bearing copy of this fact sat in the installation-scope section and said every other repository rejects a direct push from the App, which understated exposure. Measured across all twenty repositories rather than the seven previously recited: thirteen accept a direct push, including logmind, protocol, skdd and reporulez, and seven are blocked. The residual-risk paragraph said one repository is exposed under key compromise; it is thirteen. Both copies now derive from the same measurement, and the tap is noted as the only default branch that has ever carried a direct steward commit, so for every other repository the exemption is inferred from configuration and never exercised.
+
+---
+

--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -48,3 +48,14 @@
 
 ---
 
+## 2026-08-15 20:05 - orchestrator-app: review IS required org-wide; the steward escapes it by bypassing the ruleset, not by its absence
+
+**Reasoning:** My previous revision claimed every pull-request rule in the organisation required zero approvals and no code-owner review. That was read from one repository's own ruleset and generalised, which is the identical mistake to the count in the paragraph above it, made twice in the same document within an hour. Measured properly through the aggregate endpoint on three repositories: the organisation default-protection ruleset requires one approval and code-owner review everywhere, while the baseline ruleset requires neither.
+
+**Alternatives considered:** Soften the sentence to say review is inconsistent across repositories. Rejected: it is perfectly consistent, and the inconsistency was in my sampling. The corrected paragraph is also a stronger statement of the risk rather than a weaker one, because the App escapes a requirement that exists rather than benefiting from one that was never set.
+
+**Implications:**
+- A human contributor does face review in every repository. The steward does not, because bypassing a ruleset bypasses its review requirement along with its push restriction, and it holds write access to pull requests, so it can open and merge one anywhere. Read with the finding that no ruleset in the organisation requires status checks, an App-authored merge passes no automated gate and no human one; the seven repositories that block its direct push change nothing about that.
+
+---
+

--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -37,3 +37,14 @@
 
 ---
 
+## 2026-08-15 19:52 - orchestrator-app: ask the forge which rules apply, rather than enumerating rulesets and counting
+
+**Reasoning:** This is the fourth revision of one paragraph and the third wrong count, so the number was never the problem. A ruleset can exist, be active, require pull requests and name no bypass actor, and still match nothing at all: tremendous-machine's has an empty include list, so enumerating rulesets counted it as protecting a branch it does not apply to. The aggregate endpoint answers the question directly and shows that repository resolving to the same two organisation rulesets as logmind, which is the canonical accepting case. Thirteen accept a direct push and seven refuse one.
+
+**Alternatives considered:** Correct the count a third time and keep enumerating. Rejected: two of the three previous errors came from that method, once by missing classic protection entirely and once by counting an inert ruleset. The document now leads with the aggregate query and keeps enumeration only for showing which actor holds the bypass, which is the one thing the aggregate does not report.
+
+**Implications:**
+- A second claim was wrong in a way that mattered more than the count. The blocked repositories were described as limited by required review; every pull-request rule in the organisation and the one classic protection require zero approvals, with no code-owner rule and no required status checks, while the App holds write access to pull requests. It can therefore open a request and merge it itself in every repository called blocked. Those seven slow the App down and none of them puts a person in the path, which the document now says instead of implying otherwise.
+
+---
+

--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-15 16:11 - orchestrator-app: rulesets are not the only mechanism, and checking only them is how this section was wrong twice
+
+**Reasoning:** The correction I made was itself wrong, in the same shape as the thing it corrected. I swept every repository's rulesets and concluded thirteen accept a direct push. A panel checked classic branch protection as well and found arlyn-working carries it with admin enforcement on, which nothing bypasses without an administration permission the steward does not hold. The real split is twelve accepting and eight blocked. Measuring one mechanism and reporting a total is the same defect as reading one copy of a fact and believing it.
+
+**Alternatives considered:** State the ruleset finding and note that other mechanisms were out of scope. Rejected: this section is read to answer whether a push will land, and a number qualified by a methodology footnote will be quoted without the footnote. The section now names both mechanisms and shows the command for each, so the next audit cannot repeat the omission by accident.
+
+**Implications:**
+- Both probes are written into the document rather than only their answers. The steward's permission set is quoted, because the reason admin enforcement blocks it is that it holds contents, issues, metadata and pull requests and nothing else, which is checkable rather than assumed. This is the third revision of one paragraph; the first two were each internally consistent and each wrong against something they had not measured.
+
+---
+

--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-orchestrator-app-the-steward-bypasses-in-every-org-repo-not- -->
+- **2026-08-15** — orchestrator-app: the steward bypasses in every org repo, not only the tap
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:33 - orchestrator-app: the steward bypasses in every org repo, not only the tap
+
+**Reasoning:** The template v12 lane read this doc and concluded logmind's own regen push might be getting refused, which would have been a real blocker for dev reaching main. It is not: the doc was stale. Measured across all seven org repos, the two organization-level rulesets 18502737 org-baseline and 16898453 org-default-protection both list the steward App as a bypass actor with mode always, and both apply to every repo. The claim that the tap is the only repo with a bypass entry was presumably true when a repo-specific ruleset carried it and stopped being true when the entry moved to the org level, with nothing noticing.
+
+**Alternatives considered:** Leave the sentence and let readers measure for themselves. Rejected: a doc that states a false fact about who can push to a protected branch is worse than one that says nothing, because the next lane to read it will draw the same wrong conclusion this one did, and the conclusion it invites is that a release path is blocked when it is not.
+
+**Implications:**
+- The correction carries the commands that produce it rather than only the answer, and names the three repo-specific rulesets that do not list the steward, so a reader can see the probe discriminates instead of matching everything. This also confirms issue 288's premise: the bypass logmind needs for regen-on-main is granted, and what remains untested is only whether a regen commit actually lands.
+
+---
+

--- a/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
+++ b/docs/decisions-branches/fix__orchestrator-app-bypass-scope.md
@@ -59,3 +59,14 @@
 
 ---
 
+## 2026-08-15 21:26 - orchestrator-app: say six and list six, and stop asserting a review gate the same file spends a paragraph refuting
+
+**Reasoning:** Two defects, both mine, both introduced while correcting the previous pair. One sentence said seven repositories add their own ruleset and then listed six, so a reader adding the classic-protection case reached eight blocked and twelve accepting, which is the exact wrong split of the previous round re-encoded as a word instead of a numeral. The other left a clause asserting the App is gated by human review, three lines above the paragraph this change added to explain that it is not; the sentence containing it was rewritten in the same edit and the contradicting half survived.
+
+**Alternatives considered:** Restate the totals in each section so every reader meets them. Rejected: this file has now been wrong five times and four of those were a second copy of a fact disagreeing with the first. The arithmetic is stated once, at the point where the two mechanisms combine, and every other mention refers to it rather than recomputing.
+
+**Implications:**
+- The exposure sentence now says the App can merge, not merely open, because bypassing a ruleset bypasses its review requirement along with its push restriction, and the bypass is unconditional rather than scoped to pull requests. What limits the blast radius is the token's lifetime and the App's permission set; neither installation scope nor review is doing that work, and the paragraph no longer implies otherwise.
+
+---
+

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -194,9 +194,28 @@ required_linear_history + pull_request (0 reviews, squash only). The
 steward App is added as a bypass actor so its direct pushes are exempt;
 human pushes still go through PR review. The bypass IS the audit trail —
 every direct push appears in the org audit log under the App identity.
-`homebrew-tap` is the only repo in the org with a bypass entry — see
-"Installation scope" above for why that matters now that the App installs
-`all` repos rather than a selected list.
+**`homebrew-tap` is no longer the only repo with a bypass entry, and has not
+been for some time.** The steward now bypasses in every repo in the org,
+because the entry rides on the two *organization-level* rulesets rather than
+on any repo's own:
+
+```sh
+gh api repos/thrillmade/<repo>/rulesets --jq '.[] | "\(.id) \(.name)"'
+gh api repos/thrillmade/<repo>/rulesets/<id> \
+  --jq '.bypass_actors[]? | "\(.actor_type) \(.actor_id) \(.bypass_mode)"'
+gh api /apps/skdd-steward --jq .id     # the id to look for
+```
+
+Measured 2026-08-15 across all seven org repos: `18502737 org-baseline` and
+`16898453 org-default-protection` both list the steward App with
+`bypass_mode: always`, and both appear in every repo. The repo-specific
+rulesets (`20570854`, `18292238`, `16434011`) do **not** list it — which is
+what makes the measurement above meaningful rather than a probe that matches
+everything.
+
+So `regen-on-main`'s direct push to `main` is exempt in any org repo, not just
+the tap. See "Installation scope" above for why that follows from the App
+installing `all` repos rather than a selected list.
 
 The GitHub Rulesets API requires a full ruleset body on `PUT` — it does
 not accept a partial patch. Use a read-merge-PUT pattern: fetch the

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -256,13 +256,33 @@ gh api repos/thrillmade/<repo>/branches/main/protection   # mechanism 2
 
 So seven are blocked and the remaining thirteen accept a direct push.
 
-**Blocked means a direct push is refused. It does NOT mean review.** Every
-`pull_request` rule in the org, and `arlyn-working`'s classic protection, sets
-`required_approving_review_count: 0`, with no code-owner requirement and no
-required status checks (see logmind#315). The steward holds
-`pull_requests: write`, so in every "blocked" repo it can open a pull request
-and merge it itself. The seven repos slow the App down; none of them puts a
-human in the path.
+**Blocked means a direct push is refused. For the steward it does not mean
+review either — but not because review is unrequired.**
+
+`16898453 org-default-protection` requires **1 approval and code-owner
+review**, in every repo:
+
+```sh
+gh api repos/thrillmade/<repo>/rules/branches/main \
+  --jq '.[]|select(.type=="pull_request")|"\(.ruleset_id) approvals=\(.parameters.required_approving_review_count) codeowners=\(.parameters.require_code_owner_review)"'
+```
+
+→ `18502737 approvals=0 codeowners=false` · `16898453 approvals=1
+codeowners=true`. Identical on `logmind`, `agent-skills` and `homebrew-tap`.
+An earlier revision of this paragraph claimed every rule required zero
+approvals; that came from reading `16434011`, one repo's own ruleset, and
+generalising — the same mistake as the count above, one ruleset standing in
+for all of them.
+
+So a human contributor does face review. **The steward does not**, because it
+bypasses `16898453` outright (`Integration:3951953`, `bypass_mode: always`) —
+and bypassing the ruleset bypasses its review requirement along with its push
+restriction. Holding `pull_requests: write`, it can open a pull request and
+merge it in any repo, blocked or not.
+
+The seven blocked repos therefore stop the App's *direct push* and nothing
+else. Combined with logmind#315 — no ruleset in the org requires status checks
+— an App-authored merge faces no automated gate and no human one.
 
 `logmind` is in the second group: it carries no repo-level ruleset, so
 `regen-on-main`'s push to its default branch is exempt. That is the fact the

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -161,9 +161,13 @@ token's 1-hour lifetime. **Thirteen of the org's twenty repos are exposed to
 a direct, unreviewed push under compromise** — not one. The org-level
 bypass, not `homebrew-tap`'s own entry, is what grants it; only the seven repos carrying either their own
 PR-requiring ruleset or classic branch protection stop a direct push — and
-stopping a direct push is NOT the same as requiring review; see below on merge — real exposure (an
-attacker could open PRs, comment, file issues, read contents across the
-org), but gated by human review rather than by installation scope.
+stopping a direct push is NOT the same as requiring review; see below.
+
+Real exposure: an attacker could open pull requests, comment, file issues and
+read contents across the org — **and merge**, because the steward bypasses the
+ruleset that requires review, not merely the one that restricts pushes. The
+limit is the token's one-hour lifetime and the App's permission set, not
+installation scope and not human review.
 
 Expansion or contraction of the installed-repo list happens via the App's
 Installation settings page on the org — never re-register the App.
@@ -238,9 +242,11 @@ first three hold zero entries — so the empty result is a real zero, not a
 missing field.
 
 **Rulesets aggregate.** A push must satisfy every ruleset matching the ref, so
-bypassing the org pair is not sufficient where a repo adds its own. Seven
+bypassing the org pair is not sufficient where a repo adds its own. **Six**
 repos do — `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
 `homebrew-logmind`, `setup-logmind` — and the steward is blocked in those.
+With `arlyn-working` below, that is **seven blocked and thirteen accepting**;
+the six here plus one is the only arithmetic in this section.
 
 **Rulesets are not the only mechanism, and checking only them is how this
 section was wrong twice.** `arlyn-working` carries no ruleset but is protected

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -125,20 +125,27 @@ coverage.
 
 Why the wider blast radius is acceptable:
 
-- **Branch rulesets force PRs on every repo.** Only
-  `thrillmade/homebrew-tap` carries the App as a ruleset bypass actor (see
-  "Ruleset bypass" below); every other repo in the org rejects a direct
-  push from the App's installation token and requires the write to land
-  through a reviewed PR like anyone else's. Installing on `all` repos does
-  not mean the App can direct-write to all of them.
+- **Branch rulesets do NOT force PRs on every repo — 13 of 20 accept a
+  direct push from the App.** Bypass is evaluated per ruleset, and rulesets
+  *aggregate*: a push must satisfy every ruleset matching the ref. The
+  steward is a bypass actor on both **organization-level** rulesets
+  (`18502737 org-baseline`, `16898453 org-default-protection`), which apply
+  everywhere. A repo is protected from the App only if it *additionally*
+  carries its own ruleset requiring pull requests without naming the steward.
+  Seven do: `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
+  `homebrew-logmind`, `setup-logmind`, `tremendous-machine`. The other
+  thirteen — including `logmind`, `protocol`, `skdd`, `reporulez` and
+  `homebrew-tap` — do not, and accept a direct push. See "Ruleset bypass"
+  below for the commands.
 - **All-repos is what the census reads today, and what the catalog
   fan-out / chore loop will require** — see "Purpose" above.
 
 **Residual risk, stated plainly:** a compromised App private key can mint
 an installation token scoped to every repository in the org, for that
-token's 1-hour lifetime. `homebrew-tap`'s bypass actor means that one repo
-is exposed to a direct, unreviewed push even under compromise; every other
-repo is limited by required PR review on merge — real exposure (an
+token's 1-hour lifetime. **Thirteen of the org's twenty repos are exposed to
+a direct, unreviewed push under compromise** — not one. The org-level
+bypass, not `homebrew-tap`'s own entry, is what grants it; only the seven
+repos carrying their own PR-requiring ruleset are limited by required review on merge — real exposure (an
 attacker could open PRs, comment, file issues, read contents across the
 org), but gated by human review rather than by installation scope.
 
@@ -194,10 +201,11 @@ required_linear_history + pull_request (0 reviews, squash only). The
 steward App is added as a bypass actor so its direct pushes are exempt;
 human pushes still go through PR review. The bypass IS the audit trail —
 every direct push appears in the org audit log under the App identity.
-**`homebrew-tap` is no longer the only repo with a bypass entry, and has not
-been for some time.** The steward now bypasses in every repo in the org,
-because the entry rides on the two *organization-level* rulesets rather than
-on any repo's own:
+**`homebrew-tap` IS the only repo whose own ruleset names the steward as a
+bypass actor** — that part was right, and an earlier revision of this section
+wrongly called it false. What it omitted is that the steward ALSO bypasses via
+two *organization-level* rulesets that apply to every repo, so a repo's own
+ruleset is not the only thing granting exemption:
 
 ```sh
 gh api repos/thrillmade/<repo>/rulesets --jq '.[] | "\(.id) \(.name)"'
@@ -206,16 +214,29 @@ gh api repos/thrillmade/<repo>/rulesets/<id> \
 gh api /apps/skdd-steward --jq .id     # the id to look for
 ```
 
-Measured 2026-08-15 across all seven org repos: `18502737 org-baseline` and
-`16898453 org-default-protection` both list the steward App with
-`bypass_mode: always`, and both appear in every repo. The repo-specific
-rulesets (`20570854`, `18292238`, `16434011`) do **not** list it — which is
-what makes the measurement above meaningful rather than a probe that matches
-everything.
+Measured 2026-08-15 across all **20** org repos: `18502737 org-baseline` and
+`16898453 org-default-protection` both list the steward with
+`bypass_mode: always`, and both apply everywhere. Control: `20570854`,
+`18292238`, `16434011` and `17128312` all have a `bypass_actors` key, and the
+first three hold zero entries — so the empty result is a real zero, not a
+missing field.
 
-So `regen-on-main`'s direct push to `main` is exempt in any org repo, not just
-the tap. See "Installation scope" above for why that follows from the App
-installing `all` repos rather than a selected list.
+**Rulesets aggregate.** A push must satisfy every ruleset matching the ref, so
+bypassing the org pair is not sufficient where a repo adds its own. Seven
+repos do — `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
+`homebrew-logmind`, `setup-logmind`, `tremendous-machine` — and the steward is
+blocked in those. The remaining thirteen accept a direct push.
+
+`logmind` is in the second group: it carries no repo-level ruleset, so
+`regen-on-main`'s push to its default branch is exempt. That is the fact the
+release path depends on, and it is measured rather than generalised — an
+earlier revision of this section claimed exemption "in any org repo", which is
+wrong for the seven above.
+
+Corroboration, and a caution: `homebrew-tap` is the only default branch in the
+org carrying direct steward commits. `logmind`, `agent-skills` and `clud-bug`
+have zero. So for every repo except the tap this exemption is inferred from
+configuration and has never actually been exercised.
 
 The GitHub Rulesets API requires a full ruleset body on `PUT` — it does
 not accept a partial patch. Use a read-merge-PUT pattern: fetch the

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -125,29 +125,43 @@ coverage.
 
 Why the wider blast radius is acceptable:
 
-- **Branch rulesets do NOT force PRs on every repo — 12 of 20 accept a
+- **Branch rulesets do NOT force PRs on every repo — 13 of 20 accept a
   direct push from the App.** Bypass is evaluated per ruleset, and rulesets
   *aggregate*: a push must satisfy every ruleset matching the ref. The
   steward is a bypass actor on both **organization-level** rulesets
   (`18502737 org-baseline`, `16898453 org-default-protection`), which apply
   everywhere. A repo is protected from the App only if it *additionally*
   carries its own ruleset requiring pull requests without naming the steward.
-  Seven do: `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
-  `homebrew-logmind`, `setup-logmind`, `tremendous-machine`. An eighth, `arlyn-working`, is protected by **classic branch protection**
-  instead of a ruleset (`enforce_admins: true`), and the steward holds no
-  Administration permission to override it. The other twelve — including
-  `logmind`, `protocol`, `skdd`, `reporulez` and `homebrew-tap` — accept a
-  direct push. See "Ruleset bypass"
-  below for the commands.
+  Six do: `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
+  `homebrew-logmind`, `setup-logmind`. A seventh, `arlyn-working`, is
+  protected by **classic branch protection** instead of a ruleset
+  (`enforce_admins: true`), and the steward holds no Administration
+  permission to override it. The other thirteen — including `logmind`,
+  `protocol`, `skdd`, `reporulez` and `homebrew-tap` — accept a direct push.
+
+  **`tremendous-machine` looks blocked and is not.** Its ruleset `4741217`
+  exists, is `active`, requires pull requests and names no bypass actor — but
+  its `conditions.ref_name.include` is `[]`, so it matches no ref at all. That
+  is why the enumerate-the-rulesets method got this wrong twice. **Ask the
+  forge which rules actually apply** instead:
+
+  ```sh
+  gh api repos/thrillmade/<repo>/rules/branches/main --jq '[.[].ruleset_id]|unique'
+  ```
+
+  `tremendous-machine` → `[16898453, 18502737]`, identical to `logmind`, the
+  canonical accepting case. Control: `agent-skills` → `[16434011, 16898453,
+  18502737]`, its own ruleset present.
 - **All-repos is what the census reads today, and what the catalog
   fan-out / chore loop will require** — see "Purpose" above.
 
 **Residual risk, stated plainly:** a compromised App private key can mint
 an installation token scoped to every repository in the org, for that
-token's 1-hour lifetime. **Twelve of the org's twenty repos are exposed to
+token's 1-hour lifetime. **Thirteen of the org's twenty repos are exposed to
 a direct, unreviewed push under compromise** — not one. The org-level
-bypass, not `homebrew-tap`'s own entry, is what grants it; only the eight repos carrying either their own
-PR-requiring ruleset or classic branch protection are limited by required review on merge — real exposure (an
+bypass, not `homebrew-tap`'s own entry, is what grants it; only the seven repos carrying either their own
+PR-requiring ruleset or classic branch protection stop a direct push — and
+stopping a direct push is NOT the same as requiring review; see below on merge — real exposure (an
 attacker could open PRs, comment, file issues, read contents across the
 org), but gated by human review rather than by installation scope.
 
@@ -226,8 +240,7 @@ missing field.
 **Rulesets aggregate.** A push must satisfy every ruleset matching the ref, so
 bypassing the org pair is not sufficient where a repo adds its own. Seven
 repos do — `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
-`homebrew-logmind`, `setup-logmind`, `tremendous-machine` — and the steward is
-blocked in those.
+`homebrew-logmind`, `setup-logmind` — and the steward is blocked in those.
 
 **Rulesets are not the only mechanism, and checking only them is how this
 section was wrong twice.** `arlyn-working` carries no ruleset but is protected
@@ -241,7 +254,15 @@ gh api repos/thrillmade/<repo>/rulesets              # mechanism 1
 gh api repos/thrillmade/<repo>/branches/main/protection   # mechanism 2
 ```
 
-So eight are blocked and the remaining twelve accept a direct push.
+So seven are blocked and the remaining thirteen accept a direct push.
+
+**Blocked means a direct push is refused. It does NOT mean review.** Every
+`pull_request` rule in the org, and `arlyn-working`'s classic protection, sets
+`required_approving_review_count: 0`, with no code-owner requirement and no
+required status checks (see logmind#315). The steward holds
+`pull_requests: write`, so in every "blocked" repo it can open a pull request
+and merge it itself. The seven repos slow the App down; none of them puts a
+human in the path.
 
 `logmind` is in the second group: it carries no repo-level ruleset, so
 `regen-on-main`'s push to its default branch is exempt. That is the fact the

--- a/docs/orchestrator-app.md
+++ b/docs/orchestrator-app.md
@@ -125,7 +125,7 @@ coverage.
 
 Why the wider blast radius is acceptable:
 
-- **Branch rulesets do NOT force PRs on every repo — 13 of 20 accept a
+- **Branch rulesets do NOT force PRs on every repo — 12 of 20 accept a
   direct push from the App.** Bypass is evaluated per ruleset, and rulesets
   *aggregate*: a push must satisfy every ruleset matching the ref. The
   steward is a bypass actor on both **organization-level** rulesets
@@ -133,19 +133,21 @@ Why the wider blast radius is acceptable:
   everywhere. A repo is protected from the App only if it *additionally*
   carries its own ruleset requiring pull requests without naming the steward.
   Seven do: `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
-  `homebrew-logmind`, `setup-logmind`, `tremendous-machine`. The other
-  thirteen — including `logmind`, `protocol`, `skdd`, `reporulez` and
-  `homebrew-tap` — do not, and accept a direct push. See "Ruleset bypass"
+  `homebrew-logmind`, `setup-logmind`, `tremendous-machine`. An eighth, `arlyn-working`, is protected by **classic branch protection**
+  instead of a ruleset (`enforce_admins: true`), and the steward holds no
+  Administration permission to override it. The other twelve — including
+  `logmind`, `protocol`, `skdd`, `reporulez` and `homebrew-tap` — accept a
+  direct push. See "Ruleset bypass"
   below for the commands.
 - **All-repos is what the census reads today, and what the catalog
   fan-out / chore loop will require** — see "Purpose" above.
 
 **Residual risk, stated plainly:** a compromised App private key can mint
 an installation token scoped to every repository in the org, for that
-token's 1-hour lifetime. **Thirteen of the org's twenty repos are exposed to
+token's 1-hour lifetime. **Twelve of the org's twenty repos are exposed to
 a direct, unreviewed push under compromise** — not one. The org-level
-bypass, not `homebrew-tap`'s own entry, is what grants it; only the seven
-repos carrying their own PR-requiring ruleset are limited by required review on merge — real exposure (an
+bypass, not `homebrew-tap`'s own entry, is what grants it; only the eight repos carrying either their own
+PR-requiring ruleset or classic branch protection are limited by required review on merge — real exposure (an
 attacker could open PRs, comment, file issues, read contents across the
 org), but gated by human review rather than by installation scope.
 
@@ -225,7 +227,21 @@ missing field.
 bypassing the org pair is not sufficient where a repo adds its own. Seven
 repos do — `.github`, `agent-skills`, `clud-bug`, `clud-bug-app`,
 `homebrew-logmind`, `setup-logmind`, `tremendous-machine` — and the steward is
-blocked in those. The remaining thirteen accept a direct push.
+blocked in those.
+
+**Rulesets are not the only mechanism, and checking only them is how this
+section was wrong twice.** `arlyn-working` carries no ruleset but is protected
+by classic branch protection with `enforce_admins: true`, which nothing bypasses
+without Administration permission — and the steward has none
+(`gh api /apps/skdd-steward --jq .permissions` → contents, issues, metadata,
+pull_requests). Any audit here MUST check both:
+
+```sh
+gh api repos/thrillmade/<repo>/rulesets              # mechanism 1
+gh api repos/thrillmade/<repo>/branches/main/protection   # mechanism 2
+```
+
+So eight are blocked and the remaining twelve accept a direct push.
 
 `logmind` is in the second group: it carries no repo-level ruleset, so
 `regen-on-main`'s push to its default branch is exempt. That is the fact the


### PR DESCRIPTION
`docs/orchestrator-app.md` said:

> `homebrew-tap` is the only repo in the org with a bypass entry

That is false, and the template v12 lane read it and concluded logmind's own `regen-on-main` push might be getting GH013-refused — which would have been a genuine blocker for `dev` reaching `main`. It isn't.

## Measured, 2026-08-15, across all seven org repos

The steward's bypass rides on the two **organization-level** rulesets, which appear in every repo:

| ruleset | name | bypass actors |
|---|---|---|
| `18502737` | org-baseline | `3951953` (steward) |
| `16898453` | org-default-protection | `2`, `5`, `3951953` |

```sh
gh api repos/thrillmade/<repo>/rulesets --jq '.[] | "\(.id) \(.name)"'
gh api repos/thrillmade/<repo>/rulesets/<id> \
  --jq '.bypass_actors[]? | "\(.actor_type) \(.actor_id) \(.bypass_mode)"'
gh api /apps/skdd-steward --jq .id     # → 3951953
```

**Control:** the repo-specific rulesets `20570854`, `18292238` and `16434011` do **not** list the steward. That is what makes the measurement meaningful rather than a probe matching everything.

The claim was presumably true when a repo-specific ruleset carried the entry, and stopped being true when it moved to the org level — with nothing noticing, because no one re-measured.

This also confirms #288's premise: the bypass is granted. What remains untested there is only whether a regen commit actually lands on `main`.