### PR TITLE
fix(redirect): splice logmind's own entry, copy every other byte through — SPEC:1101 + protocol#77

### DIFF
--- a/docs/ai-agent-files.md
+++ b/docs/ai-agent-files.md
@@ -52,7 +52,7 @@ etc. — is preserved as-is.
 ### Per-tool files (stubs)
 
 For every enabled agent, `logmind init` / `logmind agents add <name>`
-writes (or overwrites) a 2-line stub:
+installs a marked stub entry:
 
 ```
 <!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->
@@ -60,11 +60,36 @@ See [AGENTS.md](AGENTS.md) for project-specific AI agent instructions, including
 the decision-logging requirement (logmind) and required reading.
 ```
 
+**These files are shared, and logmind writes only the entry it owns**
+(SPEC:1101, [protocol#77](https://github.com/thrillmade/protocol/issues/77)).
+Several components install into the same `CLAUDE.md` — this repository's own
+opens with Claude Code's `@AGENTS.md` import directive above the stub, and
+`protocol`'s carries clud-bug's marked block below it. What logmind rewrites
+is the span from its `<!-- logmind-stub: -->` line to the next blank line,
+next component marker, or end of file. Every byte outside that span is left
+exactly as found.
+
+Which means, per state of the file:
+
+| the file … | logmind |
+|---|---|
+| does not exist | writes it, carrying the `logmind-stub` marker |
+| carries logmind's marker | rewrites that entry only |
+| carries another component's marker and no logmind entry | leaves it, and says so on stderr |
+| carries no marker at all | leaves it, and says so on stderr |
+
+For the two JSON tools (`cody`, `zed`) the marker is the top-level
+`"logmind"` key, since JSON carries no comments — logmind refreshes that key
+and leaves every other setting in the file alone. A settings file it cannot
+parse (Zed's routinely carries comments) is one it cannot claim, so it is
+left alone too.
+
 If a per-tool file already exists with real hand-written content (not yet
 a stub), `logmind agents add <name>` falls back to splicing a
 `<!-- logmind-start -->` / `<!-- logmind-end -->` section into that file
 in place (the legacy, pre-AGENTS.md insertion path) rather than clobbering
-it. `logmind agents migrate` consolidates any such files into stubs.
+it. `logmind agents migrate` consolidates any such files into stubs — but
+never one carrying another component's marker.
 
 ### Context files
 

--- a/docs/decisions-branches/fix__redirect-file-ownership.md
+++ b/docs/decisions-branches/fix__redirect-file-ownership.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-16 10:41 - redirect files: splice logmind's own entry and copy every other byte through, per SPEC:1101 and protocol#77
+
+**Reasoning:** logmind init replaced the SPEC §1.2 redirect files wholesale. Measured: one init run destroyed a hand-written CLAUDE.md while AGENTS.md's user prose survived in the same run — so preservation logic existed and this path simply did not use it. Silent, exit 0. The protocol owner then ruled that the governing sentence is SPEC:1101's FIRST — an installer MUST merge rather than replace, writing only the entry it owns — which applies whether or not logmind's marker is present. A file carrying our marker is not a file we own end to end. And the severity was worse than filed: line 1 of CLAUDE.md in agent-skills, reporulez and logmind itself is @AGENTS.md, Claude Code's import directive, so a whole-file replace does not cost a paragraph, it costs every rule in AGENTS.md being loaded at all.
+
+**Alternatives considered:** Refuse only unmarked and foreign-marked files, and keep replacing our own — rejected on the ruling; that leaves the bug in the one state my first brief told the lane to leave alone. Anchor detection to line 1 — rejected; four of five CLAUDE.md files in this org carry @AGENTS.md on line 1, so line-1-only refuses all of them forever.
+
+**Implications:**
+- One classifier, planRedirectWrite, shaped after planBlockRefresh (#267) and reusing the existing MarkerOwnership vocabulary rather than a fourth copy — MarkerForeign is the only new value. CreateAgentFile now owns the read as well as the write, so writing without checking is unrepresentable; the signature change forced all three call sites. Refresh is a splice: everything outside the logmind entry's span is copied through, so a foreign marker and a bare @import are handled by one rule — outside our span — not two. Verified against the REAL files: agent-skills' and protocol's CLAUDE.md are sha256-identical after init, and the control on the pre-fix binary changes both and drops @AGENTS.md from 1 to 0. Full suite run by me, not taken on report: 23 packages ok, exit 0.
+
+---
+

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -144,14 +144,14 @@ func newAgentsAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runAgentsAdd(cwd, args[0], noCommit, cmd.OutOrStdout())
+			return runAgentsAdd(cwd, args[0], noCommit, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	cmd.Flags().BoolVar(&noCommit, "no-commit", false, "Don't commit the new file")
 	return cmd
 }
 
-func runAgentsAdd(cwd, agentName string, noCommit bool, stdout io.Writer) error {
+func runAgentsAdd(cwd, agentName string, noCommit bool, stdout, stderr io.Writer) error {
 	a, ok := agents.Lookup(agentName)
 	if !ok {
 		fmt.Fprintf(stdout, "Error: Unknown agent '%s'. Valid agents: %s\n",
@@ -178,15 +178,24 @@ func runAgentsAdd(cwd, agentName string, noCommit bool, stdout io.Writer) error 
 		return nil
 	}
 
-	created, err := inserter.CreateAgentFile(agentName, cwd)
+	written, refused, err := inserter.CreateAgentFile(agentName, cwd)
 	if err != nil {
 		return err
 	}
-	if created == "" {
+	// Reachable only by losing the race with whoever created the file between
+	// the fileExists check above and the read inside CreateAgentFile — which
+	// is precisely why the check inside the write primitive is the one that
+	// counts, and why this branch is not folded into the "Failed to create"
+	// error below: the file was not created because it was not ours.
+	if refused != nil {
+		reportRedirectRefusal(stderr, refused)
+		return nil
+	}
+	if written.Path == "" {
 		fmt.Fprintf(stdout, "Error: Failed to create file for agent '%s'\n", agentName)
 		return ErrSilent
 	}
-	fmt.Fprintf(stdout, "✓ Created %s with logmind instructions\n", filepath.Base(created))
+	fmt.Fprintf(stdout, "✓ Created %s with logmind instructions\n", filepath.Base(written.Path))
 	noteDeferredCommit(noCommit, stdout)
 	return nil
 }
@@ -474,13 +483,17 @@ func newAgentsMigrateCmd() *cobra.Command {
 }
 
 func runAgentsMigrate(cwd string, noCommit bool, stdout, stderr io.Writer) error {
-	messages, declined, err := inserter.MigrateToAgentsMD(cwd)
+	messages, declined, refused, err := inserter.MigrateToAgentsMD(cwd)
 	if err != nil {
 		return err
 	}
 	// Reported before the messages: migrate consolidates the per-agent
-	// files either way, but AGENTS.md's own block was left alone (#267).
+	// files either way, but AGENTS.md's own block was left alone (#267),
+	// and a file another component owns was left where it is (#336).
 	reportAgentsBlockRefusal(stderr, declined)
+	for i := range refused {
+		reportRedirectRefusal(stderr, &refused[i])
+	}
 	if len(messages) == 0 {
 		fmt.Fprintln(stdout, "No agent files to migrate (already consolidated).")
 		return nil

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -64,7 +64,7 @@ func TestAgentsList_ForeignFile(t *testing.T) {
 func TestAgentsAdd_Unknown(t *testing.T) {
 	dir := t.TempDir()
 	var stdout bytes.Buffer
-	err := runAgentsAdd(dir, "unknown_agent", false, &stdout)
+	err := runAgentsAdd(dir, "unknown_agent", false, &stdout, io.Discard)
 	if !errors.Is(err, ErrSilent) {
 		t.Fatalf("runAgentsAdd err = %v; want ErrSilent", err)
 	}
@@ -76,7 +76,7 @@ func TestAgentsAdd_Unknown(t *testing.T) {
 func TestAgentsAdd_NewCursor(t *testing.T) {
 	dir := t.TempDir()
 	var stdout bytes.Buffer
-	if err := runAgentsAdd(dir, "cursor", true, &stdout); err != nil {
+	if err := runAgentsAdd(dir, "cursor", true, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsAdd: %v", err)
 	}
 	checkGolden(t, "agents_add_cursor_new.golden", stdout.String())
@@ -101,7 +101,7 @@ func TestAgentsAdd_ExistingForeign(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout bytes.Buffer
-	if err := runAgentsAdd(dir, "claude", true, &stdout); err != nil {
+	if err := runAgentsAdd(dir, "claude", true, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsAdd: %v", err)
 	}
 	checkGolden(t, "agents_add_claude_foreign.golden", stdout.String())
@@ -124,7 +124,7 @@ func TestAgentsAdd_ExistingWithMarker(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	var stdout bytes.Buffer
-	if err := runAgentsAdd(dir, "claude", true, &stdout); err != nil {
+	if err := runAgentsAdd(dir, "claude", true, &stdout, io.Discard); err != nil {
 		t.Fatalf("runAgentsAdd: %v", err)
 	}
 	checkGolden(t, "agents_add_claude_already.golden", stdout.String())

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -236,17 +236,35 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 		reportAgentsBlockRefusal(cmd.ErrOrStderr(), agentsDeclined)
 	}
+	// refusedRedirects is what init WANTED to write and may not (#336,
+	// protocol#77): a per-tool file carrying another component's marker, or no
+	// marker at all. It is a legitimate repository state, not a failure — so
+	// it is reported on stderr and does NOT join `unwritten`, exactly like the
+	// workflow-template ownership refusals above.
+	refusedRedirects := map[string]bool{}
 	for _, agentName := range enabled {
-		filePath, err := inserter.CreateAgentFile(agentName, cwd)
+		written, refused, err := inserter.CreateAgentFile(agentName, cwd)
 		if err != nil {
 			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: create agent file:", agentName, err)
 			continue
 		}
-		if filePath == "" {
+		if refused != nil {
+			reportRedirectRefusal(cmd.ErrOrStderr(), refused)
+			refusedRedirects[refused.Path] = true
 			continue
 		}
-		if rel, err := filepath.Rel(cwd, filePath); err == nil {
-			fmt.Fprintln(out, "✓ Created", rel)
+		if written.Path == "" {
+			continue
+		}
+		if rel, err := filepath.Rel(cwd, written.Path); err == nil {
+			// Two verbs, because they are two events: a file this run brought
+			// into existence, and one that was already there and had logmind's
+			// entry — and only logmind's entry — rewritten inside it.
+			if written.Created {
+				fmt.Fprintln(out, "✓ Created", rel)
+			} else {
+				fmt.Fprintln(out, "↻ Refreshed the logmind entry in", rel)
+			}
 		}
 	}
 
@@ -388,9 +406,19 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 		}
 		for _, agent := range enabled {
 			if rel, ok := agents.FilePath(agent, cwd); ok && pathExists(rel) {
-				if relPath, err := filepath.Rel(cwd, rel); err == nil {
-					filesToCommit = append(filesToCommit, relPath)
+				relPath, err := filepath.Rel(cwd, rel)
+				if err != nil {
+					continue
 				}
+				// A file logmind declined to write is not a file logmind
+				// commits. It exists — that is WHY it was refused — so the
+				// pathExists test above cannot tell it apart from one this run
+				// created, and staging it would sweep the user's own
+				// (or another component's) file into logmind's initial commit.
+				if refusedRedirects[filepath.ToSlash(relPath)] {
+					continue
+				}
+				filesToCommit = append(filesToCommit, relPath)
 			}
 		}
 		if pathExists(filepath.Join(cwd, "AGENTS.md")) {

--- a/internal/cli/redirect_ownership_test.go
+++ b/internal/cli/redirect_ownership_test.go
@@ -1,0 +1,306 @@
+// redirect_ownership_test.go — logmind#336 / protocol#77 / SPEC:1101:
+// `logmind init` replaced the per-tool redirect files whole, so it destroyed a
+// hand-written CLAUDE.md, another component's entry, and — in the two
+// repositories that publish this toolchain — the `@AGENTS.md` import line that
+// is how Claude Code loads AGENTS.md at all. Silently, on exit 0.
+//
+// SPEC:1101 is two sentences and the FIRST one governs here:
+//
+//	An installer MUST merge rather than replace: it writes only the entry it
+//	owns and leaves every other entry — including one the user wrote by hand —
+//	exactly as it found it.
+//
+//	An artifact carrying no marker at all belongs to the user and MUST NOT be
+//	overwritten.
+//
+// Merge-rather-than-replace binds whether or not logmind's marker is present,
+// so "the file carries our marker" is not permission to rewrite the file. Five
+// states, and the fix is only correct if all five hold in the same run — two
+// that logmind LEAVES a file alone, three that it still writes into one.
+// "Stop writing the redirect files" satisfies the first half and breaks SPEC
+// §0.1's promise that a logmind-only repository still gets a working
+// CLAUDE.md.
+//
+// Asserted through `logmind init` rather than against the inserter helper: the
+// harm was the bytes on disk after the command the user ran, and a test on the
+// helper goes green again the day a caller stops routing through it.
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// stubBody is logmind's entry as this binary ships it, without the trailing
+// newline — the shape it takes when spliced INTO a file rather than being the
+// whole of one.
+func stubBody() string { return strings.TrimRight(templates.Stub(), "\n") }
+
+// redirectCase is one row of SPEC §1.2's table as `init` finds it on disk.
+type redirectCase struct {
+	name  string
+	agent string // registry name passed to --agents
+	rel   string // repo-root-relative path init writes
+	seed  string // bytes planted before init; "" means the file is absent
+	want  string // EXACT bytes required afterwards
+	// refused says logmind must leave the file alone AND say so on stderr.
+	refused bool
+	// survives is a byte sequence whose loss is the reported harm — named so a
+	// failure says WHAT was destroyed rather than dumping two files.
+	survives string
+}
+
+// redirectCases is the five-way control, run as ONE `logmind init`. One run,
+// because the halves have to hold simultaneously: a fix that refuses
+// everything passes the three refusal rows on its own, and the run that proves
+// it wrong has to be the same run.
+var redirectCases = []redirectCase{{
+	// ROW 1 — ABSENT. Nothing but logmind writes these files in a repository
+	// that has not installed the harness, so this row is SPEC §0.1's
+	// independence clause.
+	name:  "absent is created",
+	agent: "cline",
+	rel:   ".clinerules",
+	seed:  "",
+	want:  templates.Stub(),
+}, {
+	// ROW 2 — LOGMIND'S ENTRY, ALONE. Still refreshed, so the fix is not
+	// "stop writing": the stale body must be gone afterwards.
+	name:  "logmind entry alone is refreshed",
+	agent: "aider",
+	rel:   "CONVENTIONS.md",
+	seed:  "<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->\nSTALE LOGMIND STUB BODY\n",
+	want:  templates.Stub(),
+}, {
+	// ROW 3 — THE ONE WITH TEETH. This is `agent-skills`' and `reporulez`'
+	// CLAUDE.md byte for byte. Line 1 is Claude Code's import directive: not
+	// prose, not part of the stub, and not something anyone would think to
+	// re-add. A whole-file replace here does not cost a paragraph, it costs
+	// every rule in AGENTS.md being loaded by the agent that reads it.
+	name:     "logmind entry under an @import is refreshed around it",
+	agent:    "claude",
+	rel:      "CLAUDE.md",
+	seed:     "@AGENTS.md\n\n<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->\nSTALE STUB BODY UNDER AN IMPORT\n",
+	want:     "@AGENTS.md\n\n" + stubBody() + "\n",
+	survives: "@AGENTS.md",
+}, {
+	// ROW 4 — FOREIGN MARKER, NO LOGMIND ENTRY. protocol#77: nobody
+	// overwrites a file carrying someone else's marker.
+	name:     "foreign marker is left alone",
+	agent:    "cursor",
+	rel:      ".cursorrules",
+	seed:     "<!-- skdd-stub: AI agent instructions live in AGENTS.md -->\nFOREIGN STUB CONTENT\n",
+	want:     "<!-- skdd-stub: AI agent instructions live in AGENTS.md -->\nFOREIGN STUB CONTENT\n",
+	refused:  true,
+	survives: "FOREIGN STUB CONTENT",
+}, {
+	// ROW 5 — NO MARKER AT ALL. The reported defect: a CLAUDE.md-shaped file a
+	// person wrote. SPEC:1101's second sentence.
+	name:     "unmarked file is left alone",
+	agent:    "windsurf",
+	rel:      ".windsurfrules",
+	seed:     "# My own rules\n\nHAND WRITTEN BY THE USER\n",
+	want:     "# My own rules\n\nHAND WRITTEN BY THE USER\n",
+	refused:  true,
+	survives: "HAND WRITTEN BY THE USER",
+}, {
+	// ROW 5, JSON. A real .zed/settings.json is where a Zed user's whole
+	// configuration lives, and it can carry no HTML comment — so this row is
+	// what proves ownership is decided for every entry in the registry rather
+	// than for the two markdown files named in the issue.
+	name:     "unmarked JSON settings are left alone",
+	agent:    "zed",
+	rel:      ".zed/settings.json",
+	seed:     "{\n  \"theme\": \"One Dark\",\n  \"USER_ZED_SETTING\": true\n}\n",
+	want:     "{\n  \"theme\": \"One Dark\",\n  \"USER_ZED_SETTING\": true\n}\n",
+	refused:  true,
+	survives: "USER_ZED_SETTING",
+}}
+
+// seedRedirectCases plants every row's `seed` and returns the --agents value
+// covering all of them.
+func seedRedirectCases(t *testing.T) string {
+	t.Helper()
+	var names []string
+	for _, c := range redirectCases {
+		names = append(names, c.agent)
+		if c.seed != "" {
+			writeRel(t, c.rel, c.seed, 0o644)
+		}
+	}
+	return strings.Join(names, ",")
+}
+
+// TestInit_RedirectFileOwnership is the whole ruling in one run.
+func TestInit_RedirectFileOwnership(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		agentList := seedRedirectCases(t)
+
+		_, stderr := runInitCapture(t, []string{"init", "--no-git", "--agents", agentList})
+
+		for _, c := range redirectCases {
+			t.Run(c.name, func(t *testing.T) {
+				got := readRel(t, c.rel)
+				// THE HARM, asserted where the user saw it: the bytes. An
+				// exact compare rather than a sentinel search, because
+				// "somewhere in the file" is not what merge promises — every
+				// byte outside logmind's own entry has to be where it was.
+				if got != c.want {
+					t.Errorf("%s:\n got: %q\nwant: %q", c.rel, got, c.want)
+				}
+				if c.survives != "" && !strings.Contains(got, c.survives) {
+					t.Errorf("%s lost %q — that is the reported harm", c.rel, c.survives)
+				}
+				if !c.refused {
+					return
+				}
+				// SPEC §3.4's rule for the analogous fail-open case: a refusal
+				// the user is never told about is the failure mode, not the
+				// remedy. protocol#77 says it in as many words — "leave it,
+				// and say so on stderr".
+				if !strings.Contains(stderr, c.rel) {
+					t.Errorf("nothing on stderr names %s; the refusal was silent.\nstderr: %s", c.rel, stderr)
+				}
+			})
+		}
+	})
+}
+
+// TestInit_RedirectEntryRefreshIsIdempotent — the second run must write
+// nothing at all. A merge that re-splices its own output (an extra newline, a
+// dropped one) shows up here and nowhere else, and a repository that gets a
+// one-line diff on every `init` learns to ignore the diff.
+func TestInit_RedirectEntryRefreshIsIdempotent(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		agentList := seedRedirectCases(t)
+		runInitCapture(t, []string{"init", "--no-git", "--agents", agentList})
+		after := map[string]string{}
+		for _, c := range redirectCases {
+			after[c.rel] = readRel(t, c.rel)
+		}
+
+		// A second fresh-install run (init is idempotent by design).
+		runInitCapture(t, []string{"init", "--no-git", "--agents", agentList})
+
+		for _, c := range redirectCases {
+			if got := readRel(t, c.rel); got != after[c.rel] {
+				t.Errorf("%s changed on the second init:\n got: %q\nwant: %q", c.rel, got, after[c.rel])
+			}
+		}
+	})
+}
+
+// TestInit_PreservesAnotherComponentsEntryBelowOurOwn is `protocol`'s
+// CLAUDE.md: logmind's stub first, clud-bug's whole marked block under it.
+// Merge means logmind's three lines move and clud-bug's block does not.
+func TestInit_PreservesAnotherComponentsEntryBelowOurOwn(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		const cludBug = "\n<!-- clud-bug-start -->\n<!-- clud-bug-block-version: v2 -->\n" +
+			"## clud-bug — Claude PR review\n\nCLUD_BUG_ENTRY_SENTINEL\n<!-- clud-bug-end -->\n"
+		writeRel(t, "CLAUDE.md",
+			"<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->\n"+
+				"STALE LOGMIND BODY\n"+cludBug, 0o644)
+
+		runInitCapture(t, []string{"init", "--no-git", "--agents", "claude"})
+
+		got := readRel(t, "CLAUDE.md")
+		if want := stubBody() + "\n" + cludBug; got != want {
+			t.Errorf("CLAUDE.md:\n got: %q\nwant: %q", got, want)
+		}
+		if !strings.Contains(got, "CLUD_BUG_ENTRY_SENTINEL") {
+			t.Error("another component's entry was destroyed")
+		}
+	})
+}
+
+// TestInit_IgnoresAMarkerInsideACodeFence — a repository quoting the stub in
+// its own CLAUDE.md (this repo's docs/ai-agent-files.md does exactly that) is
+// showing an example, not claiming an entry. Detection that cannot tell the
+// difference hands logmind a write span in the middle of somebody's fenced
+// block.
+func TestInit_IgnoresAMarkerInsideACodeFence(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		const quoted = "# House rules\n\nlogmind writes this:\n\n```markdown\n" +
+			"<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->\n" +
+			"FENCED_EXAMPLE_SENTINEL\n```\n"
+		writeRel(t, "CLAUDE.md", quoted, 0o644)
+
+		_, stderr := runInitCapture(t, []string{"init", "--no-git", "--agents", "claude"})
+
+		if got := readRel(t, "CLAUDE.md"); got != quoted {
+			t.Errorf("a fenced quotation was treated as logmind's entry:\n got: %q\nwant: %q", got, quoted)
+		}
+		if !strings.Contains(stderr, "CLAUDE.md") {
+			t.Errorf("the refusal was silent.\nstderr: %s", stderr)
+		}
+	})
+}
+
+// TestInit_RedirectRefusalIsNotAFailure — the refusals are legitimate
+// repository states, not errors: `init` finishes, writes everything else, and
+// exits 0. Same contract the workflow-template refusals hold to (#286, #306).
+func TestInit_RedirectRefusalIsNotAFailure(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		agentList := seedRedirectCases(t)
+
+		stdout, _, err := tryInitCapture(t, []string{"init", "--no-git", "--agents", agentList})
+		if err != nil {
+			t.Fatalf("init exited non-zero over an ownership refusal: %v\n%s", err, stdout)
+		}
+		mustContain(t, stdout, "logmind initialized successfully!")
+		// The rest of the install still landed — a refusal costs its own file,
+		// not the run.
+		readRel(t, "docs/timeline.md")
+		readRel(t, ".logmind/config.yml")
+	})
+}
+
+// TestInit_DoesNotClaimToHaveCreatedARefusedFile: "✓ Created CLAUDE.md" over a
+// file init did not touch is the cheapest kind of lie a receipt can tell, and
+// it is what made the original defect invisible — the user saw the line and
+// had no reason to look.
+func TestInit_DoesNotClaimToHaveCreatedARefusedFile(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		agentList := seedRedirectCases(t)
+
+		stdout, _ := runInitCapture(t, []string{"init", "--no-git", "--agents", agentList})
+
+		for _, c := range redirectCases {
+			switch {
+			case c.refused:
+				if strings.Contains(stdout, "✓ Created "+c.rel) {
+					t.Errorf("stdout claims to have created %s, which was left alone:\n%s", c.rel, stdout)
+				}
+			case c.seed != "":
+				// Refreshed in place, not created — the file was already there.
+				if strings.Contains(stdout, "✓ Created "+c.rel) {
+					t.Errorf("stdout claims to have created %s, which already existed:\n%s", c.rel, stdout)
+				}
+			}
+		}
+	})
+}
+
+// TestInit_CodexDoesNotOverwriteAGENTSMD is the eleventh row of the table.
+// `--agents codex` maps to AGENTS.md itself, and the per-agent writer used to
+// render the bundled template straight over it — undoing, in the same run, the
+// careful marker-block insertion EnsureAgentsMD had just done.
+func TestInit_CodexDoesNotOverwriteAGENTSMD(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		writeRel(t, "AGENTS.md", "# AGENTS.md\n\nUSER PROSE IN AGENTS\n", 0o644)
+
+		runInitCapture(t, []string{"init", "--no-git", "--agents", "codex"})
+
+		got := readRel(t, "AGENTS.md")
+		if !strings.Contains(got, "USER PROSE IN AGENTS") {
+			t.Errorf("init destroyed the user's AGENTS.md prose:\n%s", got)
+		}
+		// And the logmind block still went in — the row is "don't overwrite",
+		// not "don't install".
+		if !strings.Contains(got, "<!-- logmind-start -->") {
+			t.Errorf("AGENTS.md carries no logmind block:\n%s", got)
+		}
+	})
+}

--- a/internal/cli/refresh.go
+++ b/internal/cli/refresh.go
@@ -289,3 +289,47 @@ func reportAgentsBlockRefusal(stderr io.Writer, d *inserter.AgentsBlockRefusal) 
 			"ships %s); refusing to guess which template it is.\n",
 		d.Path, found, d.Bundled)
 }
+
+// reportRedirectRefusal writes the one stderr line for a per-tool redirect
+// file (SPEC §1.2) logmind declined to write — protocol#77's rows 2 and 3.
+// Same contract as the two reporters above: every surface that can hit the
+// refusal calls this, so none of them can swallow it.
+//
+// THE REPORT IS HALF THE FIX. `logmind init` already left AGENTS.md's user
+// prose alone and already refused a newer workflow template; what made #336 a
+// data-loss bug rather than a policy disagreement is that the redirect files
+// were rewritten with nothing said. The ruling spells the remedy out —
+// "leave it, and say so on stderr" — and SPEC §3.4's rule for the analogous
+// fail-open case gives the shape: name the file, what was looked for, and what
+// was found.
+//
+// Two messages, because the two states want different remedies: a file another
+// component owns is not a mistake to correct, and a file with no marker at all
+// is the user's to hand over if they want to.
+//
+// A no-op on nil so callers can call it unconditionally.
+func reportRedirectRefusal(stderr io.Writer, d *inserter.RedirectRefusal) {
+	if d == nil {
+		return
+	}
+	switch d.Ownership {
+	case inserter.MarkerForeign:
+		fmt.Fprintf(stderr,
+			"note: %s left unchanged — it carries %s's marker (line %d) and no logmind entry, so it is "+
+				"%s's file, not logmind's. Every component points %s at AGENTS.md, so there is nothing "+
+				"missing; if you want logmind's entry there too, delete %s and re-run `logmind init`.\n",
+			d.Path, d.Owner, d.Line, d.Owner, d.Display, d.Path)
+	default:
+		// SPEC:1101: "an artifact carrying no marker at all belongs to the
+		// user and MUST NOT be overwritten." The remedy is
+		// delete-and-regenerate rather than "paste the marker in yourself" —
+		// the same reason the workflow message gives, plus a simpler one here:
+		// the file logmind would write is three lines pointing at AGENTS.md,
+		// so a user who wants it gets it back in one command.
+		fmt.Fprintf(stderr,
+			"note: %s left unchanged — logmind looked for %s and found none, so it treats the file as "+
+				"yours (SPEC:1101) and will not overwrite it. %s reads this file; if you want logmind's "+
+				"pointer to AGENTS.md in it, delete %s and re-run `logmind init`.\n",
+			d.Path, d.Marker, d.Display, d.Path)
+	}
+}

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -44,6 +44,7 @@
 package inserter
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -66,6 +67,17 @@ const (
 	endMarker   = "<!-- logmind-end -->"
 	stubMarker  = "<!-- logmind-stub:"
 )
+
+// agentsMDName is the one path EnsureAgentsMD owns (SPEC §5.2: "Exactly one
+// automation owns any generated or copied path"). It is also row 11 of SPEC
+// §1.2's per-tool table — the codex entry — which is why the per-tool writer
+// below has to recognise it by name rather than treating it as one more stub.
+const agentsMDName = "AGENTS.md"
+
+// logmindOwner is the component name logmind writes into its own markers.
+// The redirect files of SPEC §1.2 are shared with other components (skdd
+// today), so "whose marker is this" is a name compare, not a boolean.
+const logmindOwner = "logmind"
 
 // pinLineRE captures the workflow pin line:
 //
@@ -142,9 +154,21 @@ func HasLogmindSection(content string) bool {
 	return strings.Contains(content, startMarker)
 }
 
-// IsStub reports whether content is a per-agent stub pointing at
-// AGENTS.md. Stubs carry the `<!-- logmind-stub:` marker so they're
-// distinguishable from full files that happen to mention AGENTS.md.
+// IsStub reports whether content MENTIONS logmind's stub marker at all.
+// Stubs carry the `<!-- logmind-stub:` marker so they're distinguishable
+// from full files that happen to mention AGENTS.md.
+//
+// This is NOT the ownership test, and the two must not be confused — that
+// confusion is #299. IsStub answers "has this file been stubbed", for
+// `agents list`'s status column and for `agents migrate`'s
+// already-consolidated skip; ReadRedirectOwner answers "may logmind WRITE
+// this file", and is line-1-only.
+//
+// The looser rule is safe HERE and only here, because both consumers fail
+// safe when it over-matches: the status column says "configured" about a file
+// nobody will write, and migrate SKIPS it. An over-inclusive answer on the
+// write side is what destroys a file, which is why that side does not use
+// this function.
 func IsStub(content string) bool {
 	return strings.Contains(content, stubMarker)
 }
@@ -319,30 +343,81 @@ func InsertLogmindSection(filePath string) (bool, error) {
 	return true, nil
 }
 
-// CreateAgentFile writes a new per-agent instruction file using the
-// canonical stub (for markdown agents other than codex) or the JSON
-// template (for cody/zed) or the full AGENTS.md template (for codex).
-// Returns the absolute path of the written file, or "" + nil for an
-// unknown agent name (matches Python's None return).
+// RedirectWrite is what CreateAgentFile did, for a caller that has to print a
+// receipt. Path is "" when nothing was written — which now includes the
+// ordinary idempotent case, an entry already carrying the current body.
 //
-// Mirrors create_agent_file(agent_name, root_path).
-func CreateAgentFile(agentName, repoRoot string) (string, error) {
+// Created distinguishes the two writes that are not the same event: a file
+// this run brought into existence, and one that was already there and had its
+// logmind entry refreshed in place. Reporting both as "✓ Created" is the
+// cheapest kind of lie for a receipt to tell, and it is the line that made
+// #336 invisible — the user saw "✓ Created CLAUDE.md" over the file the run
+// had just destroyed, and had no reason to look.
+type RedirectWrite struct {
+	Path    string
+	Created bool
+}
+
+// CreateAgentFile installs logmind's entry in a per-agent instruction file —
+// the canonical stub for markdown agents, the JSON body for cody/zed, the
+// AGENTS.md template for codex — MERGING it into whatever is already there.
+//
+// It is the single write primitive for SPEC §1.2's redirect files, and it owns
+// the read as well as the write for the reason RefreshMarkerBlockFile does: a
+// caller that cannot hold the bytes cannot decide about them, so there is no
+// way to express "write it without checking". Pre-#336 this function took an
+// agent name and wrote the bundled body over the path, unconditionally, and
+// the whole of SPEC:1101 was unrepresentable in its signature — a repository's
+// hand-written CLAUDE.md was destroyed by `logmind init` on exit 0, and so was
+// the `@AGENTS.md` import line that is how Claude Code loads AGENTS.md at all.
+//
+// Returns (write, nil, nil) when bytes were written, ("", refusal, nil) when
+// the file on disk is not logmind's — the caller MUST report the refusal — and
+// the zero write for an unknown agent name (matching Python's None return), an
+// AGENTS.md whose refresher is EnsureAgentsMD, or an entry already current.
+//
+// Mirrors create_agent_file(agent_name, root_path), plus the ownership rule.
+func CreateAgentFile(agentName, repoRoot string) (RedirectWrite, *RedirectRefusal, error) {
 	a, ok := agents.Lookup(agentName)
 	if !ok {
-		return "", nil
+		return RedirectWrite{}, nil, nil
 	}
 	filePath := filepath.Join(repoRoot, filepath.FromSlash(a.FilePattern))
-	body := agentTemplate(agentName)
-	// atomicio.WriteFile makes its own parent directory, and — unlike the
-	// bare os.WriteFile this replaced — refuses (atomicio.RefuseSymlink,
-	// #300) rather than silently writing through a symlink at filePath (a
-	// per-agent path like CLAUDE.md or .cursorrules); no ReadFile precedes
-	// this call, so a dangling symlink here was never even caught by an
-	// ErrNotExist check.
-	if err := atomicio.WriteFile(filePath, []byte(body), 0o644); err != nil {
-		return "", err
+
+	// Refuse a symlink BEFORE the read, not just before the write. The
+	// ownership verdict below is made from the file's own bytes and
+	// os.ReadFile resolves the final component, so a link pointing outside the
+	// repository would have some other file's content answer "is CLAUDE.md
+	// logmind's?" — and whatever the answer, it was answered about the wrong
+	// file. Same ordering, for the same reason, as the workflow loop in
+	// internal/cli/init.go.
+	if err := atomicio.RefuseSymlink(filePath); err != nil {
+		return RedirectWrite{}, nil, err
 	}
-	return filePath, nil
+	// os.ReadFile follows a symlink, so a DANGLING one at filePath reports
+	// fs.ErrNotExist exactly as an absent file does; the RefuseSymlink above
+	// has already declined it, and atomicio.WriteFile below closes the window
+	// between the two syscalls.
+	existing, err := os.ReadFile(filePath)
+	exists := err == nil
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return RedirectWrite{}, nil, err
+	}
+
+	plan := planRedirectWrite(a, string(existing), exists)
+	if plan.Refusal != nil {
+		return RedirectWrite{}, plan.Refusal, nil
+	}
+	if plan.Body == "" {
+		return RedirectWrite{}, nil, nil
+	}
+	// atomicio.WriteFile makes its own parent directory and refuses
+	// (atomicio.RefuseSymlink, #300) rather than silently writing through a
+	// symlink at filePath.
+	if err := atomicio.WriteFile(filePath, []byte(plan.Body), 0o644); err != nil {
+		return RedirectWrite{}, nil, err
+	}
+	return RedirectWrite{Path: filePath, Created: !exists}, nil, nil
 }
 
 // RemoveAgentFile deletes a per-agent instruction file. Returns
@@ -440,7 +515,7 @@ func jsonAgentBody() string {
 // non-nil *AgentsBlockRefusal when the block was deliberately left alone.
 // The status strings match Python's three return values verbatim.
 func EnsureAgentsMD(repoRoot string) (string, *AgentsBlockRefusal, error) {
-	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	agentsPath := filepath.Join(repoRoot, agentsMDName)
 
 	data, err := os.ReadFile(agentsPath)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -572,7 +647,7 @@ type OutdatedMarkerEntry struct {
 // here, but doing it silently let `agents update` report a block that is
 // ahead of the binary as "current" (#267).
 func FindOutdatedMarkerBlocks(repoRoot string) ([]OutdatedMarkerEntry, *AgentsBlockRefusal, error) {
-	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	agentsPath := filepath.Join(repoRoot, agentsMDName)
 	data, err := os.ReadFile(agentsPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil, nil
@@ -809,6 +884,12 @@ const (
 	// guessed at — the same "unknown means refuse, never guess" rule #267 and
 	// #286 landed on.
 	MarkerDisplaced
+	// MarkerForeign — the marker on line 1 names a DIFFERENT component (#336,
+	// protocol#77: "present, carrying another component's marker → nobody").
+	// Only the shared artifacts of SPEC §1.2 can be in this state; the
+	// workflow templates carry no other component's marker, so
+	// ExtractTemplateMarker never returns it.
+	MarkerForeign
 )
 
 // TemplateMarker is the result of reading an installed artifact's
@@ -867,6 +948,396 @@ func ExtractTemplateMarker(text string) TemplateMarker {
 		return TemplateMarker{Ownership: MarkerDisplaced, Version: m[1], Line: i + 1}
 	}
 	return TemplateMarker{Ownership: MarkerAbsent}
+}
+
+// redirectMarkerRE matches a component's OWNER MARKER at the start of a line
+// in a per-tool redirect file, capturing the component that claimed it and the
+// KIND of claim:
+//
+//	<!-- logmind-stub: ... -->         → "logmind", "stub"
+//	<!-- skdd-stub: ... -->            → "skdd",    "stub"
+//	<!-- clud-bug-start -->            → "clud-bug","start"
+//	<!-- clud-bug-block-version: … --> → "clud-bug","block-version"
+//
+// The kind matters because only "stub" names a SPAN this package may rewrite.
+// A `<!-- logmind-start -->` in a CLAUDE.md is logmind's too, but it is the
+// legacy in-place section — a different artifact with a different writer — and
+// splicing a stub over its opening line orphans its `-end` and drops what is
+// between them.
+//
+// The kinds are enumerated rather than left open (`<!-- (\S+) -->`) so an
+// ordinary HTML comment a person wrote is not mistaken for a component's
+// claim. A marker shape this does not know falls through to MarkerAbsent,
+// which refuses the write anyway — the rule degrades toward leaving the file
+// alone, never toward claiming it.
+var redirectMarkerRE = regexp.MustCompile(
+	`^<!--\s*([A-Za-z0-9][A-Za-z0-9._-]*?)-(stub|start|end|block-version)\b`)
+
+// markerKindStub is the only claim kind that names a rewritable span.
+const markerKindStub = "stub"
+
+// fenceRE matches a markdown code-fence delimiter. A marker INSIDE a fence is
+// a quotation, not a claim: `docs/ai-agent-files.md` shows the stub verbatim,
+// and a repository is entitled to do the same in its own CLAUDE.md without
+// handing logmind a write span in the middle of its example.
+var fenceRE = regexp.MustCompile("^\\s*(?:```|~~~)")
+
+// RedirectOwner is the answer to the only question a write path may ask about
+// an existing per-tool redirect file (SPEC §1.2's table): whose is it?
+//
+// Marker is what ownership was decided FROM, phrased for a human — the three
+// file forms in that table prove ownership three different ways, and a refusal
+// that cannot name what it looked for is not a report (SPEC §3.4).
+type RedirectOwner struct {
+	Ownership MarkerOwnership
+	Owner     string // component named by the marker, e.g. "skdd"; "" when there is none
+	Line      int    // 1-based line the marker sat on; 0 when there is none
+	Marker    string // what logmind looks for here, e.g. "a `<!-- logmind-stub: -->` line"
+}
+
+// Writable reports whether logmind may write ITS OWN ENTRY in this redirect
+// file. Only MarkerOwned qualifies — the SAME predicate, spelled the same way,
+// that TemplateMarker.Writable gives the workflow path. protocol#77 and SPEC
+// §5.2 are one rule over two artifacts, so they get one predicate: another
+// component's marker and no marker at all are both "not ours", and a caller
+// cannot accidentally handle one and forget the other.
+//
+// Writable is NOT permission to write the whole file. SPEC:1101's first
+// sentence — "An installer MUST merge rather than replace: it writes only the
+// entry it owns and leaves every other entry, including one the user wrote by
+// hand, exactly as it found it" — binds whether or not logmind's marker is
+// there. A file carrying logmind's marker is not thereby logmind's file:
+// `protocol`'s CLAUDE.md carries four markers and no component owns it. What
+// this predicate gates is a splice, planned by planRedirectWrite.
+func (r RedirectOwner) Writable() bool { return r.Ownership == MarkerOwned }
+
+// ReadRedirectOwner is the SINGLE OWNER of "whose is this per-tool redirect
+// file", for every one of the eleven rows in SPEC §1.2's table.
+//
+// It exists because `logmind init` used to answer the question by not asking
+// it: CreateAgentFile rendered the bundled body straight over whatever was
+// there, so a hand-written CLAUDE.md was destroyed on exit 0 with nothing on
+// stderr (#336). protocol#77's ruling is the contract now —
+//
+//	absent                     → whichever component is installing, with its own marker
+//	another component's marker → nobody; leave it, and say so on stderr
+//	no marker at all           → nobody; SPEC:1101, it belongs to the user
+//
+// — and this is where rows 2 and 3 are decided, once, so the two commands that
+// write these files cannot answer differently.
+//
+// WHY NOT "MARKER ON LINE 1", the rule ExtractTemplateMarker uses for
+// workflows. It was the first thing tried here and it is wrong for this
+// artifact, measurably: the CLAUDE.md in `agent-skills`, `reporulez`,
+// `clud-bug` and this repository all open with Claude Code's `@AGENTS.md`
+// import directive, so logmind's marker sits on line 3 in four of the five
+// repositories that carry one. Line-1-only reads every one of them as
+// displaced and refuses forever. The workflow rule can be strict because a
+// workflow is a whole file logmind renders; a redirect file is SHARED, and a
+// component's entry does not get to be first just because it installed first.
+//
+// What replaces it is that a match no longer authorises a whole-file write. A
+// marker anywhere identifies the SPAN logmind owns (see logmindEntrySpan), and
+// everything outside that span is left exactly as found — so the read side can
+// afford to be permissive because the write side stopped being destructive.
+// Two narrower guards remain, both of which a naive substring search fails:
+// the marker must START a line (a mention inside a sentence is prose), and it
+// must not be inside a code fence (a mention inside ``` is a quotation).
+//
+// Three forms, three proofs of ownership, one verdict type:
+//
+//   - MARKDOWN STUB (nine rows) — the `<!-- logmind-stub: -->` line.
+//   - JSON (cody, zed) — JSON has no comments, so the marker is a KEY; see
+//     jsonRedirectOwner.
+//   - AGENTS.md (codex) — the logmind marker block, which is what
+//     EnsureAgentsMD reads and writes.
+func ReadRedirectOwner(a agents.Agent, content string) RedirectOwner {
+	if a.IsJSON {
+		return jsonRedirectOwner(content)
+	}
+	if a.FilePattern == agentsMDName {
+		return agentsMDRedirectOwner(content)
+	}
+	const proof = "a `<!-- logmind-stub: -->` line"
+	var found *RedirectOwner
+	forEachMarkerLine(strings.Split(content, "\n"), func(i int, owner, _ string) bool {
+		if owner == logmindOwner {
+			found = &RedirectOwner{Ownership: MarkerOwned, Owner: logmindOwner, Line: i + 1, Marker: proof}
+			return false // logmind's own claim ends the search; a foreign one does not
+		}
+		if found == nil {
+			found = &RedirectOwner{Ownership: MarkerForeign, Owner: owner, Line: i + 1, Marker: proof}
+		}
+		return true // keep looking: logmind's entry may sit below another component's
+	})
+	if found != nil {
+		return *found
+	}
+	return RedirectOwner{Ownership: MarkerAbsent, Marker: proof}
+}
+
+// forEachMarkerLine calls fn with the 0-based index, component name and claim
+// kind of every component marker that STARTS a line and is not inside a code
+// fence, stopping when fn returns false. The fence state is tracked rather
+// than the fences merely skipped, so an opening ``` protects everything up to
+// its close.
+func forEachMarkerLine(lines []string, fn func(i int, owner, kind string) bool) {
+	inFence := false
+	for i, line := range lines {
+		if fenceRE.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		m := redirectMarkerRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if !fn(i, m[1], m[2]) {
+			return
+		}
+	}
+}
+
+// logmindEntrySpan returns the half-open LINE range [start, end) that
+// logmind's entry occupies, and whether there is one at all.
+//
+// THE SPAN IS THE WHOLE FIX. Everything outside it survives byte-for-byte —
+// the `@AGENTS.md` import above it, another component's block below it, a
+// paragraph the user wrote.
+//
+// The entry is the marker line plus the lines immediately under it, ending at
+// the first BLANK line, the first line that opens another component's HTML
+// comment, or end of file. That is markdown's own paragraph boundary, and it
+// is exactly the shape logmind writes (a marker plus two body lines, then
+// nothing or a blank). Measured against the five CLAUDE.md files in this org:
+// it selects lines 1-3 of `protocol`'s (whose blank line 4 separates
+// clud-bug's block) and lines 3-5 of `agent-skills`' (whose lines 1-2 are the
+// import and its blank), and re-splicing the current stub into either
+// reproduces the file byte-for-byte.
+//
+// The alternative — bracketing the entry with an end marker, the way
+// AGENTS.md's block is — was rejected: every stub already installed in the
+// fleet lacks one, so the boundary would still have to be inferred for exactly
+// the files this bug is about, and protocol#77 settled these files as "one
+// line, one owner, one marker". The cost of the paragraph rule is that prose
+// glued to the marker with no blank line between is inside the entry and is
+// replaced; that is stated here and pinned by a test, rather than discovered.
+func logmindEntrySpan(lines []string) (int, int, bool) {
+	start := -1
+	forEachMarkerLine(lines, func(i int, owner, kind string) bool {
+		// STUB ONLY. `<!-- logmind-start -->` is logmind's as well, but it
+		// opens the legacy in-place section, and treating its first line as
+		// the head of a stub span replaces it plus the line under it and
+		// leaves the `-end` marker dangling over content that is now gone.
+		if owner != logmindOwner || kind != markerKindStub {
+			return true
+		}
+		start = i
+		return false
+	})
+	if start < 0 {
+		return 0, 0, false
+	}
+	for i := start + 1; i < len(lines); i++ {
+		t := strings.TrimSpace(lines[i])
+		if t == "" || strings.HasPrefix(t, "<!--") {
+			return start, i, true
+		}
+	}
+	return start, len(lines), true
+}
+
+// jsonRedirectOwner decides ownership for the two JSON rows of SPEC §1.2's
+// table (.sourcegraph/cody.json, .zed/settings.json).
+//
+// JSON has no comment syntax, so these files cannot carry the marker the
+// markdown rows do — logmind's entry is the top-level `"logmind"` KEY, which
+// the body it already ships is built around (see jsonAgentBody). A file
+// carrying that key is one logmind installed into and may refresh; a file
+// without it is somebody's real configuration. That is not hypothetical for
+// `.zed/settings.json`: it is where a Zed user's entire configuration lives,
+// and init used to render the logmind object straight over it.
+//
+// Unparseable is MarkerAbsent, deliberately — and it is the common case for
+// Zed, whose settings file is JSONC and routinely carries comments. A file
+// logmind cannot read is a file logmind cannot claim.
+func jsonRedirectOwner(content string) RedirectOwner {
+	const proof = `a top-level "logmind" key`
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(content), &top); err != nil {
+		return RedirectOwner{Ownership: MarkerAbsent, Marker: proof}
+	}
+	if _, ok := top[logmindOwner]; ok {
+		return RedirectOwner{Ownership: MarkerOwned, Owner: logmindOwner, Marker: proof}
+	}
+	return RedirectOwner{Ownership: MarkerAbsent, Marker: proof}
+}
+
+// agentsMDRedirectOwner decides ownership for row 11 — AGENTS.md itself, which
+// the registry reaches under the name "codex".
+//
+// Its marker is the logmind BLOCK, the same one EnsureAgentsMD installs and
+// refreshes. Reusing HasLogmindSection/IsStub here rather than looking for a
+// stub marker is the point: AGENTS.md is a file whose own content the user
+// writes AROUND the block, so the block being present is what makes the file
+// logmind-installed.
+func agentsMDRedirectOwner(content string) RedirectOwner {
+	const proof = "a `<!-- logmind-start -->` block"
+	if HasLogmindSection(content) || IsStub(content) {
+		return RedirectOwner{Ownership: MarkerOwned, Owner: logmindOwner, Marker: proof}
+	}
+	return RedirectOwner{Ownership: MarkerAbsent, Marker: proof}
+}
+
+// RedirectRefusal records one per-tool redirect file (SPEC §1.2) a run left
+// alone because the bytes on disk are not logmind's — protocol#77's rows 2
+// and 3. It is a REFUSAL, not a failure: the run continues, exits 0, and the
+// caller MUST report it (SPEC §3.4's rule for the analogous fail-open case —
+// "Failing open MUST NOT be silent"). Silence is the whole defect in #336.
+type RedirectRefusal struct {
+	Path      string          // repo-root-relative, e.g. "CLAUDE.md"
+	Agent     string          // registry name, e.g. "claude"
+	Display   string          // human tool name, e.g. "Claude Code"
+	Ownership MarkerOwnership // which refusing state this is
+	Owner     string          // component that owns it, when one is named
+	Line      int             // 1-based line its marker sat on
+	Marker    string          // what logmind looked for and did not find
+}
+
+// redirectPlan is what a write path may do with one per-tool redirect file:
+// the exact bytes to write, or the refusal that says why nothing may be. At
+// most one field is set — Body "" with a nil Refusal is the third outcome,
+// "it is ours and there is nothing to change".
+//
+// Shaped after blockPlan, and for the same reason: one classifier that every
+// path routes through cannot disagree with itself about what a file's state
+// means, and the disagreement between two of them WAS #267.
+type redirectPlan struct {
+	Body    string
+	Refusal *RedirectRefusal
+}
+
+// planRedirectWrite decides what happens to one per-tool redirect file, from
+// its agent registry entry and the bytes already on disk. `exists` is passed
+// separately because "" is a legitimate content for a file that IS there, and
+// an empty file is the user's, not an invitation.
+//
+// The five states of protocol#77's ruling as amended by SPEC:1101, in order:
+//
+//  1. ABSENT → write the bundled body, carrying logmind's own marker. Nothing
+//     but logmind produces these files in a repository that has not installed
+//     the harness, so this row is what keeps SPEC §0.1's independence clause
+//     true.
+//  2. LOGMIND'S ENTRY, ALONE → splice the current body over that span. Same
+//     mechanism as row 3; there is simply nothing else in the file.
+//  3. LOGMIND'S ENTRY, ALONGSIDE SOMEBODY ELSE'S → splice the same span. The
+//     `@AGENTS.md` import above it and another component's block below it are
+//     outside the span and are copied through untouched.
+//  4. FOREIGN MARKER, NO LOGMIND ENTRY → refuse and report.
+//  5. NO MARKER AT ALL → refuse and report (SPEC:1101).
+func planRedirectWrite(a agents.Agent, existing string, exists bool) redirectPlan {
+	body := agentTemplate(a.Name)
+	if !exists {
+		return redirectPlan{Body: body}
+	}
+	owner := ReadRedirectOwner(a, existing)
+	if !owner.Writable() {
+		return redirectPlan{Refusal: refusalFor(a, owner)}
+	}
+	if a.FilePattern == agentsMDName {
+		// Ours, and NOT ours to rewrite HERE. SPEC §5.2: "Exactly one
+		// automation owns any generated or copied path" — AGENTS.md's is
+		// EnsureAgentsMD, which rewrites the marked block and preserves every
+		// byte around it. Rendering the bundled template over the file from
+		// here undid that surgical refresh in the same `init` run, taking the
+		// repository's own prose with it.
+		return redirectPlan{}
+	}
+	if a.IsJSON {
+		return redirectPlan{Body: mergeJSONEntry(existing, body)}
+	}
+	return redirectPlan{Body: mergeStubEntry(existing, body)}
+}
+
+// mergeStubEntry splices `body` over the span logmind owns in `existing`,
+// returning "" when that leaves the file unchanged (so an idempotent re-run
+// writes nothing and claims nothing).
+//
+// Returns "" as well when the file carries a logmind marker with no entry span
+// to replace — a CLAUDE.md holding the LEGACY in-place `<!-- logmind-start -->`
+// section rather than a stub. That file is logmind's, but converting it is
+// `agents migrate`'s job, which folds its content into AGENTS.md first;
+// stamping a stub over it from here would drop everything the block contains.
+func mergeStubEntry(existing, body string) string {
+	lines := strings.Split(existing, "\n")
+	start, end, ok := logmindEntrySpan(lines)
+	if !ok {
+		return ""
+	}
+	// TrimRight, not Split-and-drop-last: the body's own trailing newline is
+	// represented by whatever followed the entry in the ORIGINAL file, which
+	// lines[end:] already carries. Re-adding it here would insert a blank line
+	// on every refresh.
+	merged := make([]string, 0, len(lines))
+	merged = append(merged, lines[:start]...)
+	merged = append(merged, strings.Split(strings.TrimRight(body, "\n"), "\n")...)
+	merged = append(merged, lines[end:]...)
+	out := strings.Join(merged, "\n")
+	if out == existing {
+		return ""
+	}
+	return out
+}
+
+// mergeJSONEntry replaces the top-level "logmind" value in `existing` with the
+// one from `body`, leaving every other top-level key as it was, and returns ""
+// when nothing changed.
+//
+// The re-render is deliberately skipped when logmind's key is the only one:
+// the bundled body is hand-formatted, and round-tripping it through
+// encoding/json would sort its keys and rewrite the file on the first run in
+// every repository that has one. When there ARE other keys, re-rendering is
+// unavoidable — and it is still the right trade, because the alternative is
+// dropping the user's Zed configuration.
+func mergeJSONEntry(existing, body string) string {
+	var top, fresh map[string]json.RawMessage
+	if json.Unmarshal([]byte(existing), &top) != nil || json.Unmarshal([]byte(body), &fresh) != nil {
+		return ""
+	}
+	if len(top) == 1 {
+		if existing == body {
+			return ""
+		}
+		return body
+	}
+	top[logmindOwner] = fresh[logmindOwner]
+	out, err := json.MarshalIndent(top, "", "  ")
+	if err != nil {
+		return ""
+	}
+	rendered := string(out) + "\n"
+	if rendered == existing {
+		return ""
+	}
+	return rendered
+}
+
+// refusalFor packages a non-writable verdict for the caller to report. One
+// constructor, so a refusal cannot be raised without the fields the reporter
+// needs to describe it.
+func refusalFor(a agents.Agent, owner RedirectOwner) *RedirectRefusal {
+	return &RedirectRefusal{
+		Path:      a.FilePattern,
+		Agent:     a.Name,
+		Display:   a.Display,
+		Ownership: owner.Ownership,
+		Owner:     owner.Owner,
+		Line:      owner.Line,
+		Marker:    owner.Marker,
+	}
 }
 
 // OutdatedPinEntry records one stale workflow pin:
@@ -963,14 +1434,16 @@ func UpdateWorkflowPin(content, newVersion string) (string, string) {
 // matches Python's accumulator pattern; the migrate command renders
 // the slice line-by-line. The second return is EnsureAgentsMD's refusal
 // (#267): migrate still consolidates the per-agent files, but the caller
-// must say that AGENTS.md's own block was left alone.
-func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
+// must say that AGENTS.md's own block was left alone. The third is the set of
+// files this run declined to claim (#336) — see the loop for which.
+func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []RedirectRefusal, error) {
 	var messages []string
+	var refusals []RedirectRefusal
 	_, declined, err := EnsureAgentsMD(repoRoot)
 	if err != nil {
-		return nil, declined, err
+		return nil, declined, refusals, err
 	}
-	agentsPath := filepath.Join(repoRoot, "AGENTS.md")
+	agentsPath := filepath.Join(repoRoot, agentsMDName)
 	var appendedBlocks []string
 
 	for _, a := range agents.All() {
@@ -989,6 +1462,20 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 		if IsStub(content) {
 			continue // already migrated
 		}
+		// ANOTHER COMPONENT'S FILE IS NOT THE USER'S CONTENT TO CONSOLIDATE
+		// (protocol#77 row 2, #336). Migrate reads an UNMARKED file as the
+		// user's own instructions and moves them into AGENTS.md — which
+		// preserves every byte and is the whole point of the command, so an
+		// absent marker is deliberately NOT refused here the way it is in
+		// CreateAgentFile. A marker naming skdd is a different thing: folding
+		// its pointer line into AGENTS.md under "## From Claude Code" and
+		// stamping logmind's stub on the path re-owns a file logmind was told
+		// not to touch, which is the silent re-ownership the ruling exists to
+		// stop. One classifier, two commands, two policies stated out loud.
+		if owner := ReadRedirectOwner(a, content); owner.Ownership == MarkerForeign {
+			refusals = append(refusals, *refusalFor(a, owner))
+			continue
+		}
 
 		remaining := strings.TrimSpace(stripLogmindBlock(content))
 		if remaining != "" {
@@ -1006,7 +1493,7 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 		// .cursorrules / etc. is refused (atomicio.RefuseSymlink, #300) instead
 		// of silently written through.
 		if err := atomicio.WriteFile(filePath, []byte(templates.Stub()), 0o644); err != nil {
-			return messages, declined, err
+			return messages, declined, refusals, err
 		}
 		messages = append(messages,
 			fmt.Sprintf("✓ %s replaced with stub", filepath.Base(filePath)))
@@ -1015,16 +1502,16 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, error) {
 	if len(appendedBlocks) > 0 {
 		existing, err := os.ReadFile(agentsPath)
 		if err != nil {
-			return messages, declined, err
+			return messages, declined, refusals, err
 		}
 		// Match Python: existing.rstrip() + "\n\n" + "\n".join(appended).
 		body := strings.TrimRight(string(existing), " \t\n\r") +
 			"\n\n" + strings.Join(appendedBlocks, "\n")
 		if err := atomicio.WriteFile(agentsPath, []byte(body), 0o644); err != nil {
-			return messages, declined, err
+			return messages, declined, refusals, err
 		}
 	}
-	return messages, declined, nil
+	return messages, declined, refusals, nil
 }
 
 // fileExists returns true when path refers to an existing regular

--- a/internal/inserter/inserter_test.go
+++ b/internal/inserter/inserter_test.go
@@ -399,7 +399,7 @@ func TestMigrateToAgentsMD_PreservesUserContent(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	msgs, _, err := MigrateToAgentsMD(dir)
+	msgs, _, _, err := MigrateToAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("MigrateToAgentsMD: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestMigrateToAgentsMD_Idempotent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(templates.Stub()), 0o644); err != nil {
 		t.Fatalf("write stub: %v", err)
 	}
-	msgs, _, err := MigrateToAgentsMD(dir)
+	msgs, _, _, err := MigrateToAgentsMD(dir)
 	if err != nil {
 		t.Fatalf("MigrateToAgentsMD: %v", err)
 	}
@@ -447,14 +447,17 @@ func TestMigrateToAgentsMD_Idempotent(t *testing.T) {
 // default markdown agent.
 func TestCreateAgentFile_Stub(t *testing.T) {
 	dir := t.TempDir()
-	path, err := CreateAgentFile("claude", dir)
+	written, _, err := CreateAgentFile("claude", dir)
 	if err != nil {
 		t.Fatalf("CreateAgentFile: %v", err)
 	}
-	if path != filepath.Join(dir, "CLAUDE.md") {
-		t.Errorf("path = %q; want CLAUDE.md", path)
+	if written.Path != filepath.Join(dir, "CLAUDE.md") {
+		t.Errorf("path = %q; want CLAUDE.md", written.Path)
 	}
-	body, err := os.ReadFile(path)
+	if !written.Created {
+		t.Error("Created = false for a file that did not exist")
+	}
+	body, err := os.ReadFile(written.Path)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -466,14 +469,14 @@ func TestCreateAgentFile_Stub(t *testing.T) {
 // TestCreateAgentFile_Codex creates AGENTS.md (slim).
 func TestCreateAgentFile_Codex(t *testing.T) {
 	dir := t.TempDir()
-	path, err := CreateAgentFile("codex", dir)
+	written, _, err := CreateAgentFile("codex", dir)
 	if err != nil {
 		t.Fatalf("CreateAgentFile: %v", err)
 	}
-	if path != filepath.Join(dir, "AGENTS.md") {
-		t.Errorf("path = %q; want AGENTS.md", path)
+	if written.Path != filepath.Join(dir, "AGENTS.md") {
+		t.Errorf("path = %q; want AGENTS.md", written.Path)
 	}
-	body, err := os.ReadFile(path)
+	body, err := os.ReadFile(written.Path)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -486,12 +489,12 @@ func TestCreateAgentFile_Codex(t *testing.T) {
 // unknown agents — we return ("", nil).
 func TestCreateAgentFile_UnknownReturnsEmpty(t *testing.T) {
 	dir := t.TempDir()
-	path, err := CreateAgentFile("unknown", dir)
+	written, _, err := CreateAgentFile("unknown", dir)
 	if err != nil {
 		t.Fatalf("CreateAgentFile: %v", err)
 	}
-	if path != "" {
-		t.Errorf("path = %q; want empty for unknown agent", path)
+	if written.Path != "" {
+		t.Errorf("path = %q; want empty for unknown agent", written.Path)
 	}
 }
 

--- a/internal/inserter/json_agent_body_test.go
+++ b/internal/inserter/json_agent_body_test.go
@@ -51,10 +51,11 @@ func TestCreateAgentFile_JSONAgentsPointAtTheBranchAwareLayout(t *testing.T) {
 	for _, name := range jsonAgents {
 		t.Run(name, func(t *testing.T) {
 			root := t.TempDir()
-			path, err := CreateAgentFile(name, root)
+			written, _, err := CreateAgentFile(name, root)
 			if err != nil {
 				t.Fatalf("CreateAgentFile(%s): %v", name, err)
 			}
+			path := written.Path
 			if path == "" {
 				t.Fatalf("CreateAgentFile(%s) returned no path for a registered agent", name)
 			}

--- a/internal/inserter/redirect_entry_test.go
+++ b/internal/inserter/redirect_entry_test.go
@@ -1,0 +1,300 @@
+// redirect_entry_test.go — logmind#336: the unit-level half of SPEC:1101's
+// merge rule. redirect_ownership_test.go in internal/cli pins the bytes on
+// disk after the command the user ran; these pin the boundary decisions that
+// command is made of, where a failure can say WHICH one moved.
+package inserter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+func writeAgentFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func readAgentFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+// claudeAgent is the registry entry for the markdown row the issue reported.
+func claudeAgent(t *testing.T) agents.Agent {
+	t.Helper()
+	a, ok := agents.Lookup("claude")
+	if !ok {
+		t.Fatal("the registry no longer has a claude entry")
+	}
+	return a
+}
+
+// TestLogmindEntrySpan pins where logmind's entry starts and stops. The span
+// IS the fix: everything outside it is copied through byte-for-byte, so a
+// boundary that moves is content that disappears.
+func TestLogmindEntrySpan(t *testing.T) {
+	const marker = "<!-- logmind-stub: AI agent instructions for this project live in AGENTS.md -->"
+	for _, tc := range []struct {
+		name       string
+		content    string
+		start, end int
+		ok         bool
+	}{{
+		name:    "stub alone, trailing newline",
+		content: marker + "\nSee AGENTS.md.\n",
+		start:   0, end: 2, ok: true, // line 2 (the "" after the final \n) is blank and ends it
+	}, {
+		// agent-skills / reporulez / clud-bug / this repo.
+		name:    "under an @import",
+		content: "@AGENTS.md\n\n" + marker + "\nSee AGENTS.md.",
+		start:   2, end: 4, ok: true,
+	}, {
+		// protocol: a blank line, then clud-bug's block.
+		name:    "above another component's block",
+		content: marker + "\nSee AGENTS.md.\n\n<!-- clud-bug-start -->\nx\n<!-- clud-bug-end -->\n",
+		start:   0, end: 2, ok: true,
+	}, {
+		// No blank line between: the HTML comment itself ends the entry, so a
+		// component that installs flush against ours still keeps its bytes.
+		name:    "flush against another component's block",
+		content: marker + "\nSee AGENTS.md.\n<!-- clud-bug-start -->\nx\n",
+		start:   0, end: 2, ok: true,
+	}, {
+		name:    "marker is the last line",
+		content: "@AGENTS.md\n\n" + marker,
+		start:   2, end: 3, ok: true,
+	}, {
+		name:    "no logmind entry",
+		content: "# mine\n\nnothing of yours here\n",
+		ok:      false,
+	}, {
+		// Constraint the write side depends on: a quotation is not a claim.
+		name:    "marker inside a code fence",
+		content: "# mine\n\n```markdown\n" + marker + "\nexample\n```\n",
+		ok:      false,
+	}, {
+		// A mention mid-sentence is prose, not a line-start claim.
+		name:    "marker mid-line",
+		content: "logmind writes " + marker + " at the top.\n",
+		ok:      false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := logmindEntrySpan(strings.Split(tc.content, "\n"))
+			if ok != tc.ok {
+				t.Fatalf("ok = %v; want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if start != tc.start || end != tc.end {
+				t.Errorf("span = [%d,%d); want [%d,%d)", start, end, tc.start, tc.end)
+			}
+		})
+	}
+}
+
+// TestMergeStubEntry_PreservesEverythingOutsideTheSpan is SPEC:1101's first
+// sentence at the level it is implemented, and its round trip: splicing the
+// CURRENT body into a file that already carries it must change nothing at all.
+func TestMergeStubEntry_PreservesEverythingOutsideTheSpan(t *testing.T) {
+	const importLine = "@AGENTS.md\n\n"
+	const below = "\n## My own notes\n\nKEEP_ME\n"
+	stale := importLine + "<!-- logmind-stub: old -->\nOLD BODY\n" + below
+
+	got := mergeStubEntry(stale, templates.Stub())
+
+	// The blank line that TERMINATED the entry is outside the span, so it
+	// survives too — the span ends AT it, not after it.
+	want := importLine + strings.TrimRight(templates.Stub(), "\n") + "\n" + below
+	if got != want {
+		t.Fatalf("merge:\n got: %q\nwant: %q", got, want)
+	}
+	// Idempotence, which is what stops a repository seeing a diff per init.
+	if again := mergeStubEntry(got, templates.Stub()); again != "" {
+		t.Errorf("re-merging an already-current entry rewrote the file: %q", again)
+	}
+}
+
+// TestPlanRedirectWrite covers the five states over the three file forms in
+// SPEC §1.2's table, on the ONE classifier both write paths route through.
+func TestPlanRedirectWrite(t *testing.T) {
+	claude := claudeAgent(t)
+	zed, ok := agents.Lookup("zed")
+	if !ok {
+		t.Fatal("the registry no longer has a zed entry")
+	}
+
+	t.Run("absent markdown is written", func(t *testing.T) {
+		p := planRedirectWrite(claude, "", false)
+		if p.Refusal != nil || p.Body != templates.Stub() {
+			t.Fatalf("plan = %+v; want the bundled stub", p)
+		}
+	})
+
+	t.Run("empty existing file is the user's", func(t *testing.T) {
+		// An existing empty file is a file, not an invitation — `exists` is
+		// passed separately from the content for exactly this case.
+		p := planRedirectWrite(claude, "", true)
+		if p.Refusal == nil {
+			t.Fatalf("plan = %+v; want a refusal", p)
+		}
+	})
+
+	t.Run("foreign marker refuses and names the owner", func(t *testing.T) {
+		p := planRedirectWrite(claude, "<!-- skdd-stub: x -->\nbody\n", true)
+		if p.Refusal == nil {
+			t.Fatal("a file carrying skdd's marker was not refused")
+		}
+		if p.Refusal.Ownership != MarkerForeign || p.Refusal.Owner != "skdd" {
+			t.Errorf("refusal = %+v; want MarkerForeign owned by skdd", p.Refusal)
+		}
+		if p.Body != "" {
+			t.Errorf("a refusal carried bytes to write: %q", p.Body)
+		}
+	})
+
+	t.Run("logmind entry below a foreign one is still ours to refresh", func(t *testing.T) {
+		// Order must not decide ownership: whoever installed first is not
+		// thereby the owner of the file.
+		p := planRedirectWrite(claude,
+			"<!-- skdd-stub: x -->\ntheirs\n\n<!-- logmind-stub: old -->\nSTALE\n", true)
+		if p.Refusal != nil {
+			t.Fatalf("refused a file carrying our own entry: %+v", p.Refusal)
+		}
+		if !strings.Contains(p.Body, "theirs") {
+			t.Errorf("the other component's entry did not survive: %q", p.Body)
+		}
+		if strings.Contains(p.Body, "STALE") {
+			t.Errorf("our own entry was not refreshed: %q", p.Body)
+		}
+	})
+
+	t.Run("legacy in-place block is left to migrate", func(t *testing.T) {
+		// A CLAUDE.md carrying the legacy `<!-- logmind-start -->` section is
+		// ours, but it is not a stub — converting it is `agents migrate`'s
+		// job, which folds the content into AGENTS.md first. Neither a write
+		// nor a refusal.
+		legacy := "# CLAUDE.md\n\n" + startMarker + "\nold section\n" + endMarker + "\n"
+		p := planRedirectWrite(claude, legacy, true)
+		if p.Refusal != nil || p.Body != "" {
+			t.Fatalf("plan = %+v; want no write and no refusal", p)
+		}
+	})
+
+	t.Run("JSON without our key is the user's", func(t *testing.T) {
+		p := planRedirectWrite(zed, "{\n  \"theme\": \"One Dark\"\n}\n", true)
+		if p.Refusal == nil {
+			t.Fatal("a real settings.json was not refused")
+		}
+		if p.Refusal.Ownership != MarkerForeign && p.Refusal.Ownership != MarkerAbsent {
+			t.Errorf("refusal = %+v; want an unmarked verdict", p.Refusal)
+		}
+	})
+
+	t.Run("JSONC is unreadable and therefore unclaimable", func(t *testing.T) {
+		// Zed's settings file routinely carries comments. json.Unmarshal
+		// fails, and a file logmind cannot read is a file logmind cannot own.
+		p := planRedirectWrite(zed, "{\n  // theme\n  \"theme\": \"One Dark\"\n}\n", true)
+		if p.Refusal == nil {
+			t.Fatal("a JSONC settings file was not refused")
+		}
+	})
+
+	t.Run("JSON merges our key and keeps the others", func(t *testing.T) {
+		p := planRedirectWrite(zed,
+			"{\n  \"theme\": \"One Dark\",\n  \"logmind\": {\"enabled\": false}\n}\n", true)
+		if p.Refusal != nil {
+			t.Fatalf("refused a settings.json carrying our own key: %+v", p.Refusal)
+		}
+		if !strings.Contains(p.Body, `"theme"`) || !strings.Contains(p.Body, "One Dark") {
+			t.Errorf("the user's own settings were dropped: %q", p.Body)
+		}
+		if !strings.Contains(p.Body, "docs/timeline.md") {
+			t.Errorf("our own entry was not refreshed: %q", p.Body)
+		}
+	})
+
+	t.Run("JSON we wrote alone stays byte-identical", func(t *testing.T) {
+		if p := planRedirectWrite(zed, jsonAgentBody(), true); p.Body != "" || p.Refusal != nil {
+			t.Fatalf("plan = %+v; want no write for an already-current file", p)
+		}
+	})
+}
+
+// TestMigrateToAgentsMD_LeavesAnotherComponentsFileAlone covers the SECOND
+// writer of these paths. `agents migrate` reads an unmarked per-tool file as
+// the user's own instructions and moves them into AGENTS.md, which preserves
+// every byte and is the whole point of the command — so an absent marker is
+// deliberately not refused there. Another component's entry is different: it
+// is not the user's content to consolidate, and folding it into AGENTS.md
+// under "## From Cursor" while stamping logmind's stub on the path is the
+// silent re-ownership protocol#77 exists to stop.
+func TestMigrateToAgentsMD_LeavesAnotherComponentsFileAlone(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "AGENTS.md", agentsMDTemplate())
+	const foreign = "<!-- skdd-stub: instructions live in AGENTS.md -->\nFOREIGN_SENTINEL\n"
+	writeAgentFile(t, dir, ".cursorrules", foreign)
+	// A CONTROL in the same run: an ordinary hand-written file still migrates,
+	// so this is not "migrate stopped touching things".
+	writeAgentFile(t, dir, "CLAUDE.md", "# mine\n\nUSER_PROSE_TO_MIGRATE\n")
+
+	_, _, refused, err := MigrateToAgentsMD(dir)
+	if err != nil {
+		t.Fatalf("MigrateToAgentsMD: %v", err)
+	}
+
+	if got := readAgentFile(t, dir, ".cursorrules"); got != foreign {
+		t.Errorf(".cursorrules was re-owned:\n got: %q\nwant: %q", got, foreign)
+	}
+	if len(refused) != 1 || refused[0].Path != ".cursorrules" {
+		t.Fatalf("refused = %+v; want exactly the .cursorrules entry", refused)
+	}
+	agentsMD := readAgentFile(t, dir, "AGENTS.md")
+	if strings.Contains(agentsMD, "FOREIGN_SENTINEL") {
+		t.Error("another component's entry was folded into AGENTS.md")
+	}
+	if !strings.Contains(agentsMD, "USER_PROSE_TO_MIGRATE") {
+		t.Error("the control did not migrate — the guard is too wide")
+	}
+	if got := readAgentFile(t, dir, "CLAUDE.md"); got != templates.Stub() {
+		t.Errorf("the control was not stubbed: %q", got)
+	}
+}
+
+// TestCreateAgentFile_RefusesAndWritesNothing is the guard at the level a
+// caller sees it: a refusal must leave the bytes exactly as found.
+func TestCreateAgentFile_RefusesAndWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	const original = "# mine\n\nUSER_SENTINEL\n"
+	writeAgentFile(t, dir, "CLAUDE.md", original)
+
+	written, refused, err := CreateAgentFile("claude", dir)
+	if err != nil {
+		t.Fatalf("CreateAgentFile: %v", err)
+	}
+	if refused == nil {
+		t.Fatal("an unmarked CLAUDE.md was not refused")
+	}
+	if written.Path != "" {
+		t.Errorf("a refusal reported a written path: %q", written.Path)
+	}
+	if got := readAgentFile(t, dir, "CLAUDE.md"); got != original {
+		t.Errorf("the file was modified:\n got: %q\nwant: %q", got, original)
+	}
+	// The refusal has to be reportable: a note that cannot name the file or
+	// what was looked for is not a report (SPEC §3.4).
+	if refused.Path != "CLAUDE.md" || refused.Marker == "" || refused.Display == "" {
+		t.Errorf("refusal = %+v; want Path, Marker and Display set", refused)
+	}
+}

--- a/internal/inserter/symlink_write_test.go
+++ b/internal/inserter/symlink_write_test.go
@@ -123,7 +123,7 @@ func TestCreateAgentFile_RefusesDanglingSymlink(t *testing.T) {
 		t.Fatalf("plant dangling symlink: %v", err)
 	}
 
-	_, err := CreateAgentFile("claude", repoRoot)
+	_, _, err := CreateAgentFile("claude", repoRoot)
 
 	if err == nil {
 		t.Fatal("CreateAgentFile did not error on a dangling CLAUDE.md symlink")
@@ -165,7 +165,7 @@ func TestMigrateToAgentsMD_RefusesSymlinkedPerAgentFile(t *testing.T) {
 		t.Fatalf("plant symlink: %v", err)
 	}
 
-	_, _, err := MigrateToAgentsMD(repoRoot)
+	_, _, _, err := MigrateToAgentsMD(repoRoot)
 
 	if err == nil {
 		t.Fatal("MigrateToAgentsMD did not error on a symlinked .cursorrules")
@@ -256,7 +256,7 @@ func TestMigrateToAgentsMD_RefusesSymlinkedAGENTSMD(t *testing.T) {
 		t.Fatalf("seed .cursorrules: %v", err)
 	}
 
-	_, _, err := MigrateToAgentsMD(repoRoot)
+	_, _, _, err := MigrateToAgentsMD(repoRoot)
 
 	if err == nil {
 		t.Fatal("MigrateToAgentsMD did not error on a symlinked AGENTS.md")


### PR DESCRIPTION
Closes #336. Implements [protocol#77](https://github.com/thrillmade/protocol/issues/77)'s ruling.

## The defect

`logmind init` replaced the SPEC §1.2 redirect files (`CLAUDE.md`, `.cursorrules`, …) wholesale. One `init` run in a repo carrying user content in both files:

| file | after |
|---|---|
| `AGENTS.md` — user prose | **survives** |
| `CLAUDE.md` — user prose | **gone** |

`AGENTS.md` is the control and the point: the preservation logic already existed and worked in the same run. This path simply didn't use it. Silent on stderr, exit 0.

## What the ruling corrected

I first read SPEC:1101's *second* sentence (unmarked artifacts belong to the user). The governing one is the **first**:

> An installer **MUST merge rather than replace**: it writes only the entry it owns and leaves every other entry — including one the user wrote by hand — exactly as it found it.

That holds **whether or not logmind's marker is present**. A file carrying our marker is not a file we own end to end.

And the blast radius is larger than "lost prose". Line 1 of `CLAUDE.md` in `agent-skills`, `reporulez` and **logmind itself** is `@AGENTS.md` — Claude Code's import directive, the mechanism that loads `AGENTS.md` at all. A whole-file replace there costs every rule in `AGENTS.md` being loaded: decision-logging, the branch convention, the review bar. Silently, in the repo that publishes the catalog.

## The fix

One classifier, `planRedirectWrite`, that every writer of these files routes through — shaped after `planBlockRefresh` (#267) and reusing the existing `MarkerOwnership` vocabulary and `Writable()` predicate rather than adding a fourth copy of a rule that has already drifted three times (#267, #286, #295). `MarkerForeign` is the only new value.

`CreateAgentFile` now owns the read as well as the write, so "write without checking" is unrepresentable; the signature change forced all three call sites.

Refresh is a **splice**, not a replace: `logmindEntrySpan` returns the line range of our own entry and everything outside it is copied through. A foreign marker and a bare `@import` are then the same rule — *outside our span* — rather than two.

Detection is line-start-anchored and fence-aware, and deliberately **not** line-1-only: four of the five `CLAUDE.md` files in this org carry `@AGENTS.md` on line 1, so a line-1 rule would refuse all of them forever.

## Five-way control, one real `init` run

| file | state | result | stderr |
|---|---|---|---|
| `CLAUDE.md` | our entry under `@AGENTS.md` | entry refreshed, `@AGENTS.md` intact | 0 |
| `CONVENTIONS.md` | our entry alone | refreshed | 0 |
| `.clinerules` | absent | created with our marker | 0 |
| `.cursorrules` | `skdd-stub` | **unchanged** | 1 |
| `.windsurfrules` | unmarked | **unchanged** | 1 |
| `.zed/settings.json` | user settings | **unchanged** | 1 |

stdout now says `↻ Refreshed the logmind entry in CLAUDE.md` rather than `✓ Created` over a file it did not create.

## Field-tested against the real files

`agent-skills/CLAUDE.md` and `protocol/CLAUDE.md`, copied into scratch repos and `init` run:

```
ORIGINAL          sha=c2f7ccd2d79d  @import=1
FIXED             sha=c2f7ccd2d79d  @import=1   identical=YES
PRE-FIX (control) sha=3f5df384bd44  @import=0   identical=NO
```

## Mutations — 8, each compiling, each grepped present before running, all reverted

| mutant | killed by |
|---|---|
| refusal removed | 6 tests incl. all 3 refusal rows |
| replace-not-merge | `@import` row + multi-entry row |
| span runs to EOF | span table + multi-entry row |
| fence ignored | fenced-quotation test |
| JSON always ours | zed row |
| refusal not reported | all 3 stderr assertions |
| legacy block treated as stub | legacy-block test |
| migrate foreign guard | migrate test |

Full suite run by the orchestrator, not taken on report: **23 packages ok, exit 0**, `go vet` clean, `gofmt -l` empty.

## Found while here

Fixed in this PR because they are the same class: `init --agents codex` rendered the bundled template over `AGENTS.md`, undoing `EnsureAgentsMD`'s surgical insert in the same run; `agents migrate` re-owned a foreign-marked file; and `<!-- logmind-start -->` matched the entry scanner and would have been spliced, orphaning its `-end`.

Left deliberately: `agents add <name>` against a foreign file still splices a logmind block in — that adds an entry and preserves the rest, which is merge-compliant and explicitly user-directed.

Not fixed, filing separately: `agents migrate` on an unmarked `CLAUDE.md` beginning with `@AGENTS.md` folds that line into `AGENTS.md`, creating a self-import. Pre-existing and content-preserving.