### PR TITLE
fix(site): pin the areas mirror to version.go, and gate the areas line on its own release

### DIFF
--- a/docs/decisions-branches/fix__site-version-mirror-pin.md
+++ b/docs/decisions-branches/fix__site-version-mirror-pin.md
@@ -11,3 +11,14 @@
 
 ---
 
+## 2026-08-16 05:57 - site: key each feature's availability to the release that introduced it, not to whatever NEXT_VERSION happens to be
+
+**Reasoning:** A panel found the areas-line fix was one instance of a class I had treated as a single defect. Two more sites gated the commit-guard prose on !IS_NEXT_RELEASED — but the guard ships in 2.0.0 specifically, not in 'the next release'. The reviewer built the site at CURRENT=2.0.0/NEXT=2.1.0 and read the rendered HTML: 'v2.1.0 adds a guard in front of every substantive commit — in design, not yet released. Not yet released — ships with v2.1.0.' The site would have announced its own shipped enforcement gate as unreleased, and the NEXT_VERSION pin added in this same branch is what forces that state to arrive on the first commit of the next cycle.
+
+**Alternatives considered:** Patch the two sites the panel named — rejected; that is what produced this round in the first place. Delete IS_NEXT_RELEASED entirely — rejected; two sites legitimately ask whether the next release is out, which is exactly what it answers.
+
+**Implications:**
+- The rule is now that a feature's availability keys to the release that introduced that feature. ENFORCEMENT_SINCE joins AREAS_SINCE; both read 2.0.0 today because both features ship in 2.0.0, and they are kept as separate constants so they can diverge when one moves. All four IS_NEXT_RELEASED sites were decided individually: the hero badge and the install footnote genuinely ask whether NEXT_VERSION is out and keep it. Verified by npm install + next build at three release states, reading the rendered HTML rather than the source; a SHOWS_ENFORCEMENT_AVAILABLE forced to true compiles clean and renders the wrong claim, so the guard is load-bearing. Also corrected repoRootFromCaller's comment, which claimed independence from the working directory while calling os.Getwd().
+
+---
+

--- a/docs/decisions-branches/fix__site-version-mirror-pin.md
+++ b/docs/decisions-branches/fix__site-version-mirror-pin.md
@@ -22,3 +22,14 @@
 
 ---
 
+## 2026-08-16 08:10 - site mirror: skip only when the guarded content is not rendered, and fail when it is rendered and unverifiable
+
+**Reasoning:** The guard skipped whenever the tree was not building the release the site describes, and reported that loudly — but CI runs make test with GO_TEST_FLAGS empty, so a t.Skipf message prints nothing but ok. Measured: go test ./internal/version/ emits only 'ok'. The guard was therefore off for an entire dev cycle with nothing saying so, which is the same failing-open shape as #332 and #298. The lane's own mutation report had already said as much — always-off produced 'not a literal red, but a self-contradictory skip message' — and a tell nobody reads is not a tell.
+
+**Alternatives considered:** Add -v to the Makefile or CI — rejected; widening the whole suite's output to rescue one test makes every future skip invisible-but-louder rather than accounted for. Keep the loud skip and accept it — rejected on the measurement above.
+
+**Implications:**
+- Skipping is now defensible only where the content is not rendered: below AREAS_SINCE the areas line does not appear at all, so AREAS is dead content and unconstrained. At or above it with the tree moved on, the line IS rendered and nothing can verify it, so that now FAILS and names both remedies. Driven rather than argued, with plain go test as CI runs it: today skips at exit 0, aligned passes, post-tag misaligned exits 1 where it used to skip green. The mutation that matters — turning that branch back into a skip — flips a plain go test from FAIL to ok, which is a genuine red rather than last round's self-contradictory message.
+
+---
+

--- a/docs/decisions-branches/fix__site-version-mirror-pin.md
+++ b/docs/decisions-branches/fix__site-version-mirror-pin.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-16 05:33 - site: pin the areas mirror to the Go constant that owns it, and gate the areas line on its own release rather than on NEXT_VERSION
+
+**Reasoning:** site/app/page.tsx and internal/version/version.go both spelled the SPEC §7.3 areas string, and nothing checked they agreed — zero test files and zero workflow files referenced page.tsx or AREAS (control: page.tsx IS referenced by 7 files under docs/, so the search finds things when they exist). A hand-kept second copy diverges at exactly the wrong moment: a hand-edit at tag time, when the site is claiming what the new binary prints and nobody re-runs the binary. Pinning it surfaced a second defect in the code it pins to. The areas line was gated on IS_NEXT_RELEASED (CURRENT_VERSION === NEXT_VERSION), which answers 'is the next release out' — but the question the site asks is 'does the CURRENT release print this line'. Those coincide only because 2.0.0 happens to be the first release that prints it, and they diverge the moment NEXT_VERSION moves on. Worse, the new pin forces NEXT_VERSION to track version.Version, which becomes 2.1.0-dev right after the tag, so the pin would have SCHEDULED the regression for the first commit of the next cycle.
+
+**Alternatives considered:** Pin AREAS and leave the predicate alone — rejected, that ships a known-wrong render on a known date. Pin CURRENT_VERSION/CURRENT_SPEC to the Go version too — rejected, those deliberately name the released 1.2.0 build while the binary is 2.0.0-dev, so equality there would be wrong today.
+
+**Implications:**
+- Gating is now SHOWS_AREAS_LINE = compareVersions(CURRENT_VERSION, AREAS_SINCE) >= 0, compared numerically rather than lexically because '2.10.0' < '2.9.0' as strings and that is a real future value. IS_NEXT_RELEASED is unchanged and still gates the four 'not yet released' caveats, each of which genuinely asks whether NEXT_VERSION itself shipped. Verified by extracting the real constants from page.tsx and evaluating them, not by reading: 1.2.0 hides the line, 2.0.0 shows it whether NEXT is 2.0.0 or 2.1.0, 2.10.0 shows it. An always-true comparator turns the first row red. Still uncovered: no CI-level test guards the TS render logic itself — only the two Go tests guard the raw string constants.
+
+---
+

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -127,12 +127,17 @@ func TestSatisfiesMin_UnparseableFailsOpen(t *testing.T) {
 // version.go is the source of truth in every pair; the site is the
 // mirror, and a mismatch is fixed by editing the site, never this file.
 
-// repoRootFromCaller walks up from this test file's location to the
+// repoRootFromCaller walks up from the process's working directory (via
+// os.Getwd, not the caller's file location — despite the name) to the
 // directory holding go.mod. Mirrors internal/cli/version_test.go's
-// helper of the same name and purpose: lets the tests below locate
-// site/app/page.tsx regardless of how `go test` was invoked (CI, IDE,
-// `cd internal/version && go test`), rather than guessing off the test
-// binary's working directory.
+// helper of the same name and purpose: `go test` itself always sets that
+// working directory to the package under test, so this locates
+// site/app/page.tsx correctly whether run via `go test ./internal/version`
+// from the repo root, from inside the package (`cd internal/version &&
+// go test`), or from an IDE's own runner. A precompiled test binary
+// executed from an unrelated directory (`go test -c` then run elsewhere)
+// is not covered by that guarantee — it fails loudly here (Fatalf below),
+// which is the correct outcome, not a silent wrong guess.
 func repoRootFromCaller(t *testing.T) string {
 	t.Helper()
 	wd, err := os.Getwd()

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -122,10 +122,19 @@ func TestSatisfiesMin_UnparseableFailsOpen(t *testing.T) {
 // --- site/app/page.tsx mirror -------------------------------------------
 //
 // TypeScript can't import a Go package, so site/app/page.tsx hand-copies
-// a few of this file's constants (its own comment says as much). Nothing
-// checked the copy agreed with the original before the tests below:
-// version.go is the source of truth in every pair; the site is the
-// mirror, and a mismatch is fixed by editing the site, never this file.
+// a few of this package's facts into its own constants. Nothing checked
+// the copy agreed with the original before the tests below: version.go
+// is the source of truth in every pair; the site is the mirror, and a
+// flagged mismatch is fixed by editing the site, never this file.
+//
+// One pair — AREAS — needs a qualifier the others don't: it sits beside
+// the site's CURRENT_SPEC and CURRENT_RELEASE_DATE, both claims about
+// the RELEASED binary, not this tree's still-moving dev Version. CI runs
+// `make test` with GO_TEST_FLAGS empty (no -v), so a skip's reason is
+// invisible in the normal run — which means a skip is only acceptable
+// here when there is provably nothing to check, never merely as a
+// quieter way of saying "can't verify this." See
+// TestAreasMirroredInSitePage's own doc comment for the three cases.
 
 // repoRootFromCaller walks up from the process's working directory (via
 // os.Getwd, not the caller's file location — despite the name) to the
@@ -196,12 +205,56 @@ func extractTSConst(src, name string) (string, error) {
 	return m[1], nil
 }
 
-// TestAreasMirroredInSitePage closes the gap site/app/page.tsx's own
-// comment admits to: its AREAS constant is "a hand-maintained mirror" of
-// this package's Areas, and nothing checked the two agreed. Areas is the
-// source of truth — it's the second `--version` line the binary actually
-// prints, SPEC §7.3 — so the site's copy must match it, never the
-// reverse.
+// treeDescribesRelease reports whether siteVersion (site/app/page.tsx's
+// CURRENT_VERSION) and treeVersion (this package's Version) name the
+// same release, using parseVersionCore's tolerant major.minor.patch
+// compare — the same parse SatisfiesMin and SameMajor already use, so a
+// "-dev" suffix on treeVersion doesn't defeat the comparison. Also
+// returns treeVersion's formatted core (e.g. "2.0.0-dev" -> "2.0.0") for
+// callers building a message around it. A version string that fails to
+// parse on either side is a hard failure, not a false/skip: that means
+// something is broken enough that no comparison should be trusted
+// silently.
+func treeDescribesRelease(t *testing.T, siteVersion, treeVersion string) (aligned bool, treeCore string) {
+	t.Helper()
+	sc, ok := parseVersionCore(siteVersion)
+	if !ok {
+		t.Fatalf("site/app/page.tsx's CURRENT_VERSION = %q does not parse as major.minor.patch; fix CURRENT_VERSION, not this test", siteVersion)
+	}
+	tc, ok := parseVersionCore(treeVersion)
+	if !ok {
+		t.Fatalf("internal/version/version.go's Version = %q does not parse as major.minor.patch(-suffix); fix Version, not site/app/page.tsx", treeVersion)
+	}
+	return sc == tc, fmt.Sprintf("%d.%d.%d", tc[0], tc[1], tc[2])
+}
+
+// TestAreasMirroredInSitePage closes the gap that gave rise to this
+// test: TypeScript can't import a Go package, so site/app/page.tsx
+// hand-copies this package's Areas into its own AREAS constant, and
+// nothing checked the two agreed. Areas is the source of truth — it's
+// the second `--version` line the binary actually prints, SPEC §7.3 —
+// so the site's copy must match it, never the reverse.
+//
+// AREAS is a claim about the RELEASED binary named by CURRENT_VERSION —
+// the same kind of fact as the site's CURRENT_SPEC and
+// CURRENT_RELEASE_DATE, neither of which is pinned to this tree's
+// still-moving dev Version. version.go's Areas (and its neighbors:
+// SpecVersion alone moved five times inside one still-unreleased cycle)
+// can and does move mid-cycle without the release it'll ship in having
+// changed. But a skip is invisible under `make test` (no -v in CI), so
+// it is only defensible when there is nothing to check — never merely
+// when this tree can't check it. Three cases, checked in this order:
+//
+//  1. CURRENT_VERSION is before AREAS_SINCE: the site's own
+//     SHOWS_AREAS_LINE gate means the areas line does not render at all.
+//     AREAS is dead content — skip, and say so.
+//  2. CURRENT_VERSION is at or after AREAS_SINCE (the line DOES render)
+//     but doesn't name the same release as this tree's Version: the
+//     rendered claim can't be verified against anything this tree knows
+//     — a rendered, unverifiable claim is exactly the drift this test
+//     exists to catch, so this FAILS rather than passing through quietly.
+//  3. CURRENT_VERSION names the same release as Version: assert equality
+//     directly.
 func TestAreasMirroredInSitePage(t *testing.T) {
 	src := readSitePageTSX(t)
 
@@ -210,27 +263,65 @@ func TestAreasMirroredInSitePage(t *testing.T) {
 		t.Fatalf("site/app/page.tsx: %v — its version-truth comment block above AREAS may have been restructured; update this test's extraction, not version.go's Areas", err)
 	}
 
-	if siteAreas != Areas {
-		t.Fatalf("site/app/page.tsx's AREAS = %q does not match internal/version/version.go's Areas = %q.\n"+
-			"internal/version/version.go's Areas is authoritative (it's what `logmind --version` actually prints, SPEC §7.3) — "+
+	currentVersion, err := extractTSConst(src, "CURRENT_VERSION")
+	if err != nil {
+		t.Fatalf("site/app/page.tsx: %v — its version-truth comment block above CURRENT_VERSION may have been restructured; update this test's extraction, not version.go's Areas", err)
+	}
+
+	areasSince, err := extractTSConst(src, "AREAS_SINCE")
+	if err != nil {
+		t.Fatalf("site/app/page.tsx: %v — its version-truth comment block above AREAS_SINCE may have been restructured; update this test's extraction, not version.go's Areas", err)
+	}
+	if _, ok := parseVersionCore(areasSince); !ok {
+		t.Fatalf("site/app/page.tsx's AREAS_SINCE = %q does not parse as major.minor.patch; fix AREAS_SINCE, not this test", areasSince)
+	}
+
+	aligned, treeCore := treeDescribesRelease(t, currentVersion, Version)
+	// renders reproduces site/app/page.tsx's own SHOWS_AREAS_LINE gate
+	// (CURRENT_VERSION >= AREAS_SINCE) using SatisfiesMin — the same
+	// numeric floor check already used elsewhere in this package, not a
+	// second hand-rolled comparator.
+	renders := SatisfiesMin(currentVersion, areasSince)
+
+	switch {
+	case !renders:
+		t.Skipf("AREAS mirror check inactive: site/app/page.tsx's CURRENT_VERSION (v%s) is before AREAS_SINCE (v%s), so the areas line does not render on the page at this CURRENT_VERSION — AREAS is dead content, nothing to verify. Expected pre-v%s, not a bug.",
+			currentVersion, areasSince, areasSince)
+
+	case !aligned:
+		t.Fatalf("site/app/page.tsx's CURRENT_VERSION (v%s) is at or after AREAS_SINCE (v%s), so the areas line DOES render — but this tree's Version (%s, core v%s) has moved past the release CURRENT_VERSION names, so nothing here can verify the rendered AREAS is still true of that release. A rendered, unverifiable claim must fail, not skip.\n"+
+			"Either: record v%s's actual released areas line (not this dev tree's) and check against that instead — see the separately-tracked follow-up on sourcing \"the latest release\" for CI — or, if this IS release time, bump CURRENT_VERSION (with CURRENT_SPEC, CURRENT_RELEASE_DATE, and AREAS) together to describe v%s, the release this tree is actually building, so this test can verify it directly.",
+			currentVersion, areasSince, Version, treeCore, currentVersion, treeCore)
+
+	case siteAreas != Areas:
+		t.Fatalf("site/app/page.tsx's AREAS = %q does not match internal/version/version.go's Areas = %q, and both describe the same release (v%s) right now.\n"+
+			"internal/version/version.go's Areas is authoritative for that release (it's what `logmind --version` actually prints, SPEC §7.3) — "+
 			"edit the AREAS constant in site/app/page.tsx to match it. Do not change Areas in version.go to make this pass.",
-			siteAreas, Areas)
+			siteAreas, Areas, currentVersion)
 	}
 }
 
 // TestNextVersionMirrorsGoDevVersion applies the same "Go owns it, the
 // site mirrors it" rule to site/app/page.tsx's NEXT_VERSION.
 //
-// NEXT_VERSION names, per the site's own comment, "the release the
-// 'enforced' section and hero badge describe ahead of time" — exactly
-// what Version's un-tagged default ("2.0.0-dev": see that var's doc
-// comment, "Bumped at release") names too, spelled two ways: Go carries a
-// "-dev" prerelease suffix on its default; the site names the bare
-// release the dev binary is building toward. parseVersionCore is the
-// same tolerant major.minor.patch parse SatisfiesMin and SameMajor
-// already use to strip that suffix before comparing, so this reuses it
-// rather than a raw string compare that would never agree by
-// construction.
+// NEXT_VERSION names the release the site's hero badge and install
+// footnote describe ahead of time — generically, "there's a next release
+// and it isn't out yet" (see site/app/page.tsx's own top-of-file
+// comment for the exact sites this covers today; deliberately not
+// quoted here — a paraphrase of the site's prose would silently go
+// stale the moment that wording changes, which is the same
+// hand-kept-copy problem this whole file exists to close, just one
+// layer up in a comment instead of a constant). That's exactly what
+// Version's un-tagged default ("2.0.0-dev": see that var's doc comment,
+// "Bumped at release") names too, spelled two ways: Go carries a "-dev"
+// prerelease suffix on its default; the site names the bare release the
+// dev binary is building toward. Unlike AREAS above, NEXT_VERSION is
+// unconditional — it never claims anything about a release that's
+// already shipped, only about the one still coming, so there's no
+// release-alignment window to gate it on. parseVersionCore is the same
+// tolerant major.minor.patch parse SatisfiesMin and SameMajor already
+// use to strip that suffix before comparing, so this reuses it rather
+// than a raw string compare that would never agree by construction.
 func TestNextVersionMirrorsGoDevVersion(t *testing.T) {
 	src := readSitePageTSX(t)
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,6 +1,12 @@
 package version
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
 
 // TestSatisfiesMin_DevPrereleaseSatisfiesItsOwnFloor pins the deliberate
 // departure from strict semver precedence (see SatisfiesMin's doc comment):
@@ -110,5 +116,134 @@ func TestSatisfiesMin_UnparseableFailsOpen(t *testing.T) {
 		if !SatisfiesMin(c.v, c.min) {
 			t.Errorf("SatisfiesMin(%q, %q) = false; want true (fail open on unparseable input)", c.v, c.min)
 		}
+	}
+}
+
+// --- site/app/page.tsx mirror -------------------------------------------
+//
+// TypeScript can't import a Go package, so site/app/page.tsx hand-copies
+// a few of this file's constants (its own comment says as much). Nothing
+// checked the copy agreed with the original before the tests below:
+// version.go is the source of truth in every pair; the site is the
+// mirror, and a mismatch is fixed by editing the site, never this file.
+
+// repoRootFromCaller walks up from this test file's location to the
+// directory holding go.mod. Mirrors internal/cli/version_test.go's
+// helper of the same name and purpose: lets the tests below locate
+// site/app/page.tsx regardless of how `go test` was invoked (CI, IDE,
+// `cd internal/version && go test`), rather than guessing off the test
+// binary's working directory.
+func repoRootFromCaller(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := wd
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate go.mod walking up from %s", wd)
+	return "" // unreachable
+}
+
+// readSitePageTSX returns site/app/page.tsx's contents. It skips — loudly,
+// with the resolved path in the message — only when the whole site/
+// subproject is absent, the one legitimate reason not to run the mirror
+// checks below. Any other failure (site/ present but app/page.tsx missing
+// or unreadable) is a hard failure: that means this test's own locator is
+// broken, not that there is nothing left to guard, and a broken locator
+// must not read as a passing (or silently skipped) test.
+func readSitePageTSX(t *testing.T) string {
+	t.Helper()
+	repoRoot := repoRootFromCaller(t)
+
+	siteDir := filepath.Join(repoRoot, "site")
+	if _, err := os.Stat(siteDir); os.IsNotExist(err) {
+		t.Skipf("site/ not found at %s — skipping the site/binary version mirror check (expected only if the site subproject has been removed; if site/ still exists on disk, this skip means this test's locator is wrong, not that there's nothing to check)", siteDir)
+	}
+
+	pagePath := filepath.Join(siteDir, "app", "page.tsx")
+	data, err := os.ReadFile(pagePath)
+	if err != nil {
+		t.Fatalf("site/ exists at %s but %s could not be read (%v) — site/app/page.tsx may have moved; fix this test's path, not the constants it checks", siteDir, pagePath, err)
+	}
+	return string(data)
+}
+
+// extractTSConst pulls `const <name> = "value";` (an optional `: string`
+// type annotation tolerated) out of TypeScript source. Not a real TS
+// parser — the tests below only need the literal string value of a
+// handful of top-level const declarations.
+func extractTSConst(src, name string) (string, error) {
+	re := regexp.MustCompile(`(?m)^const\s+` + regexp.QuoteMeta(name) + `(?:\s*:\s*string)?\s*=\s*"([^"]*)"`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return "", fmt.Errorf(`no "const %s = \"...\";" declaration found`, name)
+	}
+	return m[1], nil
+}
+
+// TestAreasMirroredInSitePage closes the gap site/app/page.tsx's own
+// comment admits to: its AREAS constant is "a hand-maintained mirror" of
+// this package's Areas, and nothing checked the two agreed. Areas is the
+// source of truth — it's the second `--version` line the binary actually
+// prints, SPEC §7.3 — so the site's copy must match it, never the
+// reverse.
+func TestAreasMirroredInSitePage(t *testing.T) {
+	src := readSitePageTSX(t)
+
+	siteAreas, err := extractTSConst(src, "AREAS")
+	if err != nil {
+		t.Fatalf("site/app/page.tsx: %v — its version-truth comment block above AREAS may have been restructured; update this test's extraction, not version.go's Areas", err)
+	}
+
+	if siteAreas != Areas {
+		t.Fatalf("site/app/page.tsx's AREAS = %q does not match internal/version/version.go's Areas = %q.\n"+
+			"internal/version/version.go's Areas is authoritative (it's what `logmind --version` actually prints, SPEC §7.3) — "+
+			"edit the AREAS constant in site/app/page.tsx to match it. Do not change Areas in version.go to make this pass.",
+			siteAreas, Areas)
+	}
+}
+
+// TestNextVersionMirrorsGoDevVersion applies the same "Go owns it, the
+// site mirrors it" rule to site/app/page.tsx's NEXT_VERSION.
+//
+// NEXT_VERSION names, per the site's own comment, "the release the
+// 'enforced' section and hero badge describe ahead of time" — exactly
+// what Version's un-tagged default ("2.0.0-dev": see that var's doc
+// comment, "Bumped at release") names too, spelled two ways: Go carries a
+// "-dev" prerelease suffix on its default; the site names the bare
+// release the dev binary is building toward. parseVersionCore is the
+// same tolerant major.minor.patch parse SatisfiesMin and SameMajor
+// already use to strip that suffix before comparing, so this reuses it
+// rather than a raw string compare that would never agree by
+// construction.
+func TestNextVersionMirrorsGoDevVersion(t *testing.T) {
+	src := readSitePageTSX(t)
+
+	nextVersion, err := extractTSConst(src, "NEXT_VERSION")
+	if err != nil {
+		t.Fatalf("site/app/page.tsx: %v — its version-truth comment block above NEXT_VERSION may have been restructured; update this test's extraction, not version.go's Version", err)
+	}
+
+	core, ok := parseVersionCore(Version)
+	if !ok {
+		t.Fatalf("internal/version/version.go's Version = %q does not parse as major.minor.patch(-suffix); fix Version, not site/app/page.tsx", Version)
+	}
+	wantNext := fmt.Sprintf("%d.%d.%d", core[0], core[1], core[2])
+
+	if nextVersion != wantNext {
+		t.Fatalf("site/app/page.tsx's NEXT_VERSION = %q does not match internal/version/version.go's Version = %q (core %q, prerelease suffix stripped).\n"+
+			"NEXT_VERSION names the release the dev binary is building toward; version.go's Version is authoritative — "+
+			"edit NEXT_VERSION in site/app/page.tsx to %q. Do not change Version in version.go to make this pass.",
+			nextVersion, Version, wantNext, wantNext)
 	}
 }

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -14,12 +14,18 @@ const PIP_LEGACY = "pip install 'logmind==0.6.16'";
 // TO RELEASE v2.0.0: update these three lines (CURRENT_VERSION,
 // CURRENT_SPEC, CURRENT_RELEASE_DATE) — everything below derives from
 // them, and every "forthcoming" / "in design" caveat on the page clears
-// itself automatically once CURRENT_VERSION === NEXT_VERSION. No other
-// edit is required — UNLESS internal/version/version.go's own `Areas`
-// string has changed since AREAS below was last copied. AREAS is not
-// part of the three-line flip: it mirrors what the binary claims under
-// SPEC §7.3, which is orthogonal to the version number, so it only needs
-// touching when the binary's declared areas change, not at every release.
+// itself automatically once CURRENT_VERSION === NEXT_VERSION. The areas
+// line (see AREAS_SINCE below) clears the same way, off the same flip,
+// because AREAS_SINCE is set to "2.0.0" too — but it derives from
+// CURRENT_VERSION >= AREAS_SINCE, not from NEXT_VERSION, so it keeps
+// showing once CURRENT_VERSION moves past v2.0.0 into whatever comes
+// after. No other edit is required — UNLESS internal/version/version.go's
+// own `Areas` string has changed since AREAS below was last copied.
+// AREAS is not part of the three-line flip: it mirrors what the binary
+// claims under SPEC §7.3, which is orthogonal to the version number, so
+// it only needs touching when the binary's declared areas change, not at
+// every release. AREAS_SINCE only needs touching if that first-printed
+// release is ever revised (it should not be, once true).
 //
 // CURRENT_* is what `brew install thrillmade/tap/logmind` / curl / the
 // skill installs *today*. Verified against `gh release list --repo
@@ -43,13 +49,38 @@ const NEXT_VERSION: string = "2.0.0";
 const IS_NEXT_RELEASED = CURRENT_VERSION === NEXT_VERSION;
 // SPEC §7.3's second `--version` line — mirrored byte-for-byte from
 // internal/version/version.go's `Areas` (comma-and-space-joined, fixed
-// vocabulary order). The released 1.2.0 binary predates this line — it
-// shipped after 1.2.0, ahead of internal/version/version.go's own
-// CURRENT_VERSION bump — so it's gated on IS_NEXT_RELEASED rather than
-// shown unconditionally; hardcoding it in today's one-line output would
-// claim something the installed binary doesn't print.
+// vocabulary order). AREAS_SINCE names the release whose binary first
+// prints this line (it landed alongside the v2.0.0 cut). Gated on
+// "CURRENT_VERSION >= AREAS_SINCE", NOT on IS_NEXT_RELEASED
+// (CURRENT_VERSION === NEXT_VERSION): those two questions only coincide
+// while NEXT_VERSION happens to equal AREAS_SINCE, today. The moment the
+// v2.0.0 tag lands and the next dev cycle opens NEXT_VERSION on to
+// "2.1.0", IS_NEXT_RELEASED goes permanently false even though the
+// *released* 2.0.0 binary keeps printing the areas line — using it here
+// would silently drop the line from the site the day after the release
+// it was added to celebrate. compareVersions compares numerically, not
+// as strings: "2.10.0" < "2.9.0" lexically, and that is a real future
+// version number.
+const AREAS_SINCE = "2.0.0";
 const AREAS = "orient, work, record, propagate, gates";
-const VERIFY_OUTPUT = IS_NEXT_RELEASED
+
+// compareVersions compares two plain "major.minor.patch" version strings
+// numerically. CURRENT_VERSION / NEXT_VERSION / AREAS_SINCE on this page
+// are always plain release numbers — no "-dev"/prerelease suffix; that
+// only exists on the Go binary's own unreleased builds — so a bare
+// split-on-"." + Number compare is sufficient here.
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+const SHOWS_AREAS_LINE = compareVersions(CURRENT_VERSION, AREAS_SINCE) >= 0;
+const VERIFY_OUTPUT = SHOWS_AREAS_LINE
   ? `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})\nareas: ${AREAS}`
   : `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})`;
 

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -13,30 +13,46 @@ const PIP_LEGACY = "pip install 'logmind==0.6.16'";
 //
 // TO RELEASE v2.0.0: update these three lines (CURRENT_VERSION,
 // CURRENT_SPEC, CURRENT_RELEASE_DATE) — everything below derives from
-// them, and every "forthcoming" / "in design" caveat on the page clears
-// itself automatically once CURRENT_VERSION === NEXT_VERSION. The areas
-// line (see AREAS_SINCE below) clears the same way, off the same flip,
-// because AREAS_SINCE is set to "2.0.0" too — but it derives from
-// CURRENT_VERSION >= AREAS_SINCE, not from NEXT_VERSION, so it keeps
-// showing once CURRENT_VERSION moves past v2.0.0 into whatever comes
-// after. No other edit is required — UNLESS internal/version/version.go's
-// own `Areas` string has changed since AREAS below was last copied.
-// AREAS is not part of the three-line flip: it mirrors what the binary
-// claims under SPEC §7.3, which is orthogonal to the version number, so
-// it only needs touching when the binary's declared areas change, not at
-// every release. AREAS_SINCE only needs touching if that first-printed
-// release is ever revised (it should not be, once true).
+// them. The hero badge's "vX design in progress" caveat clears itself
+// automatically once CURRENT_VERSION === NEXT_VERSION: NEXT_VERSION only
+// ever names "whatever comes after CURRENT_VERSION", so that comparison
+// is the right one for it.
+//
+// Every feature-specific caveat is different: it clears when
+// CURRENT_VERSION reaches the release that ACTUALLY introduced that
+// feature, which is a fixed fact about the past, not "whatever
+// NEXT_VERSION currently says". IS_NEXT_RELEASED (CURRENT_VERSION ===
+// NEXT_VERSION) is wrong for these — it goes false again the moment the
+// next dev cycle opens and NEXT_VERSION moves on, even though the
+// feature that shipped at the earlier release is still shipped. AREAS_SINCE
+// (the areas line) and ENFORCEMENT_SINCE (the commit-guard hooks) are
+// both this shape: each is gated on "CURRENT_VERSION >= <ITS_OWN>_SINCE"
+// via compareVersions, and the version NAMED in that section's prose is
+// the same `*_SINCE` constant too — never NEXT_VERSION, which would name
+// the wrong release the moment it moves past the one that actually
+// shipped the feature. `*_SINCE` constants only need touching if the
+// release that introduced their feature is ever revised (it should not
+// be, once true) — not at every version bump, and not in sync with
+// NEXT_VERSION.
+//
+// No other edit is required at release time — UNLESS
+// internal/version/version.go's own `Areas` string has changed since
+// AREAS below was last copied. AREAS is not part of the three-line flip:
+// it mirrors what the binary claims under SPEC §7.3, which is orthogonal
+// to the version number, so it only needs touching when the binary's
+// declared areas change, not at every release.
 //
 // CURRENT_* is what `brew install thrillmade/tap/logmind` / curl / the
 // skill installs *today*. Verified against `gh release list --repo
 // thrillmade/logmind` (latest tag) and the installed binary's own
 // `logmind --version` output — re-verify both at every release.
 //
-// NEXT_VERSION names the release the "enforced" section and the hero
-// badge describe ahead of time (commit-guard hooks, zero-conflict
-// derived docs). The site can't import internal/version/version.go (Go
-// vs TS), so this block is a hand-maintained mirror of it — keep them in
-// sync at tag time.
+// NEXT_VERSION names the release the hero badge and the install
+// footnote describe ahead of time, generically — "there's a next
+// release and it isn't out yet" — never a specific feature's own
+// availability; see the `*_SINCE` constants above for those. The site
+// can't import internal/version/version.go (Go vs TS), so this block is
+// a hand-maintained mirror of it — keep them in sync at tag time.
 // ---------------------------------------------------------------------------
 // Typed `string` (not narrowed to a literal) so the equality check below
 // type-checks at every point in the release cycle, including the moment
@@ -64,11 +80,24 @@ const IS_NEXT_RELEASED = CURRENT_VERSION === NEXT_VERSION;
 const AREAS_SINCE = "2.0.0";
 const AREAS = "orient, work, record, propagate, gates";
 
+// The "enforced" section's two-layer commit guard (commit-msg hook +
+// Claude Code PreToolUse hook) shipped in v2.0.0 — see
+// internal/version/version.go's SameMajor doc comment: "the enforcement
+// gate itself arrived in 2.0.0". Same shape as AREAS_SINCE above, and
+// for the same reason: the guard is a fact about the release that
+// introduced it, not about whatever NEXT_VERSION currently is. Both the
+// "enforced" section's caveat AND the version it names in its own prose
+// (v{ENFORCEMENT_SINCE}, not v{NEXT_VERSION}) key off this constant —
+// naming NEXT_VERSION there would claim the wrong release added the
+// guard the moment NEXT_VERSION moves past v2.0.0.
+const ENFORCEMENT_SINCE = "2.0.0";
+
 // compareVersions compares two plain "major.minor.patch" version strings
-// numerically. CURRENT_VERSION / NEXT_VERSION / AREAS_SINCE on this page
-// are always plain release numbers — no "-dev"/prerelease suffix; that
-// only exists on the Go binary's own unreleased builds — so a bare
-// split-on-"." + Number compare is sufficient here.
+// numerically. CURRENT_VERSION / NEXT_VERSION / AREAS_SINCE /
+// ENFORCEMENT_SINCE on this page are always plain release numbers — no
+// "-dev"/prerelease suffix; that only exists on the Go binary's own
+// unreleased builds — so a bare split-on-"." + Number compare is
+// sufficient here.
 function compareVersions(a: string, b: string): number {
   const pa = a.split(".").map(Number);
   const pb = b.split(".").map(Number);
@@ -80,6 +109,7 @@ function compareVersions(a: string, b: string): number {
 }
 
 const SHOWS_AREAS_LINE = compareVersions(CURRENT_VERSION, AREAS_SINCE) >= 0;
+const SHOWS_ENFORCEMENT_AVAILABLE = compareVersions(CURRENT_VERSION, ENFORCEMENT_SINCE) >= 0;
 const VERIFY_OUTPUT = SHOWS_AREAS_LINE
   ? `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})\nareas: ${AREAS}`
   : `logmind ${CURRENT_VERSION} (spec ${CURRENT_SPEC})`;
@@ -352,17 +382,17 @@ export default function Home() {
               enforced<span className="text-accent">.</span>
             </h2>
             <p className="text-[15px] mt-4 text-foreground/70 leading-relaxed max-w-xs">
-              A convention only holds if the tooling holds the door. v{NEXT_VERSION}{" "}
+              A convention only holds if the tooling holds the door. v{ENFORCEMENT_SINCE}{" "}
               adds a guard in front of every substantive commit
-              {!IS_NEXT_RELEASED && " — in design, not yet released"}.
+              {!SHOWS_ENFORCEMENT_AVAILABLE && " — in design, not yet released"}.
             </p>
           </div>
           <div className="sm:col-span-8">
             <p className="text-[15px] leading-[1.65] text-foreground/85 mb-6">
-              {!IS_NEXT_RELEASED && (
+              {!SHOWS_ENFORCEMENT_AVAILABLE && (
                 <>
                   <strong className="text-accent">Not yet released</strong> —
-                  ships with v{NEXT_VERSION}.{" "}
+                  ships with v{ENFORCEMENT_SINCE}.{" "}
                 </>
               )}
               A <code className="font-mono text-foreground text-[0.85em]">commit-msg</code> hook and a Claude


### PR DESCRIPTION
Remainder of #279. That issue's two stated halves are already built on `dev` — I posted measured evidence there — but pinning the last loose thread surfaced a second defect in the code being pinned.

## 1. The mirror had no owner

`site/app/page.tsx` and `internal/version/version.go` both spell the SPEC §7.3 areas string. Nothing checked they agreed: **zero** test files and **zero** workflow files referenced `page.tsx` or `AREAS`. Control: `page.tsx` IS referenced by 7 files under `docs/`, so the search finds things when they exist.

The site's own comment conceded it is "a hand-maintained mirror" because TS cannot import Go. That copy diverges at exactly the wrong moment — a hand-edit at tag time, when the site is claiming what the new binary prints and nobody re-runs the binary to check.

Two tests in `internal/version/version_test.go`, with the Go constant as the owner in both: the failure message names `site/app/page.tsx` as the file to edit and says explicitly not to change `version.go` to make it pass.

## 2. The pin exposed a gate that answers the wrong question

The areas line was shown when `IS_NEXT_RELEASED = CURRENT_VERSION === NEXT_VERSION`. That answers *"is the next release out"*. The question the site is actually asking is *"does the current release print this line"*. They coincide only because 2.0.0 happens to be the first release that prints it.

| | CURRENT | NEXT | before | after | truth |
|---|---|---|---|---|---|
| today | 1.2.0 | 2.0.0 | one line | one line | 1.2.0 has no areas line |
| at the v2.0.0 tag | 2.0.0 | 2.0.0 | two lines | two lines | ✅ |
| next dev cycle | 2.0.0 | 2.1.0 | **one line** | two lines | 2.0.0 does print it |

And the pin made it worse before it made it better: pinning `NEXT_VERSION` to `version.Version` forces it to `2.1.0` right after the tag, so the pin would have **scheduled** that regression for the first commit of the next cycle.

Now gated on `SHOWS_AREAS_LINE = compareVersions(CURRENT_VERSION, AREAS_SINCE) >= 0` — the line's own introducing release, compared **numerically**, because `"2.10.0" < "2.9.0"` lexically and that is a real future value.

`IS_NEXT_RELEASED` is unchanged and still gates the four "not yet released" caveats; each was checked, and each genuinely asks whether `NEXT_VERSION` itself has shipped.

## Verification

Evaluated by extracting the real constants and the real comparator out of `page.tsx` and running them — not by reading the file:

```
today            CURRENT=1.2.0   showsAreas=false want=false ok
at the tag       CURRENT=2.0.0   showsAreas=true  want=true  ok
next dev cycle   CURRENT=2.0.0   showsAreas=true  want=true  ok
2.10.0 era       CURRENT=2.10.0  showsAreas=true  want=true  ok
naive lexical "2.10.0" >= "2.9.0" = false   <- why the numeric compare is load-bearing
```

Mutations, each compiling / still valid TS:

| mutation | result |
|---|---|
| site `AREAS` changed | RED |
| `version.Areas` changed | RED, message correctly points at the site file |
| test locator `go.mod` → nonexistent | **both tests FAIL LOUD**, no silent skip |
| `compareVersions` → `return 1` | RED on the `today` row |

That third one is the one that matters: a locator that misses must not read as green, because a silently skipped test is a failing-open gate.

Gates: `go build ./...` · `go vet ./...` · `gofmt -l .` · `go test ./internal/version/ -count=1` all clean.

## Known gap, not fixed here

No CI-level test guards the TS render logic itself — the two Go tests pin the raw string constants only. The evaluation above is a scratch harness, not a committed one.