### PR TITLE
fix(writeaudit): route managed writes through the symlink-refusing primitive, and fail CI on the next raw one

### DIFF
--- a/docs/decisions-branches/fix__writefile-symlink-sweep.md
+++ b/docs/decisions-branches/fix__writefile-symlink-sweep.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-15 15:55 - atomicio: an atomic replace swaps the name, it does not write into the inode — one rule, and the earlier entry was wrong
+
+**Reasoning:** Two independent panels found the same thing: converting an existing-file write silently widened its permissions, severed hardlinks and detached a deliberately symlinked target. This branch had argued in one place that exactly those consequences were the reason a write-through must be kept, and then caused them elsewhere with no note. The earlier decision entry on this branch argues that forcing the mode is inherent to the primitive; that is now false and is corrected here rather than left standing. The primitive reproduces the standard call exactly: the permission argument is a create mode, the umask applies to it, and an existing regular file keeps whatever mode it had.
+
+**Alternatives considered:** Exempt the one site that needs write-through and convert everything else. Rejected: an exemption records that a rule was inconvenient, not why it does not apply. The keep now survives on the rule itself, because writing through a deliberately shared hook is the intent and git never checks out into the git directory, so a hostile repository cannot plant the link. Its old justification about mode clobbering was deleted because the rule made it untrue.
+
+**Implications:**
+- Sites are identified by the function that encloses them rather than by a count or a line number: a count lets a kept call be laundered into a helper that anything may call, and line numbers churn until people re-baseline the ledger out of habit. The guard catches aliased and dot imports by resolving from the import declarations, and states plainly what it cannot see, which is any write through a file handle already held. Nineteen mutations, all compiled, all died; one initially survived because no probe existed for a create without a truncate, which is the lock file's shape.
+
+---
+

--- a/docs/decisions-branches/fix__writefile-symlink-sweep.md
+++ b/docs/decisions-branches/fix__writefile-symlink-sweep.md
@@ -48,3 +48,14 @@
 
 ---
 
+## 2026-08-15 16:59 - atomicio: pin the fsync's order, not its presence, and stop banning the flag a safe open needs
+
+**Reasoning:** The test I accepted for the durability promise could not see the thing it promised. Moving the sync to after the rename compiled and the whole suite stayed green, because the file handle reports the name it was opened with, so a check for the temporary suffix still matched and a stat of that name still failed. Deleting the call was the only breakage it could detect, and deleting the call was not the only way to break it. Separately the open-file whitelist banned the flag that opens a path without following a symlink, which is the exact defence this change exists to encourage, so the most careful possible caller would have been flagged and would most likely have answered with an allowlist entry exempting their file forever.
+
+**Alternatives considered:** Widen the whitelist by name shape, since the safe flags share a prefix. Rejected because a constant can be named like a safe flag and not be one: the flag that creates an unnamed inode matches the shape and is now excluded deliberately, with a test asserting it stays excluded so the widening cannot drift into accepting anything that merely looks right.
+
+**Implications:**
+- The spy now asserts the destination does not yet exist at the moment the sync fires, which is the ordering signal rather than a proxy for it, and both mutations die: moving the call after the rename and removing it entirely. A bare zero is accepted as read-only, on the same reasoning as the symlink flag, while any other unlabelled number stays banned because an unverifiable constant must not be the quiet way past the audit.
+
+---
+

--- a/docs/decisions-branches/fix__writefile-symlink-sweep.md
+++ b/docs/decisions-branches/fix__writefile-symlink-sweep.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-15 15:08 - writeaudit: the stale-entry check fired on its first real handoff, exactly as intended
+
+**Reasoning:** CI went red on this branch while the same suite was green in the worktree it was built in, because CI tests the merge with the default branch and that branch had moved. The 300 lane routed one of init.go's writes through the primitive, taking that file from five raw calls to four, and the allowlist still claimed five. The audit refuses a listed file whose count has dropped as well as one whose count has risen, so it reported the entry as stale rather than quietly permitting a number that no longer described the file.
+
+**Alternatives considered:** Make the allowlist a ceiling rather than an exact count, so a file getting safer never fails. Rejected: an entry that keeps passing after the reason for it disappears is how a temporary exemption becomes permanent permission, which is the specific decay this audit exists to prevent. The lane-handoff entries are supposed to be deleted as their branches land, and the only thing that reliably forces a deletion is a failure.
+
+**Implications:**
+- The count is lowered to four rather than removed, because the remaining calls are still real and still belong to another lane. When that lane lands the entry must disappear entirely, and the audit will say so by failing rather than by staying quiet. Full suite after merging the default branch: twenty-three packages passing, none failing.
+
+---
+

--- a/docs/decisions-branches/fix__writefile-symlink-sweep.md
+++ b/docs/decisions-branches/fix__writefile-symlink-sweep.md
@@ -37,3 +37,14 @@
 
 ---
 
+## 2026-08-15 16:30 - writeaudit: a banned primitive referenced is as dangerous as one called, and a flag whitelist beats a name prefix
+
+**Reasoning:** The guard inspected only the function position of a call, so assigning the banned primitive to a variable and calling that hid it completely. This is not hypothetical: the codebase already contains that idiom with the safe primitive, so someone copying the pattern with the unsafe one is exactly the accident the guard names as its target, and it was not in the documented list of things it cannot see. Separately the open-file check accepted any identifier whose name began with the flag prefix, which contradicted the guard's own doc promising that an unreadable flag is banned rather than waved through.
+
+**Alternatives considered:** Document both as known limits rather than closing them. Rejected: a limit worth stating is one the guard cannot close, and both of these were a few lines. A guard whose stated limits are wider than its real ones teaches people to route around it, and the whole argument for having a source scan here is that no behavioural test can cover this class.
+
+**Implications:**
+- Safe open-file flags are now a closed whitelist of the six the standard library defines as non-creating, so a constant merely named like one falls through to banned rather than passing on its spelling. The fsync this change introduced was itself unpinned and its removal survived the suite, which is now fixed by routing it through a replaceable reference a test can observe. The hardlink asymmetry between the two write sites is documented rather than equalised, because a shared hook is an advertised arrangement and a hardlinked agent file is not.
+
+---
+

--- a/docs/decisions-branches/fix__writefile-symlink-sweep.md
+++ b/docs/decisions-branches/fix__writefile-symlink-sweep.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-writeaudit-route-every-managed-write-through-the-symlink-ref -->
+- **2026-08-15** — writeaudit: route every managed write through the symlink-refusing primitive, and fail CI on the next raw one
+<!-- logmind-entry-end -->
+
+## 2026-08-15 14:51 - writeaudit: route every managed write through the symlink-refusing primitive, and fail CI on the next raw one
+
+**Reasoning:** os.WriteFile follows symlinks, so any site that asks whether a file exists, reads not-exist as safe to create, and then writes, can be redirected outside the repository by a planted dangling link. logmind runs inside repositories its user did not write. My own search found twenty-six sites across thirteen files rather than the twenty-three across twelve I was handed, and the difference was found by planting a call in a scratch file and confirming the pattern returned it before trusting where it returned nothing. Reproduced through real command paths rather than helpers: before the change a skill file, a provenance file, an executable pre-commit hook, a rendered file structure, a settings file and a draft were all written outside the repository, with sizes recorded; after it every one of those targets is absent and the tool path is a regular file.
+
+**Alternatives considered:** Convert every site mechanically. Rejected: one site is reached only after a read already succeeded, so a dangling link cannot arrive there, and a deliberately symlinked pre-commit hook is a normal arrangement that the atomic rename would detach while also forcing the mode to executable, breaking a documented contract. That one is kept with the argument recorded rather than converted for consistency.
+
+**Implications:**
+- Fixing twenty-six sites without a guard only means the twenty-seventh arrives later, so the change adds an audit that parses the syntax tree rather than grepping, because a dozen comments mention the function in prose. It fails on an unlisted file, on a higher count in a listed file, and on a stale entry, so the entries covering other lanes must be deleted as those land instead of decaying into blanket permission. Two sites in dependabot.go are vulnerable and belong to another lane; they are listed as an explicit gap rather than silently permitted. Nine mutations, all compiled, all died, including one proving the guard catches a second raw call in a file the allowlist permits once.
+
+---
+

--- a/internal/atomicio/atomicio.go
+++ b/internal/atomicio/atomicio.go
@@ -1,16 +1,50 @@
-// Package atomicio provides a single crash-safe file-write primitive:
-// write to a temp sibling in the file's own directory, then atomically
-// rename it into place.
+// Package atomicio provides this codebase's file-write primitive: write to
+// a temp sibling in the destination's own directory, then atomically rename
+// it into place.
 //
-// Why this matters: os.WriteFile on an EXISTING path opens with O_TRUNC,
+// Why a rename at all: os.WriteFile on an EXISTING path opens with O_TRUNC,
 // then writes — two separate syscalls. A crash (power loss, OOM kill,
 // SIGKILL) between the truncate and the write completing leaves the file
-// empty or partially written on disk. WriteFile here never touches the
-// destination path directly: the temp file is written and fsync'd-by-Close
-// in full, then os.Rename swaps it in — a single filesystem operation that
-// is atomic on the platforms Go supports (same-directory rename). The
-// destination either has its OLD full content or its NEW full content,
-// never a partial one.
+// empty or partially written on disk. WriteFile here never opens the
+// destination path: the temp file is written in full, then os.Rename swaps
+// it in — a single filesystem operation that is atomic on the platforms Go
+// supports (same-directory rename).
+//
+// # THE ONE RULE
+//
+// An atomic replace swaps the destination NAME. It does not write into the
+// destination's inode. Every consequence below follows from that one fact,
+// and every caller — and every deliberate NON-caller — is justified by it:
+//
+//  1. MODE. Because the bytes land in a new file, the mode is whatever we
+//     give it, so it has to be chosen deliberately. WriteFile reproduces
+//     os.WriteFile exactly: perm is the CREATE mode and is subject to the
+//     process umask; an existing regular file KEEPS the mode it already has.
+//     A caller that means to assert a mode says so, by calling WriteFileMode.
+//
+//  2. SYMLINKS. A symlink on the destination is refused — not followed, not
+//     silently replaced. That refusal is what closes the dangling-symlink
+//     arbitrary-write primitive. It also means a DELIBERATELY symlinked
+//     target is refused rather than updated through the link; see
+//     RefuseSymlink, which spells out both halves and what it does not cover.
+//
+//  3. IDENTITY. Rename gives the destination a NEW inode. Hardlinks to the
+//     old inode are severed and keep the OLD content; an open file
+//     descriptor, an flock, or an inode-keyed cache still refers to the old
+//     inode and no longer to this path. A caller that needs the inode
+//     preserved — appending through a link the user set up on purpose,
+//     writing a file something else holds a lock on — must NOT use this
+//     package. TestWriteFile_RenameSeversHardlinks pins this so it is a
+//     stated contract rather than a surprise.
+//
+// # DURABILITY
+//
+// WriteFile fsyncs the temp file before renaming, so the bytes are on disk
+// before the name points at them: the destination has either its OLD full
+// content or its NEW full content, never a partial one. It does NOT fsync
+// the containing directory, so a crash immediately after the rename may lose
+// the rename itself and leave the old content in place. That is the entire
+// promise — there is no stronger one.
 //
 // This consolidates a pattern that already existed twice in this codebase
 // under different names — internal/skill/sync.go's realAtomicWriteFile and
@@ -19,15 +53,16 @@
 // (and, per audit, three sites — internal/claudehook, internal/hooks,
 // internal/inserter — hadn't derived it at all, using a bare os.WriteFile
 // against an existing file).
-//
-// It also refuses to write through a symlink at the destination — see
-// RefuseSymlink.
 package atomicio
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 )
 
 // RefuseSymlink returns a clear error when path already exists as a
@@ -45,6 +80,25 @@ import (
 // link and whatever it points to untouched, beats guessing which of
 // those two outcomes the caller wanted.
 //
+// SAY IT PLAINLY: this cuts both ways. A symlink somebody planted is
+// refused, and so is a symlink somebody MEANT — point docs/timeline.md at a
+// shared file and logmind will decline to write it rather than detach the
+// link. The error names the link's target so the caller can write that path
+// directly instead. Refusing is the deliberate trade: the tool cannot tell a
+// deliberate link from a planted one, and quietly picking either behaviour
+// is worse than saying so.
+//
+// WHAT THIS DOES NOT COVER: only the FINAL path component is checked. If an
+// ancestor DIRECTORY is a symlink (`ln -s /elsewhere repo/.claude`), every
+// path beneath it resolves through that link and the write lands wherever it
+// points — this function returns nil and WriteFile proceeds. That is
+// deliberate: symlinked ancestors are ordinary (a repo under a symlinked
+// ~/code, /tmp -> /private/tmp on macOS), refusing them would break normal
+// setups, and the only real fix is a beneath-the-root resolve (openat2
+// RESOLVE_BENEATH) that is Linux-only and belongs at the layer that knows
+// the repo root, not here. Do not read a nil return as "this path is inside
+// the repository".
+//
 // A path that does not exist yet, or exists as a regular file or
 // directory, returns nil — there is nothing to refuse.
 func RefuseSymlink(path string) error {
@@ -56,17 +110,62 @@ func RefuseSymlink(path string) error {
 		return nil
 	}
 	if target, rerr := os.Readlink(path); rerr == nil {
-		return fmt.Errorf("refusing to write %s: it is a symlink to %s; remove it and retry", path, target)
+		return fmt.Errorf("refusing to write %s: it is a symlink to %s. "+
+			"Writes here replace the file by rename, which would detach the link instead of "+
+			"updating what it points at — if the link is deliberate, run logmind against %s "+
+			"(or write that path directly); if it is not, remove the link and retry",
+			path, target, target)
 	}
-	return fmt.Errorf("refusing to write %s: it is a symlink; remove it and retry", path)
+	return fmt.Errorf("refusing to write %s: it is a symlink. "+
+		"Writes here replace the file by rename, which would detach the link instead of "+
+		"updating what it points at — remove the link and retry, or write the file it names directly",
+		path)
 }
 
-// WriteFile atomically writes data to path with permission bits perm,
-// whether path already exists or not. On any failure the temp file is
-// removed and path is left completely untouched.
+// WriteFile atomically writes data to path, whether path already exists or
+// not. On any failure the temp file is removed and path is left completely
+// untouched.
 //
-// Refuses up front, via RefuseSymlink, when path is currently a symlink.
+// MODE — os.WriteFile's rule, reproduced: perm applies only when this call
+// CREATES the file, and the kernel applies the process umask to it there. An
+// existing regular file keeps the mode it already has, and perm is ignored.
+// Converting an os.WriteFile call site to this one therefore does not change
+// what the user sees in `ls -l`. Call WriteFileMode when the mode is the
+// point.
+//
+// SYMLINKS — refused up front, via RefuseSymlink, when path is currently a
+// symlink. Read that doc comment: it refuses deliberate links too, and it
+// only inspects the final path component.
+//
+// IDENTITY — the rename gives path a NEW inode. Hardlink twins are severed
+// and keep the old content; open descriptors and advisory locks on the old
+// inode stop referring to this path. If that matters at your call site, this
+// is the wrong primitive.
+//
+// DURABILITY — the temp file is fsynced before the rename; the containing
+// directory is not. See the package doc.
 func WriteFile(path string, data []byte, perm os.FileMode) error {
+	return write(path, data, perm, false)
+}
+
+// WriteFileMode is WriteFile with the mode ASSERTED rather than inherited:
+// the file ends up at mode, whether it already existed or not, and the umask
+// does not apply. It is the atomic equivalent of os.WriteFile followed by an
+// unconditional os.Chmod.
+//
+// Use it only where the mode is part of what the call site is for — a git
+// hook that must stay executable, a config the tool keeps at 0600, a copy
+// that must reproduce its source's bits. Everywhere else use WriteFile, so
+// that routing a write through this package never silently re-permissions a
+// file the user owns.
+//
+// Every other clause of the one rule is unchanged: symlinks are refused, and
+// the rename still severs hardlinks and changes the inode.
+func WriteFileMode(path string, data []byte, mode os.FileMode) error {
+	return write(path, data, mode, true)
+}
+
+func write(path string, data []byte, perm os.FileMode, assertMode bool) error {
 	if err := RefuseSymlink(path); err != nil {
 		return err
 	}
@@ -74,11 +173,38 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+
+	// Two ways to land the mode, and which one applies is the whole of
+	// rule 1:
+	//
+	//   createMode is handed to open(2), so the kernel applies the umask
+	//   to it — the same path os.WriteFile takes when it creates a file.
+	//
+	//   chmodTo is applied to the temp file before the rename, which the
+	//   umask does NOT touch — used to carry an existing file's mode
+	//   across the replace (WriteFile), or to assert one (WriteFileMode).
+	//
+	// When a chmod is coming, the file is created 0600 first so it is
+	// never briefly wider than it will end up.
+	createMode := perm
+	chmodTo := os.FileMode(0)
+	chmod := false
+	switch {
+	case assertMode:
+		chmodTo, chmod, createMode = perm, true, 0o600
+	default:
+		// os.Lstat, not os.Stat: RefuseSymlink already established the
+		// final component is not a link, and Lstat cannot be talked into
+		// resolving one that appears between the two calls.
+		if fi, err := os.Lstat(path); err == nil && fi.Mode().IsRegular() {
+			chmodTo, chmod, createMode = fi.Mode().Perm(), true, 0o600
+		}
+	}
+
+	tmp, tmpName, err := createTemp(dir, filepath.Base(path), createMode)
 	if err != nil {
 		return err
 	}
-	tmpName := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpName) }
 
 	if _, err := tmp.Write(data); err != nil {
@@ -86,7 +212,15 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 		cleanup()
 		return err
 	}
-	if err := tmp.Chmod(perm); err != nil {
+	if chmod {
+		if err := tmp.Chmod(chmodTo); err != nil {
+			_ = tmp.Close()
+			cleanup()
+			return err
+		}
+	}
+	// Data on disk before the name points at it — see DURABILITY.
+	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		cleanup()
 		return err
@@ -100,4 +234,41 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	return nil
+}
+
+// createTemp makes an exclusively-created sibling of base in dir at exactly
+// mode (modulo umask, which is the point — see write).
+//
+// os.CreateTemp would be the obvious call and is what this used to use, but
+// it hardcodes 0600 and offers no way to hand a mode to open(2); the umask
+// then never gets a say, and `logmind init` under `umask 077` produced 0644
+// files where a plain os.WriteFile produced 0600. The name still carries an
+// unguessable random suffix and is still created O_EXCL, which is what makes
+// planting a symlink at the temp path useless.
+func createTemp(dir, base string, mode os.FileMode) (*os.File, string, error) {
+	prefix := filepath.Join(dir, base+".tmp-")
+	for i := 0; i < 1000; i++ {
+		name := prefix + randomSuffix()
+		f, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, mode)
+		if err == nil {
+			return f, name, nil
+		}
+		if os.IsExist(err) {
+			continue
+		}
+		return nil, "", err
+	}
+	return nil, "", fmt.Errorf("atomicio: could not create a temp sibling for %s after 1000 attempts", filepath.Join(dir, base))
+}
+
+func randomSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand does not fail on any platform this ships to. If it
+		// somehow does, a time+pid suffix keeps the write working; the
+		// O_EXCL retry loop above still guarantees exclusivity, only the
+		// unguessability weakens.
+		return strconv.FormatInt(time.Now().UnixNano(), 36) + "-" + strconv.Itoa(os.Getpid())
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/internal/atomicio/atomicio.go
+++ b/internal/atomicio/atomicio.go
@@ -165,6 +165,16 @@ func WriteFileMode(path string, data []byte, mode os.FileMode) error {
 	return write(path, data, mode, true)
 }
 
+// syncFile fsyncs f. A package-level var, not a direct tmp.Sync() call
+// inline in write(), so TestWriteFile_FsyncsBeforeRename can substitute a
+// spy that records the call (still delegating to the real fsync, so
+// behaviour is unchanged) — the same "swap in an observer, restore after"
+// shape internal/skill/sync.go uses for atomicWriteFile, applied here
+// because deleting the fsync call is otherwise a silent, compiling,
+// suite-green mutation: nothing else in this package's tests reads through
+// the OS page cache after a simulated crash to notice its absence.
+var syncFile = func(f *os.File) error { return f.Sync() }
+
 func write(path string, data []byte, perm os.FileMode, assertMode bool) error {
 	if err := RefuseSymlink(path); err != nil {
 		return err
@@ -219,8 +229,14 @@ func write(path string, data []byte, perm os.FileMode, assertMode bool) error {
 			return err
 		}
 	}
-	// Data on disk before the name points at it — see DURABILITY.
-	if err := tmp.Sync(); err != nil {
+	// Data on disk before the name points at it — see DURABILITY. Routed
+	// through syncFile, not called directly, so the durability promise is
+	// pinned by TestWriteFile_FsyncsBeforeRename rather than resting on the
+	// "19 mutations, all killed" claim alone: deleting this call is a
+	// one-line, compiling change with no other observable effect (no test
+	// in this package reads through the OS page cache after a simulated
+	// crash), so nothing else in the suite would go red for it.
+	if err := syncFile(tmp); err != nil {
 		_ = tmp.Close()
 		cleanup()
 		return err

--- a/internal/atomicio/atomicio_test.go
+++ b/internal/atomicio/atomicio_test.go
@@ -10,6 +10,12 @@ import (
 
 // TestWriteFile_CreatesNewFile covers the "file doesn't exist yet" path:
 // content and mode land correctly, and no temp file is left behind.
+//
+// The expected mode is MEASURED against os.WriteFile rather than asserted as
+// a literal, because rule 1 is "reproduce os.WriteFile" and os.WriteFile
+// hands perm to open(2), where the umask takes bits off it. A hardcoded
+// 0o644 here would pass on a 022 machine and fail on a 077 one — and would
+// have hidden the very bug this test now pins.
 func TestWriteFile_CreatesNewFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "fresh.json")
@@ -18,13 +24,13 @@ func TestWriteFile_CreatesNewFile(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	assertContent(t, path, `{"a":1}`)
-	assertMode(t, path, 0o644)
+	assertMode(t, path, referenceCreateMode(t, 0o644))
 	assertNoTmpResidue(t, dir)
 }
 
 // TestWriteFile_OverwritesExistingFile is the core guard for the MAJOR
 // fix: overwriting an EXISTING file must land the new content in full,
-// with the right mode, and leave no temp residue behind.
+// and leave no temp residue behind.
 func TestWriteFile_OverwritesExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
@@ -39,6 +45,148 @@ func TestWriteFile_OverwritesExistingFile(t *testing.T) {
 	assertContent(t, path, "new content, longer than old")
 	assertMode(t, path, 0o644)
 	assertNoTmpResidue(t, dir)
+}
+
+// TestWriteFile_PreservesExistingModeAndIgnoresPerm is rule 1, and the
+// regression for what two review panels found: converting an existing-file
+// write from os.WriteFile to atomicio.WriteFile silently RE-PERMISSIONED the
+// user's file, because the old implementation chmod'd the temp to perm
+// unconditionally. os.WriteFile hands perm to open(2), which ignores it when
+// the file already exists — so a 0600 AGENTS.md stayed 0600 under os.WriteFile
+// and became world-readable 0644 the moment the call was "made safer".
+//
+// Mutation note: this fails on a one-character change (dropping the Lstat
+// branch in write()), which is the mutation that reintroduces the bug.
+func TestWriteFile_PreservesExistingModeAndIgnoresPerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't map cleanly on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil { // defeat the seeding umask
+		t.Fatalf("chmod seed: %v", err)
+	}
+
+	if err := WriteFile(path, []byte("new"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	assertContent(t, path, "new")
+	assertMode(t, path, 0o600)
+
+	// And the reference implementation agrees — this is not our own opinion
+	// about what "preserve" means.
+	ref := filepath.Join(dir, "reference.md")
+	if err := os.WriteFile(ref, []byte("old"), 0o600); err != nil {
+		t.Fatalf("seed reference: %v", err)
+	}
+	if err := os.Chmod(ref, 0o600); err != nil {
+		t.Fatalf("chmod reference: %v", err)
+	}
+	if err := os.WriteFile(ref, []byte("new"), 0o644); err != nil {
+		t.Fatalf("rewrite reference: %v", err)
+	}
+	assertMode(t, ref, 0o600)
+}
+
+// TestWriteFileMode_AssertsModeOnExistingFile is the other half of rule 1:
+// a call site for which the mode IS the point says so, and gets it whether
+// the destination existed or not. This is what installHook (executable bit)
+// and copyTree (source bits) call.
+func TestWriteFileMode_AssertsModeOnExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't map cleanly on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pre-commit")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho old\n"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+
+	if err := WriteFileMode(path, []byte("#!/bin/sh\necho new\n"), 0o755); err != nil {
+		t.Fatalf("WriteFileMode: %v", err)
+	}
+	assertContent(t, path, "#!/bin/sh\necho new\n")
+	assertMode(t, path, 0o755)
+	assertNoTmpResidue(t, dir)
+}
+
+// TestWriteFileMode_AssertsModeIgnoringUmaskOnCreate pins that the assert
+// path is a chmod, not an open(2) mode — the umask must not take the
+// executable bit back off a hook we are creating.
+func TestWriteFileMode_AssertsModeIgnoringUmaskOnCreate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits don't map cleanly on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fresh-hook")
+
+	if err := WriteFileMode(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFileMode: %v", err)
+	}
+	assertMode(t, path, 0o755)
+}
+
+// TestWriteFile_RenameSeversHardlinks pins rule 3 as a CONTRACT rather than
+// leaving it as a surprise. An atomic replace swaps the name, so the
+// destination gets a new inode: any hardlink twin keeps pointing at the old
+// inode with the OLD content, and os.SameFile stops agreeing.
+//
+// This is exactly what the panel measured on `logmind agents update --apply`
+// (before: links=2, twin updated; after: links=1, twin stale). It is not a
+// bug to fix — it is inherent to atomic replace — so it is written down and
+// pinned here, and call sites that need the inode preserved are told not to
+// use this package.
+func TestWriteFile_RenameSeversHardlinks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	twin := filepath.Join(dir, "AGENTS-hardlink.md")
+
+	if err := os.WriteFile(path, []byte("shared original\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := os.Link(path, twin); err != nil {
+		t.Skipf("hardlinks unavailable on this filesystem: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+	// Control: prove the twin really is the same inode, or the assertion
+	// below proves nothing.
+	twinBefore, err := os.Stat(twin)
+	if err != nil {
+		t.Fatalf("stat twin before: %v", err)
+	}
+	if !os.SameFile(before, twinBefore) {
+		t.Fatalf("hardlink twin is not the same inode; test would be vacuous")
+	}
+
+	if err := WriteFile(path, []byte("rewritten\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if os.SameFile(before, after) {
+		t.Errorf("%s kept its inode across the write; the package doc promises a rename "+
+			"(new inode) and callers are told to expect severed hardlinks — one of the two is now wrong", path)
+	}
+	twinBody, err := os.ReadFile(twin)
+	if err != nil {
+		t.Fatalf("read twin: %v", err)
+	}
+	if string(twinBody) != "shared original\n" {
+		t.Errorf("hardlink twin = %q; want the OLD content — rename severs the link, "+
+			"and the doc comment on WriteFile says so", twinBody)
+	}
 }
 
 // TestWriteFile_RefusesSymlinkDestination_ExistingTargetUntouched covers
@@ -67,6 +215,14 @@ func TestWriteFile_RefusesSymlinkDestination_ExistingTargetUntouched(t *testing.
 	}
 	if !strings.Contains(err.Error(), "symlink") {
 		t.Errorf("error = %q; want it to name the symlink so the caller knows what to remove", err)
+	}
+	// The refusal has to be actionable, not just loud: it names the target
+	// so a caller with a DELIBERATE link knows which path to write instead.
+	if !strings.Contains(err.Error(), target) {
+		t.Errorf("error = %q; want it to name the link target %s so the caller knows how to proceed", err, target)
+	}
+	if !strings.Contains(err.Error(), "remove the link") {
+		t.Errorf("error = %q; want it to say what to do about the link, not only that it exists", err)
 	}
 
 	fi, err := os.Lstat(link)
@@ -115,14 +271,62 @@ func TestWriteFile_RefusesDanglingSymlinkDestination(t *testing.T) {
 	}
 }
 
-// TestWriteFile_PreservesExecutableMode covers the git-hook call site
-// (0o755) — the mode argument must round-trip exactly, matching the
-// executable-bit contract installHook relies on.
+// TestRefuseSymlink_DoesNotSeeThroughAnAncestorDirectory pins the STATED
+// LIMIT of rule 2 so nobody mistakes it for a containment boundary.
+// RefuseSymlink lstats the final component only. When an ancestor directory
+// is a symlink — `ln -s /elsewhere repo/.claude`, then `logmind skill new
+// sample` — the write resolves through it and lands outside the repo, and
+// this package returns nil.
+//
+// This test asserts the CURRENT behaviour on purpose. It exists so the limit
+// is discovered by reading a test rather than by a report: refusing every
+// symlinked ancestor would break ordinary setups (a repo under a symlinked
+// ~/code; /tmp -> /private/tmp on macOS), and a real fix is a
+// resolve-beneath-the-repo-root check at the layer that knows where the repo
+// root is, not here. If somebody later adds that check and this test goes
+// red, that is the good outcome — delete it and say so.
+func TestRefuseSymlink_DoesNotSeeThroughAnAncestorDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	outside := filepath.Join(base, "outside")
+	for _, d := range []string{repo, outside} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, ".claude")); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	dest := filepath.Join(repo, ".claude", "skills", "sample", "SKILL.md")
+	if err := RefuseSymlink(dest); err != nil {
+		t.Fatalf("RefuseSymlink returned %v; the documented behaviour is nil for a symlinked ANCESTOR", err)
+	}
+	if err := WriteFile(dest, []byte("body"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	landed := filepath.Join(outside, "skills", "sample", "SKILL.md")
+	if _, err := os.Lstat(landed); err != nil {
+		t.Fatalf("expected the write to land at %s (the documented limit); Lstat: %v", landed, err)
+	}
+}
+
+// TestWriteFile_PreservesExecutableMode covers the git-hook call site: a
+// pre-existing 0o755 hook stays 0o755 across an atomic rewrite. Under rule 1
+// this now passes by PRESERVATION rather than by an unconditional chmod —
+// which is why installHook, whose whole job is to guarantee the executable
+// bit, calls WriteFileMode instead of relying on this.
 func TestWriteFile_PreservesExecutableMode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "post-merge")
 	if err := os.WriteFile(path, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
 		t.Fatalf("seed file: %v", err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod seed: %v", err)
 	}
 
 	if err := WriteFile(path, []byte("#!/bin/sh\necho new\n"), 0o755); err != nil {
@@ -144,6 +348,30 @@ func TestWriteFile_CreatesMissingParentDir(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	assertContent(t, path, "hello")
+}
+
+// TestWriteFile_TempNameIsUnguessable keeps the property the whole
+// temp+rename design leans on after os.CreateTemp was replaced with an
+// explicit O_EXCL loop: two writes in the same directory must not reuse a
+// name an attacker could pre-plant.
+func TestWriteFile_TempNameIsUnguessable(t *testing.T) {
+	dir := t.TempDir()
+	seen := map[string]bool{}
+	for i := 0; i < 32; i++ {
+		f, name, err := createTemp(dir, "probe", 0o600)
+		if err != nil {
+			t.Fatalf("createTemp: %v", err)
+		}
+		_ = f.Close()
+		base := filepath.Base(name)
+		if seen[base] {
+			t.Fatalf("createTemp reused the name %s; the temp path must not be predictable", base)
+		}
+		seen[base] = true
+		if !strings.HasPrefix(base, "probe.tmp-") || len(base) <= len("probe.tmp-")+8 {
+			t.Fatalf("temp name %q has no substantial random suffix", base)
+		}
+	}
 }
 
 func assertContent(t *testing.T, path, want string) {
@@ -169,6 +397,22 @@ func assertMode(t *testing.T, path string, want os.FileMode) {
 	if fi.Mode().Perm() != want {
 		t.Errorf("mode = %o; want %o", fi.Mode().Perm(), want)
 	}
+}
+
+// referenceCreateMode measures what os.WriteFile — the behaviour rule 1
+// promises to reproduce — actually produces for perm on a fresh file under
+// this process's umask, instead of assuming a umask.
+func referenceCreateMode(t *testing.T, perm os.FileMode) os.FileMode {
+	t.Helper()
+	probe := filepath.Join(t.TempDir(), "umask-probe")
+	if err := os.WriteFile(probe, nil, perm); err != nil {
+		t.Fatalf("umask probe: %v", err)
+	}
+	fi, err := os.Stat(probe)
+	if err != nil {
+		t.Fatalf("stat umask probe: %v", err)
+	}
+	return fi.Mode().Perm()
 }
 
 // assertNoTmpResidue confirms WriteFile cleaned up: no "<base>.tmp-*"

--- a/internal/atomicio/atomicio_test.go
+++ b/internal/atomicio/atomicio_test.go
@@ -383,6 +383,16 @@ func TestWriteFile_TempNameIsUnguessable(t *testing.T) {
 // page cache — so that claim was not reproducible from the tree alone. This
 // substitutes a spy for the package-level syncFile hook and asserts it
 // fires, on the TEMP file, before the rename lands.
+//
+// The syncedName/tmp-residue checks below pin PRESENCE — that syncFile was
+// called, and on a temp-shaped name — not ORDER: os.File.Name() returns the
+// name the file was opened with, so it still reads ".tmp-*" and the temp
+// path still Lstats as gone even if the call were moved to fire AFTER
+// os.Rename. The destination-does-not-exist-yet check inside the spy is
+// what actually pins "before": at the instant syncFile fires, os.Rename
+// must not have run, so path must not exist yet. If the sync call moves
+// after the rename, path already exists when the spy runs and this fails —
+// where the two checks above would still pass.
 func TestWriteFile_FsyncsBeforeRename(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "durable.txt")
@@ -391,6 +401,11 @@ func TestWriteFile_FsyncsBeforeRename(t *testing.T) {
 	orig := syncFile
 	syncFile = func(f *os.File) error {
 		syncedName = f.Name()
+		if _, err := os.Lstat(path); err == nil {
+			t.Errorf("destination %s already exists when syncFile fired — the rename has already "+
+				"happened, so this is a fsync-AFTER-rename, not a fsync-BEFORE-rename; the "+
+				"DURABILITY promise in the package doc is broken", path)
+		}
 		return orig(f) // still perform the real fsync; only observe, don't change behaviour
 	}
 	defer func() { syncFile = orig }()

--- a/internal/atomicio/atomicio_test.go
+++ b/internal/atomicio/atomicio_test.go
@@ -374,6 +374,44 @@ func TestWriteFile_TempNameIsUnguessable(t *testing.T) {
 	}
 }
 
+// TestWriteFile_FsyncsBeforeRename is the HIGH-4 regression: the DURABILITY
+// promise in the package doc ("the temp file is fsynced before the
+// rename") was, until this test, backed by nothing but the mutation-testing
+// claim in the PR description. Deleting the tmp.Sync() call in write() is a
+// one-line, compiling change with no other observable effect in this
+// package's suite — no test here simulates a crash and re-reads through the
+// page cache — so that claim was not reproducible from the tree alone. This
+// substitutes a spy for the package-level syncFile hook and asserts it
+// fires, on the TEMP file, before the rename lands.
+func TestWriteFile_FsyncsBeforeRename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "durable.txt")
+
+	var syncedName string
+	orig := syncFile
+	syncFile = func(f *os.File) error {
+		syncedName = f.Name()
+		return orig(f) // still perform the real fsync; only observe, don't change behaviour
+	}
+	defer func() { syncFile = orig }()
+
+	if err := WriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if syncedName == "" {
+		t.Fatal("syncFile was never called — the temp file was not fsynced before the rename; " +
+			"the DURABILITY promise in the package doc is broken")
+	}
+	if !strings.Contains(syncedName, ".tmp-") {
+		t.Errorf("syncFile was called on %q; want the TEMP sibling (name contains \".tmp-\") — "+
+			"fsync must happen on the temp file BEFORE the rename, not on the destination after it",
+			syncedName)
+	}
+	if _, err := os.Lstat(syncedName); err == nil {
+		t.Errorf("temp file %s still exists after WriteFile returned; want it renamed away", syncedName)
+	}
+}
+
 func assertContent(t *testing.T, path, want string) {
 	t.Helper()
 	got, err := os.ReadFile(path)

--- a/internal/atomicio/atomicio_umask_unix_test.go
+++ b/internal/atomicio/atomicio_umask_unix_test.go
@@ -1,0 +1,100 @@
+//go:build !windows
+
+package atomicio
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestWriteFile_CreateRespectsUmask is the second half of the mode bug two
+// panels found. The old implementation created the temp at 0600 and then
+// chmod'd it to perm — and chmod(2) is not filtered by the umask, so
+// `logmind init` under `umask 077` produced world-readable 0644 files where
+// the os.WriteFile it replaced produced 0600.
+//
+// The fix hands perm to open(2) on the create path, exactly like
+// os.WriteFile, so the kernel applies the umask. Asserted against
+// os.WriteFile under the same umask rather than against a literal, so the
+// test states the contract ("indistinguishable from os.WriteFile") rather
+// than a number somebody has to keep in sync.
+//
+// syscall.Umask is process-global. Tests in this package do not call
+// t.Parallel(), so the mask is restored before any other test runs.
+func TestWriteFile_CreateRespectsUmask(t *testing.T) {
+	old := syscall.Umask(0o077)
+	defer syscall.Umask(old)
+
+	dir := t.TempDir()
+
+	reference := filepath.Join(dir, "reference.md")
+	if err := os.WriteFile(reference, []byte("x"), 0o644); err != nil {
+		t.Fatalf("reference os.WriteFile: %v", err)
+	}
+	refFi, err := os.Stat(reference)
+	if err != nil {
+		t.Fatalf("stat reference: %v", err)
+	}
+	// Control: prove the umask is actually in force, or the comparison
+	// below is vacuous and would pass with the bug present.
+	if refFi.Mode().Perm() != 0o600 {
+		t.Fatalf("os.WriteFile(0644) under umask 077 produced %04o, want 0600 — "+
+			"the umask is not in effect and this test proves nothing", refFi.Mode().Perm())
+	}
+
+	subject := filepath.Join(dir, "subject.md")
+	if err := WriteFile(subject, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fi, err := os.Stat(subject)
+	if err != nil {
+		t.Fatalf("stat subject: %v", err)
+	}
+	if fi.Mode().Perm() != refFi.Mode().Perm() {
+		t.Errorf("atomicio.WriteFile created %04o under umask 077; os.WriteFile created %04o. "+
+			"Rule 1 says perm is the CREATE mode and the umask applies to it — a chmod to perm "+
+			"after the fact ignores the umask and widens the file",
+			fi.Mode().Perm(), refFi.Mode().Perm())
+	}
+}
+
+// TestWriteFile_SeveredHardlinkDropsLinkCount is the syscall-level half of
+// TestWriteFile_RenameSeversHardlinks: st_nlink goes 2 -> 1, which is the
+// number the panel measured on the real command.
+func TestWriteFile_SeveredHardlinkDropsLinkCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	twin := filepath.Join(dir, "AGENTS-twin.md")
+
+	if err := os.WriteFile(path, []byte("shared\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Link(path, twin); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	if got := nlink(t, path); got != 2 {
+		t.Fatalf("link count before = %d, want 2; the test would be vacuous", got)
+	}
+
+	if err := WriteFile(path, []byte("rewritten\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := nlink(t, path); got != 1 {
+		t.Errorf("link count after = %d, want 1 — the rename is documented to sever hardlinks", got)
+	}
+}
+
+func nlink(t *testing.T, path string) uint64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skipf("no syscall.Stat_t on %T", fi.Sys())
+	}
+	return uint64(st.Nlink)
+}

--- a/internal/claudehook/claudehook.go
+++ b/internal/claudehook/claudehook.go
@@ -208,15 +208,21 @@ func EnsurePreToolUseGuard(repoRoot string) (changed bool, err error) {
 // writeFreshSettings creates repoRoot/.claude/settings.json (and the
 // .claude/ directory) from scratch, containing only the canonical
 // PreToolUse guard.
+//
+// This is reached from the ReadFile-said-ErrNotExist branch, which is
+// exactly the branch a dangling symlink at .claude/settings.json puts us
+// on: os.ReadFile follows the link, the link's target is missing, and
+// "absent" is reported for a path that is emphatically NOT absent. A bare
+// os.WriteFile here would then follow that same link and write the guard
+// config wherever it points — outside the repository. atomicio.WriteFile
+// creates the parent dir and lands the file by rename onto the NAME, so
+// the link target is never touched. Do not revert to os.WriteFile.
 func writeFreshSettings(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
 	out, err := canonicalSettingsBytes()
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0o644)
+	return atomicio.WriteFile(path, out, 0o644)
 }
 
 func canonicalSettingsBytes() ([]byte, error) {

--- a/internal/claudehook/symlink_writethrough_test.go
+++ b/internal/claudehook/symlink_writethrough_test.go
@@ -1,0 +1,77 @@
+package claudehook
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestEnsurePreToolUseGuard_DanglingSymlinkAtSettings is the regression for
+// writeFreshSettings.
+//
+// EnsurePreToolUseGuard branches on os.ReadFile(.claude/settings.json)
+// returning fs.ErrNotExist and calls writeFreshSettings for the "no settings
+// yet" case. A DANGLING symlink at that path produces exactly that error —
+// ReadFile follows the link and finds nothing at the far end — so a bare
+// os.WriteFile in writeFreshSettings followed the same link and dropped the
+// hook config outside the repository. The overwrite branch a few lines above
+// was already atomic; only the create branch was exposed, which is precisely
+// the branch the exploit steers into.
+//
+// This is the package's own entry point, called verbatim by `logmind
+// refresh`, `logmind init` and `logmind self-update` — those three commands
+// pass repoRoot and nothing else, so there is no additional command-layer
+// behaviour between them and this call.
+func TestEnsurePreToolUseGuard_DanglingSymlinkAtSettings(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	loot := filepath.Join(base, "outside", "loot-settings.json")
+	if err := os.MkdirAll(filepath.Join(base, "outside"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	settings := SettingsPath(repo)
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink(loot, settings); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Control: the trap must actually read as "absent", or the test never
+	// reaches the create branch and would pass against the unfixed code.
+	if _, err := os.ReadFile(settings); !os.IsNotExist(err) {
+		t.Fatalf("planted link does not read as absent (ReadFile err = %v); test would be vacuous", err)
+	}
+
+	_, err := EnsurePreToolUseGuard(repo)
+
+	if body, rerr := os.ReadFile(loot); rerr == nil {
+		t.Fatalf("WROTE THROUGH THE SYMLINK: %s was created outside the repository, %d bytes:\n%s",
+			loot, len(body), body)
+	} else if !os.IsNotExist(rerr) {
+		t.Fatalf("unexpected error reading %s: %v", loot, rerr)
+	}
+
+	// PR #300 turns this into an explicit refusal inside atomicio.WriteFile.
+	// Either outcome is acceptable; a refusal must say why.
+	if err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "symlink") &&
+			!strings.Contains(strings.ToLower(err.Error()), "symbolic link") {
+			t.Errorf("refused the write but the message does not name the problem: %v", err)
+		}
+		return
+	}
+	fi, lerr := os.Lstat(settings)
+	if lerr != nil {
+		t.Fatalf("succeeded but %s is missing: %v", settings, lerr)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("%s is still a symlink; the next settings write will follow it off-tree", settings)
+	}
+}

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/version"
 )
@@ -389,13 +390,20 @@ func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout, stderr io
 	}
 
 	// Apply path: rewrite each file in place.
+	//
+	// atomicio.WriteFile, not os.WriteFile: these paths come from a scan
+	// of a repository logmind did not necessarily write, and os.WriteFile
+	// follows symlinks. A symlinked AGENTS.md / workflow file would have
+	// its logmind block rewritten through the link, outside the repo.
+	// The rename lands on the NAME instead. (Also makes the rewrite
+	// crash-safe — the user's AGENTS.md is never a truncated stub.)
 	for _, e := range outdated {
 		data, err := os.ReadFile(e.Path)
 		if err != nil {
 			return err
 		}
 		refreshed := inserter.ReplaceMarkerBlock(string(data), e.NewBody)
-		if err := os.WriteFile(e.Path, []byte(refreshed), 0o644); err != nil {
+		if err := atomicio.WriteFile(e.Path, []byte(refreshed), 0o644); err != nil {
 			return err
 		}
 		rel, _ := filepath.Rel(cwd, e.Path)
@@ -407,7 +415,7 @@ func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout, stderr io
 			return err
 		}
 		rewritten, _ := inserter.UpdateWorkflowPin(string(data), p.NewVersion)
-		if err := os.WriteFile(p.Path, []byte(rewritten), 0o644); err != nil {
+		if err := atomicio.WriteFile(p.Path, []byte(rewritten), 0o644); err != nil {
 			return err
 		}
 		rel, _ := filepath.Rel(cwd, p.Path)

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -397,6 +397,27 @@ func runAgentsUpdate(cwd, currentVersion string, doApply bool, stdout, stderr io
 	// its logmind block rewritten through the link, outside the repo.
 	// The rename lands on the NAME instead. (Also makes the rewrite
 	// crash-safe — the user's AGENTS.md is never a truncated stub.)
+	//
+	// UNDISCLOSED UNTIL NOW, NOW DISCLOSED: atomicio's rule 3 (see its
+	// package doc) means the rename gives the destination a NEW inode. A
+	// HARDLINKED AGENTS.md — a twin path pointing at the same inode, set up
+	// by hand or by a dotfile manager — is silently detached: the twin keeps
+	// the OLD content, this command still exits 0, and nothing here warns
+	// that the two files just diverged. install_hook.go's force-append
+	// branch faces the identical fact and chooses the opposite behaviour
+	// (raw os.WriteFile, deliberately, to write THROUGH the link) — but that
+	// is not an inconsistency to resolve by matching it: a shared git hook
+	// via a hardlinked/symlinked .git/hooks/pre-commit is a common,
+	// documented setup (husky, chezmoi, dotfile managers), where write-
+	// through is the intent, while a hardlinked AGENTS.md twin is not a
+	// setup this command supports or has ever advertised — there is no
+	// call-site reasoning that write-through is wanted here, only the
+	// absence of a check. Detecting it (an Lstat + link-count check before
+	// every rewrite in this loop) is a real fix that belongs to whoever
+	// next touches this path; until then, the accepted behaviour is
+	// atomicio's documented one: a hardlinked destination is detached
+	// silently, same as any other atomicio.WriteFile call site that hasn't
+	// opted out for a stated reason.
 	for _, e := range outdated {
 		data, err := os.ReadFile(e.Path)
 		if err != nil {

--- a/internal/cli/install_hook.go
+++ b/internal/cli/install_hook.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/clierr"
 	"github.com/thrillmade/logmind/internal/gitcli"
 )
@@ -113,6 +114,20 @@ func runInstallHook(cwd string, force bool, stdout io.Writer) error {
 		// (Python appended a bare `logmind check-decisions` line here; #213
 		// upgrades that to the deadline-wrapped invocation).
 		newContent := strings.TrimRight(content, "\n") + "\n" + preCommitGuardedCall
+		// DELIBERATELY os.WriteFile, not atomicio.WriteFile. This is the
+		// append-onto-an-existing-hook branch, and it is the one place in
+		// the tree where write-through is the correct behaviour:
+		//   - The dangling-symlink attack cannot reach here. We are on the
+		//     ReadFile-succeeded branch, so the path resolves to a real
+		//     file; the exploit needs ReadFile to report ErrNotExist (see
+		//     the fresh-install branch below, which IS routed atomically).
+		//   - Symlinking .git/hooks/pre-commit at a shared/tracked script
+		//     is a common, deliberate setup (husky, dotfile-managed hooks).
+		//     atomicio renames onto the NAME, which would silently detach
+		//     that link and leave the user with a private copy.
+		//   - atomicio unconditionally chmods to the perm argument, which
+		//     would clobber the mode-preservation contract documented just
+		//     below.
 		if err := os.WriteFile(hookPath, []byte(newContent), 0o755); err != nil {
 			return err
 		}
@@ -120,16 +135,22 @@ func runInstallHook(cwd string, force bool, stdout io.Writer) error {
 		// already had its exec bit when read). Mirror that — don't
 		// chmod here either; if the user had a non-exec custom
 		// hook, we preserve their mode (best-effort, matches Python).
+		// os.WriteFile's perm argument above is inert for the same
+		// reason: it only applies on create.
 		fmt.Fprintln(stdout, "✓ Added logmind check-decisions to existing pre-commit hook.")
 		return nil
 
 	case errors.Is(readErr, os.ErrNotExist):
 		// Fresh install. Python writes parent dir + "#!/bin/sh\n" + hook_line + chmod 0o755.
-		if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
-			return err
-		}
+		//
+		// atomicio.WriteFile (which does the MkdirAll itself), not
+		// os.WriteFile: ErrNotExist here does NOT mean "nothing is at this
+		// path". A dangling symlink at .git/hooks/pre-commit lands us on
+		// exactly this branch, and a bare os.WriteFile would follow it and
+		// drop an executable 0o755 shell script wherever it points. The
+		// rename replaces the link itself.
 		body := "#!/bin/sh\n" + preCommitGuardedCall
-		if err := os.WriteFile(hookPath, []byte(body), 0o755); err != nil {
+		if err := atomicio.WriteFile(hookPath, []byte(body), 0o755); err != nil {
 			return err
 		}
 		// WriteFile only honours perm bits on CREATE; chmod

--- a/internal/cli/install_hook.go
+++ b/internal/cli/install_hook.go
@@ -114,20 +114,33 @@ func runInstallHook(cwd string, force bool, stdout io.Writer) error {
 		// (Python appended a bare `logmind check-decisions` line here; #213
 		// upgrades that to the deadline-wrapped invocation).
 		newContent := strings.TrimRight(content, "\n") + "\n" + preCommitGuardedCall
-		// DELIBERATELY os.WriteFile, not atomicio.WriteFile. This is the
-		// append-onto-an-existing-hook branch, and it is the one place in
-		// the tree where write-through is the correct behaviour:
-		//   - The dangling-symlink attack cannot reach here. We are on the
-		//     ReadFile-succeeded branch, so the path resolves to a real
-		//     file; the exploit needs ReadFile to report ErrNotExist (see
-		//     the fresh-install branch below, which IS routed atomically).
-		//   - Symlinking .git/hooks/pre-commit at a shared/tracked script
-		//     is a common, deliberate setup (husky, dotfile-managed hooks).
-		//     atomicio renames onto the NAME, which would silently detach
-		//     that link and leave the user with a private copy.
-		//   - atomicio unconditionally chmods to the perm argument, which
-		//     would clobber the mode-preservation contract documented just
-		//     below.
+		// DELIBERATELY os.WriteFile, not atomicio. Justified by atomicio's
+		// one rule (see internal/atomicio's package doc), not by an
+		// exception to it: an atomic replace swaps the NAME, so it refuses
+		// a symlink on the destination (rule 2) and severs hardlinks
+		// (rule 3). Both are exactly what must not happen here.
+		//
+		//   - Write-through IS the intent. Pointing .git/hooks/pre-commit
+		//     at a shared/tracked script — husky, chezmoi, a dotfile-managed
+		//     hooks dir, or a hardlink into one — is a common, deliberate
+		//     setup, and appending logmind's line to that shared script is
+		//     what --force was asked to do. atomicio would refuse the write
+		//     outright, or silently hand the user a detached private copy
+		//     that stops tracking the shared file.
+		//   - The dangling-symlink attack cannot reach this branch. We are
+		//     on the ReadFile-SUCCEEDED path, so the name resolved to a real
+		//     file; the exploit needs ErrNotExist (see the fresh-install
+		//     branch below, which IS routed through atomicio).
+		//   - Nor can a hostile repo plant the link: git never checks
+		//     anything out into .git/, so .git/hooks/pre-commit is not
+		//     attacker-supplied content in the threat model this sweep is
+		//     about — unlike AGENTS.md, .github/workflows/*, or .claude/.
+		//
+		// (This keep used to argue a third point — that atomicio
+		// "unconditionally chmods to the perm argument". That was true of
+		// the old implementation and is no longer: rule 1 preserves an
+		// existing file's mode. Deleted rather than restated, because a keep
+		// that outlives its reason is how an exception becomes permanent.)
 		if err := os.WriteFile(hookPath, []byte(newContent), 0o755); err != nil {
 			return err
 		}
@@ -149,14 +162,15 @@ func runInstallHook(cwd string, force bool, stdout io.Writer) error {
 		// exactly this branch, and a bare os.WriteFile would follow it and
 		// drop an executable 0o755 shell script wherever it points. The
 		// rename replaces the link itself.
+		//
+		// WriteFileMode, not WriteFile: 0o755 is the point, not a default.
+		// Rule 1 makes WriteFile's perm a CREATE mode that the umask filters
+		// (a user with `umask 077` would get 0o700, and one who somehow had a
+		// non-exec hook would keep it), so the mode-asserting variant states
+		// the contract at the call site and replaces the follow-up os.Chmod
+		// this branch used to need. Python chmods 0o755 unconditionally too.
 		body := "#!/bin/sh\n" + preCommitGuardedCall
-		if err := atomicio.WriteFile(hookPath, []byte(body), 0o755); err != nil {
-			return err
-		}
-		// WriteFile only honours perm bits on CREATE; chmod
-		// explicitly to make sure the exec bit survives umask
-		// stripping (Python does chmod(0o755) unconditionally too).
-		if err := os.Chmod(hookPath, 0o755); err != nil {
+		if err := atomicio.WriteFileMode(hookPath, []byte(body), 0o755); err != nil {
 			return err
 		}
 		fmt.Fprintln(stdout, "✓ Installed logmind pre-commit hook.")

--- a/internal/cli/symlink_writethrough_test.go
+++ b/internal/cli/symlink_writethrough_test.go
@@ -1,0 +1,281 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Symlink write-through regressions.
+//
+// THE BUG: os.WriteFile follows symlinks. Every call site that asked "does
+// this file exist?" and read fs.ErrNotExist as "absent, safe to create" was
+// exploitable, because os.Stat and os.ReadFile follow a symlink too — a
+// DANGLING link reports ErrNotExist for a path that is very much occupied.
+// The write that followed then resolved the same link and landed the payload
+// wherever it pointed. Outside the repository. logmind runs inside repos its
+// user did not write, so "wherever it pointed" is attacker-chosen.
+//
+// WHY THESE TESTS ARE SHAPED LIKE THIS: each one plants a link and then runs
+// the REAL command entry point — runSkillNew, runInstallHook,
+// runFileStructure, runAgentsUpdate — and asserts on the filesystem outside
+// the repo. A test that asserted "atomicio.WriteFile was called" would pass
+// its own mutation and still go green the day someone adds one more raw
+// os.WriteFile next to the converted one. These fail on the observable
+// damage, so they cover the call site no matter how it is written.
+//
+// STABLE ACROSS PR #300: that PR adds an explicit symlink refusal inside
+// atomicio.WriteFile, turning these from "silently safe" into "refused with
+// an error". The invariant asserted here — the outside target is never
+// created and never modified — holds in both worlds, so these tests do not
+// have to be rewritten when it lands. Where an error IS returned, it must
+// name the problem; assertRefusalMentionsSymlink checks that much without
+// requiring one yet.
+
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+}
+
+// plantDanglingSymlink puts a symlink at linkPath pointing at a path that
+// does not exist, and returns that (absent) target. This is the exact
+// primitive the attack needs: os.Stat(linkPath) and os.ReadFile(linkPath)
+// both report fs.ErrNotExist, so "absent" logic proceeds.
+func plantDanglingSymlink(t *testing.T, linkPath, target string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatalf("mkdir for link %s: %v", linkPath, err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", linkPath, target, err)
+	}
+	// Control: prove the trap is armed. If os.Stat does NOT report
+	// ErrNotExist here, the vulnerable branch is never entered and the whole
+	// test is vacuous — it would pass against the unfixed code too.
+	if _, err := os.Stat(linkPath); !os.IsNotExist(err) {
+		t.Fatalf("planted link %s does not read as absent (Stat err = %v); "+
+			"the test would not exercise the create-because-absent branch", linkPath, err)
+	}
+	return target
+}
+
+// assertNotWrittenThrough is the security invariant.
+func assertNotWrittenThrough(t *testing.T, outsideTarget string) {
+	t.Helper()
+	if body, err := os.ReadFile(outsideTarget); err == nil {
+		t.Fatalf("WROTE THROUGH THE SYMLINK: %s was created outside the repository, %d bytes:\n%s",
+			outsideTarget, len(body), truncate(string(body)))
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error stat-ing %s: %v", outsideTarget, err)
+	}
+}
+
+// assertRefusalMentionsSymlink lets these tests survive PR #300 landing a
+// hard refusal inside atomicio.WriteFile. Today the write is made safe by
+// rename semantics and returns nil; once #300 lands it returns an error, and
+// that error has to actually tell the user what happened.
+func assertRefusalMentionsSymlink(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "symlink") &&
+		!strings.Contains(strings.ToLower(err.Error()), "symbolic link") {
+		t.Errorf("command refused the write but the message does not name the problem: %v", err)
+	}
+}
+
+// assertRealFile checks the tool-managed path ended up a regular file (the
+// link was replaced, not followed) when the command reported success.
+func assertRealFile(t *testing.T, path string, cmdErr error) {
+	t.Helper()
+	if cmdErr != nil {
+		return // refused outright — nothing should have been written
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("command succeeded but %s does not exist: %v", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("%s is still a symlink after a successful write; "+
+			"the next write will follow it off-tree", path)
+	}
+}
+
+func truncate(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "..."
+	}
+	return s
+}
+
+// TestSkillNew_DanglingSymlinkAtSkillMD covers internal/skill.ScaffoldBasic
+// through `logmind skill new`. runSkillNew's own os.Stat guard AND
+// ScaffoldBasic's both report "absent" for the dangling link, so the
+// scaffold write is reached with the link on the destination.
+func TestSkillNew_DanglingSymlinkAtSkillMD(t *testing.T) {
+	skipIfNoSymlinks(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	loot := filepath.Join(base, "outside", "loot-skill.md")
+	if err := os.MkdirAll(filepath.Join(base, "outside"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	skillMD := filepath.Join(repo, ".claude", "skills", "sample", "SKILL.md")
+	plantDanglingSymlink(t, skillMD, loot)
+
+	var stdout bytes.Buffer
+	err := runSkillNew(repo, "sample", "A test skill", true, true, &stdout)
+
+	assertNotWrittenThrough(t, loot)
+	assertRefusalMentionsSymlink(t, err)
+	assertRealFile(t, skillMD, err)
+}
+
+// TestSkillNew_DanglingSymlinkAtProvenance covers
+// internal/skill.WriteProvenanceSkeleton on the same command. Separate test
+// because it is a separate call site behind its own os.Stat guard — routing
+// only SKILL.md would leave this one writing off-tree.
+func TestSkillNew_DanglingSymlinkAtProvenance(t *testing.T) {
+	skipIfNoSymlinks(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	loot := filepath.Join(base, "outside", "loot-provenance.md")
+	if err := os.MkdirAll(filepath.Join(base, "outside"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	prov := filepath.Join(repo, ".claude", "skills", "sample", "PROVENANCE.md")
+	plantDanglingSymlink(t, prov, loot)
+
+	var stdout bytes.Buffer
+	// noProvenance=false: the PROVENANCE.md write is part of this run.
+	err := runSkillNew(repo, "sample", "A test skill", true, false, &stdout)
+
+	assertNotWrittenThrough(t, loot)
+	assertRefusalMentionsSymlink(t, err)
+	assertRealFile(t, prov, err)
+}
+
+// TestInstallHook_DanglingSymlinkAtPreCommit covers the fresh-install branch
+// of `logmind install-hook`. The nastiest of the set: the payload is a 0o755
+// shell script, so writing through the link drops an EXECUTABLE at an
+// attacker-chosen path.
+//
+// Note the deliberate asymmetry this pins: the append branch of the same
+// function still uses os.WriteFile on purpose (a user may legitimately
+// symlink .git/hooks/pre-commit at a shared script), and it is unreachable
+// by this attack because it requires os.ReadFile to have SUCCEEDED.
+func TestInstallHook_DanglingSymlinkAtPreCommit(t *testing.T) {
+	skipIfNoSymlinks(t)
+	repo := initRepo(t)
+	base := t.TempDir()
+	loot := filepath.Join(base, "loot-hook.sh")
+
+	hookPath := filepath.Join(repo, ".git", "hooks", "pre-commit")
+	_ = os.Remove(hookPath)
+	plantDanglingSymlink(t, hookPath, loot)
+
+	var stdout bytes.Buffer
+	err := runInstallHook(repo, false, &stdout)
+
+	assertNotWrittenThrough(t, loot)
+	assertRefusalMentionsSymlink(t, err)
+	assertRealFile(t, hookPath, err)
+}
+
+// TestFileStructure_DanglingSymlinkAtPredictableTmp covers
+// internal/tree.WriteFileStructure through `logmind file-structure --write`.
+//
+// This one was a second, sharper bug on top of the class: the old code
+// hand-rolled temp+rename but wrote to the PREDICTABLE name
+// targetPath+".tmp" with a bare os.WriteFile. So the destination did not
+// even have to be attackable — planting the link at the temp name was
+// enough, and the following os.Rename then moved the LINK into place,
+// leaving docs/file-structure.md itself pointing off-tree for every
+// subsequent write. atomicio uses os.CreateTemp, whose name cannot be
+// guessed.
+func TestFileStructure_DanglingSymlinkAtPredictableTmp(t *testing.T) {
+	skipIfNoSymlinks(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	loot := filepath.Join(base, "outside", "loot-tree.md")
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "outside"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	target := filepath.Join(repo, "docs", "file-structure.md")
+	plantDanglingSymlink(t, target+".tmp", loot)
+
+	var stdout, stderr bytes.Buffer
+	err := runFileStructure(repo, target, false, 2, true, &stdout, &stderr)
+
+	assertNotWrittenThrough(t, loot)
+	assertRefusalMentionsSymlink(t, err)
+
+	// And the destination must be a real file holding the rendered tree —
+	// not a symlink inherited from the renamed temp path.
+	if err == nil {
+		assertRealFile(t, target, err)
+		body, rerr := os.ReadFile(target)
+		if rerr != nil {
+			t.Fatalf("read %s: %v", target, rerr)
+		}
+		if len(body) == 0 {
+			t.Errorf("%s is empty; the render did not land", target)
+		}
+	}
+}
+
+// TestAgentsUpdate_SymlinkedWorkflowFile covers internal/cli/agents.go's
+// apply path. This is the non-dangling half of the same class: the link
+// RESOLVES, so the scan reads real (attacker-supplied) content off-tree and
+// the rewrite goes straight back through the link. No ErrNotExist needed.
+func TestAgentsUpdate_SymlinkedWorkflowFile(t *testing.T) {
+	skipIfNoSymlinks(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(repo, ".github", "workflows"), 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	// A real file outside the repo, carrying a stale pin so the updater
+	// decides it needs rewriting.
+	victim := filepath.Join(outside, "victim.yml")
+	const victimBody = "jobs:\n  x:\n    steps:\n      - run: pip install \"logmind==0.0.1\"\n"
+	if err := os.WriteFile(victim, []byte(victimBody), 0o644); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+
+	link := filepath.Join(repo, ".github", "workflows", "regen-timeline.yml")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runAgentsUpdate(repo, "9.9.9", true, &stdout, &stderr)
+	assertRefusalMentionsSymlink(t, err)
+
+	got, rerr := os.ReadFile(victim)
+	if rerr != nil {
+		t.Fatalf("read victim: %v", rerr)
+	}
+	if string(got) != victimBody {
+		t.Fatalf("WROTE THROUGH THE SYMLINK: %s (outside the repository) was rewritten.\n got: %q\nwant: %q",
+			victim, string(got), victimBody)
+	}
+	assertRealFile(t, link, err)
+}

--- a/internal/cli/symlink_writethrough_test.go
+++ b/internal/cli/symlink_writethrough_test.go
@@ -279,3 +279,75 @@ func TestAgentsUpdate_SymlinkedWorkflowFile(t *testing.T) {
 	}
 	assertRealFile(t, link, err)
 }
+
+// TestAgentsUpdate_PreservesModeAndSeversHardlinks measures, through the REAL
+// command, the two user-visible consequences of atomicio's one rule — the
+// exact pair a review panel measured when it blocked this PR:
+//
+//	[before] mode=-rw------- links=2  twin updated   (os.WriteFile)
+//	[broken] mode=-rw-r--r-- links=1  twin stale     (atomicio, chmod'ing)
+//	[now   ] mode=-rw------- links=1  twin stale     (atomicio, rule 1)
+//
+// MODE is a regression: converting a write to atomicio must not re-permission
+// a file the user owns. A 0600 workflow file stays 0600.
+//
+// LINKS is a CONTRACT, asserted here so the next person meets it in a test
+// rather than in a bug report: an atomic replace swaps the NAME, so a
+// hardlink twin keeps the old inode and the old content. That is inherent to
+// atomic replace and is documented on atomicio.WriteFile. If a call site ever
+// needs the inode preserved, it must not use that primitive.
+func TestAgentsUpdate_PreservesModeAndSeversHardlinks(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	wf := filepath.Join(repo, ".github", "workflows")
+	if err := os.MkdirAll(wf, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+
+	target := filepath.Join(wf, "regen-timeline.yml")
+	const body = "jobs:\n  x:\n    steps:\n      - run: pip install \"logmind==0.0.1\"\n"
+	if err := os.WriteFile(target, []byte(body), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil { // defeat the ambient umask
+		t.Fatalf("chmod workflow: %v", err)
+	}
+	twin := filepath.Join(wf, "regen-timeline.hardlink.yml")
+	hardlinked := os.Link(target, twin) == nil
+
+	var stdout, stderr bytes.Buffer
+	if err := runAgentsUpdate(repo, "9.9.9", true, &stdout, &stderr); err != nil {
+		t.Fatalf("runAgentsUpdate: %v", err)
+	}
+
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat %s: %v", target, err)
+	}
+	// Control: the rewrite must actually have happened, or "mode unchanged"
+	// is unchanged-because-untouched and proves nothing.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read %s: %v", target, err)
+	}
+	if string(got) == body {
+		t.Fatalf("the workflow pin was not rewritten; this test would pass vacuously")
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode after `agents update --apply` = %04o; want 0600. Converting a write to "+
+			"atomicio must not re-permission the user's file — os.WriteFile only honours perm "+
+			"on create, and atomicio.WriteFile reproduces that", perm)
+	}
+
+	if hardlinked {
+		twinBody, rerr := os.ReadFile(twin)
+		if rerr != nil {
+			t.Fatalf("read hardlink twin: %v", rerr)
+		}
+		if string(twinBody) != body {
+			t.Errorf("hardlink twin = %q; want the OLD content. The atomic rename is documented "+
+				"to sever hardlinks; if that stopped being true, atomicio's WriteFile doc "+
+				"comment (rule 3) is now wrong and callers were told the wrong thing", twinBody)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -491,7 +491,13 @@ func SaveMap(path string, m *OrderedMap) error {
 	// 0600: matches the permission this path has always written
 	// (os.CreateTemp's mode, never explicitly widened) — unchanged by
 	// the atomicio consolidation.
-	return atomicio.WriteFile(path, buf.Bytes(), 0o600)
+	//
+	// WriteFileMode, not WriteFile: this is logmind's own file and 0600 is
+	// a deliberate choice, not a create-time default. WriteFile would
+	// preserve whatever mode an existing config.yml had (it reproduces
+	// os.WriteFile), which would let a config that got widened once stay
+	// widened forever.
+	return atomicio.WriteFileMode(path, buf.Bytes(), 0o600)
 }
 
 // deepUpdate recursively folds src into dst — matches Python

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -488,9 +488,10 @@ func SaveMap(path string, m *OrderedMap) error {
 	if err := enc.Close(); err != nil {
 		return err
 	}
-	// 0600: matches the permission this path has always written
-	// (os.CreateTemp's mode, never explicitly widened) — unchanged by
-	// the atomicio consolidation.
+	// 0600: matches the permission this path has always written —
+	// unchanged by the move to atomicio's own create-temp routine (see
+	// internal/atomicio's package doc for why it no longer calls
+	// os.CreateTemp); never explicitly widened.
 	//
 	// WriteFileMode, not WriteFile: this is logmind's own file and 0600 is
 	// a deliberate choice, not a create-time default. WriteFile would

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -657,10 +657,15 @@ func installHook(hookPath, body, marker string) (bool, error) {
 	// Write atomically (temp sibling + rename): a bare os.WriteFile here
 	// would O_TRUNC an EXISTING hook before writing the new body, so a
 	// crash mid-write could leave a truncated/corrupt git hook behind.
-	// atomicio.WriteFile also chmods the temp file before the rename, so
-	// the executable bit lands correctly whether hookPath is new or being
-	// updated — no separate re-chmod needed.
-	if err := atomicio.WriteFile(hookPath, []byte(body), 0o755); err != nil {
+	//
+	// WriteFileMode, not WriteFile: 0o755 is not a default here, it is the
+	// point — a git hook without the executable bit is silently never run.
+	// atomicio.WriteFile deliberately PRESERVES an existing file's mode (it
+	// reproduces os.WriteFile, which only honours perm on create), so a hook
+	// that somehow lost its exec bit would keep having lost it. Asserting
+	// the mode subsumes the separate re-chmod this site would otherwise
+	// need, and it says at the call site that the mode is intentional.
+	if err := atomicio.WriteFileMode(hookPath, []byte(body), 0o755); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/skill/provenance.go
+++ b/internal/skill/provenance.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
 )
 
 // provenanceTemplate is the empty PROVENANCE.md skeleton emitted
@@ -55,5 +57,10 @@ func WriteProvenanceSkeleton(skillMDPath, name string) error {
 		return fmt.Errorf("PROVENANCE.md already exists at %s: %w", target, os.ErrExist)
 	}
 	body := fmt.Sprintf(provenanceTemplate, name)
-	return os.WriteFile(target, []byte(body), 0o644)
+	// atomicio.WriteFile, not os.WriteFile: the os.Stat guard above reports
+	// "absent" for a DANGLING symlink at PROVENANCE.md (Stat follows the
+	// link and the target is missing), so we fall through to the write with
+	// a symlink sitting on the destination. os.WriteFile would follow it and
+	// write outside the repository; the rename replaces the link.
+	return atomicio.WriteFile(target, []byte(body), 0o644)
 }

--- a/internal/skill/push.go
+++ b/internal/skill/push.go
@@ -671,12 +671,15 @@ func copyTree(src, dst string, paths []string) error {
 		//      catalog shipping skills/<name>/notes.md as a symlink would
 		//      make os.WriteFile write the copied body through it, outside
 		//      the clone (and outside the repository logmind was run in).
-		//   2. It chmods the temp file to `perm` before the rename, so the
-		//      mode lands whether or not `dp` already existed. That subsumes
-		//      the explicit os.Chmod this call site used to need — os.WriteFile
+		//   2. WriteFileMode (the mode-ASSERTING variant) chmods the temp
+		//      file to `perm` before the rename, so the source's mode lands
+		//      whether or not `dp` already existed. That subsumes the
+		//      explicit os.Chmod this call site used to need — os.WriteFile
 		//      only honours `perm` on create, so a pre-staged dest kept its
 		//      old mode and the executable bit went missing without it.
-		if err := atomicio.WriteFile(dp, data, perm); err != nil {
+		//      Plain atomicio.WriteFile would be wrong here: it preserves an
+		//      existing destination's mode, which is precisely the bug.
+		if err := atomicio.WriteFileMode(dp, data, perm); err != nil {
 			return err
 		}
 	}

--- a/internal/skill/push.go
+++ b/internal/skill/push.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/clierr"
 )
 
@@ -545,7 +546,11 @@ func pushWith(opts PushOptions, git gitRunner, gh ghRunner) (PushResult, error) 
 	// into a consumer repo).
 	provPath := filepath.Join(targetDir, "PROVENANCE-push.yml")
 	provBody := renderProvenance(opts.SkillName, res, opts.Now, summarizeDescription(string(body)))
-	if err := os.WriteFile(provPath, []byte(provBody), 0o644); err != nil {
+	// atomicio.WriteFile, not os.WriteFile: targetDir lives inside a repo we
+	// just `git clone`d from a user-supplied --catalog-target, and git checks
+	// out symlinks verbatim. A catalog carrying skills/<name>/PROVENANCE-push.yml
+	// as a symlink would otherwise have this write follow it off-tree.
+	if err := atomicio.WriteFile(provPath, []byte(provBody), 0o644); err != nil {
 		return res, err
 	}
 
@@ -660,16 +665,18 @@ func copyTree(src, dst string, paths []string) error {
 		// — they don't have a portable meaning in a markdown-skill
 		// catalog and dropping them keeps the copy minimal-surprise.
 		perm := info.Mode().Perm()
-		if err := os.WriteFile(dp, data, perm); err != nil {
-			return err
-		}
-		// os.WriteFile only honours `perm` when it creates a new file
-		// via OpenFile(O_CREATE). If `dp` already existed (e.g., the
-		// dest tree was pre-staged), the create flag is a no-op for
-		// mode. An explicit Chmod after the write makes the mode
-		// outcome consistent regardless of whether dp was new or
-		// pre-existing — the executable bit lands either way.
-		if err := os.Chmod(dp, perm); err != nil {
+		// atomicio.WriteFile, not os.WriteFile, for two reasons:
+		//   1. `dst` is inside a repo just `git clone`d from a user-supplied
+		//      --catalog-target, and git checks out symlinks verbatim. A
+		//      catalog shipping skills/<name>/notes.md as a symlink would
+		//      make os.WriteFile write the copied body through it, outside
+		//      the clone (and outside the repository logmind was run in).
+		//   2. It chmods the temp file to `perm` before the rename, so the
+		//      mode lands whether or not `dp` already existed. That subsumes
+		//      the explicit os.Chmod this call site used to need — os.WriteFile
+		//      only honours `perm` on create, so a pre-staged dest kept its
+		//      old mode and the executable bit went missing without it.
+		if err := atomicio.WriteFile(dp, data, perm); err != nil {
 			return err
 		}
 	}

--- a/internal/skill/scaffold.go
+++ b/internal/skill/scaffold.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
 )
 
 // SkillsDir returns the canonical location for SKILL.md files in a repo.
@@ -105,10 +107,6 @@ func ScaffoldBasic(repoRoot, name, description string) (string, error) {
 			name, target, os.ErrExist)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return target, err
-	}
-
 	if description == "" {
 		// Python's auto-TODO description — keep byte-identical so the
 		// generated SKILL.md matches.
@@ -124,7 +122,12 @@ func ScaffoldBasic(repoRoot, name, description string) (string, error) {
 	body = strings.ReplaceAll(body, "{DESC}", description)
 	body = strings.ReplaceAll(body, "{TITLE}", titleCase(name))
 
-	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+	// atomicio.WriteFile (which does the MkdirAll itself), not os.WriteFile:
+	// the os.Stat guard at the top of this function reports "absent" for a
+	// DANGLING symlink at SKILL.md, so we arrive here with a symlink on the
+	// destination. os.WriteFile follows it and writes the scaffold outside
+	// the repository; the rename replaces the link.
+	if err := atomicio.WriteFile(target, []byte(body), 0o644); err != nil {
 		return target, err
 	}
 	return target, nil

--- a/internal/skill/suggest_llm.go
+++ b/internal/skill/suggest_llm.go
@@ -13,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/thrillmade/logmind/internal/atomicio"
 )
 
 // LLMSuggester is the network-isolatable adapter we call from the
@@ -447,7 +449,11 @@ func WriteDrafts(outDir string, suggestions []Suggestion) error {
 	}
 	for _, s := range suggestions {
 		path := filepath.Join(outDir, fmt.Sprintf("skill-proposal-%s.md", s.Slug))
-		if err := os.WriteFile(path, []byte(FormatIssueDraft(s)), 0o644); err != nil {
+		// atomicio.WriteFile, not os.WriteFile: "overwrites existing files"
+		// means overwrite the FILE, not follow whatever a symlink at that
+		// name points at. Draft names are fully derived from the slug, so a
+		// hostile repo can predict them and pre-plant links.
+		if err := atomicio.WriteFile(path, []byte(FormatIssueDraft(s)), 0o644); err != nil {
 			return err
 		}
 	}

--- a/internal/skill/symlink_writethrough_test.go
+++ b/internal/skill/symlink_writethrough_test.go
@@ -1,0 +1,164 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Symlink write-through regressions for the two internal/skill call sites
+// whose real command path cannot be driven from a unit test without an
+// external dependency:
+//
+//   - copyTree is reached by `logmind skill push`, which first clones a
+//     user-supplied --catalog-target over the network;
+//   - WriteDrafts is reached by `logmind skill suggest --write-drafts`,
+//     which is gated behind an LLM round-trip.
+//
+// Both are asserted here at the package boundary the command calls, on the
+// same observable-damage invariant the internal/cli tests use: the file
+// outside the repository is never created and never modified. The other
+// three internal/skill sites (ScaffoldBasic, WriteProvenanceSkeleton, and
+// the push provenance write) ARE covered end-to-end from internal/cli.
+
+func skipNoSymlink(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unprivileged symlink creation is unreliable on Windows CI runners")
+	}
+}
+
+func assertUntouched(t *testing.T, loot string, err error) {
+	t.Helper()
+	if body, rerr := os.ReadFile(loot); rerr == nil {
+		t.Fatalf("WROTE THROUGH THE SYMLINK: %s was created outside the destination tree, %d bytes:\n%s",
+			loot, len(body), body)
+	} else if !os.IsNotExist(rerr) {
+		t.Fatalf("unexpected error reading %s: %v", loot, rerr)
+	}
+	if err != nil &&
+		!strings.Contains(strings.ToLower(err.Error()), "symlink") &&
+		!strings.Contains(strings.ToLower(err.Error()), "symbolic link") {
+		t.Errorf("refused the write but the message does not name the problem: %v", err)
+	}
+}
+
+// TestCopyTree_SymlinkInDestination is the catalog-side attack. `logmind
+// skill push` git-clones a user-named catalog repo and copies the local
+// skill into it — and git checks out symlinks verbatim. A catalog carrying
+// skills/<name>/notes.md as a symlink pointed at, say, ~/.ssh/authorized_keys
+// would have copyTree's os.WriteFile write the copied body straight through
+// it. The destination tree here stands in for the fresh clone.
+func TestCopyTree_SymlinkInDestination(t *testing.T) {
+	skipNoSymlink(t)
+	base := t.TempDir()
+	src := filepath.Join(base, "src")
+	dst := filepath.Join(base, "clone", "skills", "sample")
+	loot := filepath.Join(base, "outside", "loot-notes.md")
+	for _, d := range []string{src, dst, filepath.Join(base, "outside")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "notes.md"), []byte("payload from the local skill\n"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	// The hostile catalog's checked-out symlink.
+	if err := os.Symlink(loot, filepath.Join(dst, "notes.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := copyTree(src, dst, []string{"notes.md"})
+	assertUntouched(t, loot, err)
+
+	if err == nil {
+		fi, lerr := os.Lstat(filepath.Join(dst, "notes.md"))
+		if lerr != nil {
+			t.Fatalf("copy succeeded but dest missing: %v", lerr)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Errorf("dest is still a symlink after copyTree")
+		}
+		// The mode contract copyTree exists to keep (review #136 / bug 3)
+		// must survive the switch to the atomic writer.
+		if got := fi.Mode().Perm(); got != 0o644 {
+			t.Errorf("dest perm = %04o; want 0644 (source mode must round-trip)", got)
+		}
+	}
+}
+
+// TestCopyTree_PreservesExecutableBitOverPreStagedDest pins the half of the
+// old call site that was NOT a security fix: os.WriteFile only honours its
+// perm argument on create, so a pre-existing destination kept its old mode
+// and the site needed a follow-up os.Chmod. atomicio.WriteFile chmods the
+// temp file before the rename, which subsumes that — this test fails if the
+// subsumption is wrong and the executable bit silently stops copying.
+func TestCopyTree_PreservesExecutableBitOverPreStagedDest(t *testing.T) {
+	base := t.TempDir()
+	src := filepath.Join(base, "src", "scripts")
+	dst := filepath.Join(base, "dst", "scripts")
+	for _, d := range []string{src, dst} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	// Pre-staged destination at a DIFFERENT mode — the case a bare
+	// os.WriteFile got wrong.
+	if err := os.WriteFile(filepath.Join(dst, "run.sh"), []byte("stale\n"), 0o600); err != nil {
+		t.Fatalf("pre-stage dst: %v", err)
+	}
+
+	if err := copyTree(filepath.Join(base, "src"), filepath.Join(base, "dst"), []string{"scripts/run.sh"}); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(dst, "run.sh"))
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o755 {
+		t.Errorf("dest perm = %04o; want 0755 — the executable bit did not survive the copy "+
+			"onto a pre-staged file", got)
+	}
+}
+
+// TestWriteDrafts_DanglingSymlinkAtDraft covers `logmind skill suggest
+// --write-drafts <dir>`. Draft filenames are fully derived from the
+// suggestion slug (skill-proposal-<slug>.md), so they are predictable and a
+// link can be pre-planted at one. "Overwrites existing files" was always
+// meant as overwrite the FILE, not follow whatever sits at that name.
+func TestWriteDrafts_DanglingSymlinkAtDraft(t *testing.T) {
+	skipNoSymlink(t)
+	base := t.TempDir()
+	outDir := filepath.Join(base, "drafts")
+	loot := filepath.Join(base, "outside", "loot-draft.md")
+	for _, d := range []string{outDir, filepath.Join(base, "outside")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	draft := filepath.Join(outDir, "skill-proposal-sample-slug.md")
+	if err := os.Symlink(loot, draft); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := os.Stat(draft); !os.IsNotExist(err) {
+		t.Fatalf("planted link does not read as absent (Stat err = %v); test would be vacuous", err)
+	}
+
+	err := WriteDrafts(outDir, []Suggestion{{Slug: "sample-slug", Phrase: "sample phrase"}})
+	assertUntouched(t, loot, err)
+
+	if err == nil {
+		fi, lerr := os.Lstat(draft)
+		if lerr != nil {
+			t.Fatalf("succeeded but draft missing: %v", lerr)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Errorf("%s is still a symlink after WriteDrafts", draft)
+		}
+	}
+}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -520,8 +520,10 @@ func WriteFileStructure(targetPath, repoRoot string, maxDepth int) (bool, error)
 	// took the rendered tree straight outside the repository — and the
 	// following os.Rename then renamed the LINK into place, leaving
 	// file-structure.md itself pointing off-tree for every later write.
-	// atomicio uses os.CreateTemp (unpredictable suffix, O_EXCL), does the
-	// MkdirAll, and renames onto the destination NAME.
+	// atomicio creates the temp sibling itself — unpredictable suffix,
+	// O_EXCL, mode handed to open(2) so the umask applies (see
+	// internal/atomicio's package doc for why this replaced os.CreateTemp)
+	// — does the MkdirAll, and renames onto the destination NAME.
 	if err := atomicio.WriteFile(targetPath, []byte(rendered), 0o644); err != nil {
 		return false, err
 	}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -29,12 +29,12 @@
 package tree
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/config"
 	"github.com/thrillmade/logmind/internal/gitcli"
 )
@@ -513,16 +513,17 @@ func WriteFileStructure(targetPath, repoRoot string, maxDepth int) (bool, error)
 	if string(existing) == rendered {
 		return false, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+	// atomicio.WriteFile replaces a hand-rolled temp+rename that wrote to
+	// the PREDICTABLE name targetPath+".tmp" with a bare os.WriteFile. Two
+	// bugs in one: os.WriteFile follows symlinks, and the temp name was
+	// guessable, so a dangling symlink planted at docs/file-structure.md.tmp
+	// took the rendered tree straight outside the repository — and the
+	// following os.Rename then renamed the LINK into place, leaving
+	// file-structure.md itself pointing off-tree for every later write.
+	// atomicio uses os.CreateTemp (unpredictable suffix, O_EXCL), does the
+	// MkdirAll, and renames onto the destination NAME.
+	if err := atomicio.WriteFile(targetPath, []byte(rendered), 0o644); err != nil {
 		return false, err
-	}
-	// Atomic-ish: write to .tmp, fsync, rename. Errors propagated.
-	tmp := targetPath + ".tmp"
-	if err := os.WriteFile(tmp, []byte(rendered), 0o644); err != nil {
-		return false, err
-	}
-	if err := os.Rename(tmp, targetPath); err != nil {
-		return false, fmt.Errorf("rename tmp file: %w", err)
 	}
 	return true, nil
 }

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -172,8 +172,6 @@ var Allowlist = map[string]Exception{
 	// ---- LANE HANDOFFS: delete each entry as its PR lands. ----
 	"internal/cli/init.go": {
 		Sites: []string{
-			"installWorkflowTemplates:os.WriteFile",
-			"installWorkflowTemplates:os.WriteFile",
 			"ensureGitignoreBlock:os.WriteFile",
 			"logFirstDecision:os.WriteFile",
 		},

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -455,10 +455,30 @@ func isSelectorSel(parent ast.Node, n *ast.Ident) bool {
 }
 
 // openFileSafeFlags is the CLOSED set of flag-constant names that neither
-// create nor truncate: exactly the os package's own published constants
-// (https://pkg.go.dev/os#pkg-constants) minus O_CREATE and O_TRUNC, which
-// the switch in openFileVerdict below already bans by name before this set
-// is even consulted.
+// create nor truncate. It starts from the os package's own published
+// constants (https://pkg.go.dev/os#pkg-constants) minus O_CREATE and
+// O_TRUNC, which the switch in openFileVerdict below already bans by name
+// before this set is even consulted, and adds two syscall/x/sys/unix flags
+// that are not exported from os at all but are exactly the ones a
+// symlink-safe open needs:
+//
+//   - O_NOFOLLOW refuses to follow a symlink at the final path component —
+//     it IS the flag this package's own RefuseSymlink-style defense is
+//     built around, at the syscall layer. Banning it because it is not
+//     spelled "os.O_something" punished exactly the caller doing the most
+//     defensive possible thing, and their only way out was an allowlist
+//     entry that permanently exempts that file from every future edit —
+//     training people around the guard instead of through it.
+//   - O_CLOEXEC sets the close-on-exec bit on the returned descriptor. It is
+//     a process/fd-table property, orthogonal to what ends up on disk: it
+//     cannot create a file, cannot truncate one, and cannot make an
+//     existing file's bytes visible or invisible to this program.
+//
+// Deliberately NOT added: O_TMPFILE. Despite the name-shape match with the
+// rest of this set, O_TMPFILE creates an unnamed inode — it is a creating
+// flag in every sense that matters here, just spelled differently than
+// O_CREATE, and adding it would reopen exactly the hole this package exists
+// to close.
 //
 // Membership is checked by exact name, matching how the banning half of
 // this function already worked (openFileVerdict has never verified that an
@@ -470,12 +490,14 @@ func isSelectorSel(parent ast.Node, n *ast.Ident) bool {
 // unrelated package's own O_-prefixed constant, a typo'd spelling — is not
 // in this set and falls through to the unresolvable-is-banned rule.
 var openFileSafeFlags = map[string]bool{
-	"O_RDONLY": true,
-	"O_WRONLY": true,
-	"O_RDWR":   true,
-	"O_APPEND": true,
-	"O_EXCL":   true,
-	"O_SYNC":   true,
+	"O_RDONLY":   true,
+	"O_WRONLY":   true,
+	"O_RDWR":     true,
+	"O_APPEND":   true,
+	"O_EXCL":     true,
+	"O_SYNC":     true,
+	"O_NOFOLLOW": true,
+	"O_CLOEXEC":  true,
 }
 
 // openFileVerdict decides whether an os.OpenFile call creates or truncates.
@@ -500,6 +522,24 @@ func openFileVerdict(call *ast.CallExpr) (bool, string) {
 			return false
 		case *ast.Ident:
 			names = append(names, e.Name)
+		case *ast.BasicLit:
+			// A bare literal 0 IS os.O_RDONLY — Go and POSIX both fix
+			// O_RDONLY at 0 on every platform this ships to, so an
+			// unadorned `0` flags argument is exactly as safe as spelling
+			// out os.O_RDONLY and just as unable to create or truncate.
+			// Accept it here — banning it would reproduce the same "guard
+			// punishes the correct pattern" problem O_NOFOLLOW had, this
+			// time against the plainest possible read-only open. Any
+			// OTHER integer literal (a raw
+			// platform-specific magic number) is deliberately left
+			// unhandled: it falls through to the same names-is-empty /
+			// unresolvable-is-banned path a look-alike identifier does,
+			// because this scan cannot verify what an arbitrary number
+			// means and "could not verify" must stay banned.
+			if e.Kind == token.INT && e.Value == "0" {
+				names = append(names, "O_RDONLY")
+			}
+			return false
 		}
 		return true
 	})

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -1,0 +1,248 @@
+// Package writeaudit is a build-time guard against one specific,
+// repeatedly-reintroduced vulnerability: os.WriteFile FOLLOWS SYMLINKS.
+//
+// The exploitable shape is everywhere in a tool like logmind, which runs
+// inside repositories its user did not write:
+//
+//	if _, err := os.Stat(p); errors.Is(err, fs.ErrNotExist) {
+//	        os.WriteFile(p, body, 0o644)   // <- writes THROUGH a link
+//	}
+//
+// A DANGLING symlink at p makes os.Stat (and os.ReadFile) report
+// fs.ErrNotExist — they follow the link and find nothing at the far end.
+// The code concludes "absent, safe to create" and the subsequent
+// os.WriteFile opens the same link with O_CREAT|O_TRUNC, resolves it, and
+// writes the payload wherever it points. Outside the repository. Possibly
+// outside the user's home.
+//
+// internal/atomicio.WriteFile is the safe primitive: it writes to an
+// os.CreateTemp sibling (unpredictable name, O_EXCL) and os.Renames it onto
+// the destination NAME. Rename replaces the name itself rather than
+// resolving it, so a symlink sitting on the destination is swapped out, not
+// written through.
+//
+// Fixing the call sites once is not enough — the 24th raw call arrives next
+// month and looks exactly like ordinary Go. So Scan finds every remaining
+// raw call site by parsing the tree, and TestNoUnauthorizedRawWriteFile
+// pins the result against Allowlist below. Adding a raw os.WriteFile to a
+// non-test file turns that test red, and the only way to green it is to
+// either route through atomicio or add an entry here with a written reason.
+package writeaudit
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Exception is one allowlisted file: how many raw call sites it may
+// contain, and why. Reason is mandatory — an allowlist without reasons is
+// just a list of bugs nobody has read.
+type Exception struct {
+	Count  int
+	Reason string
+}
+
+// Allowlist enumerates every non-test file permitted to call os.WriteFile
+// directly, keyed by slash-separated repo-relative path.
+//
+// Two kinds of entry live here and they are NOT equivalent:
+//
+//   - A JUDGED KEEP — write-through is the correct behaviour at that site.
+//     It stays until the behaviour changes.
+//   - A LANE HANDOFF — the site is vulnerable and is being converted in a
+//     different pull request that owns the file. It is debt, and the entry
+//     must be deleted when that PR lands.
+//
+// Deleting a converted site's entry is not optional housekeeping: the test
+// fails on a STALE entry too (allowed count higher than actual), so the
+// ledger cannot quietly rot into permission-to-be-unsafe.
+var Allowlist = map[string]Exception{
+	"internal/cli/install_hook.go": {
+		Count: 1,
+		Reason: "JUDGED KEEP. The single remaining call is the append-onto-an-" +
+			"existing-hook branch, reached only after os.ReadFile SUCCEEDED — so " +
+			"the dangling-symlink attack cannot arrive there (it needs ErrNotExist). " +
+			"Write-through is wanted: symlinking .git/hooks/pre-commit at a shared " +
+			"script is a deliberate, common setup, and atomicio's rename would " +
+			"silently detach it and force the mode to 0o755, breaking the " +
+			"mode-preservation contract documented at that call site. The fresh-" +
+			"install branch in the same file — the one ErrNotExist actually reaches " +
+			"— IS routed through atomicio.",
+	},
+
+	// ---- LANE HANDOFFS: delete each entry as its PR lands. ----
+	"internal/cli/init.go": {
+		Count:  5,
+		Reason: "LANE HANDOFF to PR #306, which owns internal/cli/init.go. Vulnerable; not converted here to avoid an edit collision.",
+	},
+	"internal/cli/self_update.go": {
+		Count:  1,
+		Reason: "LANE HANDOFF to PR #306, which owns internal/cli/self_update.go. Vulnerable; not converted here to avoid an edit collision.",
+	},
+	"internal/gitattr/gitattr.go": {
+		Count:  2,
+		Reason: "LANE HANDOFF to PR #301, which owns internal/gitattr/gitattr.go. Vulnerable; not converted here to avoid an edit collision.",
+	},
+	"internal/inserter/inserter.go": {
+		Count:  5,
+		Reason: "LANE HANDOFF to PR #306, which is routing exactly these five sites (283/367/402/812/827) through atomicio right now.",
+	},
+	"internal/inserter/dependabot.go": {
+		Count: 2,
+		Reason: "UNOWNED GAP, flagged rather than fixed. Lives in internal/inserter/, " +
+			"a directory PR #306 holds, but is NOT among the five inserter.go sites " +
+			"that PR enumerated — so no lane has claimed it. Both calls write " +
+			".github/dependabot.yml and are vulnerable. Needs an owner.",
+	},
+}
+
+// Finding is one raw call site.
+type Finding struct {
+	File string // slash-separated, repo-relative
+	Line int
+	Call string // e.g. "os.WriteFile"
+}
+
+// bannedSelectors maps package name -> function names that follow symlinks
+// and must not be called directly. ioutil.WriteFile is the deprecated alias
+// for the same syscall sequence and is banned for the same reason — it is
+// the obvious way to slip past a ban on the os. spelling alone.
+var bannedSelectors = map[string][]string{
+	"os":     {"WriteFile"},
+	"ioutil": {"WriteFile"},
+}
+
+// Scan parses every non-test .go file under root and reports each direct
+// call to a banned write function.
+//
+// It parses rather than greps on purpose. This very file, internal/atomicio,
+// and a dozen call-site comments all mention "os.WriteFile" in prose to
+// explain why it is dangerous; a regex would flag all of them and the guard
+// would be turned off within a week. The AST walk sees calls only.
+func Scan(root string) ([]Finding, error) {
+	var out []Finding
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
+		}
+
+		// Only treat `os.X` as the standard library when "os" is really
+		// imported under that name in THIS file — a local variable or an
+		// aliased import named os would otherwise produce a false positive.
+		live := importedNames(file)
+
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if !live[pkg.Name] {
+				return true
+			}
+			for _, fn := range bannedSelectors[pkg.Name] {
+				if sel.Sel.Name == fn {
+					out = append(out, Finding{
+						File: relSlash,
+						Line: fset.Position(sel.Pos()).Line,
+						Call: pkg.Name + "." + fn,
+					})
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out, nil
+}
+
+// importedNames returns the set of banned package names that this file
+// actually imports under their own name (unaliased, or aliased back to
+// themselves).
+func importedNames(file *ast.File) map[string]bool {
+	live := map[string]bool{}
+	for _, imp := range file.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := p
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			name = p[i+1:]
+		}
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		if _, banned := bannedSelectors[name]; banned {
+			live[name] = true
+		}
+	}
+	return live
+}
+
+// FindRepoRoot walks up from start until it finds the directory holding
+// go.mod.
+func FindRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found at or above %s", start)
+		}
+		dir = parent
+	}
+}

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -1,5 +1,6 @@
 // Package writeaudit is a build-time guard against one specific,
-// repeatedly-reintroduced vulnerability: os.WriteFile FOLLOWS SYMLINKS.
+// repeatedly-reintroduced vulnerability: the stdlib's creating/truncating
+// file primitives FOLLOW SYMLINKS.
 //
 // The exploitable shape is everywhere in a tool like logmind, which runs
 // inside repositories its user did not write:
@@ -15,18 +16,63 @@
 // writes the payload wherever it points. Outside the repository. Possibly
 // outside the user's home.
 //
-// internal/atomicio.WriteFile is the safe primitive: it writes to an
-// os.CreateTemp sibling (unpredictable name, O_EXCL) and os.Renames it onto
-// the destination NAME. Rename replaces the name itself rather than
-// resolving it, so a symlink sitting on the destination is swapped out, not
-// written through.
+// internal/atomicio.WriteFile is the safe primitive for the FINAL path
+// component: it writes to a temp sibling (unpredictable name, O_EXCL) and
+// os.Renames it onto the destination NAME, and refuses outright when that
+// name is a symlink. (It does not, and cannot cheaply, defend a symlinked
+// ANCESTOR directory — see atomicio.RefuseSymlink, which says so.)
 //
-// Fixing the call sites once is not enough — the 24th raw call arrives next
+// Fixing the call sites once is not enough — the next raw call arrives next
 // month and looks exactly like ordinary Go. So Scan finds every remaining
 // raw call site by parsing the tree, and TestNoUnauthorizedRawWriteFile
-// pins the result against Allowlist below. Adding a raw os.WriteFile to a
-// non-test file turns that test red, and the only way to green it is to
-// either route through atomicio or add an entry here with a written reason.
+// pins the result against Allowlist below.
+//
+// # WHY A SOURCE SCAN AND NOT A BEHAVIOURAL TEST
+//
+// A behavioural test cannot cover this class, and that was measured rather
+// than assumed. PR #297 removed a second AGENTS.md refresher — a loop that
+// took a path back out of the inserter API and wrote it raw. Restoring that
+// loop and re-running the outcome assertions leaves them GREEN: by the time
+// the loop runs, EnsureAgentsMD has already refreshed the block, so
+// FindOutdatedMarkerBlocks reports nothing and the second writer is a no-op
+// on that path. Being unreachable on the happy path is exactly why its
+// wrong-argument write survived untested for so long.
+//
+// The same holds for the symlink class this package is named after: a raw
+// write is only observable when someone has planted a link, which no ordinary
+// test does. So the thing pinned here is the PRIMITIVE, not an outcome — the
+// set of ways to spell a path is unbounded, the set of ways to open a file
+// for creation is small and enumerable.
+//
+// # ONE GUARD, NOT TWO
+//
+// This package is the single owner of the raw-write check for the whole
+// module. A second scanner elsewhere with its own allowlist is a duplicate to
+// fold in here, not a second opinion: two lists that mean the same thing
+// diverge, and the first time they disagree somebody silences whichever one
+// is louder. Extend bannedPaths and Allowlist instead.
+//
+// # SCOPE — what this catches, and what it cannot
+//
+// CAUGHT: os.WriteFile, io/ioutil.WriteFile, os.Create, os.Truncate, and
+// os.OpenFile carrying O_CREATE or O_TRUNC (or flags this cannot statically
+// resolve). The package is resolved from the file's import declarations, not
+// from the identifier being spelled "os", so an alias (`import w "os"` ->
+// w.Create) and a dot import (`import . "os"` -> a bare Create) are both
+// caught, and so is a call inside a file that is behind a build tag this
+// platform does not compile.
+//
+// NOT CAUGHT, and no amount of added patterns would change it: once an
+// *os.File exists, anything can write through it — tmpl.Execute(f, …),
+// json.NewEncoder(f).Encode(…), io.Copy(f, …), f.Write(b) — and shelling out
+// (exec.Command("sh", "-c", "> f")) leaves Go entirely. A determined author
+// gets a raw write past this guard in one line, and that is fine, because
+// this is NOT a sandbox and cannot be made into one.
+//
+// Its job is the accidental reintroduction: the one-line "just write the
+// file" that looks like ordinary Go, written by somebody who has never read
+// the CVE this package is named after. That is the failure mode that has
+// actually happened here, repeatedly.
 package writeaudit
 
 import (
@@ -42,61 +88,111 @@ import (
 	"strings"
 )
 
-// Exception is one allowlisted file: how many raw call sites it may
+// Exception is one allowlisted file: exactly which raw call sites it may
 // contain, and why. Reason is mandatory — an allowlist without reasons is
 // just a list of bugs nobody has read.
+//
+// Sites identifies each permitted call as "<enclosing func>:<call>", e.g.
+// "runInstallHook:os.WriteFile". It is a multiset: two permitted calls to
+// os.WriteFile inside the same function are two identical entries.
+//
+// WHY IDENTITIES AND NOT A COUNT. A count says "this file may contain N raw
+// writes" and nothing about which ones — so moving the single judged-keep
+// call out of the branch that justifies it and into a general-purpose
+// `func RawWriteFile(path string, b []byte)` keeps the count at 1, greens
+// the guard, and hands the whole module a laundered raw write. Naming the
+// enclosing function makes that relocation a failure: the ledger says the
+// exception lives in runInstallHook, and it no longer does.
+//
+// WHY NOT LINE NUMBERS. They would be exact and they would also churn on
+// every unrelated edit above the call, so the allowlist would need editing
+// in PRs that have nothing to do with it — and a ledger people re-baseline
+// out of habit is a ledger nobody reads. The function name is stable under
+// ordinary editing and unstable under exactly the move that matters.
 type Exception struct {
-	Count  int
+	Sites  []string
 	Reason string
 }
 
-// Allowlist enumerates every non-test file permitted to call os.WriteFile
-// directly, keyed by slash-separated repo-relative path.
+// Allowlist enumerates every non-test file permitted to call a raw
+// creating/truncating primitive directly, keyed by slash-separated
+// repo-relative path.
 //
 // Two kinds of entry live here and they are NOT equivalent:
 //
-//   - A JUDGED KEEP — write-through is the correct behaviour at that site.
+//   - A JUDGED KEEP — the raw call is the correct behaviour at that site.
 //     It stays until the behaviour changes.
 //   - A LANE HANDOFF — the site is vulnerable and is being converted in a
 //     different pull request that owns the file. It is debt, and the entry
 //     must be deleted when that PR lands.
 //
 // Deleting a converted site's entry is not optional housekeeping: the test
-// fails on a STALE entry too (allowed count higher than actual), so the
+// fails on a STALE entry too (a listed site that is no longer there), so the
 // ledger cannot quietly rot into permission-to-be-unsafe.
 var Allowlist = map[string]Exception{
+	"internal/atomicio/atomicio.go": {
+		Sites: []string{"createTemp:os.OpenFile"},
+		Reason: "JUDGED KEEP, and the reason the rest of this list can exist. atomicio is " +
+			"the safe primitive every other site routes through, so it is the one place " +
+			"that must touch a raw create. The call is O_CREATE|O_EXCL against an " +
+			"unguessable random name in the destination's own directory: O_EXCL fails on " +
+			"a symlink rather than following it, so there is nothing to follow. It takes " +
+			"a mode so open(2) applies the umask, which os.CreateTemp (hardcoded 0600 + a " +
+			"later chmod) cannot do.",
+	},
+	"internal/cli/filelock_unix.go": {
+		Sites: []string{"acquireRepoLock:os.OpenFile"},
+		Reason: "JUDGED KEEP. A repo lock must be the SAME INODE for every process that " +
+			"flocks it, so it cannot be written via temp+rename — atomicio replaces the " +
+			"name and gives every caller a private inode, which would silently disable " +
+			"the lock rather than fail. The symlink hole is closed at the call site " +
+			"instead: atomicio.RefuseSymlink(lockPath) runs immediately before this " +
+			"OpenFile, so a planted link is refused with the same error content writes " +
+			"give. No O_TRUNC — an existing lock file's bytes are never touched.",
+	},
 	"internal/cli/install_hook.go": {
-		Count: 1,
-		Reason: "JUDGED KEEP. The single remaining call is the append-onto-an-" +
-			"existing-hook branch, reached only after os.ReadFile SUCCEEDED — so " +
-			"the dangling-symlink attack cannot arrive there (it needs ErrNotExist). " +
-			"Write-through is wanted: symlinking .git/hooks/pre-commit at a shared " +
-			"script is a deliberate, common setup, and atomicio's rename would " +
-			"silently detach it and force the mode to 0o755, breaking the " +
-			"mode-preservation contract documented at that call site. The fresh-" +
-			"install branch in the same file — the one ErrNotExist actually reaches " +
-			"— IS routed through atomicio.",
+		Sites: []string{"runInstallHook:os.WriteFile"},
+		Reason: "JUDGED KEEP. The single remaining call is the append-onto-an-existing-hook " +
+			"branch, reached only after os.ReadFile SUCCEEDED — so the dangling-symlink " +
+			"attack cannot arrive there (it needs ErrNotExist), and git never checks " +
+			"anything out into .git/, so a hostile repo cannot plant the link either. " +
+			"Write-through is the INTENT: symlinking (or hardlinking) .git/hooks/pre-commit " +
+			"at a shared script is a deliberate, common setup, and atomicio's one rule " +
+			"would refuse that write outright or sever the link. The fresh-install branch " +
+			"in the same file — the one ErrNotExist actually reaches — IS routed through " +
+			"atomicio. See the call site for the full argument.",
 	},
 
 	// ---- LANE HANDOFFS: delete each entry as its PR lands. ----
 	"internal/cli/init.go": {
-		Count:  4,
+		Sites: []string{
+			"installWorkflowTemplates:os.WriteFile",
+			"installWorkflowTemplates:os.WriteFile",
+			"ensureGitignoreBlock:os.WriteFile",
+			"logFirstDecision:os.WriteFile",
+		},
 		Reason: "LANE HANDOFF to PR #306, which owns internal/cli/init.go. Vulnerable; not converted here to avoid an edit collision.",
 	},
 	"internal/cli/self_update.go": {
-		Count:  1,
+		Sites:  []string{"runSelfUpdate:os.WriteFile"},
 		Reason: "LANE HANDOFF to PR #306, which owns internal/cli/self_update.go. Vulnerable; not converted here to avoid an edit collision.",
 	},
 	"internal/gitattr/gitattr.go": {
-		Count:  2,
+		Sites:  []string{"ensureBlockWithLines:os.WriteFile", "RemoveBlock:os.WriteFile"},
 		Reason: "LANE HANDOFF to PR #301, which owns internal/gitattr/gitattr.go. Vulnerable; not converted here to avoid an edit collision.",
 	},
 	"internal/inserter/inserter.go": {
-		Count:  5,
-		Reason: "LANE HANDOFF to PR #306, which is routing exactly these five sites (283/367/402/812/827) through atomicio right now.",
+		Sites: []string{
+			"CreateAgentFile:os.WriteFile",
+			"EnsureAgentsMD:os.WriteFile",
+			"EnsureAgentsMD:os.WriteFile",
+			"MigrateToAgentsMD:os.WriteFile",
+			"MigrateToAgentsMD:os.WriteFile",
+		},
+		Reason: "LANE HANDOFF to PR #306, which is routing exactly these five sites through atomicio right now.",
 	},
 	"internal/inserter/dependabot.go": {
-		Count: 2,
+		Sites: []string{"EnsureDependabot:os.WriteFile", "EnsureDependabot:os.WriteFile"},
 		Reason: "UNOWNED GAP, flagged rather than fixed. Lives in internal/inserter/, " +
 			"a directory PR #306 holds, but is NOT among the five inserter.go sites " +
 			"that PR enumerated — so no lane has claimed it. Both calls write " +
@@ -108,25 +204,38 @@ var Allowlist = map[string]Exception{
 type Finding struct {
 	File string // slash-separated, repo-relative
 	Line int
-	Call string // e.g. "os.WriteFile"
+	Func string // enclosing function ("Type.Method" for methods, "<file>" at file scope)
+	Call string // canonical, import-path-resolved, e.g. "os.WriteFile"
+	Why  string // short note for the failure message, e.g. "O_CREATE"
 }
 
-// bannedSelectors maps package name -> function names that follow symlinks
-// and must not be called directly. ioutil.WriteFile is the deprecated alias
-// for the same syscall sequence and is banned for the same reason — it is
-// the obvious way to slip past a ban on the os. spelling alone.
-var bannedSelectors = map[string][]string{
-	"os":     {"WriteFile"},
-	"ioutil": {"WriteFile"},
+// Site is the allowlist identity for this finding: "<func>:<call>".
+func (f Finding) Site() string { return f.Func + ":" + f.Call }
+
+// bannedPaths maps an IMPORT PATH to the function names within it that
+// create or truncate through a symlink. Keyed by path, not by identifier, so
+// the check survives `import w "os"` and `import . "os"`.
+//
+// ioutil.WriteFile is the deprecated alias for the same syscall sequence and
+// is banned for the same reason. os.Create is O_RDWR|O_CREATE|O_TRUNC by
+// definition. os.Truncate does not create, but it resolves the path and
+// destroys the content at the far end of a link, which is the same class of
+// damage. os.OpenFile is conditional — see openFileVerdict.
+var bannedPaths = map[string]map[string]bool{
+	"os":        {"WriteFile": true, "Create": true, "OpenFile": true, "Truncate": true},
+	"io/ioutil": {"WriteFile": true},
 }
 
 // Scan parses every non-test .go file under root and reports each direct
-// call to a banned write function.
+// call to a banned primitive.
 //
 // It parses rather than greps on purpose. This very file, internal/atomicio,
 // and a dozen call-site comments all mention "os.WriteFile" in prose to
 // explain why it is dangerous; a regex would flag all of them and the guard
 // would be turned off within a week. The AST walk sees calls only.
+//
+// Build tags are ignored: files are parsed unconditionally, so a raw call
+// hidden behind `//go:build windows` is still reported on a mac.
 func Scan(root string) ([]Finding, error) {
 	var out []Finding
 	fset := token.NewFileSet()
@@ -151,44 +260,56 @@ func Scan(root string) ([]Finding, error) {
 			return fmt.Errorf("parse %s: %w", path, perr)
 		}
 
-		// Only treat `os.X` as the standard library when "os" is really
-		// imported under that name in THIS file — a local variable or an
-		// aliased import named os would otherwise produce a false positive.
-		live := importedNames(file)
-
 		rel, rerr := filepath.Rel(root, path)
 		if rerr != nil {
 			return rerr
 		}
 		relSlash := filepath.ToSlash(rel)
 
-		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			pkg, ok := sel.X.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			if !live[pkg.Name] {
-				return true
-			}
-			for _, fn := range bannedSelectors[pkg.Name] {
-				if sel.Sel.Name == fn {
-					out = append(out, Finding{
-						File: relSlash,
-						Line: fset.Position(sel.Pos()).Line,
-						Call: pkg.Name + "." + fn,
-					})
+		named, dotted := resolveImports(file)
+
+		// Walk each declaration separately so the enclosing function name is
+		// known without threading a stack through ast.Inspect.
+		for _, decl := range file.Decls {
+			fnName := "<file>"
+			var body ast.Node = decl
+			if fd, ok := decl.(*ast.FuncDecl); ok {
+				fnName = funcName(fd)
+				if fd.Body == nil {
+					continue
 				}
+				body = fd.Body
 			}
-			return true
-		})
+			ast.Inspect(body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				pkgPath, fn, pos, ok := resolveCallee(call, named, dotted)
+				if !ok {
+					return true
+				}
+				if !bannedPaths[pkgPath][fn] {
+					return true
+				}
+				why := "creates or truncates through a symlink"
+				if fn == "OpenFile" {
+					banned, note := openFileVerdict(call)
+					if !banned {
+						return true
+					}
+					why = note
+				}
+				out = append(out, Finding{
+					File: relSlash,
+					Line: fset.Position(pos).Line,
+					Func: fnName,
+					Call: canonicalName(pkgPath) + "." + fn,
+					Why:  why,
+				})
+				return true
+			})
+		}
 		return nil
 	})
 	if err != nil {
@@ -204,28 +325,146 @@ func Scan(root string) ([]Finding, error) {
 	return out, nil
 }
 
-// importedNames returns the set of banned package names that this file
-// actually imports under their own name (unaliased, or aliased back to
-// themselves).
-func importedNames(file *ast.File) map[string]bool {
-	live := map[string]bool{}
+// resolveCallee maps a call expression back to (import path, function name)
+// when it is a call into one of the banned packages, however it is spelled.
+//
+// Two spellings reach the stdlib:
+//
+//	pkg.Fn(...)  — an *ast.SelectorExpr whose X is an identifier bound to an
+//	               import in THIS file. The binding is what matters, not the
+//	               text: `import w "os"` makes w.Create an os.Create, and a
+//	               local `var os fakeOS` in a file that does not import "os"
+//	               is not one.
+//	Fn(...)      — a bare identifier, which resolves to the stdlib only when
+//	               the file dot-imports the package.
+func resolveCallee(call *ast.CallExpr, named map[string]string, dotted map[string]bool) (pkgPath, fn string, pos token.Pos, ok bool) {
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		ident, isIdent := fun.X.(*ast.Ident)
+		if !isIdent {
+			return "", "", 0, false
+		}
+		p, bound := named[ident.Name]
+		if !bound {
+			return "", "", 0, false
+		}
+		return p, fun.Sel.Name, fun.Sel.Pos(), true
+	case *ast.Ident:
+		// A dot import puts the package's exported names in file scope.
+		// Attribute the call to whichever dot-imported banned package
+		// declares that name.
+		for p := range dotted {
+			if bannedPaths[p][fun.Name] {
+				return p, fun.Name, fun.Pos(), true
+			}
+		}
+		return "", "", 0, false
+	}
+	return "", "", 0, false
+}
+
+// openFileVerdict decides whether an os.OpenFile call creates or truncates.
+//
+// The flags argument is read syntactically: every identifier appearing in it
+// is collected (os.O_CREATE, a dot-imported O_CREATE, syscall.O_CREAT, a
+// local variable). O_CREATE/O_CREAT/O_TRUNC means banned. An identifier that
+// is not an O_* constant means the flags are computed at runtime and this
+// cannot tell — banned too, deliberately, because "the audit could not read
+// it" must not be the quiet way past the audit. Purely non-creating flags
+// (O_RDONLY, O_RDWR, O_APPEND, ...) pass.
+func openFileVerdict(call *ast.CallExpr) (bool, string) {
+	if len(call.Args) < 2 {
+		return true, "unreadable os.OpenFile call"
+	}
+	var names []string
+	ast.Inspect(call.Args[1], func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.SelectorExpr:
+			names = append(names, e.Sel.Name)
+			return false
+		case *ast.Ident:
+			names = append(names, e.Name)
+		}
+		return true
+	})
+	if len(names) == 0 {
+		return true, "os.OpenFile flags could not be read statically"
+	}
+	for _, n := range names {
+		switch n {
+		case "O_CREATE", "O_CREAT":
+			return true, "os.OpenFile with O_CREATE"
+		case "O_TRUNC":
+			return true, "os.OpenFile with O_TRUNC"
+		}
+	}
+	for _, n := range names {
+		if !strings.HasPrefix(n, "O_") {
+			return true, "os.OpenFile flags are computed at runtime and cannot be audited statically"
+		}
+	}
+	return false, ""
+}
+
+// resolveImports returns (identifier -> import path) for banned packages
+// imported under a name, and the set of banned packages imported with `.`.
+// Blank imports (`_ "os"`) bind nothing and are skipped.
+func resolveImports(file *ast.File) (named map[string]string, dotted map[string]bool) {
+	named = map[string]string{}
+	dotted = map[string]bool{}
 	for _, imp := range file.Imports {
 		p, err := strconv.Unquote(imp.Path.Value)
 		if err != nil {
 			continue
 		}
-		name := p
+		if _, banned := bannedPaths[p]; !banned {
+			continue
+		}
+		local := p
 		if i := strings.LastIndex(p, "/"); i >= 0 {
-			name = p[i+1:]
+			local = p[i+1:]
 		}
 		if imp.Name != nil {
-			name = imp.Name.Name
+			switch imp.Name.Name {
+			case ".":
+				dotted[p] = true
+				continue
+			case "_":
+				continue
+			default:
+				local = imp.Name.Name
+			}
 		}
-		if _, banned := bannedSelectors[name]; banned {
-			live[name] = true
-		}
+		named[local] = p
 	}
-	return live
+	return named, dotted
+}
+
+// canonicalName renders an import path the way a call site reads:
+// "io/ioutil" -> "ioutil".
+func canonicalName(pkgPath string) string {
+	if i := strings.LastIndex(pkgPath, "/"); i >= 0 {
+		return pkgPath[i+1:]
+	}
+	return pkgPath
+}
+
+// funcName renders a declaration's identity for the allowlist: "Fn" for a
+// plain function, "Type.Method" for a method (pointer receivers included,
+// without the star, because the star adds nothing here).
+func funcName(fd *ast.FuncDecl) string {
+	name := fd.Name.Name
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return name
+	}
+	t := fd.Recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	if ident, ok := t.(*ast.Ident); ok {
+		return ident.Name + "." + name
+	}
+	return name
 }
 
 // FindRepoRoot walks up from start until it finds the directory holding

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -60,7 +60,13 @@
 // from the identifier being spelled "os", so an alias (`import w "os"` ->
 // w.Create) and a dot import (`import . "os"` -> a bare Create) are both
 // caught, and so is a call inside a file that is behind a build tag this
-// platform does not compile.
+// platform does not compile. A banned function referenced WITHOUT being
+// called — `var raw = os.WriteFile`, or `w := os.WriteFile` followed by
+// `w(...)` — is caught too, at the reference itself: laundering the
+// primitive through a variable does not change what it does, and the call
+// through that variable (`raw(...)`, `w(...)`) resolves to nothing this scan
+// recognises, so the ONE place the danger is still visible is where the
+// banned selector is named.
 //
 // NOT CAUGHT, and no amount of added patterns would change it: once an
 // *os.File exists, anything can write through it — tmpl.Execute(f, …),
@@ -280,33 +286,93 @@ func Scan(root string) ([]Finding, error) {
 				}
 				body = fd.Body
 			}
+
+			// A manual parent stack, not plain ast.Inspect: the escape check
+			// below (a banned selector used somewhere OTHER than a call's
+			// Fun) needs to know each node's immediate parent, and
+			// ast.Inspect's f(nil)-on-exit signal is the documented way to
+			// track that without a second pass. See resolveExpr's doc for
+			// why a call and a bare reference need different treatment.
+			var stack []ast.Node
 			ast.Inspect(body, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
+				if n == nil {
+					if len(stack) > 0 {
+						stack = stack[:len(stack)-1]
+					}
 					return true
 				}
-				pkgPath, fn, pos, ok := resolveCallee(call, named, dotted)
-				if !ok {
-					return true
+				var parent ast.Node
+				if len(stack) > 0 {
+					parent = stack[len(stack)-1]
 				}
-				if !bannedPaths[pkgPath][fn] {
-					return true
-				}
-				why := "creates or truncates through a symlink"
-				if fn == "OpenFile" {
-					banned, note := openFileVerdict(call)
-					if !banned {
+				stack = append(stack, n)
+
+				switch node := n.(type) {
+				case *ast.CallExpr:
+					pkgPath, fn, pos, ok := resolveExpr(node.Fun, named, dotted)
+					if !ok || !bannedPaths[pkgPath][fn] {
 						return true
 					}
-					why = note
+					why := "creates or truncates through a symlink"
+					if fn == "OpenFile" {
+						banned, note := openFileVerdict(node)
+						if !banned {
+							return true
+						}
+						why = note
+					}
+					out = append(out, Finding{
+						File: relSlash,
+						Line: fset.Position(pos).Line,
+						Func: fnName,
+						Call: canonicalName(pkgPath) + "." + fn,
+						Why:  why,
+					})
+
+				case *ast.SelectorExpr:
+					// Already handled above when this selector IS the thing
+					// being called (`os.WriteFile(...)`) — including the
+					// os.OpenFile case where the verdict depends on the call's
+					// flags argument, which only a *ast.CallExpr carries.
+					if isCallFun(parent, node) {
+						return true
+					}
+					pkgPath, fn, pos, ok := resolveExpr(node, named, dotted)
+					if !ok || !bannedPaths[pkgPath][fn] {
+						return true
+					}
+					out = append(out, Finding{
+						File: relSlash,
+						Line: fset.Position(pos).Line,
+						Func: fnName,
+						Call: canonicalName(pkgPath) + "." + fn,
+						Why:  "referenced as a value, not called directly — the guard cannot see how or whether it will be invoked",
+					})
+
+				case *ast.Ident:
+					// Two positions to exclude, both already resolved
+					// elsewhere: the Sel half of a SelectorExpr just visited
+					// above (re-checking the bare name "WriteFile" without
+					// its qualifier would either duplicate that finding or,
+					// worse, misfire on an unrelated dot-imported package
+					// that happens to share the name), and a bare call.Fun
+					// dot-import (`WriteFile(...)`), handled by the
+					// *ast.CallExpr case.
+					if isSelectorSel(parent, node) || isCallFun(parent, node) {
+						return true
+					}
+					pkgPath, fn, pos, ok := resolveExpr(node, named, dotted)
+					if !ok || !bannedPaths[pkgPath][fn] {
+						return true
+					}
+					out = append(out, Finding{
+						File: relSlash,
+						Line: fset.Position(pos).Line,
+						Func: fnName,
+						Call: canonicalName(pkgPath) + "." + fn,
+						Why:  "referenced as a value, not called directly — the guard cannot see how or whether it will be invoked",
+					})
 				}
-				out = append(out, Finding{
-					File: relSlash,
-					Line: fset.Position(pos).Line,
-					Func: fnName,
-					Call: canonicalName(pkgPath) + "." + fn,
-					Why:  why,
-				})
 				return true
 			})
 		}
@@ -325,22 +391,26 @@ func Scan(root string) ([]Finding, error) {
 	return out, nil
 }
 
-// resolveCallee maps a call expression back to (import path, function name)
-// when it is a call into one of the banned packages, however it is spelled.
+// resolveExpr maps an expression back to (import path, function name) when
+// it denotes one of the banned packages' functions, however it is spelled.
+// It is applied both to a call's Fun (an ordinary call) and to any other
+// expression position (a banned function referenced as a VALUE — see the
+// HIGH-1 escape check in Scan) — the resolution rule is the same either way,
+// only what the caller does with the answer differs.
 //
 // Two spellings reach the stdlib:
 //
-//	pkg.Fn(...)  — an *ast.SelectorExpr whose X is an identifier bound to an
+//	pkg.Fn       — an *ast.SelectorExpr whose X is an identifier bound to an
 //	               import in THIS file. The binding is what matters, not the
 //	               text: `import w "os"` makes w.Create an os.Create, and a
 //	               local `var os fakeOS` in a file that does not import "os"
 //	               is not one.
-//	Fn(...)      — a bare identifier, which resolves to the stdlib only when
+//	Fn           — a bare identifier, which resolves to the stdlib only when
 //	               the file dot-imports the package.
-func resolveCallee(call *ast.CallExpr, named map[string]string, dotted map[string]bool) (pkgPath, fn string, pos token.Pos, ok bool) {
-	switch fun := call.Fun.(type) {
+func resolveExpr(expr ast.Expr, named map[string]string, dotted map[string]bool) (pkgPath, fn string, pos token.Pos, ok bool) {
+	switch e := expr.(type) {
 	case *ast.SelectorExpr:
-		ident, isIdent := fun.X.(*ast.Ident)
+		ident, isIdent := e.X.(*ast.Ident)
 		if !isIdent {
 			return "", "", 0, false
 		}
@@ -348,14 +418,14 @@ func resolveCallee(call *ast.CallExpr, named map[string]string, dotted map[strin
 		if !bound {
 			return "", "", 0, false
 		}
-		return p, fun.Sel.Name, fun.Sel.Pos(), true
+		return p, e.Sel.Name, e.Sel.Pos(), true
 	case *ast.Ident:
 		// A dot import puts the package's exported names in file scope.
-		// Attribute the call to whichever dot-imported banned package
+		// Attribute the reference to whichever dot-imported banned package
 		// declares that name.
 		for p := range dotted {
-			if bannedPaths[p][fun.Name] {
-				return p, fun.Name, fun.Pos(), true
+			if bannedPaths[p][e.Name] {
+				return p, e.Name, e.Pos(), true
 			}
 		}
 		return "", "", 0, false
@@ -363,15 +433,61 @@ func resolveCallee(call *ast.CallExpr, named map[string]string, dotted map[strin
 	return "", "", 0, false
 }
 
+// isCallFun reports whether n is exactly the callee of parent — i.e. n is
+// being CALLED, not merely referenced. Used to keep the value-escape check
+// in Scan from re-flagging (or double-flagging) an ordinary `os.WriteFile(...)`
+// call, which the *ast.CallExpr case already handles with the extra
+// os.OpenFile flag analysis that only a call carries.
+func isCallFun(parent ast.Node, n ast.Expr) bool {
+	call, ok := parent.(*ast.CallExpr)
+	return ok && call.Fun == n
+}
+
+// isSelectorSel reports whether n is the Sel half of parent, e.g. the
+// "WriteFile" identifier inside "os.WriteFile". Used to keep a dot-imported
+// package name from colliding with an unrelated selector that merely shares
+// the banned function's bare name (`someOtherThing.WriteFile`) — the
+// *ast.SelectorExpr case already resolves that call correctly, by checking
+// what X is actually bound to.
+func isSelectorSel(parent ast.Node, n *ast.Ident) bool {
+	sel, ok := parent.(*ast.SelectorExpr)
+	return ok && sel.Sel == n
+}
+
+// openFileSafeFlags is the CLOSED set of flag-constant names that neither
+// create nor truncate: exactly the os package's own published constants
+// (https://pkg.go.dev/os#pkg-constants) minus O_CREATE and O_TRUNC, which
+// the switch in openFileVerdict below already bans by name before this set
+// is even consulted.
+//
+// Membership is checked by exact name, matching how the banning half of
+// this function already worked (openFileVerdict has never verified that an
+// "os.O_CREATE" selector's X actually resolves to the os import — it bans
+// on the name alone, which is deliberately over-inclusive). This whitelist
+// makes the SAFE half symmetric with that: an identifier passes only when
+// its name is a known non-creating flag, not merely when it happens to
+// start with "O_". A look-alike — a local `const O_LOOKALIKE = 0`, an
+// unrelated package's own O_-prefixed constant, a typo'd spelling — is not
+// in this set and falls through to the unresolvable-is-banned rule.
+var openFileSafeFlags = map[string]bool{
+	"O_RDONLY": true,
+	"O_WRONLY": true,
+	"O_RDWR":   true,
+	"O_APPEND": true,
+	"O_EXCL":   true,
+	"O_SYNC":   true,
+}
+
 // openFileVerdict decides whether an os.OpenFile call creates or truncates.
 //
 // The flags argument is read syntactically: every identifier appearing in it
 // is collected (os.O_CREATE, a dot-imported O_CREATE, syscall.O_CREAT, a
-// local variable). O_CREATE/O_CREAT/O_TRUNC means banned. An identifier that
-// is not an O_* constant means the flags are computed at runtime and this
-// cannot tell — banned too, deliberately, because "the audit could not read
-// it" must not be the quiet way past the audit. Purely non-creating flags
-// (O_RDONLY, O_RDWR, O_APPEND, ...) pass.
+// local variable). O_CREATE/O_CREAT/O_TRUNC means banned. Every other
+// identifier must match openFileSafeFlags BY NAME to pass — an identifier
+// that does not (a look-alike "O_"-prefixed spelling included) means the
+// flags cannot be verified safe, and this cannot tell — banned too,
+// deliberately, because "the audit could not read it" must not be the quiet
+// way past the audit.
 func openFileVerdict(call *ast.CallExpr) (bool, string) {
 	if len(call.Args) < 2 {
 		return true, "unreadable os.OpenFile call"
@@ -399,8 +515,9 @@ func openFileVerdict(call *ast.CallExpr) (bool, string) {
 		}
 	}
 	for _, n := range names {
-		if !strings.HasPrefix(n, "O_") {
-			return true, "os.OpenFile flags are computed at runtime and cannot be audited statically"
+		if !openFileSafeFlags[n] {
+			return true, fmt.Sprintf(
+				"os.OpenFile flag %q is not a recognized non-creating flag and cannot be verified safe", n)
 		}
 	}
 	return false, ""

--- a/internal/writeaudit/writeaudit.go
+++ b/internal/writeaudit/writeaudit.go
@@ -80,7 +80,7 @@ var Allowlist = map[string]Exception{
 
 	// ---- LANE HANDOFFS: delete each entry as its PR lands. ----
 	"internal/cli/init.go": {
-		Count:  5,
+		Count:  4,
 		Reason: "LANE HANDOFF to PR #306, which owns internal/cli/init.go. Vulnerable; not converted here to avoid an edit collision.",
 	},
 	"internal/cli/self_update.go": {

--- a/internal/writeaudit/writeaudit_test.go
+++ b/internal/writeaudit/writeaudit_test.go
@@ -516,6 +516,133 @@ func viaSafeFlags() error {
 	}
 }
 
+// TestScan_AcceptsSymlinkSafeOpenFlags is the LOW regression: the whitelist
+// used to ban syscall.O_NOFOLLOW and syscall.O_CLOEXEC even though neither
+// can create or truncate a file — O_NOFOLLOW is the flag a defensive,
+// symlink-refusing open uses BY DESIGN, so the guard was flagging the most
+// correct possible call and pushing its author toward a permanent allowlist
+// entry instead. This plants exactly that call and requires it clean.
+func TestScan_AcceptsSymlinkSafeOpenFlags(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "safe.go", `package probe
+
+import (
+	"os"
+	"syscall"
+)
+
+func viaNoFollow() error {
+	f, err := os.OpenFile("/tmp/x", os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Scan found %v; want no findings — O_NOFOLLOW|O_CLOEXEC neither creates nor "+
+			"truncates, and O_NOFOLLOW is THE flag a symlink-safe open uses", got)
+	}
+}
+
+// TestScan_AcceptsLiteralZeroFlags is the literal-0 half of the LOW
+// regression: a bare `0` as the flags argument to os.OpenFile IS O_RDONLY —
+// Go and POSIX both fix O_RDONLY at 0 on every platform this ships to — so
+// it can no more create or truncate than spelling out os.O_RDONLY would.
+func TestScan_AcceptsLiteralZeroFlags(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "safe.go", `package probe
+
+import "os"
+
+func viaLiteralZero() error {
+	f, err := os.OpenFile("/tmp/x", 0, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Scan found %v; want no findings — a literal 0 flags argument is O_RDONLY and "+
+			"cannot create or truncate", got)
+	}
+}
+
+// TestScan_RejectsUnresolvedNonZeroLiteralFlags is the control for the
+// literal-0 acceptance above: it must not generalize to "any integer
+// literal is safe". A non-zero literal could be a platform-specific magic
+// number this scan cannot verify — including one that happens to include
+// O_CREAT's bit — so it must still fall through to unresolvable-is-banned.
+func TestScan_RejectsUnresolvedNonZeroLiteralFlags(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "magic.go", `package probe
+
+import "os"
+
+func viaMagicNumber() error {
+	f, err := os.OpenFile("/tmp/x", 577, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Site() != "viaMagicNumber:os.OpenFile" {
+		t.Fatalf("Scan found %v; want exactly one finding at viaMagicNumber:os.OpenFile — a "+
+			"non-zero integer literal is an unverifiable magic number, not the special-cased "+
+			"literal 0, and must stay banned", got)
+	}
+}
+
+// TestScan_RejectsOTmpfile is the control for what stays banned in the
+// widened whitelist: O_TMPFILE creates an unnamed inode despite the
+// name-shape match with the rest of openFileSafeFlags, and must not be
+// mistaken for a non-creating flag the way O_NOFOLLOW/O_CLOEXEC are.
+func TestScan_RejectsOTmpfile(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "tmpfile.go", `package probe
+
+import (
+	"os"
+	"syscall"
+)
+
+func viaOTmpfile() error {
+	f, err := os.OpenFile("/tmp", syscall.O_TMPFILE|syscall.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Site() != "viaOTmpfile:os.OpenFile" {
+		t.Fatalf("Scan found %v; want exactly one finding at viaOTmpfile:os.OpenFile — "+
+			"O_TMPFILE creates an unnamed inode and must stay banned despite the name-shape "+
+			"match with the rest of the whitelist", got)
+	}
+}
+
 func scanOne(t *testing.T, src string) Finding {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/writeaudit/writeaudit_test.go
+++ b/internal/writeaudit/writeaudit_test.go
@@ -9,17 +9,21 @@ import (
 	"testing"
 )
 
-// TestNoUnauthorizedRawWriteFile is the guard. It scans the whole module
-// for direct os.WriteFile / ioutil.WriteFile calls in non-test files and
-// requires every one of them to be declared in Allowlist with a reason.
+// TestNoUnauthorizedRawWriteFile is the guard. It scans the whole module for
+// direct calls to the creating/truncating primitives in non-test files and
+// requires every one of them to be declared in Allowlist, by identity, with
+// a reason.
 //
 // Three ways to go red, all deliberate:
 //
 //   - a raw call in a file that is not allowlisted at all → new debt;
-//   - MORE raw calls in an allowlisted file than declared → debt grew
-//     inside a file whose entry made it look accounted-for;
-//   - FEWER than declared → the entry is stale and must be deleted, so the
-//     ledger cannot rot into a blanket permission after the owning PR lands.
+//   - a raw call in an allowlisted file at an identity the entry does not
+//     name → either a new call, or the judged-keep call was MOVED (e.g. into
+//     a general-purpose helper, which is how a single exception becomes a
+//     module-wide one);
+//   - an identity the entry names that is no longer present → the entry is
+//     stale and must be deleted, so the ledger cannot rot into a blanket
+//     permission after the owning PR lands.
 func TestNoUnauthorizedRawWriteFile(t *testing.T) {
 	root := repoRoot(t)
 
@@ -38,32 +42,45 @@ func TestNoUnauthorizedRawWriteFile(t *testing.T) {
 		if !ok {
 			t.Errorf(`%s calls %s directly at %s.
 
-os.WriteFile follows symlinks: a dangling symlink planted at that path
-makes os.Stat/os.ReadFile report "absent", and this write then lands
-OUTSIDE the repository, through the link.
+%s follows symlinks: a dangling symlink planted at that path makes
+os.Stat/os.ReadFile report "absent", and this write then lands OUTSIDE the
+repository, through the link.
 
-Route it through internal/atomicio.WriteFile (temp sibling + rename onto
-the destination name). If write-through is genuinely correct at this site,
-add an entry to Allowlist in internal/writeaudit/writeaudit.go saying why.`,
-				file, got[0].Call, lines(got))
+Route it through internal/atomicio.WriteFile (temp sibling + rename onto the
+destination name, symlink refused). If the raw call is genuinely correct at
+this site, add an entry to Allowlist in internal/writeaudit/writeaudit.go
+naming the site ("%s") and saying why.
+
+SCOPE REMINDER: this guard catches os.WriteFile, ioutil.WriteFile, os.Create,
+and os.OpenFile with O_CREATE/O_TRUNC, under any import spelling. It does NOT
+catch writes through an *os.File you already hold (template.Execute,
+json.Encoder, io.Copy, f.Write) or a shell-out. It is not a sandbox — it
+catches the ACCIDENTAL reintroduction, which is the one that keeps happening.`,
+				file, got[0].Call, lines(got), got[0].Call, got[0].Site())
 			continue
 		}
-		switch {
-		case len(got) > ex.Count:
-			t.Errorf(`%s has %d raw write call(s) at %s but the allowlist permits %d.
+		missing, extra := diffSites(ex.Sites, sites(got))
+		if len(extra) > 0 {
+			t.Errorf(`%s has raw write call(s) the allowlist does not cover: %s
+(all raw calls in this file: %s at line(s) %s)
 
-A new one was added to a file that already had an exception. The existing
-exception does not cover it — read the recorded reason and route the new
-call through internal/atomicio.WriteFile:
+Either a new one was added to a file that already had an exception, or the
+allowlisted call MOVED to a different function — which is exactly what the
+identity check exists to catch, because relocating a judged keep into a
+general-purpose helper turns one exception into a module-wide one.
 
-  %s`, file, len(got), lines(got), ex.Count, ex.Reason)
-		case len(got) < ex.Count:
-			t.Errorf(`%s has %d raw write call(s) at %s but the allowlist still claims %d.
+Route the new call through internal/atomicio.WriteFile, or update the entry.
+Recorded reason:
 
-Stale entry. Lower the count, or delete the entry outright if the file is
-now clean. Recorded reason:
+  %s`, file, strings.Join(extra, ", "), strings.Join(sites(got), ", "), lines(got), ex.Reason)
+		}
+		if len(missing) > 0 {
+			t.Errorf(`%s no longer contains allowlisted call site(s): %s
 
-  %s`, file, len(got), lines(got), ex.Count, ex.Reason)
+Stale entry. Remove those identities, or delete the entry outright if the
+file is now clean. Recorded reason:
+
+  %s`, file, strings.Join(missing, ", "), ex.Reason)
 		}
 	}
 
@@ -91,10 +108,15 @@ func TestAllowlistEntriesCarryAReason(t *testing.T) {
 	for file, ex := range Allowlist {
 		if len(strings.TrimSpace(ex.Reason)) < 40 {
 			t.Errorf("allowlist entry %s has no substantive reason (%q); "+
-				"say why write-through is correct, or who owns the conversion", file, ex.Reason)
+				"say why the raw call is correct, or who owns the conversion", file, ex.Reason)
 		}
-		if ex.Count < 1 {
-			t.Errorf("allowlist entry %s has Count=%d; delete the entry instead", file, ex.Count)
+		if len(ex.Sites) == 0 {
+			t.Errorf("allowlist entry %s names no sites; delete the entry instead", file)
+		}
+		for _, s := range ex.Sites {
+			if !strings.Contains(s, ":") {
+				t.Errorf("allowlist entry %s has malformed site %q; want \"<func>:<pkg>.<Fn>\"", file, s)
+			}
 		}
 	}
 }
@@ -151,6 +173,153 @@ func innocent() error {
 	if got[0].Line != 6 {
 		t.Errorf("finding line = %d; want 6 (the call, not the comment above it)", got[0].Line)
 	}
+	if got[0].Site() != "guilty:os.WriteFile" {
+		t.Errorf("site = %q; want %q — the allowlist identity is the enclosing function", got[0].Site(), "guilty:os.WriteFile")
+	}
+}
+
+// TestScan_DefeatsTheSpellingDodges is the HIGH-3 regression. Every case
+// below was demonstrated to compile and pass the previous guard, which only
+// recognised an *ast.SelectorExpr whose X was literally named "os".
+//
+// Each case is its own file in one probe module so a single Scan proves all
+// of them at once, and each is asserted by SITE, so a scanner that finds the
+// right number of calls in the wrong places still fails.
+func TestScan_DefeatsTheSpellingDodges(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+
+	write(t, dir, "alias.go", `package probe
+
+import w "os"
+
+func viaAlias() error { return w.WriteFile("/tmp/x", nil, 0o644) }
+`)
+	write(t, dir, "dotimport.go", `package probe
+
+import . "os"
+
+func viaDotImport() error { return WriteFile("/tmp/x", nil, 0o644) }
+`)
+	write(t, dir, "openfile.go", `package probe
+
+import "os"
+
+func viaOpenFile() error {
+	f, err := os.OpenFile("/tmp/x", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	// O_CREATE with NO O_TRUNC — the exact shape of
+	// internal/cli/filelock_unix.go, which the previous guard did not flag.
+	// Kept as its own case because a probe that carries both flags cannot
+	// tell whether the O_CREATE arm or the O_TRUNC arm did the catching.
+	write(t, dir, "createonly.go", `package probe
+
+import "os"
+
+func viaCreateOnly() error {
+	f, err := os.OpenFile("/tmp/lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	// O_TRUNC with NO O_CREATE — truncating an existing path still follows a
+	// symlink and still destroys whatever is at the far end.
+	write(t, dir, "truncateonly.go", `package probe
+
+import "os"
+
+func viaTruncOnly() error {
+	f, err := os.OpenFile("/tmp/x", os.O_TRUNC|os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	write(t, dir, "create.go", `package probe
+
+import "os"
+
+func viaCreate() error {
+	f, err := os.Create("/tmp/x")
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	// os.Truncate creates nothing, so it cannot be the dangling-symlink
+	// primitive — but it resolves the path and destroys whatever is at the
+	// far end of a link, which is the same damage. Taken from PR #306's
+	// primitive set when the two guards were unified into this one.
+	write(t, dir, "truncate.go", `package probe
+
+import "os"
+
+func viaTruncate() error { return os.Truncate("/tmp/x", 0) }
+`)
+	write(t, dir, "dynamicflags.go", `package probe
+
+import "os"
+
+func viaComputedFlags(flags int) error {
+	f, err := os.OpenFile("/tmp/x", flags, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	// NOT a finding: opening an existing file read-only neither creates
+	// nor truncates, so the guard must not cry wolf about it.
+	write(t, dir, "readonly.go", `package probe
+
+import "os"
+
+func readOnly() error {
+	f, err := os.OpenFile("/tmp/x", os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	gotSites := map[string]string{} // site -> file
+	for _, f := range got {
+		gotSites[f.Site()] = f.File
+	}
+	want := map[string]string{
+		"viaAlias:os.WriteFile":        "alias.go",
+		"viaDotImport:os.WriteFile":    "dotimport.go",
+		"viaOpenFile:os.OpenFile":      "openfile.go",
+		"viaCreateOnly:os.OpenFile":    "createonly.go",
+		"viaTruncOnly:os.OpenFile":     "truncateonly.go",
+		"viaCreate:os.Create":          "create.go",
+		"viaTruncate:os.Truncate":      "truncate.go",
+		"viaComputedFlags:os.OpenFile": "dynamicflags.go",
+	}
+	for site, file := range want {
+		if gotSites[site] != file {
+			t.Errorf("Scan missed %s in %s; a raw write spelled this way slips past the guard. got=%v",
+				site, file, got)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("Scan found %d finding(s) %v; want exactly %d — an extra one means "+
+			"the read-only os.OpenFile was flagged, which would make the guard noise", len(got), got, len(want))
+	}
 }
 
 // TestScan_DetectsIoutilAlias pins the deprecated spelling, the obvious way
@@ -171,6 +340,72 @@ func old() error { return ioutil.WriteFile("/tmp/x", nil, 0o644) }
 	if len(got) != 1 || got[0].Call != "ioutil.WriteFile" {
 		t.Fatalf("Scan found %v; want one ioutil.WriteFile finding", got)
 	}
+}
+
+// TestScan_ReportsMethodReceiverInSite pins the identity format for methods,
+// so an allowlist entry for a method is writable and stable.
+func TestScan_ReportsMethodReceiverInSite(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "method.go", `package probe
+
+import "os"
+
+type Store struct{ path string }
+
+func (s *Store) Save(b []byte) error { return os.WriteFile(s.path, b, 0o644) }
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Site() != "Store.Save:os.WriteFile" {
+		t.Fatalf("Scan found %v; want one finding with site Store.Save:os.WriteFile", got)
+	}
+}
+
+// TestScan_RelocationChangesTheSite is the HIGH-3b regression: moving an
+// allowlisted call into a general-purpose helper must not keep the ledger
+// green. Under a count-based allowlist this was invisible — one call before,
+// one call after.
+func TestScan_RelocationChangesTheSite(t *testing.T) {
+	before := scanOne(t, `package probe
+
+import "os"
+
+func installHook(p string, b []byte) error { return os.WriteFile(p, b, 0o755) }
+`)
+	after := scanOne(t, `package probe
+
+import "os"
+
+func RawWriteFile(p string, b []byte, m os.FileMode) error { return os.WriteFile(p, b, m) }
+
+func installHook(p string, b []byte) error { return RawWriteFile(p, b, 0o755) }
+`)
+	if before.Site() == after.Site() {
+		t.Fatalf("relocating the call into a helper left the site unchanged (%q); "+
+			"the allowlist would stay green while the raw write became callable "+
+			"from anywhere in the module", before.Site())
+	}
+	if after.Site() != "RawWriteFile:os.WriteFile" {
+		t.Errorf("after relocation site = %q; want RawWriteFile:os.WriteFile", after.Site())
+	}
+}
+
+func scanOne(t *testing.T, src string) Finding {
+	t.Helper()
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "x.go", src)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Scan found %d findings %v; want exactly 1", len(got), got)
+	}
+	return got[0]
 }
 
 func repoRoot(t *testing.T) string {
@@ -201,6 +436,42 @@ func write(t *testing.T, dir, name, body string) {
 	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
 		t.Fatalf("write %s: %v", name, err)
 	}
+}
+
+func sites(fs []Finding) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.Site())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diffSites compares the allowlisted identities with the observed ones as
+// MULTISETS: two permitted calls in the same function are two entries, and
+// adding a third is caught.
+func diffSites(want, got []string) (missing, extra []string) {
+	counts := map[string]int{}
+	for _, w := range want {
+		counts[w]++
+	}
+	for _, g := range got {
+		counts[g]--
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for i := 0; i < counts[k]; i++ {
+			missing = append(missing, k)
+		}
+		for i := 0; i < -counts[k]; i++ {
+			extra = append(extra, k)
+		}
+	}
+	return missing, extra
 }
 
 func lines(fs []Finding) string {

--- a/internal/writeaudit/writeaudit_test.go
+++ b/internal/writeaudit/writeaudit_test.go
@@ -393,6 +393,129 @@ func installHook(p string, b []byte) error { return RawWriteFile(p, b, 0o755) }
 	}
 }
 
+// TestScan_DetectsFunctionValueLaundering is the HIGH-1 regression. Storing
+// a banned primitive in a variable and calling THAT compiles and, before
+// this fix, was invisible: resolveCallee only inspected an *ast.CallExpr's
+// Fun, so the assignment itself was never looked at and the subsequent call
+// through the variable resolves to nothing this scanner recognises. The
+// idiom is not hypothetical — internal/skill/sync.go:693 does exactly this
+// shape with the SAFE primitive (`var atomicWriteFile = atomicio.WriteFile`)
+// so a copy-paste with the unsafe one is one keystroke away.
+//
+// Both the package-level var form and the local short-variable form are
+// probed, in separate files so each is asserted by site independently.
+func TestScan_DetectsFunctionValueLaundering(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+
+	write(t, dir, "packagevar.go", `package probe
+
+import "os"
+
+var rawWrite = os.WriteFile
+
+func viaPackageVar(p string, b []byte) error { return rawWrite(p, b, 0o644) }
+`)
+	write(t, dir, "localvar.go", `package probe
+
+import "os"
+
+func viaLocalVar(p string, b []byte) error {
+	w := os.WriteFile
+	return w(p, b, 0o644)
+}
+`)
+
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	gotSites := map[string]string{}
+	for _, f := range got {
+		gotSites[f.Site()] = f.File
+	}
+	want := map[string]string{
+		"<file>:os.WriteFile":      "packagevar.go", // top-level var decl, no enclosing func
+		"viaLocalVar:os.WriteFile": "localvar.go",
+	}
+	for site, file := range want {
+		if gotSites[site] != file {
+			t.Errorf("Scan missed the laundered reference %s in %s (probes rawWrite(...) and w(...) "+
+				"must NOT also appear as separate findings — the call through the variable resolves to "+
+				"nothing this scanner recognises, and the escape is caught at the assignment). got=%v",
+				site, file, got)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("Scan found %d finding(s) %v; want exactly %d (one per assignment, and the calls "+
+			"through rawWrite/w must NOT double-count)", len(got), got, len(want))
+	}
+}
+
+// TestScan_RejectsUnresolvedOPrefixedFlag is the HIGH-2 regression.
+// openFileVerdict used to pass ANY identifier starting with "O_" as a safe
+// non-creating flag — so a look-alike name that is not actually one of the
+// os package's own flag constants slipped through as "safe" purely because
+// of its spelling. This plants exactly that: a local constant that shares
+// the O_ prefix but names nothing the os package defines.
+func TestScan_RejectsUnresolvedOPrefixedFlag(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "lookalike.go", `package probe
+
+import "os"
+
+const O_LOOKALIKE = 0
+
+func viaLookalike() error {
+	f, err := os.OpenFile("/tmp/x", os.O_RDWR|O_LOOKALIKE, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Site() != "viaLookalike:os.OpenFile" {
+		t.Fatalf("Scan found %v; want exactly one finding at viaLookalike:os.OpenFile — "+
+			"O_LOOKALIKE is not a real os package flag constant, and the prefix-only check "+
+			"used to let it (and anything else spelled \"O_*\") pass as safe", got)
+	}
+}
+
+// TestScan_AcceptsKnownSafeOpenFileFlags is the control for the fix above: a
+// combination of GENUINE os package non-creating flags must still pass, or
+// the tightened check would make the guard cry wolf on every read-write,
+// non-creating os.OpenFile call in the tree (acquireRepoLock's O_RDWR among
+// them, once combined with something other than O_CREATE).
+func TestScan_AcceptsKnownSafeOpenFileFlags(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "safe.go", `package probe
+
+import "os"
+
+func viaSafeFlags() error {
+	f, err := os.OpenFile("/tmp/x", os.O_RDWR|os.O_APPEND|os.O_SYNC, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Scan found %v; want no findings — O_RDWR|O_APPEND|O_SYNC neither creates nor "+
+			"truncates and every name in it is a genuine os package flag constant", got)
+	}
+}
+
 func scanOne(t *testing.T, src string) Finding {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/writeaudit/writeaudit_test.go
+++ b/internal/writeaudit/writeaudit_test.go
@@ -1,0 +1,217 @@
+package writeaudit
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoUnauthorizedRawWriteFile is the guard. It scans the whole module
+// for direct os.WriteFile / ioutil.WriteFile calls in non-test files and
+// requires every one of them to be declared in Allowlist with a reason.
+//
+// Three ways to go red, all deliberate:
+//
+//   - a raw call in a file that is not allowlisted at all → new debt;
+//   - MORE raw calls in an allowlisted file than declared → debt grew
+//     inside a file whose entry made it look accounted-for;
+//   - FEWER than declared → the entry is stale and must be deleted, so the
+//     ledger cannot rot into a blanket permission after the owning PR lands.
+func TestNoUnauthorizedRawWriteFile(t *testing.T) {
+	root := repoRoot(t)
+
+	findings, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan(%s): %v", root, err)
+	}
+
+	byFile := map[string][]Finding{}
+	for _, f := range findings {
+		byFile[f.File] = append(byFile[f.File], f)
+	}
+
+	for file, got := range byFile {
+		ex, ok := Allowlist[file]
+		if !ok {
+			t.Errorf(`%s calls %s directly at %s.
+
+os.WriteFile follows symlinks: a dangling symlink planted at that path
+makes os.Stat/os.ReadFile report "absent", and this write then lands
+OUTSIDE the repository, through the link.
+
+Route it through internal/atomicio.WriteFile (temp sibling + rename onto
+the destination name). If write-through is genuinely correct at this site,
+add an entry to Allowlist in internal/writeaudit/writeaudit.go saying why.`,
+				file, got[0].Call, lines(got))
+			continue
+		}
+		switch {
+		case len(got) > ex.Count:
+			t.Errorf(`%s has %d raw write call(s) at %s but the allowlist permits %d.
+
+A new one was added to a file that already had an exception. The existing
+exception does not cover it — read the recorded reason and route the new
+call through internal/atomicio.WriteFile:
+
+  %s`, file, len(got), lines(got), ex.Count, ex.Reason)
+		case len(got) < ex.Count:
+			t.Errorf(`%s has %d raw write call(s) at %s but the allowlist still claims %d.
+
+Stale entry. Lower the count, or delete the entry outright if the file is
+now clean. Recorded reason:
+
+  %s`, file, len(got), lines(got), ex.Count, ex.Reason)
+		}
+	}
+
+	for file, ex := range Allowlist {
+		if _, still := byFile[file]; still {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(file))); os.IsNotExist(err) {
+			t.Errorf("allowlist names %s, which no longer exists — delete the entry.\n\n  %s", file, ex.Reason)
+			continue
+		}
+		t.Errorf(`%s no longer contains any raw write call, but is still allowlisted.
+
+The debt was paid; delete the entry so the next raw call in this file is
+caught. Recorded reason:
+
+  %s`, file, ex.Reason)
+	}
+}
+
+// TestAllowlistEntriesCarryAReason keeps the allowlist honest: an entry
+// with an empty or one-word reason is a rubber stamp, and the whole point
+// of the list is that each exception was argued for.
+func TestAllowlistEntriesCarryAReason(t *testing.T) {
+	for file, ex := range Allowlist {
+		if len(strings.TrimSpace(ex.Reason)) < 40 {
+			t.Errorf("allowlist entry %s has no substantive reason (%q); "+
+				"say why write-through is correct, or who owns the conversion", file, ex.Reason)
+		}
+		if ex.Count < 1 {
+			t.Errorf("allowlist entry %s has Count=%d; delete the entry instead", file, ex.Count)
+		}
+	}
+}
+
+// TestScan_DetectsAPlantedCall is the control for the guard above. A scan
+// that silently returns nothing — wrong root, parse error swallowed, walk
+// skipping everything — would make TestNoUnauthorizedRawWriteFile pass
+// vacuously forever. This plants a call Scan MUST find, in a temp tree, and
+// checks the surrounding discrimination too: comments mentioning the call,
+// _test.go files, and a same-named method on a local variable are all
+// non-findings.
+func TestScan_DetectsAPlantedCall(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+
+	write(t, dir, "guilty.go", `package probe
+
+import "os"
+
+// This comment says os.WriteFile and must NOT be counted.
+func guilty() error { return os.WriteFile("/tmp/x", nil, 0o644) }
+`)
+	write(t, dir, "innocent_test.go", `package probe
+
+import "os"
+
+func helper() error { return os.WriteFile("/tmp/x", nil, 0o644) }
+`)
+	write(t, dir, "innocent.go", `package probe
+
+// Prose about os.WriteFile following symlinks. Not a call.
+type fakeOS struct{}
+
+func (fakeOS) WriteFile(string, []byte, uint32) error { return nil }
+
+func innocent() error {
+	var os fakeOS
+	return os.WriteFile("/tmp/x", nil, 0o644)
+}
+`)
+
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Scan found %d call(s) %v; want exactly 1 (guilty.go). "+
+			"0 means the scanner is blind and the repo guard passes vacuously; "+
+			">1 means it counts comments, tests, or shadowed identifiers.", len(got), got)
+	}
+	if got[0].File != "guilty.go" || got[0].Call != "os.WriteFile" {
+		t.Errorf("finding = %+v; want guilty.go / os.WriteFile", got[0])
+	}
+	if got[0].Line != 6 {
+		t.Errorf("finding line = %d; want 6 (the call, not the comment above it)", got[0].Line)
+	}
+}
+
+// TestScan_DetectsIoutilAlias pins the deprecated spelling, the obvious way
+// to reintroduce the bug past a ban on `os.WriteFile` alone.
+func TestScan_DetectsIoutilAlias(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "go.mod", "module example.com/probe\n\ngo 1.21\n")
+	write(t, dir, "old.go", `package probe
+
+import "io/ioutil"
+
+func old() error { return ioutil.WriteFile("/tmp/x", nil, 0o644) }
+`)
+	got, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(got) != 1 || got[0].Call != "ioutil.WriteFile" {
+		t.Fatalf("Scan found %v; want one ioutil.WriteFile finding", got)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root, err := FindRepoRoot(wd)
+	if err != nil {
+		t.Fatalf("FindRepoRoot: %v", err)
+	}
+	// Control: the guard is worthless if it is pointed at an empty or wrong
+	// tree, which would make "no findings" mean "nothing scanned".
+	if _, err := os.Stat(filepath.Join(root, "internal", "atomicio", "atomicio.go")); err != nil {
+		t.Fatalf("repo root %s does not look like the logmind tree "+
+			"(internal/atomicio/atomicio.go missing): %v", root, err)
+	}
+	return root
+}
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", name, err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func lines(fs []Finding) string {
+	n := make([]int, 0, len(fs))
+	for _, f := range fs {
+		n = append(n, f.Line)
+	}
+	sort.Ints(n)
+	s := make([]string, 0, len(n))
+	for _, ln := range n {
+		s = append(s, strconv.Itoa(ln))
+	}
+	return strings.Join(s, ", ")
+}


### PR DESCRIPTION
Closes most of #310. See "Gaps" below for what remains and who owns it.

`os.WriteFile` **follows symlinks**. Any site that asks "does this exist?", reads `fs.ErrNotExist` as "absent, safe to create", and then writes, can be redirected outside the repository by a planted dangling link. logmind runs inside repositories its user did not write.

## Site count — measured, not inherited

```
grep -rn "os\.WriteFile(" --include="*.go" . | grep -v "_test\.go"
```

**26 sites across 13 files** — not the 23/12 the originating panel reported.

**Control:** planted an `os.WriteFile(...)` in a temp `internal/skill/zz_control_probe.go`; the grep returned it (`CONTROL: HIT`), then it was removed. So the places it found *nothing* mean something. Also swept `ioutil.WriteFile`, `os.Create`, `os.OpenFile`, `os.Truncate` — one hit (`filelock_unix.go:39`), already inside #300's audited scope.

## Converted, and the one kept

| site | verdict |
|---|---|
| `claudehook.go:219` `writeFreshSettings` | converted — the `ErrNotExist` create branch, the exact exploit path |
| `cli/agents.go:398,410` | converted |
| `cli/install_hook.go:132` fresh install | converted — a dangling link dropped a `0o755` script off-tree |
| **`cli/install_hook.go:116` append** | **KEPT** — reached only after `ReadFile` *succeeded*, so a dangling link cannot arrive. A symlinked `.git/hooks/pre-commit` (husky, dotfiles) is deliberate, and the atomic rename would detach it *and* force-chmod `0o755`, breaking the mode-preservation contract documented there. |
| `skill/provenance.go:58`, `skill/scaffold.go:127` | converted — `os.Stat` reports absent for a dangling link |
| `skill/push.go:548,663` | converted — destination is a `git clone` of a user-supplied `--catalog-target`, and git checks out symlinks verbatim. The now-redundant `os.Chmod` removed (atomicio chmods pre-rename), pinned by a mode test |
| `skill/suggest_llm.go:450` | converted — draft names derive from the slug, so they're predictable |
| `tree/tree.go:521` | converted — hand-rolled temp+rename to a *predictable* `<target>.tmp`; the following `os.Rename` then moved the **link** into place, leaving `file-structure.md` pointing off-tree permanently |

## The guard — `internal/writeaudit`

Fixing 26 sites without one just means the 27th arrives next month.

AST-based, not grep — a dozen comments mention `os.WriteFile` in prose. It fails on an unlisted file, on a **higher count** in a listed file, and on a **stale entry**, so the lane-handoff entries must be *deleted* as those PRs land rather than decaying into blanket permission.

Allowlist: `install_hook.go` (judged keep, full argument inline), `init.go` / `self_update.go` / `inserter.go` (#306), `gitattr.go` (#301), `dependabot.go` (unowned gap).

## Repro through real command paths, before → after

Before, actual payloads written outside the repo: `SKILL.md` 501B · `PROVENANCE.md` 611B · pre-commit hook 903B **executable** · `file-structure` 370B · `settings.json` 330B · draft 554B · copyTree 29B; `agents update` rewrote an outside `.yml` in place. After: every target absent, tool path a regular file.

## Mutations — 9, all compiled, all died

Each converted file reverted to a raw call → regression **and** guard both red. Plus two on the scanner itself: blinding it, and dropping import resolution (which then miscounts a shadowed identifier). **Mutation 3 is the sharpest** — the guard caught "2 raw calls where the allowlist permits 1", which is exactly the 24th-call case. All restored from private copies (`cp`, never `git checkout`), all SHA-256 byte-identical.

## Gaps, stated rather than hidden

- **`internal/inserter/dependabot.go:112,154`** — vulnerable, in #306's package but not among its five named sites. Handed to that lane.
- `cli/init.go` ×5, `cli/self_update.go` ×1, `inserter.go` ×5 → #306. `gitattr.go` ×2 → #301.

`go build` / `go vet` / `gofmt -l .` clean · `go test ./...` **23 packages `ok`, 0 failed** (25 packages in the module; `cmd/logmind` and `internal/clierr` have no test files). Measured with `go test ./... | grep -c '^ok'`, not recited.
