### PR TITLE
docs(roadmap): mark what landed, and hand the remaining-work list back to git

### DIFF
--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -136,3 +136,14 @@
 
 ---
 
+## 2026-08-16 07:46 - roadmap: make the emitted inventory carry its own control, distinguish absent from refused, and name the unblocking action
+
+**Reasoning:** Round 11 replaced a hand-written inventory with a command, and the command inherited three of the defects the file exists to prevent. It printed only refusals while the prose claimed the marked rows were its control — a control the reader had to write. Its empty case could not tell a missing file from a refused lookup, which is the exact defect this file calls out for the block above it. And its four workflow names were hand-written against ListWorkflowTemplates, which reads the embed directory precisely because adding a template is meant to be purely additive, so a fifth would have dropped out silently.
+
+**Alternatives considered:** Fix only the two the reviewer called blocking — rejected; the other two are this file's own stated defect appearing in its own commands, and shipping that is worse than shipping a wrong number. Keep the two-file version table alongside the four-column inventory — rejected; that is two owners for one fact, so the loop is deleted and the table now says outright that it tracks two of four templates and points at the inventory for scoping #257.
+
+**Implications:**
+- The command now derives its names from internal/templates/github/*.yml.template and prints all four states: 80 rows, 26 marked, 6 needing hands, 48 absent, 0 lookup failures. The 26 marked rows are the control the prose promised, and they are now actually emitted. The lane control-tested its own zero on the LOOKUP FAILED arm by querying ?ref=nosuchref, proving the branch is live rather than dead — that zero is real. Also corrected: 'wherever it applies, regen-on-main fails with GH013' was false, because homebrew-tap has the same ruleset applied WITH the steward on its bypass list; applying is not refusing. And 'Blocked on a person' now names the move — add App 3951953 to that ruleset's bypass list, per repository, because there is no org-wide switch, which is why one grant on logmind cleared nothing else.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -92,3 +92,14 @@
 
 ---
 
+## 2026-08-16 06:11 - roadmap: run every command the file hands the reader, and let one paragraph own the tag boundary
+
+**Reasoning:** A panel found the file's replacement for the stale-SHA line was a command that cannot execute: git rev-parse --short takes exactly one revision, so the two-ref form exits 128 with 'Needed a single revision'. A doc whose thesis is 'state the command, not the answer' had shipped a command nobody ran — worse than the stale number it replaced. Every fenced block and inline command in the file has now been executed and its documented output reproduced. Separately the file asserted the tag boundary in three places that had drifted apart: #310's remaining sites were filed pre-tag as closing when #301 lands, while #265+#257 were paired as post-tag — and #301, which closes #265, is open against dev and lands pre-tag.
+
+**Alternatives considered:** for-each-ref for the two-SHA case — rejected; it exits 0 and prints nothing on a typo'd ref, and a silent wrong answer is the failure this file exists to prevent. Fix the three sequencing statements to agree — rejected; three agreeing copies are still three copies, and they drifted once already.
+
+**Implications:**
+- Ruling recorded: #265 is pre-tag and lands in #301; #257 is the single item in the run to the tag that waits for the tag, because setup-logmind installs from /releases/latest and v1.2.0 lacks --base. One paragraph in §2 now decides that boundary and the other sections link to it. Also corrected: skdd is refused generically, not with a reason — 'logmind auto skdd' is byte-identical to 'logmind auto banana', while only night carries a retirement note; the naive closes-probe drops one issue, not two, and #284 survives it by luck rather than coverage; and two transcripts were not verbatim. The lane also caught two errors it introduced mid-pass, including a boundary sentence that contradicted the ten post-tag items in the same file.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -147,3 +147,14 @@
 
 ---
 
+## 2026-08-16 07:59 - roadmap: defer the dogfood split to the note that owns it instead of asserting it wrongly
+
+**Reasoning:** The sentence said logmind's own rows appear as NEEDS HAND-REPLACEMENT. Three of its four do; logmind-self-update.yml comes back marked v10. The round-13 lens judged no reader was misled, because the dogfood note four paragraphs up already names that exception, and still returned MERGE. I fixed it anyway: 'no statement in this file is false' is the bar this PR has spent thirteen rounds meeting, and the sentence describing logmind's own repository is a poor place to make the first exception.
+
+**Alternatives considered:** Restate the count as three-of-four — rejected; a hand-written number here rots exactly like every other one this file has shed, and there are now two places it would have to stay true. Leave it on the lens's judgement that nobody is misled — rejected on the bar above.
+
+**Implications:**
+- The sentence now defers to the note rather than repeating it, so the two say it once between them and the claim stays true unless the note itself changes. Verified file by file against the command's real output rather than by reading: the three the note calls markerless each return NEEDS HAND-REPLACEMENT, the one it calls the exception returns marked v10, four of four. Render unchanged at 4 tables / 24 rows / 2 blockquotes.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-16 00:16 - roadmap: four numbers were wrong again, including two the fix pass introduced
+
+**Reasoning:** The recheck found the shipped template versions stated as five and eleven when they are six and twelve, and the twelve had landed in the very commit this branch was cut from. It also found the bound I added to the two listing commands lower in the file was not added to the two higher up, so the same silent truncation remained one screen away from its own warning. The consumer count was true only by excluding this repository from a search that includes it, and the symlink class was described as fully built while its last two writes are still open and close only when the sibling branch lands.
+
+**Alternatives considered:** Trust the counts I had already verified once. Rejected: three of the four had been verified at some point and went stale or were verified against the wrong scope. The versions now carry the command that reads them, the search states what it returns rather than what remains after excluding this repository, and the class is described as open with the condition that closes it.
+
+**Implications:**
+- The limit is now described as headroom rather than a fact, because a number chosen to exceed today's total is the same defect with a longer fuse, and it is paired with a total from an endpoint that cannot truncate so a reader can tell when it has been outgrown. Both places that list carry the warning now, rather than one of them.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-15-roadmap-mark-what-landed-and-hand-the-remaining-work-list-ba -->
+- **2026-08-15** — roadmap: mark what landed, and hand the remaining-work list back to git
+<!-- logmind-entry-end -->
+
+## 2026-08-15 22:21 - roadmap: mark what landed, and hand the remaining-work list back to git
+
+**Reasoning:** Eleven pull requests merged to the development branch since this file was written, and three of its sections described work as pending that is now built. Two of them were the load-bearing ones: the template reconciliation the fleet migration waits on, and the ignore-source merge that a protocol question was supposed to gate. That question turned out not to gate it at all, because giving the defaults their own source and resolving positionally conforms to the specification as written rather than needing a ruling.
+
+**Alternatives considered:** Rewrite the remaining-work list to name exactly what is left. Rejected on this file's own history: it was blocked four times for carrying a second copy of a fact that git already owned, and a hand-kept list of what remains is precisely that. The reasoning for each item stays, because reasoning does not go stale; the question of whether an item is done is answered by a command.
+
+**Implications:**
+- The three issues filed after this section was written are recorded with what they actually were, since two were live paths that lost a user's file: self-update wrote a fragment over the whole of an agents file, and doctor overwrote one it had misjudged as unmarked. The reader is warned that an issue named here may already be built, because the closing keyword only fires on the default branch, so anything merged stays open until the branch reaches it.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -48,3 +48,14 @@
 
 ---
 
+## 2026-08-16 01:52 - roadmap: count repositories, never result rows, and let the regeneration command tell absent from unmarked
+
+**Reasoning:** Two findings, both of them a shown command failing to produce the number beside it, which is this file's recurring failure. The row counts I added were not reproducible: the same query returned twenty-five rows for me and twenty-three for the reviewer on the same day, because the search endpoint's row count is not stable, while the repository count was eight for both of us. And the regeneration command I added to fix the previous round could not produce the table it sits under, because it collapsed a missing file and a file carrying no marker into the same word, and the table distinguishes them.
+
+**Alternatives considered:** Re-measure the rows and state the new figures. Rejected: an unstable number does not become stable by being measured again, and writing one invites the next reader to treat a disagreement as a defect rather than as noise. The line now counts repositories and shows the derivation that produces that count rather than a raw listing.
+
+**Implications:**
+- The regeneration loop distinguishes three states rather than two, and the text records what it cannot do: it reads default branches only, so the row for the repository whose workflows live on a development branch was measured separately, and this repository is the producer rather than a consumer and is deliberately absent. Verified the shown derivation returns eight and the control returns two, so the command and the prose now agree.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -114,3 +114,14 @@
 
 ---
 
+## 2026-08-16 06:59 - roadmap: scope the #288 bypass to the repository it was granted on, and stop reading per-file facts as per-repository ones
+
+**Reasoning:** I gave the lane a logmind-scoped fact — the steward bypass is granted — and it cleared a fleet-scoped row with it. Measured across every org repo: Integration:3951953 is on org-baseline and org-default-protection everywhere, but a third ruleset, reporulez-default, is active with an EMPTY bypass list on six repos including agent-skills, clud-bug and clud-bug-app. Rulesets aggregate, so one refusing ruleset overrides two that allow. Control: logmind's own two rulesets carry 2 and 3 bypass actors, so the probe distinguishes granted from refused. An operator reading the cleared row would migrate at tag time and put those repos permanently red on every merge to main touching a derived doc — the exact outcome that row exists to prevent, and something #288's own thread and docs/orchestrator-app.md both already said.
+
+**Alternatives considered:** Restate the bypass as simply missing — rejected; it is granted on logmind, and flattening that loses the fact that the mechanism works and only the grants are outstanding. Count the repositories in the prose — rejected; the count rots, so the section carries the per-repo command instead and prints refusals and grants together, which makes the output its own control.
+
+**Implications:**
+- The class is now named and swept: a true statement about a narrow thing presented as a conclusion about a wider one. It has produced a finding in three consecutive rounds, twice inside a fix from the round before. The lane's own sweep found a fourth instance — reporulez has seven workflows and its logmind-self-update.yml carries marker v8, so 'reporulez is unreachable by refresh' was true per file and false per repository. Also corrected: #244's entry said 'Nothing to do' while the feature is unbuilt (git grep for LOGMIND_ISSUE on dev returns nothing; control, newAutoCmd resolves for #241, which the same section marks built), and a byte-identity pointer aimed at a template listed below it rather than above.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -59,3 +59,14 @@
 
 ---
 
+## 2026-08-16 03:25 - roadmap: one issue was on both the built list and the after-the-tag list
+
+**Reasoning:** The section this change exists to correct listed an issue as built and on the development branch, while a later section still listed the same issue as work remaining after the tag. Its fix is on that branch, measured directly rather than inferred from the issue state, which stays open because the closing keyword only fires on the default branch. A file whose purpose is recording what landed cannot carry the stale copy it was written to remove.
+
+**Alternatives considered:** Annotate the later list rather than removing the entry. Rejected: two lists that mean different things about the same item is how this file has failed five times, and an annotation is a third statement to keep in agreement rather than one fewer.
+
+**Implications:**
+- The symlink class is now stated once as the single exception on that list rather than as a claim and a contradiction two sentences apart, since it genuinely is open and its remaining writes close with the branch still in review. The link-checking template carries the same forward reference the regeneration template already had, because the same branch moves both and only one said so.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -125,3 +125,14 @@
 
 ---
 
+## 2026-08-16 07:21 - roadmap: stop hand-writing the markerless inventory and emit it, then trim #288's archaeology
+
+**Reasoning:** Round 10 narrowed a per-repository claim to per-file and then shipped an incomplete per-file inventory as the resolution — reporulez has three markerless workflows, not two; check-doc-links was missed, and it is a genuine refresh target (ListWorkflowTemplates enumerates all four *.yml.template with no filter, and init.go loops that list). Every other fleet repo has check-doc-links marker-owned — protocol v5, agent-skills v5, clud-bug v4, clud-bug-app v4, rezgen v4, tokenomics v4 — so reporulez is the sole outlier and an operator working a hand-written list at #257 would leave that file stale and permanently unreachable by refresh. That is the third consecutive round where the correction carried the next defect, which is what settled the shape: the file no longer states the inventory at all, it emits it.
+
+**Alternatives considered:** Write the corrected three-file list — rejected; a hand-kept list of a thing the forge owns has now been wrong twice in two rounds. Add the homebrew-tap bypass fact I measured — rejected on the reviewer's argument and the file's own rule: the checklist already carries it command-shaped, and writing the answer would be a fourth recurrence of the defect the header warns about.
+
+**Implications:**
+- The emitted list prints all three states rather than filtering, so the marked rows are the command's own control: a repository that comes back entirely marked proves the probe recognises a marker, which makes a NEEDS HAND-REPLACEMENT row a real one. Verified by running the block verbatim out of the file — rc=0, and it returns reporulez's three plus logmind's three dogfood copies, which the paragraph above already accounts for. The #288 section also lost nine lines of archaeology about its own superseded revisions; the command transcript and the labelled probe table both stay, because the transcript is what the file's rule demands and the table is the only place the control row is named.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -37,3 +37,14 @@
 
 ---
 
+## 2026-08-16 01:01 - roadmap: state the unit, correct a version the file contradicted itself on, and add the two repos the fleet table missed
+
+**Reasoning:** Three findings, all mine, and all the two shapes this file keeps failing on. The control beside the consumer count reported rows where the headline reported repositories, so no consistent reading of the sentence was true: the queries return eight repositories in twenty-five rows and two repositories in thirteen. A sentence twenty-five lines above the version table still called the shipped template eleven while the table said twelve. And the fleet table listed six repositories while the search two sections above named eight, omitting two that carry exactly the stale pair the table exists to enumerate.
+
+**Alternatives considered:** Add the two rows and move on. Rejected: the table is what sizes the fleet migration, so an undercount understates the work, and nothing in the file would have caught the next omission either. The command that regenerates the table now sits beside it, so the next reader can rebuild rather than trust it.
+
+**Implications:**
+- Both numbers in the consumer sentence now state their unit, and the sentence records that an earlier revision quoted one against the other, because that is the mistake a reader is most likely to repeat. The two added repositories were measured directly rather than inferred from the search: both carry check-decisions at two and regen-timeline at four, matching the four already listed, with a repository the table already contained as the control.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -103,3 +103,14 @@
 
 ---
 
+## 2026-08-16 06:34 - roadmap: correct the marker claim this file introduced last round, and stop asserting the tag boundary in three voices
+
+**Reasoning:** Round 8's own fix stated a falsehood: it said logmind's workflows are all hand-maintained copies carrying no template marker. logmind-self-update.yml carries v11, is byte-identical to its shipped template, and doctor reports it current — so it IS refreshed like any consumer's. Control: check-decisions.yml differs from its template, so the diff distinguishes. A doc correcting a false claim by writing another one is the failure this file exists to prevent, which is why the round that introduced it had to be the round that found it. Two further contradictions: §2 claimed to run after §3 while two of its own three rows are already answered, and it called #257 'the single item' waiting on the tag while §4 named #277 as a second.
+
+**Alternatives considered:** Say 'most workflows are markerless' — rejected; a hedge that avoids naming the exception is how the exception stays invisible. Reconcile the two sequencing sentences so they agree — rejected again; agreeing copies are still copies, and §4's duplicate clause is now deleted rather than corrected.
+
+**Implications:**
+- Ruling recorded: #277 is a payload of the fleet migration rather than a second waiter — it closes when #257 does, not on a schedule of its own. §2 owns the sequencing and §4 owns the defect. The lane also chose 'answered' over 'run' for §2's rows, because what was measured is a bypass granted on this repository, not one per consumer — a distinction the earlier wording lost. Method note now carried by both lanes: blanking a middle table row is a USELESS control, since GFM accepts pipeless rows and the counts stay identical; inserting a blank line before a middle row is the working one, dropping table 4 from 9 rows to 4.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -81,3 +81,14 @@
 
 ---
 
+## 2026-08-16 05:42 - roadmap: stop listing #241 as unbuilt, derive the merge closures instead of naming them, and correct the CI and template-guard claims
+
+**Reasoning:** A panel found four claims false. The worst: #241 was filed under blocked-on-a-person as 'unbuildable as written' while logmind auto is shipped and on dev — verified against current source (root.go registers newAutoCmd, auto.go declares 'auto <profile>', internal/auto ships exactly one profile with retired names refused by name), not against the commit message. Control: grep newPlanCmd → 0, newAutoCmd → 1. A reader sequencing pre-tag work would have re-specified a shipped command. Second: the dev→main step hand-listed eight closures where the range actually carries sixteen — the exact hand-copied-answer defect this file's own rule forbids, so it is now the command that derives them. The comma branch is load-bearing: a first-#N-only probe returns fifteen and silently loses #260, because one commit spells it 'closes #278, #260, #284'.
+
+**Alternatives considered:** Strike the #241 item — rejected; the command shipped and the issue is still open, so the honest correction is to state what is built and let the merge close it. Keep the eight-item list and just add the missing eight — rejected; a hand-kept list of a thing git already owns will drift again the next time a PR lands.
+
+**Implications:**
+- Also corrected: 'of the two workflows' claimed two where there are nine, four of which carry a branch-push trigger (all naming main) while two more fire on tags — and test.yml, the Go suite, was invisible to a reader using that section to learn what CI covers. The contradiction with the templates table is resolved by linking to it as the single owner rather than repeating the versions. And the workflow-template guard is TemplateMarker.Writable() inside installWorkflowTemplatesMode, not a symbol named installWorkflowTemplates that does not exist; refusals are reported on stderr, so 'silently left behind' was false while the conclusion it supported was right. Rendering re-verified against GitHub's own renderer: 4 tables, 24 <tr>; control, a fence planted in a middle data row, gives 22.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-15 23:08 - roadmap: a shown command that silently truncates is the defect this file exists to prevent
+
+**Reasoning:** The review found two things, both of them the exact failure shapes this file was rewritten to eliminate, reproduced by the edit meant to eliminate them. A table row still listed a protocol question as gating the ignore-source work, three sections above the paragraph I had just added saying it turned out not to gate it. And the command offered as the replacement for a hand-kept list of open issues drops eighteen of forty-eight, because the tool defaults to thirty and truncates without saying so.
+
+**Alternatives considered:** Fix the one command the review named. Rejected: sweeping the file for the same shape found two more, one unbounded and one bounded at a number that merely happens to exceed today's count. A limit chosen to be larger than the current total is the same defect with a longer fuse.
+
+**Implications:**
+- Every listing command now carries an explicit bound, and the open-issue probe is paired with a total from the search endpoint, which cannot truncate, so a reader can tell when the bound has been outgrown. The protocol row records that the question was answered by shipping rather than by a ruling, and stays open for the specification wording it raises rather than being struck.
+
+---
+

--- a/docs/decisions-branches/docs__roadmap-refresh.md
+++ b/docs/decisions-branches/docs__roadmap-refresh.md
@@ -70,3 +70,14 @@
 
 ---
 
+## 2026-08-16 04:47 - roadmap: a fenced block inside a table cell breaks the table, and the closing paragraph rendered as prose
+
+**Reasoning:** The derivation I added last round to make a count reproducible was placed inside a table cell as a fenced block, which ends the table early. Confirmed against the forge's own renderer rather than by reading the markdown: the table closes before the fence and the cell's final characters render as a stray paragraph, with the sentence truncated mid-clause. The control is a deliberately broken cell of the same shape, which reproduces the stray, against the corrected table which renders four rows and closes once.
+
+**Alternatives considered:** Move the derivation below the table. Rejected: the number it derives lives in that cell, and a command a screen away from its result is the arrangement that let a stale figure sit unnoticed here twice. Inlined as code within the sentence instead, so the claim and its derivation stay adjacent and the table survives.
+
+**Implications:**
+- The list of issues built since this section was written no longer implies a one-to-one pairing by position, because it is not one: one pull request closed two of them, another closed most of a third that is still open. The version claims in the architecture document contradict the ones corrected here, and are a second owner of a fact this file already states with its measuring command; that is routed to the branch which holds that file rather than edited across a lane boundary.
+
+---
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,17 +202,21 @@ repo and must then be fixed twice.
 Each is a hard gate on #257, not a parallel cleanup.
 
 **This paragraph is the only place the tag boundary is decided, and it decides
-one thing: the fleet move, #257, is the single item in the run to the tag that
-waits for the tag.** Everything in §3 lands before it; §5 is the backlog that
-follows it. The reason is mechanical: `setup-logmind` installs from
-`/releases/latest`, and the released v1.2.0 answers `logmind check-decisions
---base` with
+one thing: the fleet move, #257, is the only work in the run to the tag that
+waits for the tag.** #277 closes with it rather than on a schedule of its own —
+it is a payload of the migration, not a second waiter. Everything in §3 lands
+before the tag; §5 is the backlog that follows it.
+
+The reason is mechanical: `setup-logmind` installs from `/releases/latest`, and
+the released v1.2.0 answers `logmind check-decisions --base` with
 `Error: unknown flag: --base` (ruling recorded in #243). No consumer repo can
 take the new gate template until v2.0.0 exists, so the fleet move cannot start
 until the tag does.
 
-Numbering in this list is dependency order, not calendar order — which is why
-§2 sits ahead of "§3 — Remaining pre-tag work" while running after it.
+Numbering in this list is dependency order, not calendar order. Two of the
+three rows below are already answered — template v12 is on `dev`, and the
+bypass #288 reported missing has been granted (see #288 above). Only "a release
+carrying the verb" is still waiting, and what it waits for is the tag.
 
 | | why it blocks |
 |---|---|
@@ -314,8 +318,8 @@ after the tag exists to install from.
 of §3.3 — regenerating from the branch's own sources and failing on the diff, so
 it demands the branch commit exactly what §3.3 forbids. logmind's own copy and
 its shipped `v12` template are **already correct**; the defect is a stale
-installed copy in the consumer repos. So it is a #257 payload, not code to write
-here, and it closes when the fleet takes the current template.
+installed copy in the consumer repos. So it is a #257 payload, not code to
+write here.
 
 ### 5 — After the tag
 
@@ -340,10 +344,8 @@ ships.
 | reporulez | *unversioned* | *unmarked* | no |
 | skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
 
-`rezgen` and `tokenomics` were missing from an earlier revision of this table
-while the search two sections above named them — §4 sizes "one fleet move" off
-this table, so an undercount here understates the migration. Regenerate it,
-rather than trusting it:
+§4 sizes "one fleet move" off this table, so an undercount here understates the
+migration. Regenerate it rather than trusting it:
 
 ```sh
 for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
@@ -364,9 +366,11 @@ files present and unmarked; `skdd`'s are absent from its default branch and
 carry markers on `dev`). The loop reads **default branches only**, so `skdd`'s
 row was measured separately. `logmind` is the producer rather than a consumer
 and is deliberately not a row — but the loop still prints one, reading
-`present, unmarked`. That is not the reporulez defect: logmind's own workflows
-are hand-maintained dogfood copies that carry no template marker because
-nothing is meant to refresh them.
+`present, unmarked`. That is not the reporulez defect. logmind hand-maintains
+its own copies of `check-decisions.yml`, `regen-timeline.yml` and
+`check-doc-links.yml` — markerless on purpose, so refresh leaves them alone.
+The exception is `logmind-self-update.yml`: it carries the marker, is refreshed
+like any consumer's, and is byte-identical to the template listed above.
 
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | the shipped `regen-timeline` template pushes with a raw `LOGMIND_AUTO_REGEN_PAT`; logmind's own copy mints a `skdd-steward[bot]` token via `create-github-app-token@v3`. Shipping as-is deploys the credential path logmind abandoned. Also fix the action-pin regression — the template pins `setup-logmind@v1.0.0` while five repos run `@v1.0.1`. |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. |
 
 ### 3 — Remaining pre-tag work
 
@@ -207,9 +207,11 @@ ahead of the gate cluster; doing it after means relocating a **correct**
 evaluation rather than a wrong one. Its remedy restructures `regen-timeline.yml`,
 so that file moves twice regardless of what else we do.
 
-**#269** — `ignore_patterns` replaces the 16 built-in defaults instead of merging.
-§1.4 line 202 says the three sources are **merged**, so this is a spec violation,
-not a wart. Fix shape depends on protocol#89.
+**#269** — `ignore_patterns` replaced the 16 built-in defaults instead of merging.
+**Built and on `dev`** (#303). protocol#89 turned out not to gate it: the answer
+was to give the defaults their own source and resolve positionally, which
+*conforms* to §1.4 as written rather than needing a ruling. Verified against
+`git check-ignore` as an oracle across seven fixtures.
 
 **#259** — the derived-doc restore does not refuse while a merge, rebase,
 cherry-pick or revert is in progress. Restoring mid-conflict discards the
@@ -234,6 +236,25 @@ tag-time flip would not have added the `areas:` line. **Built and on `dev`**
 (#302). The issue stays open until `dev` reaches `main`, per the rule above.
 The panel verified it by building the site in both states rather than reading
 the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
+
+**#297, #298, #299, #271, #310** — filed after this section was written, all
+**built and on `dev`** (#306, #307, #308, #313). Two were live data-loss paths:
+`self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and
+`doctor --fix` overwrote a file it had misjudged as markerless. #310 is the
+class behind both — `os.WriteFile` follows symlinks, so a planted link
+redirected writes outside the repository from 26 call sites.
+
+**What is genuinely left is shorter than this list.** Rather than maintaining a
+second copy of it here, ask git:
+
+```sh
+git log --oneline origin/main..origin/dev     # built, awaiting the merge to main
+gh issue list --state open --label ''         # everything still open
+```
+
+An issue listed above may already be built — `closes #N` only fires on the
+default branch, so anything merged to `dev` stays open until `dev` reaches
+`main`. That is expected, not drift.
 
 ### 4 — #265 + #257, together (post-tag — see §2)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -145,9 +145,9 @@ It prints every ruleset in every repository, refusals and grants together —
 so the `ok` rows are the control that a `REFUSES STEWARD` row is a real
 refusal and not a probe returning nothing.
 
-### What is actually unresolved
+### Why it has never fired on `logmind`
 
-The push has still never landed a commit, and the reason is *not* a refusal.
+The push has never landed a commit, and the reason is *not* a refusal.
 **Measured 2026-08-15** against `logmind / check-derived-docs`
 (`.github/workflows/regen-timeline.yml`, workflow id `277546816`):
 
@@ -177,22 +177,12 @@ Thirteen green push runs and zero commits means the job runs, finds the derived
 docs already current, and exits 0 on that path — it never reaches the push at
 all. **Both** `push` failures carry the GH013 `Changes must be made through a
 pull request` refusal: `fcf7268` (**2026-07-25**) and `0aa9049`
-(**2026-08-01**), each dated *before* the bypass was added
-(**2026-08-07**). So the original diagnosis was correct when filed and the
-remedy has since been applied.
+(**2026-08-01**), both dated *before* the bypass was added (**2026-08-07**).
 
 **On `logmind`, the bypass is untested rather than missing.** It gets exercised
 the first time `main` receives a merge that leaves a derived doc stale — which
 is the `dev` → `main` merge at the tag, not something to manufacture
 beforehand. Elsewhere it is genuinely missing, which is what keeps #288 open.
-
-> **A caution this file has already earned.** An earlier revision reported
-> "seven `success` runs, and the single `push` event failed." The real figures
-> are 15 push runs and 13 successes. The conclusion — that the green column
-> never described `regen-on-main` — survived, but the evidence for it did not,
-> and an auditor who finds thirteen greens discounts the section that is right.
-> Every count in this file names the command that produced it for exactly this
-> reason.
 
 ### Awaiting protocol rulings
 
@@ -400,26 +390,41 @@ like any consumer's, and is byte-identical to the template it ships.
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
-Two corrections to #257's original inventory:
+**A markerless workflow is unreachable by refresh, permanently.** A file is
+logmind's to overwrite only when the `# logmind-template-version` marker sits on
+line 1 — that is what `TemplateMarker.Writable()` means, and
+`installWorkflowTemplatesMode` refuses everything else, a displaced marker
+included. The refusal is reported on stderr rather than skipped quietly, but a
+reported refusal still leaves the stale file in place, so **every markerless
+file needs hand-replacement at #257**.
 
-- **reporulez's two gate workflows are unreachable by refresh, and always will
-  be.** A workflow file is logmind's to overwrite only when the
-  `# logmind-template-version` marker is on line 1 — that is what
-  `TemplateMarker.Writable()` means, and `installWorkflowTemplatesMode` refuses
-  everything else, a displaced marker included. reporulez's `check-decisions`
-  and `regen-timeline` carry no marker at all, so no refresh reaches them and
-  they need hand-replacement. The refusal is reported on stderr rather than
-  skipped quietly, but a reported refusal still leaves the stale file in place.
-  Its `logmind-self-update.yml` is the opposite case — marker-owned at `v8`, so
-  refresh does reach that one. "reporulez is markerless" is true per file, not
-  per repository.
-- **skdd was misread, and the misreading mixed two branches.** Its `main` has no
-  `.github/workflows` at all (404); its `dev` carries `check-decisions` at **v4**,
-  added 2026-08-01. An earlier revision of this file said "already on v11, so
-  migrating it is a no-op" — that was wrong in both halves, and it would have
-  removed a repository from the migration list that genuinely needs migrating.
-  Its clean `check-derived-docs` history is still no validation: green because
-  neither derived doc exists on any skdd branch.
+Markerlessness is **per file, not per repository** — one repository can carry
+three files that need hands and a fourth that refreshes itself. So do not work
+from a list written here. Produce it:
+
+```sh
+for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
+  for w in check-decisions regen-timeline check-doc-links logmind-self-update; do
+    m=$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" \
+          --jq .content 2>/dev/null | tr -d '\n' | base64 -d 2>/dev/null | head -1)
+    case "$m" in
+      '# logmind-template-version:'*) ;;   # ours; refresh reaches it
+      '') ;;                               # no such file
+      *) printf '%s %s NEEDS HAND-REPLACEMENT\n' "$r" "$w" ;;
+    esac
+  done
+done
+```
+
+Print all three states instead of filtering and the marked rows become the
+control: a repository that comes back entirely marked proves the probe
+recognises a marker, so a `NEEDS HAND-REPLACEMENT` row is a real one. logmind's
+own rows appear and are expected — see the dogfood note above.
+
+**skdd needs migrating, and reads as though it does not.** Its `main` has no
+`.github/workflows` at all (404), so its clean `check-derived-docs` history is
+green because neither derived doc exists on any skdd branch — not because
+anything passed. Its `dev` carries `check-decisions` at **v4**.
 
 ### The cost of not migrating
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,8 +43,8 @@ Run these instead:
 ```sh
 git fetch origin --prune
 git log --oneline origin/main..origin/dev          # what is on dev, not yet on main
-gh issue list --state open --limit 60              # open issues
-gh pr list --state open                            # open pull requests
+gh issue list --state open --limit 200             # open issues
+gh pr list --state open --limit 200                # open pull requests
 gh release list --limit 1                          # what `brew install` gives
 ```
 
@@ -156,7 +156,7 @@ time `main` receives a merge that leaves a derived doc stale — which is the
 | issue | question | blocks |
 |---|---|---|
 | protocol#77 | who owns the §1.2 per-tool redirect files | skdd#6 scope |
-| protocol#89 | is `!pattern` valid in `file_structure.ignore_patterns` | the fix shape for #269 |
+| protocol#89 | is `!pattern` valid in `file_structure.ignore_patterns` | **nothing — answered by shipping.** #269 conformed to §1.4 as written, so no ruling was needed. Left open for the SPEC-wording question it raises. |
 | protocol#90 | §7.3's example declares 3 areas for logmind; we implement 5 | what the tag bakes in |
 | protocol#93 | §3.4 requires non-empty reasoning; §3.1 says an entry without it is well-formed | nothing — gate follows §3.4 today |
 
@@ -198,7 +198,7 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-15: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade` → 7 distinct repos; control: the same query for `@v1.0.0` returns hits, confined to logmind's own template sources.) |
 
 ### 3 — Remaining pre-tag work
 
@@ -249,7 +249,10 @@ second copy of it here, ask git:
 
 ```sh
 git log --oneline origin/main..origin/dev     # built, awaiting the merge to main
-gh issue list --state open --label ''         # everything still open
+gh issue list --state open --limit 200         # everything still open
+# --limit is load-bearing: gh defaults to 30 and truncates SILENTLY.
+# Cross-check the total, which cannot truncate:
+gh api 'search/issues?q=repo:thrillmade/logmind+type:issue+state:open' --jq .total_count
 ```
 
 An issue listed above may already be built — `closes #N` only fires on the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,11 +104,10 @@ the default branch. That is expected, not drift.
 
 ## Blocked on a person
 
-### #288 — the bypass is granted; it has never been exercised
+### #288 — granted on `logmind`, still missing across the fleet
 
-**Not a blocker on the tag.** An earlier revision of this file said the steward
-App was on no bypass list and called that "the tightest constraint on the tag."
-**That was wrong**, and the correction matters more than the original claim.
+**Not a blocker on the tag for this repository.** The steward App may push to
+`logmind`'s `main`:
 
 ```
 $ gh api repos/thrillmade/logmind/rulesets --jq '.[]|"\(.id) \(.name)"'
@@ -123,10 +122,28 @@ $ gh api /apps/skdd-steward --jq .id
 3951953
 ```
 
-Two active rulesets, not three — `reporulez-default` (18292242) returns **404**
-here and no longer covers this repository. Both survivors carry
-`Integration:3951953`, which is `skdd-steward`. Their `updated_at` is
-**2026-08-07T17:1x**.
+Two active rulesets on `logmind`, both carrying `Integration:3951953`, which is
+`skdd-steward`.
+
+**`reporulez-default` is the trap in that reading.** It 404s on `logmind`, so
+it is invisible from here — but it is active on other repositories with **no
+bypass actors at all**, and rulesets aggregate: one ruleset that refuses the
+steward overrides two that allow it. Wherever it applies, `regen-on-main` fails
+with GH013 exactly as it used to here. The grant is per repository, so measure
+it per repository:
+
+```sh
+for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
+  gh api "repos/thrillmade/$r/rulesets" --jq '.[].id' 2>/dev/null | while read -r id; do
+    printf '%s %s\n' "$r" "$(gh api "repos/thrillmade/$r/rulesets/$id" --jq \
+      '"\(.name) \(if any(.bypass_actors[]?; .actor_id == 3951953) then "ok" else "REFUSES STEWARD" end)"')"
+  done
+done
+```
+
+It prints every ruleset in every repository, refusals and grants together —
+so the `ok` rows are the control that a `REFUSES STEWARD` row is a real
+refusal and not a probe returning nothing.
 
 ### What is actually unresolved
 
@@ -164,9 +181,10 @@ pull request` refusal: `fcf7268` (**2026-07-25**) and `0aa9049`
 (**2026-08-07**). So the original diagnosis was correct when filed and the
 remedy has since been applied.
 
-**The bypass is therefore untested, not missing.** It gets exercised the first
-time `main` receives a merge that leaves a derived doc stale — which is the
-`dev` → `main` merge at the tag, not something to manufacture beforehand.
+**On `logmind`, the bypass is untested rather than missing.** It gets exercised
+the first time `main` receives a merge that leaves a derived doc stale — which
+is the `dev` → `main` merge at the tag, not something to manufacture
+beforehand. Elsewhere it is genuinely missing, which is what keeps #288 open.
 
 > **A caution this file has already earned.** An earlier revision reported
 > "seven `success` runs, and the single `push` event failed." The real figures
@@ -213,10 +231,13 @@ the released v1.2.0 answers `logmind check-decisions --base` with
 take the new gate template until v2.0.0 exists, so the fleet move cannot start
 until the tag does.
 
-Numbering in this list is dependency order, not calendar order. Two of the
-three rows below are already answered — template v12 is on `dev`, and the
-bypass #288 reported missing has been granted (see #288 above). Only "a release
-carrying the verb" is still waiting, and what it waits for is the tag.
+Numbering in this list is dependency order, not calendar order. One of the
+three rows below is answered: template v12 is on `dev`. **#288 is not.** The
+bypass exists on `logmind` and is missing on three of the repositories in the
+fleet table — `agent-skills`, `clud-bug` and `clud-bug-app` — and this row is
+about the fleet, so a grant on one repository does not clear it. #288 above
+carries the command that finds every repository it is missing on, inside the
+org and out of the table. "A release carrying the verb" waits on the tag.
 
 | | why it blocks |
 |---|---|
@@ -245,12 +266,16 @@ resolution someone is part-way through, and the restore paths run automatically.
 that some keys are humans-only; an agent that can lower `commit_line_threshold`
 to unblock itself has bought exactly what §3.4's gate exists to prevent.
 
-**#244** — branch→issue binding plus comment-back on merge. Pre-tag by **Ruling
-12**, not by defect: nothing in current behaviour is wrong, the feature simply
-does not exist. Recorded here rather than in §5 so the ruling stays visible.
-Its body no longer contradicts the ruling: its `## Sequencing` section was
-corrected 2026-08-01 and now reads "Pre-tag — in v2.0.0 scope by Ruling 12."
-Nothing to do.
+**#244** — bind a branch to the issue it is working, and comment back on that
+issue when the work merges. Pre-tag by **Ruling 12**, and **unbuilt**: this is
+a feature still to write. Half of it is not new scope at all — SPEC §5.3
+already requires that "a merged change leaves a trace on the issue it belongs
+to", and logmind leaves none. The design is settled in the issue thread;
+building it waits on two open items. **#301** is editing the same
+`internal/guardcommit/guardcommit.go` that #244 extends. **#330** must land
+first because `git.require_issue` is exactly the kind of blocking setting §1.6
+says an agent must not be able to write — shipping the gate before the refusal
+gives an agent a supported command for switching it off.
 
 **#241** — `logmind auto <profile>`: one command sets a repository up to be
 handed over and run unattended. Pre-tag by Ruling 12. **Built and on `dev`**
@@ -370,21 +395,24 @@ and is deliberately not a row — but the loop still prints one, reading
 its own copies of `check-decisions.yml`, `regen-timeline.yml` and
 `check-doc-links.yml` — markerless on purpose, so refresh leaves them alone.
 The exception is `logmind-self-update.yml`: it carries the marker, is refreshed
-like any consumer's, and is byte-identical to the template listed above.
+like any consumer's, and is byte-identical to the template it ships.
 
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
 Two corrections to #257's original inventory:
 
-- **reporulez is unreachable by refresh, and always will be.** A workflow file
-  is logmind's to overwrite only when the `# logmind-template-version` marker is
-  on line 1 — that is what `TemplateMarker.Writable()` means, and
-  `installWorkflowTemplatesMode` refuses everything else, a displaced marker
-  included. reporulez's two files carry no marker at all, so no refresh will
-  ever touch them. The refusal is reported on stderr rather than skipped
-  quietly, but a reported refusal still leaves the stale file in place. It needs
-  hand-replacement.
+- **reporulez's two gate workflows are unreachable by refresh, and always will
+  be.** A workflow file is logmind's to overwrite only when the
+  `# logmind-template-version` marker is on line 1 — that is what
+  `TemplateMarker.Writable()` means, and `installWorkflowTemplatesMode` refuses
+  everything else, a displaced marker included. reporulez's `check-decisions`
+  and `regen-timeline` carry no marker at all, so no refresh reaches them and
+  they need hand-replacement. The refusal is reported on stderr rather than
+  skipped quietly, but a reported refusal still leaves the stale file in place.
+  Its `logmind-self-update.yml` is the opposite case — marker-owned at `v8`, so
+  refresh does reach that one. "reporulez is markerless" is true per file, not
+  per repository.
 - **skdd was misread, and the misreading mixed two branches.** Its `main` has no
   `.github/workflows` at all (404); its `dev` carries `check-decisions` at **v4**,
   added 2026-08-01. An earlier revision of this file said "already on v11, so

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,7 +202,7 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control: the `@v1.0.0` query returns 9, so the probe is not matching nothing.) |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control, **same unit**: the `@v1.0.0` query returns **2** repos (25 vs 13 raw rows — an earlier revision quoted the row count against the repo count, which is why this now states the unit).) |
 
 ### 3 — Remaining pre-tag work
 
@@ -276,7 +276,7 @@ name two today.
 **#277 rides here too.** It reports `check-derived-docs` enforcing the opposite
 of §3.3 — regenerating from the branch's own sources and failing on the diff, so
 it demands the branch commit exactly what §3.3 forbids. logmind's own copy and
-its shipped `v11` template are **already correct**; the defect is a stale
+its shipped `v12` template are **already correct**; the defect is a stale
 installed copy in the consumer repos. So it is a #257 payload, not code to write
 here, and it closes when the fleet takes the current template.
 
@@ -298,8 +298,25 @@ ships.
 | clud-bug | `v2` | `v4` | **yes** |
 | clud-bug-app | `v2` | `v4` | **yes** |
 | agent-skills | `v2` | `v4` | **yes** |
+| rezgen | `v2` | `v4` | **yes** |
+| tokenomics | `v2` | `v4` | **yes** |
 | reporulez | *unversioned* | *unmarked* | no |
 | skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
+
+`rezgen` and `tokenomics` were missing from an earlier revision of this table
+while the search two sections above named them — §4 sizes "one fleet move" off
+this table, so an undercount here understates the migration. Regenerate it,
+rather than trusting it:
+
+```sh
+for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
+  for w in check-decisions regen-timeline; do
+    printf '%s %s %s\n' "$r" "$w" \
+      "$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" --jq .content \
+         2>/dev/null | base64 -d 2>/dev/null | head -1 | grep -oE 'v[0-9]+' || echo absent)"
+  done
+done
+```
 
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9`, `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -431,8 +431,8 @@ installs (`init.go` strips `.template` off the embedded filename, and every
 embedded template is `*.yml.template`). A hand-written `.yaml` variant is a
 separate user file that logmind will never touch.
 
-logmind's own rows appear as `NEEDS HAND-REPLACEMENT` and are expected — see the
-dogfood note above.
+logmind's own rows are expected, and split exactly as the dogfood note above
+describes.
 
 **skdd needs migrating, and reads as though it does not.** Its `main` has no
 `.github/workflows` at all (404), so its clean `check-derived-docs` history is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,7 +202,13 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control, **same unit**: the `@v1.0.0` query returns **2** repos (25 vs 13 raw rows — an earlier revision quoted the row count against the repo count, which is why this now states the unit).) |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control, **same unit**: the `@v1.0.0` query returns **2** repos. Count repos, never result rows — two measurements the same day returned 25 and 23 rows for the same query, so any row figure written here is wrong by the time it is read. An earlier revision of this line quoted a row count as the control for a repo count, which is why the unit is now named and the derivation shown:
+
+```sh
+gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100 \
+  --json repository --jq '[.[].repository.nameWithOwner] | unique | length'
+```
+) |
 
 ### 3 — Remaining pre-tag work
 
@@ -312,11 +318,21 @@ rather than trusting it:
 for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
   for w in check-decisions regen-timeline; do
     printf '%s %s %s\n' "$r" "$w" \
-      "$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" --jq .content \
-         2>/dev/null | base64 -d 2>/dev/null | head -1 | grep -oE 'v[0-9]+' || echo absent)"
+      "$(raw=$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" \
+             --jq .content 2>/dev/null | base64 -d 2>/dev/null)
+         if [ -z "$raw" ]; then echo 'file absent'
+         else echo "$raw" | head -1 | grep -oE 'v[0-9]+' || echo 'present, unmarked'
+         fi)"
   done
 done
 ```
+
+Three states, not two — `|| echo absent` collapses "no file" and "a file with no
+marker" into one word, and the table distinguishes them (`reporulez` has both
+files present and unmarked; `skdd`'s are absent from its default branch and
+carry markers on `dev`). The loop reads **default branches only**, so `skdd`'s
+row was measured separately, and `logmind` is the producer rather than a
+consumer and is deliberately not a row.
 
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9`, `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -202,13 +202,7 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control, **same unit**: the `@v1.0.0` query returns **2** repos. Count repos, never result rows — two measurements the same day returned 25 and 23 rows for the same query, so any row figure written here is wrong by the time it is read. An earlier revision of this line quoted a row count as the control for a repo count, which is why the unit is now named and the derivation shown:
-
-```sh
-gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100 \
-  --json repository --jq '[.[].repository.nameWithOwner] | unique | length'
-```
-) |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control, **same unit**: the `@v1.0.0` query returns **2** repos. Count repos, never rows — two measurements the same day gave 25 and 23 rows for one query, so a row figure is wrong by the time it is read. Derive with `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100 --json repository --jq '[.[].repository.nameWithOwner] \| unique \| length'`.) |
 
 ### 3 — Remaining pre-tag work
 
@@ -248,7 +242,8 @@ The panel verified it by building the site in both states rather than reading
 the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
 
 **#297, #298, #299, #271** — filed after this section was written, all
-**built and on `dev`** (#306, #307, #308, #313). Two were live data-loss paths:
+**built and on `dev`**. The pairing is not one-to-one: #306 closes both #297 and
+#299, #307 closes #298, #308 closes #271, and #313 closes most of #310. Two were live data-loss paths:
 `self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and
 `doctor --fix` overwrote a file it had misjudged as markerless. #310 is the
 class behind all of them, and is the one exception on this list: it is **still

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,9 @@ are gone, and their absence is the point: the pin was stale three minutes before
 the commit that introduced it, which is the fourth recurrence of the defect this
 file exists to prevent — in the file's own header, two paragraphs above the rule
 forbidding it. A branch tip is not a fact this file may own. Run
-`git rev-parse --short origin/dev origin/main` instead.
+`git rev-parse --short origin/dev` and `git rev-parse --short origin/main` —
+one revision per call, because `--short` implies `--verify`, and the
+two-argument form exits `fatal: Needed a single revision`.
 
 ---
 
@@ -115,7 +117,7 @@ $ gh api repos/thrillmade/logmind/rulesets --jq '.[]|"\(.id) \(.name)"'
 
 $ gh api repos/thrillmade/logmind/rulesets/18502737 \
     --jq '[.bypass_actors[]|"\(.actor_type):\(.actor_id)"]'
-["OrganizationAdmin:null", "Integration:3951953"]
+["OrganizationAdmin:null","Integration:3951953"]
 
 $ gh api /apps/skdd-steward --jq .id
 3951953
@@ -142,8 +144,8 @@ $ gh api repos/thrillmade/protocol/pulls/75/commits --paginate \
 # returns only the first without it, which answers 15.
 $ gh api "repos/thrillmade/logmind/actions/workflows/277546816/runs?per_page=100&event=push" \
     --paginate --jq '.workflow_runs[] | .conclusion' | sort | uniq -c
-     13 success
-      2 failure
+   2 failure
+  13 success
 ```
 
 | probe | result |
@@ -197,15 +199,20 @@ repo and must then be fixed twice.
 
 ### 2 — Prerequisites for the fleet migration
 
-Each is a hard gate on #257, not a parallel cleanup. **#257 itself is
-post-tag, not pre-tag** — `setup-logmind` installs from `/releases/latest`,
-and the released v1.2.0 answers `logmind check-decisions --base` with
-`Error: unknown flag: --base` (ruling recorded in #243). The fleet cannot
-take the new gate template until v2.0.0 exists, so this whole cluster —
-including #288 below and #265+#257 in §4 — runs after the tag by
-construction, even though it is numbered ahead of "§3 — Remaining pre-tag
-work" in this list: numbering here is dependency order, not calendar order
-across the tag boundary.
+Each is a hard gate on #257, not a parallel cleanup.
+
+**This paragraph is the only place the tag boundary is decided, and it decides
+one thing: the fleet move, #257, is the single item in the run to the tag that
+waits for the tag.** Everything in §3 lands before it; §5 is the backlog that
+follows it. The reason is mechanical: `setup-logmind` installs from
+`/releases/latest`, and the released v1.2.0 answers `logmind check-decisions
+--base` with
+`Error: unknown flag: --base` (ruling recorded in #243). No consumer repo can
+take the new gate template until v2.0.0 exists, so the fleet move cannot start
+until the tag does.
+
+Numbering in this list is dependency order, not calendar order — which is why
+§2 sits ahead of "§3 — Remaining pre-tag work" while running after it.
 
 | | why it blocks |
 |---|---|
@@ -237,19 +244,30 @@ to unblock itself has bought exactly what §3.4's gate exists to prevent.
 **#244** — branch→issue binding plus comment-back on merge. Pre-tag by **Ruling
 12**, not by defect: nothing in current behaviour is wrong, the feature simply
 does not exist. Recorded here rather than in §5 so the ruling stays visible.
-Its body no longer contradicts the ruling: it was corrected 2026-08-01 and now
-opens "Pre-tag — in v2.0.0 scope by Ruling 12." Nothing to do.
+Its body no longer contradicts the ruling: its `## Sequencing` section was
+corrected 2026-08-01 and now reads "Pre-tag — in v2.0.0 scope by Ruling 12."
+Nothing to do.
 
 **#241** — `logmind auto <profile>`: one command sets a repository up to be
 handed over and run unattended. Pre-tag by Ruling 12. **Built and on `dev`**
 (#300). It writes the standing directive `.logmind/auto.yml`, reports which
 required skills are present, and prints the handover a human must give — it
 never starts the mode, because the mode may only begin from an explicit human
-handover. Both of the issue's open questions were answered by shipping: the
-profile vocabulary is one name, `unattended` (`night` and `skdd` are each
-refused with a reason), and the limit-watch stays behavioural — the threshold
-rule lives in the written directive and is owned by the `session-heartbeat`
-skill, not tooled here. Nothing is left to build.
+handover. Both of the issue's open questions were answered by shipping. The
+profile vocabulary is one name, `unattended`. `night` is refused *with* its
+reason — the mode starts from a human handover, never from the clock. `skdd`,
+the word the issue itself used, gets only the generic
+`unknown profile "skdd". Known profiles: unattended`, because nothing yet
+defines what an skdd profile would declare; an operator typing the original
+ask is told the name is unknown and nothing more. The limit-watch stays
+behavioural — the threshold rule lives in the written directive and is owned by
+the `session-heartbeat` skill, not tooled here. The command is done.
+
+**#265** — collapse the decision layout: `main` is a branch like any other, no
+cap, no archive, `rotateDecisions` deleted rather than ported. It adds
+`docs/timeline-archive.md` as a **third** derived file that every restore path
+and `check-derived-docs` must learn; all of them name two today. **In flight** —
+PR #301 carries it, open against `dev`.
 
 **#279** — the site's `--version` example is one line; §7.3 requires two, and the
 tag-time flip would not have added the `areas:` line. **Built and on `dev`**
@@ -287,13 +305,10 @@ An issue listed above may already be built — `closes #N` only fires on the
 default branch, so anything merged to `dev` stays open until `dev` reaches
 `main`. That is expected, not drift.
 
-### 4 — #265 + #257, together (post-tag — see §2)
+### 4 — #257, the fleet migration (post-tag — see §2)
 
-One fleet move, per standing constraint. #265 collapses the decision layout —
-main is a branch like any other, no cap, no archive, `rotateDecisions` deleted
-rather than ported — and adds `docs/timeline-archive.md` as a **third** derived
-file that every restore path and `check-derived-docs` must learn. All of them
-name two today.
+One fleet move: every consumer repository takes the current templates at once,
+after the tag exists to install from.
 
 **#277 rides here too.** It reports `check-derived-docs` enforcing the opposite
 of §3.3 — regenerating from the branch's own sources and failing on the diff, so
@@ -347,8 +362,11 @@ Three states, not two — `|| echo absent` collapses "no file" and "a file with 
 marker" into one word, and the table distinguishes them (`reporulez` has both
 files present and unmarked; `skdd`'s are absent from its default branch and
 carry markers on `dev`). The loop reads **default branches only**, so `skdd`'s
-row was measured separately, and `logmind` is the producer rather than a
-consumer and is deliberately not a row.
+row was measured separately. `logmind` is the producer rather than a consumer
+and is deliberately not a row — but the loop still prints one, reading
+`present, unmarked`. That is not the reporulez defect: logmind's own workflows
+are hand-maintained dogfood copies that carry no template marker because
+nothing is meant to refresh them.
 
 **logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
@@ -424,5 +442,6 @@ git log origin/main..origin/dev --format='%B' \
 
 The comma branch is load-bearing, not decoration: one commit on this branch
 spells it `closes #278, #260, #284`, and a probe that stops at the first `#N`
-drops two issues on the floor. Confirm after the merge that each issue really
-closed, and hand-close any that did not.
+loses `#260`. `#284` survives that probe only because a different commit
+happens to spell `Closes #284.` on its own — luck, not coverage. Confirm after
+the merge that each issue really closed, and hand-close any that did not.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,10 @@ git fetch origin --prune
 git log --oneline origin/main..origin/dev          # what is on dev, not yet on main
 gh issue list --state open --limit 200             # open issues
 gh pr list --state open --limit 200                # open pull requests
+# --limit is load-bearing: gh defaults to 30 and truncates SILENTLY, with no
+# notice. 200 is not a fact about this repo, it is headroom — cross-check the
+# total, which cannot truncate:
+gh api 'search/issues?q=repo:thrillmade/logmind+type:issue+state:open' --jq .total_count
 gh release list --limit 1                          # what `brew install` gives
 ```
 
@@ -198,7 +202,7 @@ across the tag boundary.
 |---|---|
 | **#288** | the current template turns a refused push into `::error` + `exit 1`. Migrating first makes every repo go red on every merge to `main` touching a derived doc — permanently, and the job says it will not self-heal. Strictly worse than the storm it replaces. |
 | **a release carrying the verb** | the new gate template calls `logmind check-decisions --base/--head`, and `setup-logmind` installs the latest **release**. v1.2.0 does not have the verb. |
-| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-15: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade` → 7 distinct repos; control: the same query for `@v1.0.0` returns hits, confined to logmind's own template sources.) |
+| **template v12** | **Built and on `dev`** (#314). The shipped template pushed with a raw `LOGMIND_AUTO_REGEN_PAT` while logmind's own copy minted a steward token; it now degrades App → PAT → `GITHUB_TOKEN`, resolves the default branch instead of hardcoding it in four places, and pins every action ref. The pin was `@v1.0.0` against seven consumers on `@v1.0.1` — not five. (measured 2026-08-16: `gh search code "thrillmade/setup-logmind@v1.0.1" --owner thrillmade --limit 100` returns **8** repos — seven consumers plus logmind's own `logmind-self-update.yml`. Control: the `@v1.0.0` query returns 9, so the probe is not matching nothing.) |
 
 ### 3 — Remaining pre-tag work
 
@@ -241,7 +245,9 @@ the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
 **built and on `dev`** (#306, #307, #308, #313). Two were live data-loss paths:
 `self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and
 `doctor --fix` overwrote a file it had misjudged as markerless. #310 is the
-class behind both — `os.WriteFile` follows symlinks, so a planted link
+class behind both, and is **still open** — its last two raw writes live in
+`internal/gitattr/gitattr.go` and close only when #301 lands. #313 covered the
+rest of the tree and added the guard that fails on the next one — `os.WriteFile` follows symlinks, so a planted link
 redirected writes outside the repository from 26 call sites.
 
 **What is genuinely left is shorter than this list.** Rather than maintaining a
@@ -295,7 +301,7 @@ ships.
 | reporulez | *unversioned* | *unmarked* | no |
 | skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
 
-**logmind ships** `check-decisions` at **`v5`** and `regen-timeline` at `v11`. Template versions are **per file** — "the fleet is on
+**logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9`, `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
 Two corrections to #257's original inventory:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,14 +59,33 @@ them until the tag.
 
 ### How work is verified
 
-`dev` deliberately has **no CI** — of the two workflows, only
-`check-derived-docs` (`regen-timeline.yml`) carries a `push: branches: [main]`
-trigger. `check-decisions` has **no push trigger at all**; it runs only on
-`pull_request`. The bar is a **local adversarial panel** per change, plus the
-full suite run against integrated `dev`. Pull requests into `dev` still get
-CI on their own merge-ref (both workflows' `pull_request` trigger carries no
-`branches:` filter); what the panel and the local suite cover is the
-*integrated* result, which PR-level CI never sees.
+**Nothing in CI watches `dev`.** A commit landing on `dev` runs no workflow at
+all: every branch-push trigger in this repository names `main`, and the only
+other push triggers fire on tags.
+
+Pull requests *into* `dev` do get checks. The Go suite (`test.yml` — matrix
+build, `make test`, gofmt and vet), `check-decisions`, `check-derived-docs`
+(`regen-timeline.yml`) and `check-doc-links` all trigger on `pull_request`
+with no `branches:` filter, so they run on the merge-ref whatever the base
+branch is. Of the `pull_request` triggers, only `goreleaser-check`'s is
+filtered to `main`.
+
+The bar for `dev` itself is therefore a **local adversarial panel** per change,
+plus the full suite run against integrated `dev` — the *integrated* result is
+exactly what PR-level CI never sees.
+
+Read the triggers rather than trusting this paragraph; workflows get added:
+
+```sh
+for f in .github/workflows/*.yml; do
+  printf '### %s\n' "${f##*/}"
+  awk '/^on:/{p=1;next} /^[^[:space:]#]/{p=0} p&&!/^[[:space:]]*#/&&NF' "$f"
+done
+```
+
+Some of those files are also the workflow templates logmind ships to consumer
+repositories. [The fleet, measured](#the-fleet-measured) owns which ones, and
+at what version.
 
 ---
 
@@ -164,16 +183,6 @@ time `main` receives a merge that leaves a derived doc stale — which is the
 | protocol#90 | §7.3's example declares 3 areas for logmind; we implement 5 | what the tag bakes in |
 | protocol#93 | §3.4 requires non-empty reasoning; §3.1 says an entry without it is well-formed | nothing — gate follows §3.4 today |
 
-### #241 — pre-tag by Ruling 12, but unbuildable as written
-
-Underspecified — the setup surface itself has open questions (profile
-vocabulary, whether the limit-watch is tooled or purely behavioural). It is
-**no longer blocked on missing skills**: agent-skills#207 (merged
-2026-08-15) shipped both `session-heartbeat` and `unattended-operation`,
-implementing agent-skills#173 and #174. Those two tracking issues remain
-open on GitHub — that is bookkeeping, not a build blocker; the skills exist
-in the catalog today.
-
 ---
 
 ## The order
@@ -231,9 +240,16 @@ does not exist. Recorded here rather than in §5 so the ruling stays visible.
 Its body no longer contradicts the ruling: it was corrected 2026-08-01 and now
 opens "Pre-tag — in v2.0.0 scope by Ruling 12." Nothing to do.
 
-**#241** — `logmind auto`. Also pre-tag by Ruling 12. It previously needed two
-skills that did not exist; those shipped in agent-skills#207 (merged
-2026-08-15). What remains is #241's own underspecification — see above.
+**#241** — `logmind auto <profile>`: one command sets a repository up to be
+handed over and run unattended. Pre-tag by Ruling 12. **Built and on `dev`**
+(#300). It writes the standing directive `.logmind/auto.yml`, reports which
+required skills are present, and prints the handover a human must give — it
+never starts the mode, because the mode may only begin from an explicit human
+handover. Both of the issue's open questions were answered by shipping: the
+profile vocabulary is one name, `unattended` (`night` and `skdd` are each
+refused with a reason), and the limit-watch stays behavioural — the threshold
+rule lives in the written directive and is owned by the `session-heartbeat`
+skill, not tooled here. Nothing is left to build.
 
 **#279** — the site's `--version` example is one line; §7.3 requires two, and the
 tag-time flip would not have added the `areas:` line. **Built and on `dev`**
@@ -241,16 +257,20 @@ tag-time flip would not have added the `areas:` line. **Built and on `dev`**
 The panel verified it by building the site in both states rather than reading
 the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
 
-**#297, #298, #299, #271** — filed after this section was written, all
-**built and on `dev`**. The pairing is not one-to-one: #306 closes both #297 and
-#299, #307 closes #298, #308 closes #271, and #313 closes most of #310. Two were live data-loss paths:
-`self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and
-`doctor --fix` overwrote a file it had misjudged as markerless. #310 is the
-class behind all of them, and is the one exception on this list: it is **still
-open**. #313 covered the tree and added the guard that fails on the next raw
-write; its last two live in `internal/gitattr/gitattr.go` and close only when
-#301 lands — `os.WriteFile` follows symlinks, so a planted link
-redirected writes outside the repository from 26 call sites.
+**#297, #298, #299, #271** — **built and on `dev`**, and not one pull request
+each. Ask git which carried which rather than reading a pairing from here:
+`git log origin/main..origin/dev --oneline --grep='#297' -i`.
+
+**#310** is the class behind those four, and the only one of the five not done.
+The rule: **no code may create or truncate a repository file with a raw stdlib
+call.** Those calls follow symlinks, so a planted link redirects the write
+outside the repository — and a dangling link makes the preceding "does it
+exist?" check answer *no*, which is what turns the hole into an ordinary-looking
+create. Every site routes through `internal/atomicio` instead, and
+`internal/writeaudit` parses the tree on each test run so the next raw call
+fails the build rather than shipping. Its allowlist holds the exceptions, each
+with the reason it is safe — all but one. The two sites in
+`internal/gitattr/gitattr.go` are still vulnerable and close when #301 lands.
 
 **What is genuinely left is shorter than this list.** Rather than maintaining a
 second copy of it here, ask git:
@@ -335,10 +355,14 @@ v4" is not one number.
 
 Two corrections to #257's original inventory:
 
-- **reporulez is structurally unreachable by refresh.** `installWorkflowTemplates`
-  guards on `installedVer != ""`, so a file with no `# logmind-template-version`
-  marker is skipped **forever**. It needs hand-replacement or it is silently left
-  behind.
+- **reporulez is unreachable by refresh, and always will be.** A workflow file
+  is logmind's to overwrite only when the `# logmind-template-version` marker is
+  on line 1 — that is what `TemplateMarker.Writable()` means, and
+  `installWorkflowTemplatesMode` refuses everything else, a displaced marker
+  included. reporulez's two files carry no marker at all, so no refresh will
+  ever touch them. The refusal is reported on stderr rather than skipped
+  quietly, but a reported refusal still leaves the stale file in place. It needs
+  hand-replacement.
 - **skdd was misread, and the misreading mixed two branches.** Its `main` has no
   `.github/workflows` at all (404); its `dev` carries `check-decisions` at **v4**,
   added 2026-08-01. An earlier revision of this file said "already on v11, so
@@ -382,8 +406,23 @@ bypassing gates.
 
 ## Pre-tag checklist
 
-1. `dev` → `main`, which closes #264, #278, #260, #284, #285, #286, #267, #270.
+1. `dev` → `main`. That one merge fires every `closes #N` on the branch at
+   once — a good deal more than the gate-integrity cluster. Read the list from
+   git immediately before merging, never from here; the command is below.
 2. Run `release.yml` with `dry_run=true`.
 3. **Separately** re-confirm the homebrew-tap ruleset bypass — the dry run skips
    that push, so it never exercises the identity that failed with GH013.
 4. Tag. That is the CEO's action, not the lane's.
+
+What step 1 closes:
+
+```sh
+git log origin/main..origin/dev --format='%B' \
+  | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+([[:space:]]*,[[:space:]]*#[0-9]+)*' \
+  | grep -oE '#[0-9]+' | sort -u -V
+```
+
+The comma branch is load-bearing, not decoration: one commit on this branch
+spells it `closes #278, #260, #284`, and a probe that stops at the first `#N`
+drops two issues on the floor. Confirm after the merge that each issue really
+closed, and hand-close any that did not.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -122,15 +122,17 @@ $ gh api /apps/skdd-steward --jq .id
 3951953
 ```
 
-Two active rulesets on `logmind`, both carrying `Integration:3951953`, which is
-`skdd-steward`.
+`Integration:3951953` is `skdd-steward`. The transcript reads one ruleset; run
+the command below for the rest.
 
 **`reporulez-default` is the trap in that reading.** It 404s on `logmind`, so
 it is invisible from here — but it is active on other repositories with **no
 bypass actors at all**, and rulesets aggregate: one ruleset that refuses the
-steward overrides two that allow it. Wherever it applies, `regen-on-main` fails
-with GH013 exactly as it used to here. The grant is per repository, so measure
-it per repository:
+steward overrides two that allow it. Where it applies **without the steward on
+its bypass list**, `regen-on-main` fails with GH013 exactly as it used to here.
+Applying is not refusing — the same ruleset can carry the steward in one
+repository and not in another, which is why the command below reads bypass
+actors and never ruleset names:
 
 ```sh
 for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
@@ -141,9 +143,14 @@ for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
 done
 ```
 
-It prints every ruleset in every repository, refusals and grants together —
-so the `ok` rows are the control that a `REFUSES STEWARD` row is a real
-refusal and not a probe returning nothing.
+It prints every ruleset in every repository, refusals and grants together — so
+the `ok` rows are the control that a `REFUSES STEWARD` row is a real refusal and
+not a probe returning nothing.
+
+**The unblocking action, for each `REFUSES STEWARD` row:** add App `3951953`
+(`skdd-steward`) to that ruleset's bypass list, in that repository. It is
+per ruleset and per repository — there is no org-wide switch, which is why one
+grant on `logmind` cleared nothing else.
 
 ### Why it has never fired on `logmind`
 
@@ -356,32 +363,21 @@ ships.
 | agent-skills | `v2` | `v4` | **yes** |
 | rezgen | `v2` | `v4` | **yes** |
 | tokenomics | `v2` | `v4` | **yes** |
-| reporulez | *unversioned* | *unmarked* | no |
+| reporulez | *unmarked* | *unmarked* | no |
 | skdd | *absent* on `main`, **`v4`** on `dev` | *absent* on `main`, **`v11`** on `dev` | no |
 
-§4 sizes "one fleet move" off this table, so an undercount here understates the
-migration. Regenerate it rather than trusting it:
+**This table tracks two of the four templates logmind ships**, so it is not the
+size of the migration. `check-doc-links` and `logmind-self-update` are installed
+in these repositories too and are also behind. §4 sizes "one fleet move" off
+this section, and a two-column view understates it — so read the four-column
+inventory the command below emits, not this table, before scoping #257. The
+table is kept as the at-a-glance shape of the problem; the command is the
+number.
 
-```sh
-for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
-  for w in check-decisions regen-timeline; do
-    printf '%s %s %s\n' "$r" "$w" \
-      "$(raw=$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" \
-             --jq .content 2>/dev/null | base64 -d 2>/dev/null)
-         if [ -z "$raw" ]; then echo 'file absent'
-         else echo "$raw" | head -1 | grep -oE 'v[0-9]+' || echo 'present, unmarked'
-         fi)"
-  done
-done
-```
-
-Three states, not two — `|| echo absent` collapses "no file" and "a file with no
-marker" into one word, and the table distinguishes them (`reporulez` has both
-files present and unmarked; `skdd`'s are absent from its default branch and
-carry markers on `dev`). The loop reads **default branches only**, so `skdd`'s
-row was measured separately. `logmind` is the producer rather than a consumer
-and is deliberately not a row — but the loop still prints one, reading
-`present, unmarked`. That is not the reporulez defect. logmind hand-maintains
+`skdd` is measured on `dev` as well because the inventory reads **default
+branches only**, and its `main` carries no workflows at all. `logmind` is the
+producer rather than a consumer and is deliberately not a row — though the
+inventory does print one. That is not the reporulez defect. logmind hand-maintains
 its own copies of `check-decisions.yml`, `regen-timeline.yml` and
 `check-doc-links.yml` — markerless on purpose, so refresh leaves them alone.
 The exception is `logmind-self-update.yml`: it carries the marker, is refreshed
@@ -403,23 +399,40 @@ three files that need hands and a fourth that refreshes itself. So do not work
 from a list written here. Produce it:
 
 ```sh
-for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
-  for w in check-decisions regen-timeline check-doc-links logmind-self-update; do
-    m=$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w.yml" \
-          --jq .content 2>/dev/null | tr -d '\n' | base64 -d 2>/dev/null | head -1)
-    case "$m" in
-      '# logmind-template-version:'*) ;;   # ours; refresh reaches it
-      '') ;;                               # no such file
-      *) printf '%s %s NEEDS HAND-REPLACEMENT\n' "$r" "$w" ;;
-    esac
+# Run from a logmind checkout: the names come from the embed directory
+# ListWorkflowTemplates reads, so a fifth template cannot drop out silently.
+for tmpl in internal/templates/github/*.yml.template; do
+  w=$(basename "$tmpl" .template)
+  for r in $(gh repo list thrillmade --limit 200 --json name --jq '.[].name'); do
+    if out=$(gh api "repos/thrillmade/$r/contents/.github/workflows/$w" --jq .content 2>&1); then
+      line=$(printf '%s' "$out" | tr -d '\n' | base64 -d 2>/dev/null | head -1)
+      case "$line" in
+        '# logmind-template-version:'*) printf '%-22s %-24s marked %s\n' "$r" "$w" "${line##*: }" ;;
+        *)                              printf '%-22s %-24s NEEDS HAND-REPLACEMENT\n' "$r" "$w" ;;
+      esac
+    else
+      case "$out" in
+        *'Not Found'*) printf '%-22s %-24s absent\n' "$r" "$w" ;;
+        *)             printf '%-22s %-24s LOOKUP FAILED: %s\n' "$r" "$w" "$out" ;;
+      esac
+    fi
   done
 done
 ```
 
-Print all three states instead of filtering and the marked rows become the
-control: a repository that comes back entirely marked proves the probe
-recognises a marker, so a `NEEDS HAND-REPLACEMENT` row is a real one. logmind's
-own rows appear and are expected — see the dogfood note above.
+**It prints all four states, so it carries its own control.** The `marked` rows
+prove the probe recognises a marker, which is what makes a
+`NEEDS HAND-REPLACEMENT` row real rather than a probe returning nothing. And
+`absent` is separated from `LOOKUP FAILED` deliberately: a permissions error
+silently counted as "no such file" is how a repository disappears from a
+migration list. Two more things it does not hide — it reads **default branches
+only**, and it checks `<name>.yml` alone, because that is the only name logmind
+installs (`init.go` strips `.template` off the embedded filename, and every
+embedded template is `*.yml.template`). A hand-written `.yaml` variant is a
+separate user file that logmind will never touch.
+
+logmind's own rows appear as `NEEDS HAND-REPLACEMENT` and are expected — see the
+dogfood note above.
 
 **skdd needs migrating, and reads as though it does not.** Its `main` has no
 `.github/workflows` at all (404), so its clean `check-derived-docs` history is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -247,13 +247,14 @@ tag-time flip would not have added the `areas:` line. **Built and on `dev`**
 The panel verified it by building the site in both states rather than reading
 the JSX, and by byte-comparing the page's `AREAS` against `version.go`.
 
-**#297, #298, #299, #271, #310** — filed after this section was written, all
+**#297, #298, #299, #271** — filed after this section was written, all
 **built and on `dev`** (#306, #307, #308, #313). Two were live data-loss paths:
 `self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and
 `doctor --fix` overwrote a file it had misjudged as markerless. #310 is the
-class behind both, and is **still open** — its last two raw writes live in
-`internal/gitattr/gitattr.go` and close only when #301 lands. #313 covered the
-rest of the tree and added the guard that fails on the next one — `os.WriteFile` follows symlinks, so a planted link
+class behind all of them, and is the one exception on this list: it is **still
+open**. #313 covered the tree and added the guard that fails on the next raw
+write; its last two live in `internal/gitattr/gitattr.go` and close only when
+#301 lands — `os.WriteFile` follows symlinks, so a planted link
 redirected writes outside the repository from 26 call sites.
 
 **What is genuinely left is shorter than this list.** Rather than maintaining a
@@ -288,7 +289,7 @@ here, and it closes when the fleet takes the current template.
 
 ### 5 — After the tag
 
-#263 (§6.7 pre-push gate, wholly new scope) · #251 · #271 · #280 · #210 · #217 ·
+#263 (§6.7 pre-push gate, wholly new scope) · #251 · #280 · #210 · #217 ·
 #258 · #268 · #273 · #274 · #283.
 
 ---
@@ -334,7 +335,7 @@ carry markers on `dev`). The loop reads **default branches only**, so `skdd`'s
 row was measured separately, and `logmind` is the producer rather than a
 consumer and is deliberately not a row.
 
-**logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9`, `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
+**logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
 Two corrections to #257's original inventory:


### PR DESCRIPTION
Eleven PRs merged to `dev` since this file was written. Three sections described work as pending that is now built.

## Corrected

- **template v12** (§2) — built and on `dev` as #314. Also corrects a number: the action pin was `@v1.0.0` against **seven** consumers on `@v1.0.1`, not five.
- **#269** (§3) — built and on `dev` as #303. And the reasoning changed: protocol#89 turned out **not** to gate it. Giving the built-in defaults their own source and resolving positionally *conforms* to §1.4 as written, so no ruling was needed. Verified against `git check-ignore` as a differential oracle across seven fixtures.
- **#297, #298, #299, #271, #310** — filed after this section existed, all built and on `dev`. Two were live data-loss paths: `self-update` wrote a marker-block fragment over the whole of `AGENTS.md`, and `doctor --fix` overwrote a file it had misjudged as markerless.

## And the list itself goes back to git

This file was blocked by adversarial review **four times**, every time for carrying a second copy of a fact git already owned. A hand-maintained "what remains" list is exactly that, so it is replaced with the commands that answer it:

```sh
git log --oneline origin/main..origin/dev
gh issue list --state open
```

The per-item **reasoning** stays — why #261 was reordered, why #244 is pre-tag by ruling rather than by defect, why #257 and #288 are post-tag by construction. Reasoning does not go stale; status does.

One thing the file now warns about explicitly, because it has confused readers already: an issue listed here may already be built. `closes #N` only fires on the default branch, so anything merged to `dev` stays open until `dev` reaches `main`. That is expected, not drift.