### PR TITLE
fix(config): refuse an agent's attempt to weaken a blocking setting — closes #330

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,43 @@ layered guards keep proprietary skills from leaking into a public catalog:
 There is no `--force` flag — these are guard rails, not toggles. See
 `logmind skill push --help` for the full surface.
 
+### Settings a person changes, not an agent
+
+Three settings decide whether something *blocks*, and SPEC §1.6 reserves them
+for a person: `git.enforce_commits`, `review.strict_mode` and
+`review.auto_fix`. `logmind config set` refuses a write that **weakens** one of
+them — turning a gate off, or turning auto-fix on — and says why. Turning a
+gate **on** is never refused, and every other setting is written as usual: an
+agent doing setup or registering a skill it just wrote must not be blocked.
+
+How logmind decides a person is asking, in full:
+
+1. **No agent marker in the environment.** `LOGMIND_AGENT`, `CLAUDECODE`,
+   `CLAUDE_CODE`, `CURSOR_AGENT`, `CODEX_SANDBOX`. Any one of them set to a
+   non-empty value refuses the write outright, naming the variable it saw.
+2. **A terminal, and a person who retypes the key.** stderr must be a TTY and
+   stdin must be block-safe; logmind then prints what the setting governs and
+   asks for the key to be typed back. `y` does not count.
+
+Step 2 is the guard — an agent driving `logmind` as a subprocess over pipes
+cannot satisfy it whatever harness it is, listed above or not. Step 1 is a
+courtesy that produces a better message and catches an agent inside a PTY; the
+marker list is non-exhaustive on purpose and nothing rests on it being
+complete.
+
+**What defeats it.** Any agent with a shell can: unset the marker, allocate a
+PTY and answer the prompt — or skip all that and edit `.logmind/config.yml`
+directly, which no local tool can prevent. This is a speed bump and a signal,
+not a boundary. The backstops are that `logmind doctor` reports any of the
+three it finds already weakened (**Blocking settings currently weakened**, also
+`gate_advisories` in `--json`), that SPEC §6.3 reads gate settings from the
+base ref so a weakening inside a pull request cannot affect the gate judging
+it, and that a config change is a hunk in a diff a review reads like any other.
+
+A person in a workflow, a cron job or over `ssh` has no terminal and is
+refused for that reason, which the message says: these settings are
+deliberately not automatable.
+
 ## Contributing / Development Setup
 
 Working on logmind itself? It's a Go module — clone, build, run.

--- a/docs/decisions-branches/fix__agent-write-refusal.md
+++ b/docs/decisions-branches/fix__agent-write-refusal.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-24 12:26 - config: refuse an agent's attempt to weaken a blocking setting, and make config get scriptable
+
+**Reasoning:** SPEC §1.6 says review.strict_mode, git.enforce_commits and review.auto_fix MUST NOT be written by an agent, and a tool asked to weaken one MUST refuse and say why. Measured on dev: all three accepted the write under CLAUDECODE=1, exit 0, persisted — with a control showing a permitted key also succeeded, so config set worked and the refusal was simply absent. That is the enforcement story's own off-switch, reachable through the documented interface with no bug required. Second defect in the same surface: config get printed Python-capitalized False while the file held false, so a workflow comparing against 'false' took the wrong branch — against §1.6's requirement that the non-interactive form be scriptable.
+
+**Alternatives considered:** Refuse every write to those keys — rejected; §1.6's very next paragraph protects an agent's right to write everything else, and setup plus skill registration are legitimate work. Only weakening is refused, so an agent turning enforcement ON still succeeds. Detect a hand-edit and refuse to honour it — rejected as a refusal, taken as an advisory: doctor now reports a weakened blocking setting without flipping Overall, because a person is entitled to have turned one off and doctor --fix writing it back would be logmind setting a blocking value on its own account.
+
+**Implications:**
+- The guard runs before the load and the write, so a refusal leaves an existing file byte-identical and creates none where there was none. Two owners, one fact each: internal/config/blocking.go owns which keys and which direction, internal/cli/config_blocking.go owns who is asking, and both config set and doctor read the first so they cannot disagree about what is protected. The bypass surface is stated plainly in the code and the README rather than implied away: any agent with a shell defeats it by unsetting a marker and answering the prompt, or by editing the file. It is a speed bump and a signal, not a boundary. Verified by me rather than taken on report: all three refused and persisted nothing, a permitted key still written, strengthening still allowed, and config get now emits lowercase true.
+
+---
+

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,11 +18,16 @@
 //     yaml.dump default_flow_style=False sort_keys=False) but sequence
 //     items are indented one extra level vs Python (yaml.v3 vs PyYAML
 //     convention). Acceptable delta — both parse the same.
-//   - `config get` prints booleans as `True`/`False` (Python's str()
-//     output), ints as decimal integers, strings verbatim. Matches the
-//     Python click.echo() default rendering of these types.
-//   - `config set` echoes `Set k = v` in green; coerced value uses
-//     Python's str() shape (True/False, not true/false).
+//   - `config get` and `config set`'s echo print the value the way the
+//     FILE spells it — `true`/`false`, not Python's `True`/`False`, and
+//     a section or a list as YAML rather than Go's `%v`. §1.6 requires
+//     the non-interactive form to be scriptable; see formatConfigValue.
+//
+// SPEC §1.6 refusal:
+//   - `config set` refuses an agent-initiated write that WEAKENS
+//     git.enforce_commits / review.strict_mode / review.auto_fix. The
+//     key table lives in internal/config (blocking.go); how a person is
+//     told from an agent, and what defeats it, is config_blocking.go.
 //
 // Error semantics:
 //   - Missing key → red "Key '<k>' not found" to stderr, exit 1.
@@ -31,6 +36,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -103,7 +109,7 @@ func newConfigGetCmd() *cobra.Command {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Key '%s' not found\n", key)
 				return ErrSilent
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), formatValuePythonRepr(val))
+			fmt.Fprintln(cmd.OutOrStdout(), formatConfigValue(val))
 			return nil
 		},
 	}
@@ -116,21 +122,36 @@ func newConfigSetCmd() *cobra.Command {
 		Long: "Coerces the value: \"true\"/\"false\" become booleans,\n" +
 			"all-digit strings become ints, all-digit-with-one-dot\n" +
 			"strings become floats, everything else stays a string.\n" +
-			"Writes to .logmind/config.yml, creating it if missing.",
+			"Writes to .logmind/config.yml, creating it if missing.\n" +
+			"\n" +
+			"Three settings are a person's to change, not an agent's\n" +
+			"(SPEC §1.6): git.enforce_commits, review.strict_mode and\n" +
+			"review.auto_fix. A write that WEAKENS one of them — turning\n" +
+			"a gate off, or turning auto-fix on — is refused unless a\n" +
+			"person retypes the key at a terminal. Turning a gate ON is\n" +
+			"never refused, and every other setting is written as usual.\n" +
+			"How logmind tells a person from an agent, and what defeats\n" +
+			"that check, is documented in internal/cli/config_blocking.go.",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, raw := args[0], args[1]
 			repoRoot := "."
+			parsed := coerceConfigValue(raw)
+			// Before the load, before the write: a refused write must
+			// leave the file exactly as it found it (and must not
+			// CREATE one in a repo that had none).
+			if err := guardBlockingWrite(cmd, key, parsed); err != nil {
+				return err
+			}
 			merged, err := config.LoadAsMap(repoRoot)
 			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "warning:", err)
 			}
-			parsed := coerceConfigValue(raw)
 			config.SetPath(merged, key, parsed)
 			if err := config.SaveMap(configPath(repoRoot), merged); err != nil {
 				return fmt.Errorf("save config: %w", err)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Set %s = %s\n", key, formatValuePythonRepr(parsed))
+			fmt.Fprintf(cmd.OutOrStdout(), "Set %s = %s\n", key, formatConfigValue(parsed))
 			return nil
 		},
 	}
@@ -196,22 +217,60 @@ func isPythonFloatShape(s string) bool {
 	return isAllDigits(withoutDot)
 }
 
-// formatValuePythonRepr renders v the way Python's str() does for the
-// CLI output paths (`config get <k>` and `Set <k> = <v>` echo). Bools
-// become Title-case (True/False), nil is empty string, everything
-// else falls through to fmt's default Go formatting.
-func formatValuePythonRepr(v any) string {
+// formatConfigValue renders v the way the config FILE spells it, so
+// `config get <k>` is comparable against .logmind/config.yml and against the
+// documented default — SPEC §1.6 requires the non-interactive form to be
+// scriptable, "the same command in a terminal and in a workflow", and a
+// workflow doing `[ "$(logmind config get git.enforce_commits)" = "false" ]`
+// takes the wrong branch on anything else.
+//
+// It replaces formatValuePythonRepr, which rendered through Python's str():
+// bools came out `True`/`False` while the file held `false`, and everything
+// non-scalar fell through to Go's %v — so `config get file_structure.
+// ignore_patterns` printed `[a b c]` and `config get git` printed a struct
+// pointer, `&{[auto_commit ...] map[...]}`. None of the three was parseable
+// by anything.
+//
+//	bool    → true / false     — YAML, and what the file holds
+//	int     → decimal          — unchanged
+//	float   → %v               — unchanged
+//	string  → verbatim         — a caller doing `$(logmind config get
+//	                             git.commit_message_template)` wants the
+//	                             string, not a YAML scalar to unquote
+//	anything else (a section, a list) → YAML block at 2-space indent, the
+//	                             same bytes `config list` prints for that
+//	                             subtree
+//
+// `config set`'s echo uses this too, so what the command says it wrote and
+// what the file holds cannot disagree.
+func formatConfigValue(v any) string {
 	switch typed := v.(type) {
 	case bool:
 		if typed {
-			return "True"
+			return "true"
 		}
-		return "False"
+		return "false"
 	case string:
 		return typed
 	case nil:
 		return ""
-	default:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
+		float32, float64:
 		return fmt.Sprintf("%v", v)
+	default:
+		var buf bytes.Buffer
+		enc := yaml.NewEncoder(&buf)
+		enc.SetIndent(2)
+		if err := enc.Encode(v); err != nil {
+			// Nothing better to fall back to, and a get should not fail
+			// on a value the file already round-trips.
+			return fmt.Sprintf("%v", v)
+		}
+		if err := enc.Close(); err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		// The encoder ends every document with a newline; the caller
+		// Fprintln's, so hand it back without one.
+		return strings.TrimRight(buf.String(), "\n")
 	}
 }

--- a/internal/cli/config_blocking.go
+++ b/internal/cli/config_blocking.go
@@ -1,0 +1,169 @@
+// config_blocking.go — SPEC §1.6's refusal, and the rule logmind uses to tell
+// a person from an agent.
+//
+// §1.6: "A setting that decides whether something blocks is a person's to
+// change. review.strict_mode, git.enforce_commits and review.auto_fix MUST NOT
+// be written by an agent — not through the command, not by editing the file.
+// A tool asked to weaken one of these by an agent MUST refuse and say why."
+//
+// WHICH keys and WHICH direction is config.BlockingSettings — one owner, read
+// by this refusal and by doctor's hand-edit advisory alike. This file owns
+// only the second question: is a person asking?
+//
+// # How logmind tells a person from an agent
+//
+// A weakening write is permitted only when a person types the key back. Two
+// things have to be true before logmind will even ask:
+//
+//  1. No agent marker in the environment (agentEnvMarkers below). A marker is
+//     a positive identification, so it refuses outright — even at a TTY.
+//  2. stderr is a terminal AND stdin can block-and-wait (the same isatty /
+//     stdinReadable pair `logmind log`'s prompts use). An agent driving
+//     logmind as a subprocess over pipes cannot satisfy this, whatever
+//     harness it is, whether or not logmind has heard of it.
+//
+// (2) is the guard. (1) is a courtesy: it produces a message that names the
+// reason, and it catches an agent that happens to run inside a PTY. The
+// marker list is therefore NON-EXHAUSTIVE ON PURPOSE and does not need to
+// keep up with every harness — nothing rests on it being complete.
+//
+// # What this does not do
+//
+// It is a speed bump and a signal, not a boundary. An agent with a shell can
+// defeat it: unset the marker AND allocate a PTY AND answer the prompt, or
+// skip all of that and edit .logmind/config.yml directly — which §1.6
+// addresses to the agent precisely because no local tool can prevent it.
+// `logmind doctor` reports a blocking setting it finds already weakened
+// (internal/doctor collectGateAdvisories), and SPEC §6.3 keeps a weakening
+// inside a pull request from affecting the gate judging it. Those are the
+// backstops; this refusal is the front door, and it is honest about being
+// only the front door.
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thrillmade/logmind/internal/config"
+)
+
+// agentEnvMarkers are environment variables whose presence identifies an
+// agent harness driving this command.
+//
+// Non-exhaustive by construction — see the file comment. LOGMIND_AGENT is
+// first because it is the one any harness can set for itself without logmind
+// shipping a new release to recognise it.
+var agentEnvMarkers = []string{
+	"LOGMIND_AGENT", // any harness may self-declare
+	"CLAUDECODE",    // Claude Code
+	"CLAUDE_CODE",   // Claude Code, alternate spelling
+	"CURSOR_AGENT",  // Cursor agent mode
+	"CODEX_SANDBOX", // OpenAI Codex CLI
+}
+
+// detectAgentMarker returns the first marker set to a non-empty value.
+//
+// Non-empty, not merely present: a wrapper that exports `CLAUDECODE=` with no
+// value has said nothing, and reading that as "an agent is here" would refuse
+// a person's write for no reason. An agent that wants to hide unsets the
+// variable anyway, so presence-only buys no strength.
+func detectAgentMarker() (string, bool) {
+	for _, name := range agentEnvMarkers {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// guardBlockingWrite refuses an agent-initiated weakening of a §1.6 blocking
+// setting, and returns nil for everything else.
+//
+// Everything else is most of the surface, and deliberately so: §1.6's next
+// paragraph — "Every other setting an agent MAY write through the command,
+// because setup and registering a skill it just wrote are legitimate work and
+// blocking them helps nobody" — makes over-blocking the worse failure. The
+// two early returns below are what keep that true: an unprotected key and a
+// STRENGTHENING write both leave immediately.
+func guardBlockingWrite(cmd *cobra.Command, key string, parsed any) error {
+	setting, ok := config.LookupBlocking(key)
+	if !ok {
+		return nil
+	}
+	if !setting.Weakens(parsed) {
+		return nil
+	}
+
+	errOut := cmd.ErrOrStderr()
+	if marker, isAgent := detectAgentMarker(); isAgent {
+		writeBlockingRefusal(errOut, setting,
+			"$"+marker+" is set in this environment, so logmind reads this write as agent-initiated")
+		return ErrSilent
+	}
+	if !isTerminalFunc() {
+		writeBlockingRefusal(errOut, setting,
+			"stderr is not a terminal, so logmind cannot put this question to a person")
+		return ErrSilent
+	}
+	if !stdinReadable(cmd.InOrStdin()) {
+		writeBlockingRefusal(errOut, setting,
+			"stdin is a pipe, so logmind cannot put this question to a person")
+		return ErrSilent
+	}
+
+	// A person is plausibly here. Ask them to prove it by retyping the key.
+	// Retyping the KEY, not "y": an agent answering prompts by piping "y"
+	// (which `logmind agents remove` accepts, by design, for a reversible
+	// action) does not get this one, and a person who typed the command
+	// three seconds ago can type the key without thinking twice.
+	fmt.Fprintf(errOut, "About to write %s.\n", setting.Key)
+	fmt.Fprint(errOut, blockingRefusalBody(setting,
+		"logmind sees a terminal and no agent marker, so it is asking rather\n  than refusing"))
+	fmt.Fprintf(errOut, "\n  Retype the key to confirm (%s): ", setting.Key)
+	if !confirmTypedKey(cmd.InOrStdin(), setting.Key) {
+		fmt.Fprintf(errOut, "\nNot confirmed — %s was not written.\n", setting.Key)
+		return ErrSilent
+	}
+	return nil
+}
+
+// writeBlockingRefusal emits the refusal: what was refused, what it governs,
+// who may change it and how, and why this particular invocation did not
+// qualify. §1.6 requires the refusal to "say why"; naming only the rule and
+// not the reason leaves the caller guessing which of the two conditions it
+// failed.
+func writeBlockingRefusal(w io.Writer, setting config.BlockingSetting, reason string) {
+	fmt.Fprintf(w, "Refusing to write %s.\n", setting.Key)
+	fmt.Fprint(w, blockingRefusalBody(setting, reason))
+}
+
+func blockingRefusalBody(setting config.BlockingSetting, reason string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n  It governs %s\n", setting.Governs)
+	fmt.Fprintf(&b, "  (%s), and SPEC §1.6 makes a setting that decides\n", setting.File)
+	fmt.Fprintf(&b, "  whether something blocks a person's to change.\n")
+	fmt.Fprintf(&b, "\n  Who may change it: a person, running this same command at a terminal —\n")
+	fmt.Fprintf(&b, "  logmind asks them to retype the key before it writes.\n")
+	fmt.Fprintf(&b, "  Here: %s.\n", reason)
+	return b.String()
+}
+
+// confirmTypedKey reads one line and returns true only when it is exactly the
+// key, ignoring surrounding whitespace. Case-sensitive: config keys are
+// snake_case (§1.6) and there is no near-miss worth accepting on a setting
+// this one guards.
+func confirmTypedKey(stdin io.Reader, key string) bool {
+	if stdin == nil {
+		return false
+	}
+	scanner := bufio.NewScanner(stdin)
+	if !scanner.Scan() {
+		return false
+	}
+	return strings.TrimSpace(scanner.Text()) == key
+}

--- a/internal/cli/config_blocking_test.go
+++ b/internal/cli/config_blocking_test.go
@@ -1,0 +1,308 @@
+// config_blocking_test.go — SPEC §1.6's refusal: `logmind config set` must
+// not weaken git.enforce_commits / review.strict_mode / review.auto_fix on
+// behalf of an agent, must still write every other setting, and must let a
+// person write all three.
+//
+// The over-blocking controls are as load-bearing as the refusals. §1.6's next
+// paragraph — "Every other setting an agent MAY write through the command,
+// because setup and registering a skill it just wrote are legitimate work and
+// blocking them helps nobody" — is the failure mode a careless guard causes,
+// so every refusal case here has a permitted-key twin.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runConfigCmd fires `logmind config ...` with a caller-supplied stdin and
+// returns (stdout+stderr, error). Unlike runCommand it tolerates a failure —
+// the refusal path is the point.
+func runConfigCmd(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	root := NewRootCmd()
+	root.SetArgs(args)
+	var sink bytes.Buffer
+	root.SetOut(&sink)
+	root.SetErr(&sink)
+	root.SetIn(strings.NewReader(stdin))
+	err := root.Execute()
+	return sink.String(), err
+}
+
+// inFakeTTYRepo runs fn in a fresh temp cwd with isTerminalFunc pinned, and
+// returns the temp dir so the caller can inspect (or assert the absence of)
+// .logmind/config.yml afterwards.
+func inFakeTTYRepo(t *testing.T, asTTY bool, fn func()) string {
+	t.Helper()
+	var dir string
+	withFakeTTY(t, asTTY, func() {
+		dir = withTempCwd(t, func(d string) { fn() })
+	})
+	return dir
+}
+
+// configFileBody returns .logmind/config.yml under dir, or "" when the
+// command never created it.
+func configFileBody(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".logmind", "config.yml"))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// clearAgentEnv unsets every marker for the duration of the test, so a real
+// agent harness running `go test` does not turn the person-path tests red.
+// t.Setenv first so the original value is restored on cleanup.
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, marker := range agentEnvMarkers {
+		t.Setenv(marker, "")
+		_ = os.Unsetenv(marker)
+	}
+}
+
+// TestConfigSet_AgentWeakeningRefused is the issue-#330 regression: all three
+// §1.6 keys, weakened, by an agent. Each must exit non-zero, say why, name who
+// may change it, and leave nothing on disk.
+func TestConfigSet_AgentWeakeningRefused(t *testing.T) {
+	cases := []struct {
+		key   string
+		value string
+		// governs is the clause the refusal must carry so the reader
+		// learns what they would be turning off.
+		governs string
+	}{
+		{"git.enforce_commits", "false", "whether a substantive commit must carry a decision"},
+		{"review.strict_mode", "false", "whether a critical review finding blocks the merge"},
+		{"review.auto_fix", "true", "whether a reviewer may push a fix without a person"},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			clearAgentEnv(t)
+			t.Setenv("CLAUDECODE", "1")
+			// A TTY and a stdin already carrying the confirmation: the
+			// marker must win anyway, or the guard is a formality.
+			dir := inFakeTTYRepo(t, true, func() {
+				out, err := runConfigCmd(t, c.key+"\n", "config", "set", c.key, c.value)
+				if err == nil {
+					t.Fatalf("config set %s %s: want refusal error, got nil\n%s", c.key, c.value, out)
+				}
+				mustContain(t, out, "Refusing to write "+c.key)
+				mustContain(t, out, c.governs)
+				mustContain(t, out, "a person")
+				mustContain(t, out, "CLAUDECODE")
+				mustNotContain(t, out, "Set "+c.key)
+			})
+			if body := configFileBody(t, dir); body != "" {
+				t.Errorf("refused write still created .logmind/config.yml:\n%s", body)
+			}
+		})
+	}
+}
+
+// TestConfigSet_AgentPermittedKeysStillWritten is the over-blocking control.
+// Same environment as the refusals; these must sail through.
+func TestConfigSet_AgentPermittedKeysStillWritten(t *testing.T) {
+	cases := []struct{ key, value, wantInFile string }{
+		{"git.commit_line_threshold", "30", "commit_line_threshold: 30"},
+		{"git.auto_push", "false", "auto_push: false"},
+		{"agents.claude", "false", "claude: false"},
+		{"context.spec_file", "docs/spec.md", "spec_file: docs/spec.md"},
+		// Near misses on the protected keys — a prefix or substring match
+		// would block these, and they are ordinary settings.
+		{"git.enforce_commits_note", "hi", "enforce_commits_note: hi"},
+		{"review.trigger", "pre-push", "trigger: pre-push"},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			clearAgentEnv(t)
+			t.Setenv("CLAUDECODE", "1")
+			dir := inFakeTTYRepo(t, false, func() {
+				out, err := runConfigCmd(t, "", "config", "set", c.key, c.value)
+				if err != nil {
+					t.Fatalf("config set %s %s: %v\n%s", c.key, c.value, err, out)
+				}
+				mustContain(t, out, "Set "+c.key+" = ")
+			})
+			mustContain(t, configFileBody(t, dir), c.wantInFile)
+		})
+	}
+}
+
+// TestConfigSet_AgentMayStrengthen is ruling 4: §1.6 says "asked to weaken",
+// so writing the value that keeps a person in the loop is allowed. Refusing
+// `enforce_commits true` would block the setup §1.6 protects.
+func TestConfigSet_AgentMayStrengthen(t *testing.T) {
+	cases := []struct{ key, value, wantInFile string }{
+		{"git.enforce_commits", "true", "enforce_commits: true"},
+		{"review.strict_mode", "true", "strict_mode: true"},
+		{"review.auto_fix", "false", "auto_fix: false"},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			clearAgentEnv(t)
+			t.Setenv("CLAUDECODE", "1")
+			dir := inFakeTTYRepo(t, false, func() {
+				out, err := runConfigCmd(t, "", "config", "set", c.key, c.value)
+				if err != nil {
+					t.Fatalf("config set %s %s: %v\n%s", c.key, c.value, err, out)
+				}
+				mustContain(t, out, "Set "+c.key+" = ")
+			})
+			mustContain(t, configFileBody(t, dir), c.wantInFile)
+		})
+	}
+}
+
+// TestConfigSet_PersonMayWeakenAllThree — a person at a terminal who retypes
+// the key gets the write. §1.6 makes these settings theirs; a guard that
+// blocked them would be a different bug.
+func TestConfigSet_PersonMayWeakenAllThree(t *testing.T) {
+	cases := []struct{ key, value, wantInFile string }{
+		{"git.enforce_commits", "false", "enforce_commits: false"},
+		{"review.strict_mode", "false", "strict_mode: false"},
+		{"review.auto_fix", "true", "auto_fix: true"},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			clearAgentEnv(t)
+			dir := inFakeTTYRepo(t, true, func() {
+				out, err := runConfigCmd(t, c.key+"\n", "config", "set", c.key, c.value)
+				if err != nil {
+					t.Fatalf("config set %s %s as a person: %v\n%s", c.key, c.value, err, out)
+				}
+				mustContain(t, out, "Set "+c.key+" = ")
+			})
+			mustContain(t, configFileBody(t, dir), c.wantInFile)
+		})
+	}
+}
+
+// A person who does not retype the key — or types something else — is not
+// confirmed, and nothing is written. "y" is on the list on purpose: it is what
+// `logmind agents remove` accepts, and what an autoresponder pipes.
+func TestConfigSet_PersonWhoDoesNotRetypeTheKeyIsRefused(t *testing.T) {
+	for _, reply := range []string{"y", "yes", "", "git.enforce_commit", "GIT.ENFORCE_COMMITS"} {
+		t.Run("reply="+reply, func(t *testing.T) {
+			clearAgentEnv(t)
+			dir := inFakeTTYRepo(t, true, func() {
+				out, err := runConfigCmd(t, reply+"\n", "config", "set", "git.enforce_commits", "false")
+				if err == nil {
+					t.Fatalf("reply %q: want refusal, got nil\n%s", reply, out)
+				}
+				mustContain(t, out, "Not confirmed")
+			})
+			if body := configFileBody(t, dir); body != "" {
+				t.Errorf("unconfirmed write still wrote:\n%s", body)
+			}
+		})
+	}
+}
+
+// No agent marker, no terminal — a script, a workflow, a cron. logmind cannot
+// put the question to a person, so it refuses and says that is the reason.
+func TestConfigSet_NoTerminalRefusedWithItsOwnReason(t *testing.T) {
+	clearAgentEnv(t)
+	dir := inFakeTTYRepo(t, false, func() {
+		out, err := runConfigCmd(t, "git.enforce_commits\n", "config", "set", "git.enforce_commits", "false")
+		if err == nil {
+			t.Fatalf("want refusal without a terminal, got nil\n%s", out)
+		}
+		mustContain(t, out, "Refusing to write git.enforce_commits")
+		mustContain(t, out, "not a terminal")
+	})
+	if body := configFileBody(t, dir); body != "" {
+		t.Errorf("refused write still wrote:\n%s", body)
+	}
+}
+
+// A non-bool coerced into one of these keys is a weakening too — `0` is not
+// `true`, and it also makes the typed load fall back to the whole default
+// config (see config.BlockingSetting.Weakens).
+func TestConfigSet_NonBoolIntoBlockingKeyRefused(t *testing.T) {
+	for _, value := range []string{"0", "1", "no", "off"} {
+		t.Run("value="+value, func(t *testing.T) {
+			clearAgentEnv(t)
+			t.Setenv("CLAUDECODE", "1")
+			dir := inFakeTTYRepo(t, false, func() {
+				out, err := runConfigCmd(t, "", "config", "set", "git.enforce_commits", value)
+				if err == nil {
+					t.Fatalf("config set git.enforce_commits %s: want refusal, got nil\n%s", value, out)
+				}
+			})
+			if body := configFileBody(t, dir); body != "" {
+				t.Errorf("refused write still wrote:\n%s", body)
+			}
+		})
+	}
+}
+
+// Every marker in the list identifies an agent, and the refusal names the one
+// it saw. A marker added without a row here would go untested.
+func TestConfigSet_EveryAgentMarkerRefuses(t *testing.T) {
+	for _, marker := range agentEnvMarkers {
+		t.Run(marker, func(t *testing.T) {
+			clearAgentEnv(t)
+			t.Setenv(marker, "1")
+			dir := inFakeTTYRepo(t, true, func() {
+				out, err := runConfigCmd(t, "git.enforce_commits\n", "config", "set", "git.enforce_commits", "false")
+				if err == nil {
+					t.Fatalf("marker %s: want refusal, got nil\n%s", marker, out)
+				}
+				mustContain(t, out, marker)
+			})
+			if body := configFileBody(t, dir); body != "" {
+				t.Errorf("marker %s: refused write still wrote:\n%s", marker, body)
+			}
+		})
+	}
+}
+
+// An empty marker is not a marker — `CLAUDECODE=` exported by a wrapper script
+// must not make a person look like an agent.
+func TestConfigSet_EmptyMarkerIsNotAnAgent(t *testing.T) {
+	clearAgentEnv(t)
+	t.Setenv("CLAUDECODE", "")
+	dir := inFakeTTYRepo(t, true, func() {
+		out, err := runConfigCmd(t, "git.enforce_commits\n", "config", "set", "git.enforce_commits", "false")
+		if err != nil {
+			t.Fatalf("empty marker must not read as an agent: %v\n%s", err, out)
+		}
+	})
+	mustContain(t, configFileBody(t, dir), "enforce_commits: false")
+}
+
+// A refused write must not disturb a config file that was already there.
+func TestConfigSet_RefusedWriteLeavesExistingFileByteIdentical(t *testing.T) {
+	clearAgentEnv(t)
+	t.Setenv("CLAUDECODE", "1")
+	var before, after string
+	inFakeTTYRepo(t, false, func() {
+		// An allowed write first, so there IS a file to preserve.
+		if out, err := runConfigCmd(t, "", "config", "set", "git.commit_line_threshold", "30"); err != nil {
+			t.Fatalf("seed write: %v\n%s", err, out)
+		}
+		data, err := os.ReadFile(filepath.Join(".logmind", "config.yml"))
+		if err != nil {
+			t.Fatalf("read seeded config: %v", err)
+		}
+		before = string(data)
+		if _, err := runConfigCmd(t, "", "config", "set", "git.enforce_commits", "false"); err == nil {
+			t.Fatalf("want refusal, got nil")
+		}
+		data, err = os.ReadFile(filepath.Join(".logmind", "config.yml"))
+		if err != nil {
+			t.Fatalf("read config after refusal: %v", err)
+		}
+		after = string(data)
+	})
+	if before != after {
+		t.Errorf("refused write rewrote the file\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -11,6 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/thrillmade/logmind/internal/config"
 )
 
 // withTempCwd runs fn inside a fresh temp directory, restoring the
@@ -68,8 +72,11 @@ func TestConfigGet_Boolean(t *testing.T) {
 		if err := root.Execute(); err != nil {
 			t.Fatalf("execute: %v", err)
 		}
-		if got := strings.TrimSpace(out.String()); got != "True" {
-			t.Errorf("get git.auto_push = %q; want True", got)
+		// `true`, not Python's `True`: SPEC §1.6 requires the
+		// non-interactive form to be scriptable, and the file holds
+		// `auto_push: true`. See formatConfigValue.
+		if got := strings.TrimSpace(out.String()); got != "true" {
+			t.Errorf("get git.auto_push = %q; want true", got)
 		}
 	})
 }
@@ -115,7 +122,7 @@ func TestConfigSet_BooleanCoercion(t *testing.T) {
 		if err := root.Execute(); err != nil {
 			t.Fatalf("execute: %v", err)
 		}
-		mustContain(t, out.String(), "Set git.auto_push = False")
+		mustContain(t, out.String(), "Set git.auto_push = false")
 		// File should exist + contain the new value.
 		data, err := os.ReadFile(filepath.Join(dir, ".logmind", "config.yml"))
 		if err != nil {
@@ -223,4 +230,87 @@ func mustContain(t *testing.T, body, needle string) {
 	if !strings.Contains(body, needle) {
 		t.Errorf("output missing %q\n--- got ---\n%s", needle, body)
 	}
+}
+
+// TestConfigGet_ScriptableShapes pins SPEC §1.6's "its non-interactive form
+// MUST be scriptable — the same command in a terminal and in a workflow".
+//
+// Before #330 this path rendered through Python's str() and then fell through
+// to Go's %v: a bool printed `False` while the file held `false` (so
+// `[ "$(logmind config get git.enforce_commits)" = "false" ]` took the wrong
+// branch), a list printed `[a b c]`, and a whole section printed a struct
+// pointer — `&{[auto_commit ...] map[...]}`. Every case below is a value type
+// `config get` can actually be handed.
+func TestConfigGet_ScriptableShapes(t *testing.T) {
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"git.auto_push", "true"},
+		{"git.auto_rebase", "false"},
+		{"git.enforce_commits", "true"},
+		{"git.commit_line_threshold", "20"},
+		{"git.commit_message_template", "logmind: {decision}"},
+		{"allow_promote_from_private", "false"},
+		{"catalog_target", "thrillmade/agent-skills"},
+		// A section renders as the YAML it is in the file, not as a Go
+		// struct pointer.
+		{"privacy_scanner", "keywords: []\norg_domains: []\nseverity_overrides: {}"},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			withTempCwd(t, func(_ string) {
+				root := NewRootCmd()
+				root.SetArgs([]string{"config", "get", c.key})
+				var out, errOut bytes.Buffer
+				root.SetOut(&out)
+				root.SetErr(&errOut)
+				if err := root.Execute(); err != nil {
+					t.Fatalf("execute: %v (%s)", err, errOut.String())
+				}
+				if got := strings.TrimRight(out.String(), "\n"); got != c.want {
+					t.Errorf("config get %s = %q; want %q", c.key, got, c.want)
+				}
+			})
+		})
+	}
+}
+
+// A list renders as YAML a workflow can parse — one item per line, quoted
+// where YAML needs it (`- '*.pyc'`, because a bare `*` opens an alias), which
+// is exactly how the same list is spelled in .logmind/config.yml. Before #330
+// it rendered as Go slice syntax, `[__pycache__ .git ...]`, which nothing
+// parses and which loses any pattern containing a space.
+//
+// Asserted by round-tripping the output back through YAML and comparing to
+// the one owner of the defaults, rather than by pinning the quoting — the
+// property §1.6 asks for is that a workflow can read it.
+func TestConfigGet_ListIsYAMLNotGoSliceSyntax(t *testing.T) {
+	withTempCwd(t, func(_ string) {
+		root := NewRootCmd()
+		root.SetArgs([]string{"config", "get", "file_structure.ignore_patterns"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v (%s)", err, errOut.String())
+		}
+		body := out.String()
+		if strings.HasPrefix(strings.TrimSpace(body), "[") {
+			t.Fatalf("config get rendered Go slice syntax, not YAML:\n%s", body)
+		}
+		var got []string
+		if err := yaml.Unmarshal([]byte(body), &got); err != nil {
+			t.Fatalf("output is not parseable YAML: %v\n%s", err, body)
+		}
+		want := config.DefaultIgnorePatterns()
+		if len(got) != len(want) {
+			t.Fatalf("parsed %d patterns, want %d\n%s", len(got), len(want), body)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("pattern %d = %q; want %q", i, got[i], want[i])
+			}
+		}
+	})
 }

--- a/internal/cli/decisions_uncapped_test.go
+++ b/internal/cli/decisions_uncapped_test.go
@@ -100,8 +100,11 @@ func TestLoad_UnknownMaxRecentKeyIsIgnored(t *testing.T) {
 		if err := root.Execute(); err != nil {
 			t.Fatalf("config get with a stale max_recent key errored: %v\n%s", err, out.String())
 		}
-		if got := strings.TrimSpace(out.String()); got != "False" {
-			t.Errorf("branch_aware = %q; want False — the neighbouring key must still resolve", got)
+		// `false`, the way the file spells it — see formatConfigValue.
+		// What this test is actually pinning is that the neighbouring key
+		// still resolves past the unrecognised max_recent.
+		if got := strings.TrimSpace(out.String()); got != "false" {
+			t.Errorf("branch_aware = %q; want false — the neighbouring key must still resolve", got)
 		}
 	})
 }

--- a/internal/config/blocking.go
+++ b/internal/config/blocking.go
@@ -1,0 +1,116 @@
+// blocking.go — SPEC §1.6's person-only settings: which keys they are, and
+// which direction of write counts as weakening one. Nothing here knows who is
+// asking; that question belongs to the command surface.
+//
+// This is the one owner of that fact. `logmind config set` refuses an
+// agent-initiated weakening (internal/cli/config.go) and `logmind doctor`
+// reports one that arrived by hand edit (internal/doctor); both read this
+// table, so the set of protected keys and the direction that counts as
+// weakening can never disagree between the refusal and the report.
+package config
+
+// BlockingSetting is one of the three settings SPEC §1.6 names as a person's
+// to change: "A setting that decides whether something blocks is a person's
+// to change. review.strict_mode, git.enforce_commits and review.auto_fix MUST
+// NOT be written by an agent — not through the command, not by editing the
+// file."
+//
+// Every OTHER setting is deliberately absent. §1.6's next paragraph is just
+// as binding — "Every other setting an agent MAY write through the command,
+// because setup and registering a skill it just wrote are legitimate work and
+// blocking them helps nobody" — so growing this table is a SPEC change, not a
+// judgement call.
+type BlockingSetting struct {
+	// Key is the dotted key as typed on the command line.
+	Key string
+	// File is where §1.6 puts the setting. Named in the refusal so a
+	// person knows which file to open if they choose to.
+	File string
+	// Governs is a one-clause summary of what turns off, for the message.
+	Governs string
+	// PersonInLoop is the value that keeps a person in the loop. It is the
+	// anchor for "weaken": §1.6 says a tool asked to WEAKEN one of these
+	// must refuse, and the uniform reading of weaken across all three is
+	// "moves the setting away from the value that keeps a person in the
+	// loop".
+	//
+	//   git.enforce_commits  true  — a substantive commit carries a decision
+	//   review.strict_mode   true  — a critical finding blocks the merge
+	//   review.auto_fix      false — a person, not a bot, pushes the fix
+	//
+	// Writing PersonInLoop is STRENGTHENING and stays agent-writable: the
+	// refusal exists to stop oversight being removed, and refusing
+	// `enforce_commits true` would block the setup §1.6 protects.
+	PersonInLoop any
+}
+
+// blockingSettings is the table. Package-level and returned by value through
+// BlockingSettings() so no caller can scribble on it.
+var blockingSettings = []BlockingSetting{
+	{
+		Key:          "git.enforce_commits",
+		File:         ".logmind/config.yml",
+		Governs:      "whether a substantive commit must carry a decision",
+		PersonInLoop: true,
+	},
+	{
+		Key:          "review.strict_mode",
+		File:         ".claude/skills/.clud-bug.json",
+		Governs:      "whether a critical review finding blocks the merge",
+		PersonInLoop: true,
+	},
+	{
+		Key:          "review.auto_fix",
+		File:         ".claude/skills/.clud-bug.json",
+		Governs:      "whether a reviewer may push a fix without a person",
+		PersonInLoop: false,
+	},
+}
+
+// BlockingSettings returns the §1.6 table in a fresh slice.
+func BlockingSettings() []BlockingSetting {
+	out := make([]BlockingSetting, len(blockingSettings))
+	copy(out, blockingSettings)
+	return out
+}
+
+// LookupBlocking returns the blocking setting for an exact dotted key.
+//
+// Exact match, never a prefix: `git.enforce_commits.x` and `enforce_commits`
+// are different keys and neither is the protected one. A prefix match would
+// over-block, which §1.6 calls out as the worse failure.
+func LookupBlocking(key string) (BlockingSetting, bool) {
+	for _, b := range blockingSettings {
+		if b.Key == key {
+			return b, true
+		}
+	}
+	return BlockingSetting{}, false
+}
+
+// Weakens reports whether writing v to this setting moves it away from
+// PersonInLoop — the direction §1.6 requires a tool to refuse.
+//
+// Anything that is not the PersonInLoop boolean weakens, including a non-bool
+// (`config set git.enforce_commits 0` coerces to int). That is deliberate and
+// is not merely a fallback: a non-bool in one of these keys makes the typed
+// load fail, and LoadPath answers a failed unmarshal with the whole DEFAULT
+// config — so a stray `0` silently reverts every other setting in the file
+// too. Refusing it is right for both reasons.
+//
+// The comparison is bool-only rather than `==` on `any`, because `==` panics
+// on an uncomparable dynamic type (a coerced list would take down the
+// command it was supposed to refuse).
+func (b BlockingSetting) Weakens(v any) bool {
+	want, ok := b.PersonInLoop.(bool)
+	if !ok {
+		// Unreachable with today's table; a non-bool PersonInLoop would
+		// need its own comparison, so refuse rather than guess.
+		return true
+	}
+	got, ok := v.(bool)
+	if !ok {
+		return true
+	}
+	return got != want
+}

--- a/internal/config/blocking_test.go
+++ b/internal/config/blocking_test.go
@@ -1,0 +1,81 @@
+// blocking_test.go — the SPEC §1.6 blocking-setting table: which keys it
+// covers, and which direction of write counts as a weakening.
+package config
+
+import "testing"
+
+func TestBlockingSettings_CoversTheThreeKeysSpecNames(t *testing.T) {
+	want := map[string]bool{
+		"git.enforce_commits": false,
+		"review.strict_mode":  false,
+		"review.auto_fix":     false,
+	}
+	for _, b := range BlockingSettings() {
+		if _, ok := want[b.Key]; !ok {
+			t.Errorf("BlockingSettings has unexpected key %q — §1.6 names exactly three", b.Key)
+			continue
+		}
+		want[b.Key] = true
+	}
+	for key, seen := range want {
+		if !seen {
+			t.Errorf("BlockingSettings is missing %q — §1.6 names it", key)
+		}
+	}
+}
+
+func TestLookupBlocking_OnlyTheNamedKeys(t *testing.T) {
+	for _, key := range []string{"git.enforce_commits", "review.strict_mode", "review.auto_fix"} {
+		if _, ok := LookupBlocking(key); !ok {
+			t.Errorf("LookupBlocking(%q) = not found; want found", key)
+		}
+	}
+	// Controls: keys an agent legitimately writes (§1.6's next paragraph).
+	for _, key := range []string{
+		"git.commit_line_threshold", "git.auto_push", "agents.claude",
+		"enforce_commits", "review", "git.enforce_commits.x",
+	} {
+		if _, ok := LookupBlocking(key); ok {
+			t.Errorf("LookupBlocking(%q) = found; want not found (over-blocking)", key)
+		}
+	}
+}
+
+func TestWeakens_DirectionPerSetting(t *testing.T) {
+	cases := []struct {
+		key  string
+		val  any
+		want bool
+	}{
+		// enforce_commits / strict_mode: the gate is ON when true, so
+		// false — or anything that is not true — weakens it.
+		{"git.enforce_commits", false, true},
+		{"git.enforce_commits", true, false},
+		{"git.enforce_commits", 0, true},
+		{"git.enforce_commits", "no", true},
+		{"review.strict_mode", false, true},
+		{"review.strict_mode", true, false},
+		// auto_fix: a person pushes the fix when it is OFF, so turning it
+		// on — or raising the round cap — is the weakening direction.
+		{"review.auto_fix", true, true},
+		{"review.auto_fix", 3, true},
+		{"review.auto_fix", false, false},
+	}
+	for _, c := range cases {
+		b, ok := LookupBlocking(c.key)
+		if !ok {
+			t.Fatalf("LookupBlocking(%q) not found", c.key)
+		}
+		if got := b.Weakens(c.val); got != c.want {
+			t.Errorf("%s.Weakens(%#v) = %v; want %v", c.key, c.val, got, c.want)
+		}
+	}
+}
+
+// A slice is not a comparable type; Weakens must classify it, not panic.
+func TestWeakens_UncomparableValueDoesNotPanic(t *testing.T) {
+	b, _ := LookupBlocking("git.enforce_commits")
+	if !b.Weakens([]any{"a", "b"}) {
+		t.Errorf("Weakens([]any{...}) = false; want true (not the person-in-loop value)")
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -187,6 +187,26 @@ type StatusReport struct {
 	// `logmind auto <profile>` is the deliberate remediation, exactly as
 	// `logmind init --spec` is for the spec nudge.
 	AutoAdvisories []string `json:"auto_advisories"`
+
+	// GateAdvisories is an ADVISORY list (#330) naming any SPEC §1.6
+	// blocking setting — git.enforce_commits, review.strict_mode,
+	// review.auto_fix — this repository currently has in its weakened
+	// state.
+	//
+	// It is the other half of §1.6's sentence. `logmind config set`
+	// refuses an agent-initiated weakening through the command; "not by
+	// editing the file" is addressed to the agent, and no local tool can
+	// enforce it. What a tool CAN do is notice afterwards and say so, so a
+	// person reading `logmind doctor` learns their commit gate is off
+	// without having to go looking.
+	//
+	// Advisory, and deliberately never Overall: these are a person's
+	// settings, and a person is entitled to have turned one off. Reporting
+	// a legitimate choice as drift would send them to `doctor --fix`,
+	// which correctly will not touch it (fixing it would be logmind
+	// writing a blocking setting on its own account — the very thing §1.6
+	// reserves for a person).
+	GateAdvisories []string `json:"gate_advisories"`
 }
 
 // ToJSON serialises the report with 2-space indent, matching Python's
@@ -260,7 +280,100 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		SummariesNeeded: collectSummariesNeeded(projectRoot),
 		SpecAdvisories:  collectSpecAdvisories(projectRoot),
 		AutoAdvisories:  collectAutoAdvisories(projectRoot),
+		GateAdvisories:  collectGateAdvisories(projectRoot),
 	}
+}
+
+// cludBugConfigPath is where SPEC §1.6 puts review.strict_mode and
+// review.auto_fix. logmind does not write this file; it reads the two keys so
+// the gate advisory can cover all three settings §1.6 names rather than only
+// the one that happens to live in logmind's own config.
+const cludBugConfigPath = ".claude/skills/.clud-bug.json"
+
+// collectGateAdvisories returns the ADVISORY list of SPEC §1.6 blocking
+// settings currently in their weakened state — see StatusReport.GateAdvisories
+// for why this is advisory and never Overall.
+//
+// Which keys count, and which direction is a weakening, come from
+// config.BlockingSettings — the same table `logmind config set`'s refusal
+// reads, so the report and the refusal cannot disagree about what is
+// protected.
+//
+// Reads the EFFECTIVE value: a repository that never set enforce_commits gets
+// the documented default (true) and no advisory. A missing or unparseable
+// file says nothing — doctor is read-only and a broken config is already
+// reported elsewhere; inventing a gate warning out of a YAML syntax error
+// would be a second, wronger message about the same file.
+func collectGateAdvisories(projectRoot string) []string {
+	// Each value carries the file it was actually READ from, not the file
+	// §1.6 designates. `logmind config set review.strict_mode` writes into
+	// .logmind/config.yml, so naming .clud-bug.json for a value that came
+	// from somewhere else would send the reader to the wrong file.
+	type found struct {
+		value  any
+		source string
+	}
+	values := map[string]found{}
+
+	const logmindConfig = ".logmind/config.yml"
+	merged, err := config.LoadPathAsMap(filepath.Join(projectRoot, filepath.FromSlash(logmindConfig)))
+	if err == nil {
+		for _, b := range config.BlockingSettings() {
+			if v, ok := config.GetPath(merged, b.Key); ok && v != nil {
+				values[b.Key] = found{v, logmindConfig}
+			}
+		}
+	}
+	// .clud-bug.json wins for its own keys: §1.6 names it as their home, so
+	// a value there is the one in force. A stray review.* in config.yml
+	// (which `logmind config set review.strict_mode` writes, inertly — see
+	// the note in internal/cli/config_blocking.go) is still reported when
+	// .clud-bug.json is silent, because it is still evidence of the write.
+	if review, ok := readCludBugReview(filepath.Join(projectRoot, filepath.FromSlash(cludBugConfigPath))); ok {
+		for _, key := range []string{"strict_mode", "auto_fix"} {
+			if v, ok := review[key]; ok && v != nil {
+				values["review."+key] = found{v, cludBugConfigPath}
+			}
+		}
+	}
+
+	var out []string
+	for _, b := range config.BlockingSettings() {
+		f, ok := values[b.Key]
+		if !ok || !b.Weakens(f.value) {
+			continue
+		}
+		line := fmt.Sprintf(
+			"%s is %v in %s — the weakened value; it governs %s. SPEC §1.6 makes this a "+
+				"person's to change: if you did not change it, an agent did.",
+			b.Key, f.value, f.source, b.Governs)
+		if f.source == logmindConfig {
+			line += fmt.Sprintf(" Restore with `logmind config set %s %v`.", b.Key, b.PersonInLoop)
+		} else {
+			line += fmt.Sprintf(" Restore it to %v in that file — it is clud-bug's to write, not logmind's.", b.PersonInLoop)
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// readCludBugReview returns the `review` object from .clud-bug.json.
+//
+// Tolerant on purpose: a missing file is the common case (a repository that
+// has not configured review), and an unparseable one belongs to clud-bug to
+// complain about, not to logmind's stack-status command.
+func readCludBugReview(path string) (map[string]any, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var doc struct {
+		Review map[string]any `json:"review"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, false
+	}
+	return doc.Review, doc.Review != nil
 }
 
 // collectAutoAdvisories returns the ADVISORY list for `.logmind/auto.yml`
@@ -1175,6 +1288,13 @@ func RenderStatus(r StatusReport) string {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("Unattended-operation directive (%d):", len(r.AutoAdvisories)))
 		for _, s := range r.AutoAdvisories {
+			lines = append(lines, fmt.Sprintf("  • %s", s))
+		}
+	}
+	if len(r.GateAdvisories) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("Blocking settings currently weakened (%d):", len(r.GateAdvisories)))
+		for _, s := range r.GateAdvisories {
 			lines = append(lines, fmt.Sprintf("  • %s", s))
 		}
 	}

--- a/internal/doctor/gate_advisory_test.go
+++ b/internal/doctor/gate_advisory_test.go
@@ -1,0 +1,142 @@
+// gate_advisory_test.go — the other half of SPEC §1.6's sentence. The command
+// refuses an agent-initiated weakening; nothing local can stop an agent
+// editing the file, so doctor reports a blocking setting it finds already
+// weakened. Advisory only: a person is allowed to have turned it off, so
+// Overall must stay OK.
+package doctor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGateAdvisories_CleanRepoSaysNothing(t *testing.T) {
+	dir := freshRepo(t)
+	r := CollectStatus(dir, true)
+	if len(r.GateAdvisories) != 0 {
+		t.Errorf("GateAdvisories = %v; want none (nothing weakened)", r.GateAdvisories)
+	}
+}
+
+// Control for the test above: the same probe DOES fire when the file says so.
+func TestGateAdvisories_HandEditedConfigYML(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"),
+		"git:\n  auto_commit: true\n  enforce_commits: false\n")
+	r := CollectStatus(dir, true)
+	if len(r.GateAdvisories) != 1 {
+		t.Fatalf("GateAdvisories = %v; want exactly one", r.GateAdvisories)
+	}
+	got := r.GateAdvisories[0]
+	for _, needle := range []string{
+		"git.enforce_commits",
+		".logmind/config.yml",
+		"whether a substantive commit must carry a decision",
+		"the weakened value",
+		"logmind config set git.enforce_commits true",
+	} {
+		if !strings.Contains(got, needle) {
+			t.Errorf("advisory missing %q:\n%s", needle, got)
+		}
+	}
+	if r.Overall == "DRIFT" {
+		t.Errorf("Overall = DRIFT; a weakened gate is a person's choice to report, not drift")
+	}
+}
+
+// The two review keys live in .clud-bug.json per §1.6, and a hand edit there
+// is the same defeat.
+func TestGateAdvisories_HandEditedCludBugJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "strict_mode off",
+			body: `{"review": {"strict_mode": false}}`,
+			want: []string{"review.strict_mode", ".claude/skills/.clud-bug.json",
+				"whether a critical review finding blocks the merge"},
+		},
+		{
+			name: "auto_fix on",
+			body: `{"review": {"auto_fix": true}}`,
+			want: []string{"review.auto_fix", "whether a reviewer may push a fix without a person",
+				"clud-bug's to write, not logmind's"},
+		},
+		{
+			name: "auto_fix given a round count",
+			body: `{"review": {"auto_fix": 3}}`,
+			want: []string{"review.auto_fix"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := freshRepo(t)
+			mustWrite(t, filepath.Join(dir, ".claude", "skills", ".clud-bug.json"), c.body)
+			r := CollectStatus(dir, true)
+			if len(r.GateAdvisories) != 1 {
+				t.Fatalf("GateAdvisories = %v; want exactly one", r.GateAdvisories)
+			}
+			for _, needle := range c.want {
+				if !strings.Contains(r.GateAdvisories[0], needle) {
+					t.Errorf("advisory missing %q:\n%s", needle, r.GateAdvisories[0])
+				}
+			}
+			if r.Overall == "DRIFT" {
+				t.Errorf("Overall = DRIFT; the gate advisory must never be drift")
+			}
+		})
+	}
+}
+
+// Controls: the strengthened values, and a .clud-bug.json that configures
+// something else entirely, must say nothing. Over-reporting trains a reader to
+// ignore the list.
+func TestGateAdvisories_StrengthenedAndUnrelatedStaySilent(t *testing.T) {
+	cases := []struct{ name, path, body string }{
+		{"enforce_commits on", filepath.Join(".logmind", "config.yml"),
+			"git:\n  enforce_commits: true\n"},
+		{"strict_mode on", filepath.Join(".claude", "skills", ".clud-bug.json"),
+			`{"review": {"strict_mode": true}}`},
+		{"auto_fix off", filepath.Join(".claude", "skills", ".clud-bug.json"),
+			`{"review": {"auto_fix": false}}`},
+		{"unrelated review keys", filepath.Join(".claude", "skills", ".clud-bug.json"),
+			`{"review": {"trigger": "pre-push", "ci_checks": ["build"]}, "installed": ["x"]}`},
+		{"unparseable json", filepath.Join(".claude", "skills", ".clud-bug.json"), `{not json`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := freshRepo(t)
+			mustWrite(t, filepath.Join(dir, c.path), c.body)
+			r := CollectStatus(dir, true)
+			if len(r.GateAdvisories) != 0 {
+				t.Errorf("GateAdvisories = %v; want none", r.GateAdvisories)
+			}
+		})
+	}
+}
+
+// All three at once, so a reader who defeated every gate is told about every
+// gate rather than the first one.
+func TestGateAdvisories_ReportsAllThree(t *testing.T) {
+	dir := freshRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"),
+		"git:\n  enforce_commits: false\n")
+	mustWrite(t, filepath.Join(dir, ".claude", "skills", ".clud-bug.json"),
+		`{"review": {"strict_mode": false, "auto_fix": true}}`)
+	r := CollectStatus(dir, true)
+	if len(r.GateAdvisories) != 3 {
+		t.Fatalf("GateAdvisories = %v; want three", r.GateAdvisories)
+	}
+	joined := strings.Join(r.GateAdvisories, "\n")
+	for _, key := range []string{"git.enforce_commits", "review.strict_mode", "review.auto_fix"} {
+		if !strings.Contains(joined, key) {
+			t.Errorf("missing %s:\n%s", key, joined)
+		}
+	}
+	if !strings.Contains(RenderStatus(r), "Blocking settings") {
+		t.Errorf("RenderStatus does not surface the gate advisories:\n%s", RenderStatus(r))
+	}
+}


### PR DESCRIPTION
Closes #330. Unblocks #244, which adds a fourth setting of the same kind.

## The defect

SPEC §1.6:

> **A setting that decides whether something blocks is a person's to change.** `review.strict_mode`, `git.enforce_commits` and `review.auto_fix` MUST NOT be written by an agent — not through the command, not by editing the file. A tool asked to weaken one of these by an agent MUST refuse and say why.

Measured on `dev`: all three accepted the write under `CLAUDECODE=1`, exit 0, persisted. Control: `git.commit_line_threshold` also succeeded — so `config set` worked and the refusal was simply **absent**.

That is the enforcement story's own off-switch, reachable through the documented interface with no bug required. `[skip-logmind]` and `LOGMIND_ALLOW_GIT_COMMIT=1` are deliberate, scoped to one commit, and visible in the log. Flipping the config is none of those.

## What it does NOT do, which is half the design

§1.6's next paragraph is equally binding:

> Every other setting an agent MAY write through the command, because setup and registering a skill it just wrote are legitimate work and blocking them helps nobody.

So only **weakening** is refused — away from the value that keeps a person in the loop. An agent turning `enforce_commits` **on** still succeeds; setup must not break. Over-blocking here would have been a worse failure than the bug.

## Verified by the orchestrator, not taken on report

| invocation | exit | persisted |
|---|---|---|
| `CLAUDECODE=1 config set git.enforce_commits false` | **1** | no |
| `CLAUDECODE=1 config set review.strict_mode false` | **1** | no |
| `CLAUDECODE=1 config set review.auto_fix true` | **1** | no |
| `CLAUDECODE=1 config set git.commit_line_threshold 30` (control) | 0 | **yes** |
| `CLAUDECODE=1 config set git.enforce_commits true` (strengthen) | 0 | yes |
| `config get git.enforce_commits` | — | `true`, lowercase |

## The bypass surface, stated plainly

Any agent with a shell defeats this: unset the marker, get a PTY, answer the prompt — or just edit `.logmind/config.yml`. **It is a speed bump and a signal, not a boundary**, and the code comment and README say so rather than implying otherwise. A guard I'd mistakenly trust is worse than a narrow one I understand.

A person is distinguished by having to **retype the key** at a real terminal, with no agent marker set. A person in CI or over `ssh` has no terminal and is refused with that as the stated reason — these settings are deliberately not automatable.

## Structure

Two owners, one fact each. `internal/config/blocking.go` owns *which* keys and *which direction*; `internal/cli/config_blocking.go` owns *who is asking*. `config set` and `doctor` both read the first, so they cannot disagree about what is protected. The guard runs **before** the load and write, so a refusal leaves an existing file byte-identical and creates none where there was none.

`doctor` gains `GateAdvisories` — reports a weakened blocking setting, naming the file it actually read, without flipping `Overall`. A person is entitled to have turned one off, and `doctor --fix` writing it back would be logmind setting a blocking value on its own account.

## Second defect fixed: scriptability

`config get` printed `False` while the file held `false`, so `[ "$(logmind config get git.enforce_commits)" = "false" ]` took the wrong branch. Now emits `true`/`false`, and sections and lists as parseable YAML rather than `&{[...] map[...]}`.

## Mutations — 12, every mutant compiled, run on the shipped path

Guard returns nil · agent-marker branch never taken · `Weakens` forced false · `Weakens` forced true (over-block) · `LookupBlocking` prefix-matches · prompt accepts any line · no-terminal refusal dropped · bool back to `True`/`False` · non-scalar back to `%v` · advisories nil · guard moved after the write · marker read by presence not non-emptiness. **All red.** Two mutants initially failed to compile and were reworked until they did.

Full suite: 23 packages, `SUITE_EXIT=0`, `go vet` clean, `gofmt -l` empty.

## Found while here — filing separately, not fixed

1. **`logmind doctor --json` writes to stderr** — stdout 0 bytes, stderr 4195. `doctor --json | jq` gets nothing.
2. **`config set review.strict_mode` writes an inert key** — §1.6 puts `review.*` in `.clud-bug.json`; logmind writes it to `.logmind/config.yml` where nothing reads it. The refusal is correct regardless (§1.6 says "asked to weaken"), but the write path is wrong and needs a ruling.
3. **The AGENTS templates and `skill/SKILL.md` still advertise the now-refused route** — they say `git.enforce_commits: false` disables enforcement, with no "not by an agent". Changing them means a marker bump and the downgrade machinery, so it is a separate decision.
4. **`internal/cli` runs 585s here and 667s on untouched `dev`** — over Go's default 10m test timeout. CI uses `make test` with no `-timeout`, so `dev` today is ~11% from red on slower hardware.