### PR TITLE
docs: cite protocol#77's ruling rather than the issue thread

### DIFF
--- a/docs/ai-agent-files.md
+++ b/docs/ai-agent-files.md
@@ -61,7 +61,7 @@ the decision-logging requirement (logmind) and required reading.
 ```
 
 **These files are shared, and logmind writes only the entry it owns**
-(SPEC:1101, [protocol#77](https://github.com/thrillmade/protocol/issues/77)).
+(SPEC:1101, [protocol#77's ruling](https://github.com/thrillmade/protocol/issues/77#issuecomment-5308058696)).
 Several components install into the same `CLAUDE.md` — this repository's own
 opens with Claude Code's `@AGENTS.md` import directive above the stub, and
 `protocol`'s carries clud-bug's marked block below it. What logmind rewrites

--- a/docs/decisions-branches/docs__repoint-protocol77-citation.md
+++ b/docs/decisions-branches/docs__repoint-protocol77-citation.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-16 11:03 - docs: cite protocol#77's ruling rather than the issue thread
+
+**Reasoning:** The protocol owner ruled on #77 and asked for exactly this follow-through: logmind implemented the behaviour on the strength of a comment left on our own issue rather than a ruling there, so the citation pointed at a three-comment thread rather than at the operative text. The ruling names why that matters — a correct rule whose emphasis reads backwards to every implementer is in practice an unwritten one — which makes the difference between citing a discussion and citing a ruling load-bearing rather than cosmetic.
+
+**Alternatives considered:** Leave it pointing at the issue — rejected; the thread now has three comments and a reader landing on the first would get the framing the ruling explicitly overturns. Restate the ruling in the doc — rejected; one owner per fact, and the doc already states the rule correctly in its own words.
+
+**Implications:**
+- The doc's prose and its five-state table already matched the ruling before it landed, which is the useful signal: the implementation and the contract were derived from the same reading. One row of that table — a foreign-marked file is left alone and reported — is true of logmind init and false of logmind agents add, which is filed as #338 and awaits a ruling on whether an explicit user request outranks another tool's ownership. Deliberately not pre-empted here.
+
+---
+


### PR DESCRIPTION
One line. [protocol#77](https://github.com/thrillmade/protocol/issues/77) was ruled today, and the ruling asks for this follow-through by name:

> **logmind#337**: the behaviour is right and now has something real to cite. Repoint from "implements protocol#77's ruling" to this comment once it lands.

`docs/ai-agent-files.md:64` linked at the issue. The thread now carries three comments, and a reader landing on the first gets the framing the ruling overturns — that the *second* sentence of SPEC:1101 (unmarked artifacts belong to the user) is the operative one. The ruling's point is that the **first** governs:

> A file carrying your marker is not a file you own end to end. The merge rule applies whether or not your marker is present, so "my marker is in this file" never licenses a whole-file write. Ownership is per **entry**, not per file.

Why that is worth a commit rather than a shrug, in the ruling's own words: *"a correct rule whose emphasis reads backwards to every implementer is, in practice, an unwritten one."*

## Nothing else changed

The doc's prose and its five-state table already matched the ruling before it landed — which is the useful signal here: #337's implementation and the contract were derived from the same reading of SPEC:1101, independently. No restatement was added; one owner per fact, and the doc already says it in its own words.

`logmind check-links` clean. Link verified live against the API (`repos/thrillmade/protocol/issues/comments/5308058696` → comment by `thrillmot`, 2026-08-16T15:00).

## Known-stale row, deliberately not touched

The table row *"carries another component's marker and no logmind entry | leaves it, and says so on stderr"* is true of `logmind init` and **false of `logmind agents add`** — filed as #338, which awaits a ruling on whether an explicit user request outranks another tool's ownership. Correcting it here would pre-empt that ruling.