### PR TITLE
fix(gates): read the job definition from the base ref — a PR must not rewrite the gate that judges it

### DIFF
--- a/.github/workflows/check-decisions.yml
+++ b/.github/workflows/check-decisions.yml
@@ -4,9 +4,36 @@ name: logmind / check-decisions
 # updating docs/decisions.md or a docs/decisions-branches/<branch>.md file.
 # Mirrors the local `logmind check-decisions` pre-commit hook but against
 # the PR diff. Installed by `logmind init`.
+#
+# NOT the shipped template. This repository runs a variant that predates the
+# template's v5 rewrite (which deleted the `[skip-logmind]` title override,
+# the wholesale `*.md` exclusion, the path-match decision test and the
+# hardcoded threshold, and moved the evaluation into `logmind
+# check-decisions --base/--head`). Bringing this copy onto the verb is
+# logmind#260/#278, and it is deliberately NOT what logmind#261 did here:
+# #261 moved WHERE this file is read from and changed nothing about what it
+# decides, so the two can be reviewed one at a time. Every byte of the
+# `Compute diff vs base` and `Enforce` steps below is what it was.
+#
+# logmind#261 / SPEC §6.3: the trigger is `pull_request_target`, so the forge
+# reads THIS FILE from the base branch. Under `pull_request` it read the
+# pull request's own merge commit, which meant a branch could delete the
+# `Enforce` step — or add `[skip-logmind]` handling of its own invention —
+# in the very diff being judged, and pass. Reading the base ref from inside
+# the job does not help: what the pull request replaced is the job, not the
+# job's inputs.
+#
+# The two costs of the trigger, so nobody rediscovers them as bugs. This
+# gate is one merge behind its own source: a pull request editing this file
+# is judged by the base branch's copy, which is the property, not a defect
+# (§6.6's bypass is what that case exists for). And on the one pull request
+# that MIGRATES this file off `pull_request`, neither trigger fires —
+# `pull_request` reads the PR's copy, which no longer subscribes, and
+# `pull_request_target` reads the base's, which does not yet. The check is
+# absent from that pull request rather than green on it.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -17,9 +44,35 @@ jobs:
   check-decisions:
     runs-on: ubuntu-latest
     steps:
+      # The WORKSPACE is the base ref, never the pull request's content —
+      # §6.3's other half, and the condition on which §6.3 permits the
+      # `pull_request_target` route at all: "a gate taking the second route
+      # MUST NOT check out the pull request's content, which is the hazard
+      # that trigger is otherwise known for." `ref:` is explicit rather than
+      # left to the trigger's default (the base BRANCH TIP, which moves under
+      # a long-lived pull request) so that deleting these lines is a visible
+      # change, not a silent fall-through. Nothing below reads a file out of
+      # this workspace; it exists so the two SHAs in the range resolve.
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      # The base checkout carries the base branch's history; the range below
+      # also needs the pull request's head commit, which for a fork PR sits
+      # on no branch of this repository. `refs/pull/N/head` reaches it either
+      # way. Under the old `pull_request` trigger the merge-ref checkout
+      # happened to contain the head commit already, so this step is what
+      # keeps the range resolvable now — not a change to what is compared.
+      # If it fails the range is unresolvable and the job goes red, which is
+      # §6.5: a gate that cannot run says so rather than exiting green.
+      - name: Fetch the PR head commit
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
 
       - name: Compute diff vs base
         id: diff
@@ -64,8 +117,8 @@ jobs:
           # effect (issue #212). Fetch the LIVE title instead. PR_NUMBER
           # comes from the event too, but it IS stable across reruns (a PR
           # keeps its number for life; only the title payload goes stale).
-          # This workflow only triggers on `pull_request`, so there's no
-          # non-PR event to guard against. Fail OPEN to the event payload
+          # This workflow only triggers on `pull_request_target`, so there's
+          # no non-PR event to guard against. Fail OPEN to the event payload
           # title if the API call errors (rate limit, transient outage,
           # etc.) — a `gh` hiccup must never crash this check.
           live_title="$(gh pr view "$PR_NUMBER" --json title -q .title 2>/dev/null)" || live_title=""

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -64,6 +64,39 @@ name: logmind / check-derived-docs
 # stray `timeline-archive.md` beside git's merge scratch file at the worktree
 # root, and, where a file of that name was tracked, replaced its contents.
 #
+# v14 (logmind#261): the PR gate's trigger moves `pull_request` →
+# `pull_request_target`, and the comment on the gate job that claimed
+# immunity is deleted rather than softened. That comment said staying
+# checkout-free meant "there is nothing here for a PR to influence about its
+# own gate". It was wrong in the one direction nobody re-reads: being
+# checkout-free protects the WORKSPACE, and what a pull request rewrites on
+# a `pull_request` trigger is the JOB DEFINITION — this file, read by the
+# forge from the pull request's own merge commit. §6.3: "a workspace-free
+# job is not exempt: what the pull request rewrote is the definition, not
+# the workspace." So a branch could edit the derived docs AND, in the same
+# diff, change the `grep` below to match nothing. `pull_request_target`
+# reads this file from the base branch instead, which is the whole fix; the
+# gate's logic, its three paths and its exit codes are byte-for-byte what
+# v13 had.
+#
+# The trigger's known hazard does not apply and must not be introduced: this
+# job takes no checkout at all, so there is no workspace for the pull
+# request's content to land in. §6.3 permits this route only on that
+# condition.
+#
+# Two consequences, both intended. This gate is one merge behind its own
+# source — the pull request that edits it is judged by the base branch's
+# copy, which is the point — and the pull request that MIGRATES an installed
+# copy off `pull_request` fires neither trigger, so `check-derived-docs` is
+# absent from that one pull request rather than green on it. Absent fails a
+# required-checks rule; green would have satisfied it.
+#
+# v14 also narrows `contents: write` to the job that pushes. Under
+# `pull_request` the forge forced a fork's token read-only however this file
+# was written; under `pull_request_target` the permissions block is what the
+# job actually gets, on a fork pull request too. The gate needs no write and
+# now cannot have one.
+#
 # NOTE on the version number: this was v12 until logmind#301 round 5 caught
 # it colliding with a DIFFERENT, already in-flight v12 (logmind#314) — two
 # branches independently bumped v11 to v12 with unrelated content, and nothing
@@ -73,7 +106,10 @@ name: logmind / check-derived-docs
 # the resolved default branch below are #314's and are NOT reverted here.
 
 on:
-  pull_request:
+  # `pull_request_target`, not `pull_request` — see the v14 note above. The
+  # forge reads a `pull_request` workflow from the pull request's own merge
+  # commit, so the gate below would be the branch's copy of itself.
+  pull_request_target:
     types: [opened, synchronize, reopened]
   push:
     # NOT hardcoded to `main`. A workflow's `on:` filter cannot take an
@@ -103,23 +139,39 @@ on:
     branches: [main]
 
 permissions:
-  contents: write        # regen-on-main commits + pushes the regen to the default branch
+  contents: read         # every job reads; only regen-on-main writes, and it asks for that itself
   pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
   # NOTE: specifying ANY permission zeroes all others (GitHub default), so
   # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
   # the gate fails-closed on EVERY PR, not just violators.
+  #
+  # `contents: write` used to live here, at workflow level, where it reached
+  # both jobs. Under `pull_request` that cost nothing — the forge forced a
+  # fork's token read-only whatever this file asked for. Under
+  # `pull_request_target` (v14) the ask is granted for real, on a fork pull
+  # request too, so the write moves down to `regen-on-main`, the one job that
+  # pushes. A job-level block REPLACES this one rather than adding to it,
+  # which is why the block below names `contents: write` outright.
 
 jobs:
   check-derived-docs:
     name: check-derived-docs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      # NO checkout, deliberately. This job only needs the PR's file list —
-      # never the PR's own content — via `gh pr diff`. A checkout on a
-      # pull_request event lands refs/pull/N/merge (the PR's own content);
-      # staying checkout-free means there is nothing here for a PR to
-      # influence about its own gate.
+      # NO checkout, deliberately — and that is a statement about the
+      # WORKSPACE only. This job needs the PR's file list and nothing else,
+      # and `gh pr diff` gets it from the API. Under `pull_request_target`
+      # §6.3 additionally REQUIRES the absence: "a gate taking the second
+      # route MUST NOT check out the pull request's content." Adding a
+      # checkout here is not a convenience, it is the hazard the trigger is
+      # known for.
+      #
+      # What being checkout-free does NOT buy — this used to claim otherwise,
+      # and the claim is why nobody looked again — is immunity for the gate
+      # ITSELF. That is bought one line up, by the trigger: `pull_request`
+      # would have the forge read this whole file from the branch's own merge
+      # commit, workspace or no workspace.
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
@@ -152,6 +204,13 @@ jobs:
     # resolved, not assumed.)
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    # The write lives HERE, on the one job that pushes, rather than at
+    # workflow level where it also reached the pull-request gate (v14). A
+    # job-level block replaces the workflow-level one outright — it does not
+    # merge with it — so this must restate every permission the job needs,
+    # and `contents: write` implies the read the checkout below does.
+    permissions:
+      contents: write
     # CREDENTIAL CHAIN, rung 1 — OPTIONAL. The two lines below are the only
     # thing a repository customises to enable the GitHub App rung; every
     # other line of the credential mechanism is identical in every repo that

--- a/docs/decisions-branches/fix__gate-not-self-modifiable.md
+++ b/docs/decisions-branches/fix__gate-not-self-modifiable.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-16 11:45 - gates: read the job definition from the base ref, so a pull request cannot rewrite the gate that judges it
+
+**Reasoning:** On a pull_request trigger the forge reads the workflow file from the pull request's own merge commit, so a PR that edits the gate's YAML has already replaced the job. Both gates carried their whole logic inline on that trigger: a PR changing check-decisions' Enforce step to exit 0 passed its own gate. Worse, regen-timeline's check-derived-docs carried a comment asserting immunity — 'NO checkout, deliberately... nothing here for a PR to influence about its own gate' — which is false and load-bearing in the bad direction: checkout-free protects the WORKSPACE, and what a pull request rewrites is the JOB DEFINITION. That comment is why nobody looked again, so deleting it is part of the fix rather than tidying after it.
+
+**Alternatives considered:** Move the logic into a reusable workflow or composite action pinned to an immutable ref — rejected, and the reasoning is the useful part: the CALLER stays in the gate's file, so on pull_request a PR rewrites uses:/with:/if: as easily as run:. Making that shape safe needs a base-read trigger anyway, at which point the indirection buys nothing — and a ./-local callee is itself read from the PR's ref, so it would have to live in a logmind-owned repo that every consumer's gate then depends on existing.
+
+**Implications:**
+- pull_request_target reads the workflow from the base ref, and SPEC §6.3's condition on it — MUST NOT check out the PR's content — is what both jobs were already built to do. The workspace holds base content only, pinned to base.sha rather than the branch tip; the PR's commits arrive as git OBJECTS via refs/pull/N/head and are never checked out; the binary comes from a pinned released action rather than the checkout, so a PR cannot rebuild the thing judging it; and the SHAs reach the script through env: rather than inline interpolation. Verified: zero head-ref checkouts in either gate, while check-doc-links keeps its head checkout safely on plain pull_request. Behaviour is unchanged — the decision-logic regions diff IDENTICAL at 51/51, 13/13 and 17/17 operative lines, with a control proving the probe shows a diff when one exists. Markers move check-decisions v6 to v7 and regen-timeline v13 to v14, which is what propagates the fix to consumers. CODEOWNERS is deliberately NOT added: alone it enforces nothing, the ruleset half lives in another repo, and a single-maintainer repo would block every solo change.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -360,16 +360,31 @@ auto-fix in the `check-doc-links` workflow).
     `.claude/settings.json`, which invokes guard-commit, is).
   - **L3** — CI's `check-derived-docs` job. It takes **no checkout at
     all**: it reads only the PR's file list via `gh pr diff --name-only`
-    and fails if either derived doc appears. Staying checkout-free is
-    deliberate — per SPEC §6.3 a gate must not be satisfiable by the
-    change it judges, and with no checkout there is nothing in the job for
-    a PR to influence about its own gate.
+    and fails if any of the three derived docs appears. Two separate
+    things make it non-satisfiable by the change it judges (SPEC §6.3),
+    and conflating them is how this document was wrong for a release:
+    the missing checkout keeps the **workspace** free of the PR's
+    content, and the `pull_request_target` **trigger** is what makes the
+    forge read the job's own definition from the base branch. Only the
+    second addresses the gate itself. Under the `pull_request` trigger
+    this job used to carry, a branch could have edited the `grep` in the
+    same diff that edited a derived doc, and no amount of checkout-free
+    discipline inside the body would have noticed — the body was the
+    branch's. §6.3: "a workspace-free job is not exempt: what the pull
+    request rewrote is the definition, not the workspace." The two are
+    now both required, and pinned together by
+    `TestGateWorkflows_AreNotRewritableByTheChangeTheyJudge`
+    ([#261](https://github.com/thrillmade/logmind/issues/261)).
   - **Honest caveat:** L0–L2 are local guardrails, not guarantees — every
     one of them is bypassable (`--no-verify`, deleting or disabling a
     hook, hand-editing `.claude/settings.json`, or simply using a tool
     that never goes through git or Claude Code). **L3 (CI) is the only
-    non-bypassable enforcement** — it runs server-side on every PR
-    regardless of what did or didn't happen on the contributor's machine.
+    enforcement a contributor's machine cannot reach** — it runs
+    server-side on every PR regardless of what did or didn't happen
+    locally. "Cannot reach" is the accurate claim and "non-bypassable"
+    was not: until #261 the PR itself could rewrite L3's workflow file,
+    which is a bypass that needs no local anything. What remains is the
+    ruleset bypass of §6.6, which belongs to people on purpose.
 - **Staying current on a branch:** `logmind warp` refreshes the working copy
   from the default branch (read-only — it never commits, which would break the
   pin), `logmind context` renders the last-fetched default-branch copy, and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,11 +66,19 @@ all: every branch-push trigger in this repository names `main`, and the only
 other push triggers fire on tags.
 
 Pull requests *into* `dev` do get checks. The Go suite (`test.yml` — matrix
-build, `make test`, gofmt and vet), `check-decisions`, `check-derived-docs`
-(`regen-timeline.yml`) and `check-doc-links` all trigger on `pull_request`
-with no `branches:` filter, so they run on the merge-ref whatever the base
-branch is. Of the `pull_request` triggers, only `goreleaser-check`'s is
-filtered to `main`.
+build, `make test`, gofmt and vet) and `check-doc-links` trigger on
+`pull_request` with no `branches:` filter, so they run on the merge-ref
+whatever the base branch is; of the `pull_request` triggers, only
+`goreleaser-check`'s is filtered to `main`.
+
+The two **gates** — `check-decisions` and `check-derived-docs`
+(`regen-timeline.yml`) — trigger on `pull_request_target` instead (#261,
+SPEC §6.3), so the forge reads their workflow files from the base branch and
+a pull request cannot rewrite the job that judges it. Two consequences worth
+knowing before they surprise someone: a gate is one merge behind its own
+source, so a PR that edits a gate is judged by `dev`'s copy of it; and the PR
+that migrates an installed gate off `pull_request` fires neither trigger, so
+the check is **absent** from that one PR rather than green on it.
 
 The bar for `dev` itself is therefore a **local adversarial panel** per change,
 plus the full suite run against integrated `dev` — the *integrated* result is
@@ -244,10 +252,30 @@ org and out of the table. "A release carrying the verb" waits on the tag.
 
 ### 3 — Remaining pre-tag work
 
-**#261** — gate logic inline on `pull_request` (§6.3). *Reordered:* originally
-ahead of the gate cluster; doing it after means relocating a **correct**
-evaluation rather than a wrong one. Its remedy restructures `regen-timeline.yml`,
-so that file moves twice regardless of what else we do.
+**#261** — gate logic inline on `pull_request` (§6.3). **Built**, on
+`fix/gate-not-self-modifiable`: both gates move to `pull_request_target`, so
+the forge reads their definitions from the base branch and a PR cannot rewrite
+the job that judges it. Templates bump `check-decisions` v6 → v7 and
+`regen-timeline` v13 → v14; `regen-on-main` takes `contents: write` as a job
+grant, because under the new trigger a workflow-level write is real on a fork
+PR. Chosen over a SHA-pinned reusable workflow because the *caller* stays
+inline on `pull_request` in that shape — the `uses:` line is as rewritable as
+the `run:` it replaces — and because it would make every consumer's gate
+depend on a logmind-owned repository existing.
+
+**What remains under #261, and it needs a person:** §6.3's other clause —
+"its directory SHOULD require an owner's review before a change to it can
+merge". logmind has no `CODEOWNERS` (control, same query, same unit:
+`git ls-files | grep -i codeowners` → 0 paths; `grep -i dependabot` → 5), and
+that is deliberately *not* fixed here. A `CODEOWNERS` file enforces nothing on
+its own: the ruleset must set `require_code_owner_review: true`, canonical sets
+it `false`, and canonical lives in `thrillmade/protocol`. Shipping the file
+alone would be a second thing that reads as protection while providing none,
+which is the defect this issue is about. It also has a live hazard in a
+single-maintainer repository — an owner cannot approve their own PR, so
+turning the rule on blocks every solo change until a second reviewer exists.
+And `logmind init` cannot ship a `CODEOWNERS` template at all: it would have
+to name an owner, and an unresolvable owner is silently treated as none.
 
 **#269** — `ignore_patterns` replaced the 16 built-in defaults instead of merging.
 **Built and on `dev`** (#303). protocol#89 turned out not to gate it: the answer
@@ -383,7 +411,7 @@ its own copies of `check-decisions.yml`, `regen-timeline.yml` and
 The exception is `logmind-self-update.yml`: it carries the marker, is refreshed
 like any consumer's, and is byte-identical to the template it ships.
 
-**logmind ships** `check-decisions` at **`v6`** and `regen-timeline` at **`v12`** (`v13` once #301 lands), `check-doc-links` at `v9` (`v10` once #301 lands), `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
+**logmind ships** `check-decisions` at **`v7`** and `regen-timeline` at **`v14`** (both bumped by #261 — the gate trigger), `check-doc-links` at `v10`, `logmind-self-update` at `v11` — measured 2026-08-16 with `head -1 internal/templates/github/*.template`. Template versions are **per file** — "the fleet is on
 v4" is not one number.
 
 **A markerless workflow is unreachable by refresh, permanently.** A file is
@@ -495,3 +523,4 @@ spells it `closes #278, #260, #284`, and a probe that stops at the first `#N`
 loses `#260`. `#284` survives that probe only because a different commit
 happens to spell `Closes #284.` on its own — luck, not coverage. Confirm after
 the merge that each issue really closed, and hand-close any that did not.
+

--- a/internal/templates/github/check-decisions.yml.template
+++ b/internal/templates/github/check-decisions.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v6
+# logmind-template-version: v7
 name: logmind / check-decisions
 
 # SPEC §6.2's `check-decisions` gate — the third interception point of
@@ -34,9 +34,63 @@ name: logmind / check-decisions
 # the action's current release and what every repo already running these
 # workflows resolves to via Dependabot; shipping v1.0.0 meant a freshly
 # scaffolded repo installed a pin older than the fleet's on day one.
+#
+# v7 (logmind#261): the trigger moves `pull_request` → `pull_request_target`,
+# and that one word is the whole change. Everything v5 did to make this job's
+# INPUTS trustworthy — base-ref workspace, released binary, no self-service
+# escape — left its DEFINITION untouched, and the definition was the PR's
+# copy. §6.3: "On a pull-request trigger the forge reads the workflow file
+# ITSELF from the pull request's own merge commit, so a change that edits the
+# gate's own definition has already replaced the job — whatever that job then
+# goes on to read. Being careful inside the body cannot fix it." A pull
+# request that rewrote the `Enforce` step below to `exit 0` passed its own
+# gate; nothing here read a single byte of the PR to let that happen.
+# `pull_request_target` is the forge's one lever on WHERE the file is read
+# from: the workflow that runs is the base branch's, so an edit to this file
+# takes effect only once it has merged — which needs the gate, and a review.
 
 on:
-  pull_request:
+  # The trigger §6.3 names as the second of two permitted shapes: "it runs on
+  # a trigger that reads the workflow from the base branch — and a gate
+  # taking the second route MUST NOT check out the pull request's content,
+  # which is the hazard that trigger is otherwise known for." That second
+  # half is not a caveat bolted on here; it is what the whole job below was
+  # already built to do, which is why this route and not the other one.
+  #
+  # The first shape — a reusable workflow or composite action pinned to an
+  # immutable ref — was rejected for two reasons. It does not, on its own,
+  # answer the defect: the CALLER stays in this file, so on a `pull_request`
+  # trigger a pull request rewrites `uses:`, `with:` or the job's `if:` as
+  # easily as it rewrites a `run:`. Making it safe means putting the caller
+  # on a base-read trigger — this line — at which point the indirection has
+  # bought nothing it did not already have. And it must live somewhere: a
+  # `./`-local callee is read from the pull request's ref like everything
+  # else, so it would have to be a logmind-owned repository, which every
+  # consumer's gate would then depend on existing and staying reachable.
+  # logmind must work standalone. (`setup-logmind`, further down, is a
+  # different kind of dependency: it installs a binary and its absence
+  # fails the job loudly rather than passing it.)
+  #
+  # TWO CONSEQUENCES, both intended, both surprising the first time:
+  #
+  #   1. This workflow does not run on the pull request that ADDS it, or on
+  #      any pull request that edits it, because the base branch's copy is
+  #      what runs and the base branch does not have the change yet. The
+  #      gate is one merge behind its own source, permanently. That is the
+  #      property, not a defect — and it is exactly the case §6.6's ruleset
+  #      bypass exists for.
+  #   2. The one-time migration gap: on the pull request that moves an
+  #      installed copy of this file from `pull_request` to
+  #      `pull_request_target`, NEITHER trigger fires — `pull_request` reads
+  #      the PR's copy, which no longer subscribes to it, and
+  #      `pull_request_target` reads the base's copy, which does not yet.
+  #      The check is absent from that one pull request rather than green on
+  #      it, so it fails a required-checks rule instead of satisfying it.
+  #      Every trigger migration costs this once; carrying both triggers
+  #      through the transition would cost more, because the two runs post
+  #      the same check name and the forge takes the most recent — the
+  #      PR's own copy would be the one that counted.
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -44,6 +98,12 @@ permissions:
   # `contents: read` and nothing else. v4 also took `pull-requests: read`,
   # solely for the `gh pr view` title fetch behind the removed override;
   # with that gone, no step here touches pull-request data through the API.
+  #
+  # v7 makes this block load-bearing rather than tidy. Under `pull_request`
+  # the forge forced a fork's token read-only whatever this said; under
+  # `pull_request_target` what is written here is what the job gets, on a
+  # fork pull request too. Read is all this gate has ever needed, and it is
+  # now all it can have.
 
 jobs:
   check-decisions:
@@ -56,10 +116,19 @@ jobs:
       # workflow's own logic — MUST be read from the pull request's base
       # ref. Never from the head ref, and never from a workspace populated
       # with the pull request's content." The threshold this gate enforces
-      # is `git.commit_line_threshold` in .logmind/config.yml, so a default
-      # (merge-ref) checkout would let a PR raise its own threshold in the
+      # is `git.commit_line_threshold` in .logmind/config.yml, so a
+      # PR-content checkout would let a PR raise its own threshold in the
       # very diff being judged. The PR's content is read only as git
       # objects, through the range passed to the verb below.
+      #
+      # `ref:` stays EXPLICIT under `pull_request_target` even though the
+      # trigger's default checkout is already the base branch. Two reasons,
+      # and the second is the one that matters: the default is the base
+      # BRANCH TIP, which moves under a long-lived pull request, while the
+      # range below is judged against `base.sha`; and an explicit ref is
+      # what makes deleting these two lines a visible change rather than a
+      # silent fall-through to whatever the trigger's default happens to be
+      # — which, one trigger ago, was the pull request's own merge ref.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v13
+# logmind-template-version: v14
 name: logmind / check-derived-docs
 
 # v2.0.0 derived-docs-on-main. The derived docs are regenerated ONLY here on
@@ -65,6 +65,39 @@ name: logmind / check-derived-docs
 # stray `timeline-archive.md` beside git's merge scratch file at the worktree
 # root, and, where a file of that name was tracked, replaced its contents.
 #
+# v14 (logmind#261): the PR gate's trigger moves `pull_request` →
+# `pull_request_target`, and the comment on the gate job that claimed
+# immunity is deleted rather than softened. That comment said staying
+# checkout-free meant "there is nothing here for a PR to influence about its
+# own gate". It was wrong in the one direction nobody re-reads: being
+# checkout-free protects the WORKSPACE, and what a pull request rewrites on
+# a `pull_request` trigger is the JOB DEFINITION — this file, read by the
+# forge from the pull request's own merge commit. §6.3: "a workspace-free
+# job is not exempt: what the pull request rewrote is the definition, not
+# the workspace." So a branch could edit the derived docs AND, in the same
+# diff, change the `grep` below to match nothing. `pull_request_target`
+# reads this file from the base branch instead, which is the whole fix; the
+# gate's logic, its three paths and its exit codes are byte-for-byte what
+# v13 had.
+#
+# The trigger's known hazard does not apply and must not be introduced: this
+# job takes no checkout at all, so there is no workspace for the pull
+# request's content to land in. §6.3 permits this route only on that
+# condition.
+#
+# Two consequences, both intended. This gate is one merge behind its own
+# source — the pull request that edits it is judged by the base branch's
+# copy, which is the point — and the pull request that MIGRATES an installed
+# copy off `pull_request` fires neither trigger, so `check-derived-docs` is
+# absent from that one pull request rather than green on it. Absent fails a
+# required-checks rule; green would have satisfied it.
+#
+# v14 also narrows `contents: write` to the job that pushes. Under
+# `pull_request` the forge forced a fork's token read-only however this file
+# was written; under `pull_request_target` the permissions block is what the
+# job actually gets, on a fork pull request too. The gate needs no write and
+# now cannot have one.
+#
 # NOTE on the version number: this was v12 until logmind#301 round 5 caught
 # it colliding with a DIFFERENT, already in-flight v12 (logmind#314) — two
 # branches independently bumped v11 to v12 with unrelated content, and nothing
@@ -74,7 +107,10 @@ name: logmind / check-derived-docs
 # the resolved default branch below are #314's and are NOT reverted here.
 
 on:
-  pull_request:
+  # `pull_request_target`, not `pull_request` — see the v14 note above. The
+  # forge reads a `pull_request` workflow from the pull request's own merge
+  # commit, so the gate below would be the branch's copy of itself.
+  pull_request_target:
     types: [opened, synchronize, reopened]
   push:
     # NOT hardcoded to `main`. A workflow's `on:` filter cannot take an
@@ -104,23 +140,39 @@ on:
     branches: [__LOGMIND_DEFAULT_BRANCH__]
 
 permissions:
-  contents: write        # regen-on-main commits + pushes the regen to the default branch
+  contents: read         # every job reads; only regen-on-main writes, and it asks for that itself
   pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
   # NOTE: specifying ANY permission zeroes all others (GitHub default), so
   # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
   # the gate fails-closed on EVERY PR, not just violators.
+  #
+  # `contents: write` used to live here, at workflow level, where it reached
+  # both jobs. Under `pull_request` that cost nothing — the forge forced a
+  # fork's token read-only whatever this file asked for. Under
+  # `pull_request_target` (v14) the ask is granted for real, on a fork pull
+  # request too, so the write moves down to `regen-on-main`, the one job that
+  # pushes. A job-level block REPLACES this one rather than adding to it,
+  # which is why the block below names `contents: write` outright.
 
 jobs:
   check-derived-docs:
     name: check-derived-docs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      # NO checkout, deliberately. This job only needs the PR's file list —
-      # never the PR's own content — via `gh pr diff`. A checkout on a
-      # pull_request event lands refs/pull/N/merge (the PR's own content);
-      # staying checkout-free means there is nothing here for a PR to
-      # influence about its own gate.
+      # NO checkout, deliberately — and that is a statement about the
+      # WORKSPACE only. This job needs the PR's file list and nothing else,
+      # and `gh pr diff` gets it from the API. Under `pull_request_target`
+      # §6.3 additionally REQUIRES the absence: "a gate taking the second
+      # route MUST NOT check out the pull request's content." Adding a
+      # checkout here is not a convenience, it is the hazard the trigger is
+      # known for.
+      #
+      # What being checkout-free does NOT buy — this used to claim otherwise,
+      # and the claim is why nobody looked again — is immunity for the gate
+      # ITSELF. That is bought one line up, by the trigger: `pull_request`
+      # would have the forge read this whole file from the branch's own merge
+      # commit, workspace or no workspace.
       - name: Assert the branch did not edit the derived docs
         env:
           GH_TOKEN: ${{ github.token }}
@@ -153,6 +205,13 @@ jobs:
     # resolved, not assumed.)
     if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    # The write lives HERE, on the one job that pushes, rather than at
+    # workflow level where it also reached the pull-request gate (v14). A
+    # job-level block replaces the workflow-level one outright — it does not
+    # merge with it — so this must restate every permission the job needs,
+    # and `contents: write` implies the read the checkout below does.
+    permissions:
+      contents: write
     # CREDENTIAL CHAIN, rung 1 — OPTIONAL. The two lines below are the only
     # thing a repository customises to enable the GitHub App rung; every
     # other line of the credential mechanism is identical in every repo that

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -274,8 +274,12 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	// fix/template-v12's unrelated, already in-flight v12. v13 is v12's body
 	// PLUS the archive — the credential chain and the resolved default branch
 	// the v12 tests below assert are still there, and are asserted there.
-	if !strings.Contains(body, "# logmind-template-version: v13") {
-		t.Errorf("regen-timeline template missing v13 marker")
+	// v13 → v14: the PR gate's trigger moves to `pull_request_target` and
+	// `contents: write` narrows to the job that pushes (logmind#261). What
+	// the gate DECIDES is untouched — every assertion in this function is
+	// v13's, unchanged, which is the evidence for that claim.
+	if !strings.Contains(body, "# logmind-template-version: v14") {
+		t.Errorf("regen-timeline template missing v14 marker")
 	}
 	// The required-check name MUST stay check-derived-docs (ruleset matching),
 	// and the main regen is a distinct job.
@@ -302,10 +306,15 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	if !strings.Contains(body, `grep -qxE 'docs/(timeline|timeline-archive|file-structure)\.md'`) {
 		t.Errorf("regen-timeline PR gate must match exactly the three derived docs as whole lines")
 	}
-	// Event-gated jobs: gate runs only on pull_request, regen only on push.
-	if !strings.Contains(body, "github.event_name == 'pull_request'") ||
+	// Event-gated jobs: gate runs only on the pull-request event, regen only
+	// on push. v14 moved the gate's event to `pull_request_target` (§6.3),
+	// so the `if:` moves with it — a job whose `if:` still names the old
+	// event would simply never run, and a job that never runs reports
+	// SUCCESS rather than skipped, which is the shape of a gate that has
+	// been switched off without anyone seeing red.
+	if !strings.Contains(body, "github.event_name == 'pull_request_target'") ||
 		!strings.Contains(body, "github.event_name == 'push'") {
-		t.Errorf("regen-timeline v10 must event-gate the two jobs (pull_request gate / push regen)")
+		t.Errorf("regen-timeline v14 must event-gate the two jobs (pull_request_target gate / push regen)")
 	}
 	// The main regen commit carries the [skip-logmind] convention and pushes
 	// via an explicit credentialed URL built from the chain's chosen rung —
@@ -324,6 +333,28 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	// this MUST be explicit or the gate 403s and fails-closed on every PR.
 	if !strings.Contains(body, "pull-requests: read") {
 		t.Errorf("regen-timeline v10 must grant pull-requests: read (else gh pr diff 403s and blocks every PR)")
+	}
+	// v14: `contents: write` is the PUSHING job's, not the file's. Under
+	// `pull_request` the distinction cost nothing — the forge forced a
+	// fork's token read-only whatever the file asked for — but under
+	// `pull_request_target` the ask is granted for real, on a fork pull
+	// request too, so a workflow-level write would hand a write token to
+	// the gate job on every fork PR that opens. Read the WORKFLOW-level
+	// block specifically (everything above the first job), or a job-level
+	// grant three screens down would satisfy a whole-file search.
+	workflowLevel, _, found := strings.Cut(body, "\njobs:\n")
+	if !found {
+		t.Fatalf("regen-timeline v14: could not locate the `jobs:` boundary")
+	}
+	if strings.Contains(stripCommentLines(workflowLevel), "contents: write") {
+		t.Errorf("regen-timeline v14 must NOT grant contents: write at workflow level — that reaches " +
+			"check-derived-docs too, and under pull_request_target the grant is real on fork PRs. " +
+			"It belongs on regen-on-main, the one job that pushes.")
+	}
+	if !strings.Contains(body, "    permissions:\n      contents: write\n") {
+		t.Errorf("regen-timeline v14 must grant contents: write on the regen-on-main JOB — a " +
+			"job-level permissions block replaces the workflow-level one rather than merging, " +
+			"so without this the push has a read-only token and every regen fails")
 	}
 	// No credential AT ALL is a freshness-only gap, not a failure: warn +
 	// exit 0 (never blocks the push event; the invariant guarantee lives in
@@ -481,7 +512,13 @@ var templateMarkerPins = map[string]struct {
 	// costs nothing downstream; minting v14 for an edit to v13's own
 	// unreleased body would only repeat the confusion this comment
 	// already describes.
-	"regen-timeline.yml.template": {"v13", "151276d1e2790b84e9400c07762ec1fc13aea4a0db9159997b6f0827706dbeb2"},
+	// Moved v13 → v14 by logmind#261: the PR gate's trigger and the
+	// permission scoping. Unlike the three re-pins above, THIS one is a
+	// marker bump rather than a repin — v13 is the marker this branch's
+	// merge-base already carries on `dev`, so an installed v13 is reachable
+	// and a content change under it would be a change no repository could
+	// ever be told about.
+	"regen-timeline.yml.template": {"v14", "8be4b55b27379c92433c1b4b0a3fb82a9287730b50fcde868b378f6d7ea49902"},
 }
 
 func TestWorkflowTemplateMarkers_PinnedToContent(t *testing.T) {
@@ -654,8 +691,12 @@ func TestCheckDecisionsTemplate_V5_CallsTheVerb(t *testing.T) {
 	active := stripCommentLines(body)
 
 	// Marker bump v5 → v6 (setup-logmind action pin v1.0.0 → v1.0.1).
-	if !strings.Contains(body, "# logmind-template-version: v6") {
-		t.Errorf("check-decisions template missing v6 marker")
+	// v6 → v7: the trigger moves to `pull_request_target` so the forge reads
+	// this file from the base branch (logmind#261, SPEC §6.3). Everything
+	// v5 pinned below is v5's, unchanged — the gate's evaluation did not
+	// move, only where its definition is read from.
+	if !strings.Contains(body, "# logmind-template-version: v7") {
+		t.Errorf("check-decisions template missing v7 marker")
 	}
 
 	// The one thing this workflow does: call the verb over the PR's range.
@@ -1076,9 +1117,22 @@ func TestRegenTimelineWorkflow_LockstepWithTemplate(t *testing.T) {
 // archive layered ONTO v12 rather than replacing it — a v13 that had reverted
 // #314 would have moved B (the regen-on-main preamble) and D (the checkout
 // stanza) as well.
+//
+// v14 (logmind#261) moved A and B, and what it did NOT move is the point.
+// A moved by exactly three lines — the `on:` event, the gate job's `if:`,
+// and `contents: write` → `contents: read` at workflow level. The `run:`
+// block inside A, which is the whole of what this gate decides, is
+// byte-for-byte v13's: the same three derived-doc paths, the same
+// `grep -qxE`, the same `exit 1`, the same drifted-default-branch warning.
+// That is the evidence for "where the definition is read from changed, the
+// logic did not" — the failure prints the region it hashed, so it is
+// checkable rather than asserted. B moved by the two lines giving
+// `regen-on-main` its own `permissions: contents: write`. D and F did not
+// move at all: the checkout stanza and the whole credential chain are
+// untouched.
 const (
-	digestRegionA = "75a4a82048f9b28379db76cd5630c3c7aa9918bba1341a149ff2e00b68c68c18"
-	digestRegionB = "60c9f3ef2d00a0a58c4057f1c36637b1054658019a21f47ef3667059e4445346"
+	digestRegionA = "a01ac1d4b02eedcf277961b1678da8ee2eb11876ddc50463a89c161d7609cb17"
+	digestRegionB = "a3c158cdc04d4dc533c0c59bb13bf245e41798fd1c20ef2afa5793aab69d99fc"
 	digestRegionD = "7e2d788d136cdff688f698527cd505c1d70633f4134d4df2951fbff59b7fc612"
 	digestRegionF = "bbe3a145536916b0c0ae850ae84e5e5e0662554d9d7059f79d9c7cd1844e117a"
 )
@@ -1331,27 +1385,7 @@ func pinActionRefs(t *testing.T, label, s string) string {
 // a quoted key (`"defaults":`), an aliased anchor, odd spacing — are read
 // as what GitHub would read, not as what a substring search would.
 func TestWorkflowActionSurface_IsPinned(t *testing.T) {
-	repoRoot := repoRootFromCaller(t)
-
-	type file struct{ label, body string }
-	var files []file
-	for _, name := range ListWorkflowTemplates() {
-		files = append(files, file{"template " + name, Workflow(name)})
-	}
-	entries, err := os.ReadDir(filepath.Join(repoRoot, ".github", "workflows"))
-	if err != nil {
-		t.Fatalf("read .github/workflows: %v", err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yml") {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", e.Name()))
-		if err != nil {
-			t.Fatalf("read %s: %v", e.Name(), err)
-		}
-		files = append(files, file{".github/workflows/" + e.Name(), string(data)})
-	}
+	files := allWorkflowFiles(t)
 
 	sawUses := 0
 	for _, f := range files {
@@ -1388,15 +1422,277 @@ func TestWorkflowActionSurface_IsPinned(t *testing.T) {
 		})
 	}
 
-	// Controls: both halves of the search must be demonstrably live, or
-	// every assertion above was vacuous.
-	if len(files) < 2 {
-		t.Fatalf("found %d workflow files — this test's file discovery is broken, not the tree", len(files))
-	}
+	// Control: the search must be demonstrably live, or every assertion
+	// above was vacuous. (The file count has its own control, inside
+	// allWorkflowFiles.)
 	if sawUses == 0 {
 		t.Fatalf("found no `uses:` keys in %d workflow files — this test's YAML walk is broken, "+
 			"not the tree", len(files))
 	}
+}
+
+// workflowFile is one YAML document this suite reasons about: a template
+// logmind ships to a consumer repository, or a workflow this repository
+// runs on itself.
+type workflowFile struct{ label, body string }
+
+// allWorkflowFiles returns every one of them, and is the ONE discovery the
+// class-level guards below share. Two lists would be two things to forget
+// to add a file to, and a guard that never sees a file reports nothing
+// about it while reading exactly like one that cleared it.
+func allWorkflowFiles(t *testing.T) []workflowFile {
+	t.Helper()
+	repoRoot := repoRootFromCaller(t)
+
+	var files []workflowFile
+	for _, name := range ListWorkflowTemplates() {
+		files = append(files, workflowFile{"template " + name, Workflow(name)})
+	}
+	entries, err := os.ReadDir(filepath.Join(repoRoot, ".github", "workflows"))
+	if err != nil {
+		t.Fatalf("read .github/workflows: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		files = append(files, workflowFile{".github/workflows/" + e.Name(), string(data)})
+	}
+	if len(files) < 2 {
+		t.Fatalf("found %d workflow files — this discovery is broken, not the tree", len(files))
+	}
+	return files
+}
+
+// gateJobIDs — every job whose result decides whether a change may merge.
+// Keyed by the job ID, which is also the context name a ruleset's
+// required-status-check rule pins ([§6.4](SPEC)); the two are the same
+// string on purpose, and renaming one without the other is caught by the
+// per-gate control at the bottom of the test below.
+var gateJobIDs = map[string]string{
+	"check-decisions":    "SPEC §3.4's decision gate — a substantive change must carry a decision",
+	"check-derived-docs": "SPEC §3.3's zero-conflict gate — a branch must not edit a derived doc",
+}
+
+// The one ref a gate's checkout may name. Not the trigger's default (the
+// base BRANCH TIP, which moves under a long-lived pull request), and
+// emphatically not the pull request's merge ref.
+const gateCheckoutRef = "${{ github.event.pull_request.base.sha }}"
+
+// TestGateWorkflows_AreNotRewritableByTheChangeTheyJudge is the class guard
+// for logmind#261, and the reason it is a class guard rather than two
+// assertions is that the defect it pins was invisible to every assertion
+// either gate already had.
+//
+// On a `pull_request` trigger the forge reads the workflow file ITSELF from
+// the pull request's own merge commit. So a pull request that edited a
+// gate's YAML had already replaced the job before it ran, and nothing the
+// job then did about its inputs mattered: `check-decisions` could be made
+// to `exit 0`, `check-derived-docs`'s `grep` could be made to match
+// nothing. SPEC §6.3: "Being careful inside the body cannot fix it, and a
+// workspace-free job is not exempt: what the pull request rewrote is the
+// definition, not the workspace."
+//
+// Both gates had, and still have, careful bodies — a base-ref workspace, a
+// released binary from a pinned action, no checkout at all. `regen-timeline`
+// even carried a comment asserting that being checkout-free left "nothing
+// here for a PR to influence about its own gate", which is true of the
+// workspace and false of the job. A false reassurance is worse than no
+// comment; it is why nobody looked again, and the assertion that would have
+// caught it is this one.
+//
+// So the property is stated where the forge actually decides it — the
+// trigger — over EVERY workflow logmind ships and EVERY workflow this
+// repository runs:
+//
+//   - a file carrying a gate job MUST subscribe to `pull_request_target`,
+//     whose workflow definition the forge reads from the BASE branch;
+//   - and MUST NOT subscribe to `pull_request`, which would put the same
+//     job back under the pull request's control — carrying both is not
+//     belt-and-braces but a hole, because the two runs post the same check
+//     name and the forge takes the most recent for a context;
+//   - and a checkout inside a gate job MUST name the base SHA, because
+//     `pull_request_target` is licensed by §6.3 only on the condition that
+//     it never checks out the pull request's content.
+//
+// It reads PARSED YAML, so `on: [pull_request]`, `on: pull_request` and a
+// quoted `"pull_request":` key are all read as what GitHub would read
+// rather than as what a substring search would.
+func TestGateWorkflows_AreNotRewritableByTheChangeTheyJudge(t *testing.T) {
+	files := allWorkflowFiles(t)
+
+	gateFilesPerJob := map[string]int{}
+	sawGateCheckout := 0
+	sawNonGateOnPullRequest := ""
+
+	for _, f := range files {
+		var doc yaml.Node
+		if err := yaml.Unmarshal([]byte(f.body), &doc); err != nil {
+			t.Errorf("%s: does not parse as YAML (%v) — GitHub would not run it, and this test "+
+				"cannot read it", f.label, err)
+			continue
+		}
+		root := yamlDocumentRoot(&doc)
+		triggers := yamlTriggerNames(yamlMappingValue(root, "on"))
+
+		// Which of this file's jobs are gates? The job ID is the check
+		// name, so this is the same question as "does this file post a
+		// check a ruleset can require".
+		jobs := yamlMappingValue(root, "jobs")
+		var gates []string
+		if jobs != nil && jobs.Kind == yaml.MappingNode {
+			for i := 0; i+1 < len(jobs.Content); i += 2 {
+				id := jobs.Content[i].Value
+				if _, ok := gateJobIDs[id]; !ok {
+					continue
+				}
+				gates = append(gates, id)
+				gateFilesPerJob[id]++
+				sawGateCheckout += requireGateCheckoutsReadTheBase(t, f.label, id, jobs.Content[i+1])
+			}
+		}
+		if len(gates) == 0 {
+			// NOT a gate, and this branch is load-bearing rather than a
+			// skip: `check-doc-links` is advisory by design (§6.2 — it
+			// never blocks), triggers on `pull_request`, and legitimately
+			// checks out the pull request's own head to self-heal a broken
+			// link. The rule above would be wrong for it, so recording
+			// that at least one such file went through here unflagged is
+			// what shows the rule discriminates instead of banning
+			// `pull_request` outright.
+			if triggers["pull_request"] && sawNonGateOnPullRequest == "" {
+				sawNonGateOnPullRequest = f.label
+			}
+			continue
+		}
+
+		if !triggers["pull_request_target"] {
+			t.Errorf("%s carries gate job(s) %v but does not trigger on `pull_request_target`. "+
+				"A gate MUST NOT carry its logic inline on a `pull_request` trigger (SPEC §6.3): "+
+				"the forge reads the workflow file itself from the pull request's own merge "+
+				"commit, so the job that runs is the pull request's copy of it and any check "+
+				"inside the body is checking inputs to a job the change already replaced.",
+				f.label, gates)
+		}
+		if triggers["pull_request"] {
+			t.Errorf("%s carries gate job(s) %v and triggers on `pull_request`. That trigger hands "+
+				"the pull request its own gate's definition (SPEC §6.3). Carrying it ALONGSIDE "+
+				"`pull_request_target` is not safer than carrying it alone: both runs post the "+
+				"same check name, and the forge takes the most recent run for a context — so the "+
+				"pull request's own copy is the one that counts.", f.label, gates)
+		}
+	}
+
+	// Controls. Each gate must have been FOUND, in both of the copies that
+	// exist (the template logmind ships and this repository's own), or the
+	// assertions above ran against nothing and reported success for it.
+	for id, what := range gateJobIDs {
+		if gateFilesPerJob[id] < 2 {
+			t.Errorf("found job id %q (%s) in %d workflow file(s), want at least 2 — the shipped "+
+				"template and this repository's own copy. Either a copy was deleted, or the job "+
+				"was renamed on one side, in which case this test just stopped checking it AND "+
+				"any ruleset requiring that check name stopped being satisfiable.",
+				id, what, gateFilesPerJob[id])
+		}
+	}
+	if sawGateCheckout == 0 {
+		t.Errorf("no gate job carried an `actions/checkout` step — the base-ref half of this test " +
+			"inspected nothing. `check-decisions` has one; if it no longer does, this control is " +
+			"what says so rather than the assertion quietly passing.")
+	}
+	if sawNonGateOnPullRequest == "" {
+		t.Errorf("no NON-gate workflow triggering on `pull_request` was examined, so this test " +
+			"cannot show it discriminates: a rule that flagged every workflow would look " +
+			"identical from here. `check-doc-links` is advisory and belongs on `pull_request`.")
+	}
+}
+
+// requireGateCheckoutsReadTheBase asserts every `actions/checkout` inside a
+// gate job names the base SHA, and returns how many it inspected so the
+// caller can prove the check was not vacuous.
+//
+// §6.3 licenses the `pull_request_target` route only on this condition —
+// "a gate taking the second route MUST NOT check out the pull request's
+// content, which is the hazard that trigger is otherwise known for" — and
+// under that trigger a bare `actions/checkout` does NOT default to the
+// merge ref, so an omitted `ref:` reads as harmless while leaving the
+// workspace on a branch tip that moves under the pull request.
+func requireGateCheckoutsReadTheBase(t *testing.T, label, jobID string, job *yaml.Node) int {
+	t.Helper()
+	steps := yamlMappingValue(job, "steps")
+	if steps == nil || steps.Kind != yaml.SequenceNode {
+		return 0
+	}
+	n := 0
+	for _, step := range steps.Content {
+		uses := yamlMappingValue(step, "uses")
+		if uses == nil || !strings.HasPrefix(uses.Value, "actions/checkout@") {
+			continue
+		}
+		n++
+		ref := yamlMappingValue(yamlMappingValue(step, "with"), "ref")
+		if ref == nil || ref.Value != gateCheckoutRef {
+			got := "no `ref:` at all"
+			if ref != nil {
+				got = "`ref: " + ref.Value + "`"
+			}
+			t.Errorf("%s: gate job %q checks out with %s, want `ref: %s`. A gate's workspace is "+
+				"read from the base ref or it is not read (SPEC §6.3) — the configuration this "+
+				"gate enforces lives in it, so a workspace carrying the pull request's content "+
+				"lets the change raise the bar it is judged against.", label, jobID, got, gateCheckoutRef)
+		}
+	}
+	return n
+}
+
+// yamlDocumentRoot unwraps the document node yaml.Unmarshal produces.
+func yamlDocumentRoot(doc *yaml.Node) *yaml.Node {
+	if doc != nil && doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+// yamlMappingValue returns the value node for a key, or nil.
+func yamlMappingValue(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// yamlTriggerNames reads an `on:` block in whichever of YAML's three shapes
+// it was written — `on: push`, `on: [push, pull_request]`, or a mapping of
+// event names to filters. Reading the parsed node rather than the text is
+// what makes the shape irrelevant, which is the point: a substring scan for
+// "pull_request:" sees none of the other two.
+func yamlTriggerNames(on *yaml.Node) map[string]bool {
+	out := map[string]bool{}
+	if on == nil {
+		return out
+	}
+	switch on.Kind {
+	case yaml.ScalarNode:
+		out[on.Value] = true
+	case yaml.SequenceNode:
+		for _, c := range on.Content {
+			out[c.Value] = true
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(on.Content); i += 2 {
+			out[on.Content[i].Value] = true
+		}
+	}
+	return out
 }
 
 // bundledTemplateFingerprints binds each workflow template's MARKER VERSION
@@ -1435,7 +1731,11 @@ func TestWorkflowActionSurface_IsPinned(t *testing.T) {
 // Update procedure: change a template → bump its marker → the test prints
 // the new digest → paste it here, same commit.
 var bundledTemplateFingerprints = map[string]string{
-	"check-decisions.yml.template": "v6:5fbd605bfc774cae66e321405a634baa0f0d3e93a47ffa661623100219430559",
+	// v7 = v6's body with `pull_request` → `pull_request_target`
+	// (logmind#261, SPEC §6.3). v6 is on `dev` and reachable, so this is a
+	// bump, not a repin: a repo already holding v6 gets the new trigger
+	// only because the marker moved.
+	"check-decisions.yml.template": "v7:297484d6c4c4c7e9855eb42c568dba186e9eccc5567b52ebb88638f83d91c5d5",
 	// v10 = v9's body plus the archive half of the derived-doc self-heal:
 	// `logmind timeline --write docs/timeline-archive.md --half archive`.
 	// The marker moves WITH the content by the rule this map exists to
@@ -1466,7 +1766,13 @@ var bundledTemplateFingerprints = map[string]string{
 	// Re-pinned again in #301 round 11 — same rule, third time: v13 still
 	// has not shipped, this edit swaps the v13 note's hand-typed "50" for
 	// __LOGMIND_RECENT_LIMIT__.
-	"regen-timeline.yml.template": "v13:151276d1e2790b84e9400c07762ec1fc13aea4a0db9159997b6f0827706dbeb2",
+	//
+	// v14 = v13's body with the PR gate on `pull_request_target` and
+	// `contents: write` narrowed to `regen-on-main` (logmind#261). v13 has
+	// SHIPPED to `dev` by now, so this is the ordinary case this map is for:
+	// the marker moves with the content, and every repo holding v13 is
+	// refreshed onto v14 because — and only because — the strings differ.
+	"regen-timeline.yml.template": "v14:8be4b55b27379c92433c1b4b0a3fb82a9287730b50fcde868b378f6d7ea49902",
 }
 
 // TestWorkflowTemplateMarkers_MoveWithContent enforces the binding above.


### PR DESCRIPTION
Closes #261.

## The defect

On a `pull_request` trigger the forge reads the **workflow file itself** from the PR's own merge commit. A PR that edits the gate's YAML has already replaced the job. Both gates carried their entire logic inline on that trigger — a PR changing `check-decisions`' `Enforce` step to `exit 0` passed its own gate.

`regen-timeline`'s `check-derived-docs` was worse, because it asserted immunity:

> NO checkout, deliberately… staying checkout-free means there is nothing here for a PR to influence about its own gate.

False. Checkout-free protects the **workspace**; what a PR rewrites is the **job definition**. That comment is why nobody looked again, so removing it is part of the fix rather than cleanup after it.

## Shape chosen: `pull_request_target`, and why the alternative is worse *here*

The issue offered a reusable workflow / composite action pinned to an immutable ref. Rejected, and the reasoning is the useful part: **the caller stays in the gate's file**, so on `pull_request` a PR rewrites `uses:` / `with:` / `if:` as easily as it rewrites `run:`. Making that shape safe needs a base-read trigger anyway — at which point the indirection buys nothing. And a `./`-local callee is itself read from the PR's ref, so it would have to live in a logmind-owned repo that **every consumer's gate then depends on existing** — which breaks the standalone guarantee.

`pull_request_target` reads the workflow from the base ref. SPEC §6.3's condition on it — *MUST NOT check out the PR's content* — is what both jobs were already built to do.

## The `pull_request_target` discipline, verified rather than asserted

| | |
|---|---|
| workspace | base content only, pinned to `base.sha` — not the branch tip, which moves under a long-lived PR |
| PR commits | reach the job as git **objects** via `refs/pull/N/head`; never checked out |
| the binary | a pinned released action, never built from the checkout — a PR cannot rebuild the thing judging it |
| the SHAs | reach the script through `env:`, not inline interpolation |
| workflow permissions | `contents: read`; `regen-on-main` carries its own `write` at job level |

Measured across all four shipped templates — **zero** head-ref checkouts in either gate. `check-doc-links` does check out head content and keeps doing so, safely, on plain `pull_request`.

## Behaviour unchanged, measured

Whole-file operative diff (blank/comment lines stripped) is *only* the trigger word per file, plus the permissions scoping in `regen-timeline` and the base-pinned `ref:` + PR-head fetch in `check-decisions`. The decision-logic regions diff **IDENTICAL**: 51/51, 13/13, 17/17 operative lines. Control: changing `total=$((total + added + removed))` to `+ added))` makes the same probe print a diff.

## Mutations — 11, each applied, YAML re-linted, guard run, restored

Trigger reverted to `pull_request` in each of the 4 files (M1–M4) → RED. Both triggers carried at once → RED. Gate checkout loses `ref:` → RED. Gate checkout takes `head.sha` → RED. Gate job renamed out of sight → RED. Every non-gate workflow off `pull_request`, killing the discrimination control → RED. `contents: write` back at workflow level → RED. `regen-on-main` loses its job permissions → RED.

Validated with `actionlint` 1.7.12 (repo-wide clean apart from a pre-existing SC2012 in `goreleaser-check.yml` that reproduces unmutated). Control: a bogus event name plus list-valued `permissions` gives rc=1.

Full suite run by the orchestrator, not taken on report: **23 packages ok, exit 0**; `go vet` clean, `gofmt -l` empty.

## Template markers move

`check-decisions` v6 → **v7**, `regen-timeline` v13 → **v14** — the bump is what propagates the fix to consumers via drift detection. Every pin moved with them: `bundledTemplateFingerprints`, `templateMarkerPins`, `digestRegionA`/`B`, two marker assertions, and the roadmap's fleet table.

Consumer check: `logmind init` in a fresh repo with default branch `trunk` installs v7/v14, substitutes `trunk` correctly, and `doctor` reports both current. Downgrading the markers and re-running `init` refreshes both back.

## CODEOWNERS — deliberately not added; it needs a person

SPEC §6.3 recommends it, and logmind has none (control: the same search returns 5 paths for `dependabot`). Left out on purpose: alone it enforces nothing — the ruleset must set `require_code_owner_review: true`, and `rulesets/canonical-v1.json` lives in **`thrillmade/protocol`**, not here. Shipping the file alone would be a second artifact that reads as protection while providing none. It also has a live hazard: an owner cannot approve their own PR, so enabling it in a single-maintainer repo blocks every solo change. Recorded as the remainder of #261 in `docs/roadmap.md`.

## Found, not fixed here

`.github/workflows/check-decisions.yml` (this repo's own) is still the pre-v5 gate — hardcoded `THRESHOLD: "20"`, wholesale `*.md` exclusion, a `gh pr view` title override. logmind runs the "second list" §3.4 forbids while shipping the verb-based template. That is #260/#278; preserved byte-for-byte here per the no-behaviour-change constraint and noted in the file header.