### PR TITLE
fix(migrate): preserve before destroying — closes #350

### DIFF
--- a/docs/decisions-branches/fix__migrate-ordering.md
+++ b/docs/decisions-branches/fix__migrate-ordering.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-24 13:39 - agents migrate: preserve before destroying, and hoist every refusal ahead of the first write
+
+**Reasoning:** MigrateToAgentsMD stubbed each per-tool file inside the loop and wrote AGENTS.md afterwards, so the user's content existed only in an in-memory slice that the error return discarded. Reproduced: two files carrying user conventions, AGENTS.md a symlink so the final write refuses — exit 1, both sources overwritten with the stub, the content in neither place. The control is what makes it an ordering defect rather than a design one: where the final write succeeds the migration is correct, moving the content into AGENTS.md and stubbing the source. It is the one command whose whole job is moving a user's words, and its failure mode destroyed exactly those words.
+
+**Alternatives considered:** Stage every write and commit atomically — rejected; N renames is still N renames, so it moves the window rather than closing it, and leaves temp litter on failure. Pre-flight RefuseSymlink on AGENTS.md — written, then deleted: it duplicated the check inside atomicio.WriteFile with no observable difference, no mutant could kill it, and it read as though the invariant rested on it when it did not.
+
+**Implications:**
+- Three phases now: PLAN reads, refuses and classifies while writing nothing; PRESERVE writes AGENTS.md; STUB replaces the sources. The invariant is carried by the ordering rather than by a check, so nothing has to predict a full disk or a link planted mid-window — every PRESERVE failure happens while the sources are intact, and every STUB failure happens after AGENTS.md already holds the content. Two other late guards were hoisted: the per-source symlink refusal fired inside each file's own stub write, so a link on the fourth file was found after three had already been consolidated, and a link made ReadRedirectOwner classify some other file's bytes. An unreadable source now aborts the whole run instead of silently continuing — half a consolidation with no record of which half is worse than fix-it-and-re-run. Residual, documented rather than emergent: a STUB failure after PRESERVE leaves duplication, never loss. Verified by me: both sources sha256-identical after the refusal, and the happy path still moves content into AGENTS.md and leaves none behind.
+
+---
+

--- a/docs/decisions-branches/fix__migrate-ordering.md
+++ b/docs/decisions-branches/fix__migrate-ordering.md
@@ -1,5 +1,9 @@
 ← back to [docs/timeline.md](../timeline.md)
 
+<!-- logmind-entry-start: 2026-08-24-migrate-move-the-symlink-refusal-below-the-stub-foreign-clas -->
+- **2026-08-24** — migrate: move the symlink refusal below the stub/foreign classification, so a source logmind never intended to write no longer aborts the whole migration
+<!-- logmind-entry-end -->
+
 ## 2026-08-24 13:39 - agents migrate: preserve before destroying, and hoist every refusal ahead of the first write
 
 **Reasoning:** MigrateToAgentsMD stubbed each per-tool file inside the loop and wrote AGENTS.md afterwards, so the user's content existed only in an in-memory slice that the error return discarded. Reproduced: two files carrying user conventions, AGENTS.md a symlink so the final write refuses — exit 1, both sources overwritten with the stub, the content in neither place. The control is what makes it an ordering defect rather than a design one: where the final write succeeds the migration is correct, moving the content into AGENTS.md and stubbing the source. It is the one command whose whole job is moving a user's words, and its failure mode destroyed exactly those words.
@@ -8,6 +12,17 @@
 
 **Implications:**
 - Three phases now: PLAN reads, refuses and classifies while writing nothing; PRESERVE writes AGENTS.md; STUB replaces the sources. The invariant is carried by the ordering rather than by a check, so nothing has to predict a full disk or a link planted mid-window — every PRESERVE failure happens while the sources are intact, and every STUB failure happens after AGENTS.md already holds the content. Two other late guards were hoisted: the per-source symlink refusal fired inside each file's own stub write, so a link on the fourth file was found after three had already been consolidated, and a link made ReadRedirectOwner classify some other file's bytes. An unreadable source now aborts the whole run instead of silently continuing — half a consolidation with no record of which half is worse than fix-it-and-re-run. Residual, documented rather than emergent: a STUB failure after PRESERVE leaves duplication, never loss. Verified by me: both sources sha256-identical after the refusal, and the happy path still moves content into AGENTS.md and leaves none behind.
+
+---
+
+## 2026-08-24 14:44 - migrate: move the symlink refusal below the stub/foreign classification, so a source logmind never intended to write no longer aborts the whole migration
+
+**Reasoning:** The panel confirmed a regression: RefuseSymlink ran before IsStub and MarkerForeign, both of which 'continue' without ever adding the path to planned. So a symlinked source that was already a stub, or carried another tool's marker, turned two soft outcomes into a hard abort — measured exit 0 to 1 with the sentinel count going 1 to 0. The guard's own comment stated the principle it violated: a run that intends no write there has nothing to refuse. The call now sits immediately before planned=append, still inside phase 1 and still ahead of every write.
+
+**Alternatives considered:** Classify symlinks as their own case, or defer the refusal to phase 3. Rejected both: phase 3 already has an independent atomicio.WriteFile guard, so deferring would duplicate it and widen the window, and a separate symlink class adds a fourth state to a three-state classification that is already correct — the bug was ordering, not vocabulary.
+
+**Implications:**
+- Honest limit on the mutation evidence, reported by the lane rather than papered over: the two new tests kill the hoist-it-back mutant but NOT the delete-it-entirely mutant, because a test asserting 'a non-write-intended symlink succeeds' cannot by construction distinguish a correct gate from no gate. The delete mutant is killed by the pre-existing TestMigrateToAgentsMD_SymlinkedSourceLeavesEarlierSourcesIntact. The suite as a whole kills both; the two new tests alone kill one.
 
 ---
 

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -1429,13 +1429,60 @@ func UpdateWorkflowPin(content, newVersion string) (string, string) {
 //
 // Mirrors migrate_to_agents_md(root_path).
 //
+// # ORDER IS THE SAFETY PROPERTY (#350)
+//
+// This is the one command whose job is to MOVE the user's own words rather
+// than to add logmind's, so the single unrecoverable outcome is a source
+// stubbed while its content exists nowhere else. That used to be reachable:
+// the stub write ran inside the loop and the AGENTS.md write ran after it,
+// with the collected content living only in a slice the error return
+// discarded. A symlinked AGENTS.md — where the guard fires, correctly, at
+// the append write — left two per-tool files holding the stub and the user's
+// paragraphs in neither place.
+//
+// The three phases below are separate, and MUST stay in this order:
+//
+//  1. PLAN     — read, refuse and classify every source. Writes nothing.
+//  2. PRESERVE — write AGENTS.md. Every source still holds its own bytes.
+//  3. STUB     — only now replace the sources.
+//
+// EVERY REFUSAL RUNS BEFORE THE FIRST SOURCE IS TOUCHED, which is what the
+// old shape got wrong — not the refusals themselves, whose messages are
+// good. A per-tool file's symlink refusal moved up into phase 1 (it used to
+// live in that file's own stub write, so a link on the fourth file was found
+// after three had been consolidated); AGENTS.md's symlink refusal and its
+// read both sit in phase 2, ahead of all of phase 3.
+//
+// But the invariant is carried by the ORDER, not by any of those checks. A
+// check that a path is writable is stale the moment it returns, and nothing
+// here can predict a full disk, a mode change, or a link planted in the
+// window between the check and the write — none of it has to. Every phase-2
+// failure, predicted or not, happens while the sources are intact, and every
+// phase-3 failure happens after AGENTS.md already holds the content. The
+// user's words exist in at least one place at every instant. The checks buy
+// a better error, not the invariant.
+//
+// ALL OR NOTHING. A source that cannot be read aborts the whole migration
+// (phase 1) rather than being skipped. It costs nothing — nothing has been
+// written yet — and half a consolidation, with no record of which half
+// moved, is a worse thing to hand back than "fix .cursorrules and re-run".
+// The skip-and-carry-on this replaced was never a policy; it was the only
+// move available once the loop had already started destroying things.
+//
+// What phase 3 can still leave behind is DUPLICATION, never loss: content in
+// AGENTS.md AND in a source that failed to stub. That is legible from the
+// error and fixable by hand; what it replaces is not.
+//
 // Returns a list of human-readable status messages — the caller
 // prints them to stdout. Returning a slice (rather than a stream)
 // matches Python's accumulator pattern; the migrate command renders
-// the slice line-by-line. The second return is EnsureAgentsMD's refusal
-// (#267): migrate still consolidates the per-agent files, but the caller
-// must say that AGENTS.md's own block was left alone. The third is the set of
-// files this run declined to claim (#336) — see the loop for which.
+// the slice line-by-line. They are composed in phase 1, so they are
+// INTENTIONS until every phase has run: on any error the slice comes back
+// nil rather than describing writes that may not have happened. The second
+// return is EnsureAgentsMD's refusal (#267): migrate still consolidates the
+// per-agent files, but the caller must say that AGENTS.md's own block was
+// left alone. The third is the set of files this run declined to claim
+// (#336) — see the plan loop for which.
 func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []RedirectRefusal, error) {
 	var messages []string
 	var refusals []RedirectRefusal
@@ -1445,7 +1492,9 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []Redire
 	}
 	agentsPath := filepath.Join(repoRoot, agentsMDName)
 	var appendedBlocks []string
+	var planned []plannedStub
 
+	// ---- PHASE 1: PLAN. Reads and refusals only; nothing is written. ----
 	for _, a := range agents.All() {
 		if a.Name == "codex" || a.IsJSON {
 			continue
@@ -1454,9 +1503,26 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []Redire
 		if !fileExists(filePath) {
 			continue
 		}
+		// Refuse a symlink BEFORE the read, for the reason CreateAgentFile
+		// gives at its own copy of this line: the ownership verdict below is
+		// made from the file's bytes, os.ReadFile resolves the final
+		// component, and a link pointing outside the repository has some
+		// other file answering "whose content is .cursorrules?". It stays
+		// AFTER fileExists, which os.Stat's its way through the link: a
+		// DANGLING link has nothing to consolidate and nothing to stub, so
+		// this run intends no write there and has nothing to refuse.
+		if err := atomicio.RefuseSymlink(filePath); err != nil {
+			return nil, declined, refusals, err
+		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			continue
+			// ALL OR NOTHING — see the doc comment. fileExists just said this
+			// path is there, so a read failure is a real fault (mode, I/O, a
+			// concurrent unlink), not an absence, and consolidating the other
+			// files around it would silently migrate some of the user's
+			// instructions and leave the rest.
+			return nil, declined, refusals, fmt.Errorf("cannot migrate %s: %w",
+				filepath.Base(filePath), err)
 		}
 		content := string(data)
 		if IsStub(content) {
@@ -1485,34 +1551,68 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []Redire
 				fmt.Sprintf("✓ Migrated %s (%s) content into AGENTS.md",
 					a.Display, filepath.Base(filePath)))
 		}
-
-		// filePath resolved and read successfully above (fileExists +
-		// os.ReadFile both followed it), so this is a per-agent artifact the
-		// user owns, potentially reached through a symlink — atomicio.WriteFile
-		// over the bare os.WriteFile this replaced so a symlinked CLAUDE.md /
-		// .cursorrules / etc. is refused (atomicio.RefuseSymlink, #300) instead
-		// of silently written through.
-		if err := atomicio.WriteFile(filePath, []byte(templates.Stub()), 0o644); err != nil {
-			return messages, declined, refusals, err
-		}
+		planned = append(planned, plannedStub{path: filePath})
 		messages = append(messages,
 			fmt.Sprintf("✓ %s replaced with stub", filepath.Base(filePath)))
 	}
 
+	// ---- PHASE 2: PRESERVE. The sources are all still intact here. ----
+	//
+	// AGENTS.md's own refusals are NOT hoisted above this block, and there is
+	// no pre-flight atomicio.RefuseSymlink(agentsPath) here on purpose: the
+	// refusal inside migrateWrite already runs before the first source is
+	// touched, because this phase does, and a second copy of the check a few
+	// lines earlier would be unobservable — same error, same untouched tree —
+	// while reading as though the invariant rested on it. It rests on the
+	// order. Note also that this whole phase is skipped when there is nothing
+	// to consolidate, so a repo that is already migrated stays a no-op rather
+	// than acquiring a new reason to fail.
 	if len(appendedBlocks) > 0 {
 		existing, err := os.ReadFile(agentsPath)
 		if err != nil {
-			return messages, declined, refusals, err
+			return nil, declined, refusals, err
 		}
 		// Match Python: existing.rstrip() + "\n\n" + "\n".join(appended).
 		body := strings.TrimRight(string(existing), " \t\n\r") +
 			"\n\n" + strings.Join(appendedBlocks, "\n")
-		if err := atomicio.WriteFile(agentsPath, []byte(body), 0o644); err != nil {
-			return messages, declined, refusals, err
+		if err := migrateWrite(agentsPath, []byte(body), 0o644); err != nil {
+			return nil, declined, refusals, err
+		}
+	}
+
+	// ---- PHASE 3: STUB. Destructive, and reached only once AGENTS.md
+	// holds every byte phase 1 collected. ----
+	for _, p := range planned {
+		// The path resolved and read cleanly in phase 1, which also refused a
+		// symlink at it, so this is a per-agent artifact the user owns —
+		// written through atomicio (over the bare os.WriteFile this replaced)
+		// so a link planted in the window since is refused, #300, rather than
+		// silently written through.
+		if err := migrateWrite(p.path, []byte(templates.Stub()), 0o644); err != nil {
+			return nil, declined, refusals, err
 		}
 	}
 	return messages, declined, refusals, nil
 }
+
+// plannedStub is one per-agent file phase 1 decided to replace with the
+// stub. A named type rather than a bare []string because the plan is the
+// thing phase 3 is not allowed to re-derive: re-walking agents.All() there
+// would re-read the sources and could act on a set phase 1 never approved.
+type plannedStub struct {
+	path string
+}
+
+// migrateWrite is atomicio.WriteFile, held as a package-level var so
+// MigrateToAgentsMD's ordering invariant can be tested against the failures
+// no pre-check can predict — a full disk, a mode change since the plan
+// phase read the file. Those are exactly the cases where the invariant has to come from
+// the ORDER rather than from the refusal, and the symlink case (which a
+// pre-check CAN see) cannot stand in for them. Same seam, and the same
+// reason, as internal/skill/sync.go's atomicWriteFile and atomicio's own
+// syncFile. Other write sites in this package call atomicio.WriteFile
+// directly; only migrate needs the injectable failure.
+var migrateWrite func(path string, data []byte, perm os.FileMode) error = atomicio.WriteFile
 
 // fileExists returns true when path refers to an existing regular
 // file or symlink target. Errors other than ErrNotExist are treated

--- a/internal/inserter/inserter.go
+++ b/internal/inserter/inserter.go
@@ -1442,7 +1442,7 @@ func UpdateWorkflowPin(content, newVersion string) (string, string) {
 //
 // The three phases below are separate, and MUST stay in this order:
 //
-//  1. PLAN     — read, refuse and classify every source. Writes nothing.
+//  1. PLAN     — read, classify and refuse every source. Writes nothing.
 //  2. PRESERVE — write AGENTS.md. Every source still holds its own bytes.
 //  3. STUB     — only now replace the sources.
 //
@@ -1450,8 +1450,12 @@ func UpdateWorkflowPin(content, newVersion string) (string, string) {
 // old shape got wrong — not the refusals themselves, whose messages are
 // good. A per-tool file's symlink refusal moved up into phase 1 (it used to
 // live in that file's own stub write, so a link on the fourth file was found
-// after three had been consolidated); AGENTS.md's symlink refusal and its
-// read both sit in phase 2, ahead of all of phase 3.
+// after three had been consolidated) — but only after this run has decided,
+// via the classification right above it, that the file is one phase 3 will
+// actually replace: a symlink to an already-migrated stub, or to a file
+// carrying another component's marker, was never going to be written and so
+// is never refused (#351). AGENTS.md's symlink refusal and its read both sit
+// in phase 2, ahead of all of phase 3.
 //
 // But the invariant is carried by the ORDER, not by any of those checks. A
 // check that a path is writable is stale the moment it returns, and nothing
@@ -1503,17 +1507,6 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []Redire
 		if !fileExists(filePath) {
 			continue
 		}
-		// Refuse a symlink BEFORE the read, for the reason CreateAgentFile
-		// gives at its own copy of this line: the ownership verdict below is
-		// made from the file's bytes, os.ReadFile resolves the final
-		// component, and a link pointing outside the repository has some
-		// other file answering "whose content is .cursorrules?". It stays
-		// AFTER fileExists, which os.Stat's its way through the link: a
-		// DANGLING link has nothing to consolidate and nothing to stub, so
-		// this run intends no write there and has nothing to refuse.
-		if err := atomicio.RefuseSymlink(filePath); err != nil {
-			return nil, declined, refusals, err
-		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			// ALL OR NOTHING — see the doc comment. fileExists just said this
@@ -1550,6 +1543,23 @@ func MigrateToAgentsMD(repoRoot string) ([]string, *AgentsBlockRefusal, []Redire
 			messages = append(messages,
 				fmt.Sprintf("✓ Migrated %s (%s) content into AGENTS.md",
 					a.Display, filepath.Base(filePath)))
+		}
+		// Refuse a symlink HERE, not ahead of the classification above: this
+		// run has now decided the file is neither an already-migrated stub
+		// nor another component's marked file, so it is one of the sources
+		// phase 3 is actually going to replace. Checking any earlier — the
+		// shape this replaced — asked "is this a symlink" before asking "was
+		// this run ever going to write here", and refused a link the two
+		// classifications above would themselves have skipped or left alone
+		// (a stub with nothing left to consolidate, a foreign file this
+		// command declines on purpose). The reason for refusing at all is
+		// still CreateAgentFile's: the ownership verdict just above is made
+		// from the file's bytes, os.ReadFile resolves the final component,
+		// and a link pointing outside the repository has some other file
+		// answering "whose content is .cursorrules?" — but that question
+		// only needs answering for a path this run is actually about to stub.
+		if err := atomicio.RefuseSymlink(filePath); err != nil {
+			return nil, declined, refusals, err
 		}
 		planned = append(planned, plannedStub{path: filePath})
 		messages = append(messages,

--- a/internal/inserter/migrate_ordering_test.go
+++ b/internal/inserter/migrate_ordering_test.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
 )
 
 // errInjected stands in for the failures no pre-check can predict: a full
@@ -264,6 +266,90 @@ func TestMigrateToAgentsMD_SymlinkedSourceLeavesEarlierSourcesIntact(t *testing.
 	if got := readAgentFile(t, dir, "AGENTS.md"); got != before["AGENTS.md"] {
 		t.Errorf("AGENTS.md was written by an aborted migration:\n got: %q\nwant: %q",
 			got, before["AGENTS.md"])
+	}
+}
+
+// TestMigrateToAgentsMD_SymlinkedAlreadyStubbedSourceDoesNotAbort is
+// logmind#351's first regression. #350 hoisted the per-tool symlink refusal
+// into phase 1, correctly, but ahead of the IsStub classification a few
+// lines below it — so a source this run was never going to write (a symlink
+// to a file that already carries logmind's own stub marker) was refused
+// anyway, turning a soft "nothing to do here" into a hard abort of the
+// WHOLE migration. .clinerules here is a symlink; that must not matter,
+// because logmind never intended to touch it.
+func TestMigrateToAgentsMD_SymlinkedAlreadyStubbedSourceDoesNotAbort(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	dir, _ := seedMigrateRepo(t)
+	stubTarget := filepath.Join(t.TempDir(), "already-a-stub.md")
+	writeAgentFile(t, filepath.Dir(stubTarget), filepath.Base(stubTarget), templates.Stub())
+	clinePath := filepath.Join(dir, ".clinerules")
+	if err := os.Symlink(stubTarget, clinePath); err != nil {
+		t.Fatalf("plant symlink to an already-stubbed file: %v", err)
+	}
+
+	_, _, refused, err := MigrateToAgentsMD(dir)
+
+	if err != nil {
+		t.Fatalf("MigrateToAgentsMD errored on a symlink to an already-migrated stub: %v", err)
+	}
+	if len(refused) != 0 {
+		t.Errorf("refused = %+v; a stub was never going to be written, so there is nothing to refuse", refused)
+	}
+	// The rest of the run must still have happened — this is not "migrate
+	// stopped doing anything", it is "one file was rightly left alone".
+	assertMigrated(t, dir)
+	// The symlink itself, and what it points at, are untouched: nothing
+	// here decided to write there, so nothing should have moved it.
+	if fi, lerr := os.Lstat(clinePath); lerr != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf(".clinerules is no longer the planted symlink: %v (mode %v)", lerr, fi.Mode())
+	}
+	if got := readAgentFile(t, filepath.Dir(stubTarget), filepath.Base(stubTarget)); got != templates.Stub() {
+		t.Errorf("the symlink's target changed: %q", got)
+	}
+}
+
+// TestMigrateToAgentsMD_SymlinkedForeignMarkerSourceDoesNotAbort is
+// logmind#351's second regression, same root cause as the test above:
+// .clinerules is a symlink to a file carrying ANOTHER component's marker
+// (protocol#77 row 2, #336's soft decline). Before #350's reordering this
+// noted the file was left alone and migrated everything else, exit 0. The
+// hoisted refusal ran before that classification ever got a chance to say
+// "this isn't ours to write", so it turned the soft decline into a hard
+// abort — the panel's second confirmed failure.
+func TestMigrateToAgentsMD_SymlinkedForeignMarkerSourceDoesNotAbort(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	dir, _ := seedMigrateRepo(t)
+	const foreign = "<!-- skdd-stub: instructions live in AGENTS.md -->\nFOREIGN_SENTINEL\n"
+	foreignTarget := filepath.Join(t.TempDir(), "foreign-marker.md")
+	writeAgentFile(t, filepath.Dir(foreignTarget), filepath.Base(foreignTarget), foreign)
+	clinePath := filepath.Join(dir, ".clinerules")
+	if err := os.Symlink(foreignTarget, clinePath); err != nil {
+		t.Fatalf("plant symlink to a foreign-marked file: %v", err)
+	}
+
+	_, _, refused, err := MigrateToAgentsMD(dir)
+
+	if err != nil {
+		t.Fatalf("MigrateToAgentsMD errored on a symlink to another component's file: %v", err)
+	}
+	if len(refused) != 1 || refused[0].Path != ".clinerules" || refused[0].Ownership != MarkerForeign {
+		t.Fatalf("refused = %+v; want exactly one MarkerForeign refusal for .clinerules", refused)
+	}
+	// The rest of the run must still have happened.
+	assertMigrated(t, dir)
+	agentsBody := readAgentFile(t, dir, "AGENTS.md")
+	if strings.Contains(agentsBody, "FOREIGN_SENTINEL") {
+		t.Error("another component's entry, reached only through the symlink, was folded into AGENTS.md")
+	}
+	// The symlink and its target are untouched — this run declined to claim
+	// the file, and a decline must not stub over the link.
+	if fi, lerr := os.Lstat(clinePath); lerr != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf(".clinerules is no longer the planted symlink: %v (mode %v)", lerr, fi.Mode())
+	}
+	if got := readAgentFile(t, filepath.Dir(foreignTarget), filepath.Base(foreignTarget)); got != foreign {
+		t.Errorf("the symlink's target changed: %q", got)
 	}
 }
 

--- a/internal/inserter/migrate_ordering_test.go
+++ b/internal/inserter/migrate_ordering_test.go
@@ -1,0 +1,294 @@
+// migrate_ordering_test.go — logmind#350. `agents migrate` is the one
+// command that MOVES the user's own words instead of adding logmind's, and
+// it used to do the destructive half first: stub each source inside the
+// loop, write the collected content into AGENTS.md afterwards, with the
+// collection living only in a slice the error return threw away. A symlinked
+// AGENTS.md (the guard fires there, correctly, at the append write) left two
+// per-tool files holding the stub and the user's paragraphs in NEITHER place.
+//
+// Every test here asserts the ordering invariant at the level the user feels
+// it: after a failure, is the sentence I wrote still on disk somewhere. Each
+// one carries its own CONTROL — the same repo migrated without the injected
+// failure — because "the source is byte-identical" is also what a migration
+// that silently stopped doing anything would report.
+package inserter
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// errInjected stands in for the failures no pre-check can predict: a full
+// disk, a read-only mount, a mode change between the check and the write.
+// The symlink case CAN be pre-checked and is covered separately — it cannot
+// stand in for this one, because a fix that only hoisted the symlink guard
+// would pass there and still lose content here.
+var errInjected = errors.New("simulated: no space left on device")
+
+// failMigrateWriteOn swaps in a writer that fails for exactly one path and
+// delegates every other path to the real primitive, so the run reaches the
+// injected failure through ordinary behaviour rather than being short-
+// circuited wholesale. Restored on cleanup; these tests must not run in
+// parallel with each other, and none of them calls t.Parallel.
+func failMigrateWriteOn(t *testing.T, target string) {
+	t.Helper()
+	previous := migrateWrite
+	migrateWrite = func(path string, data []byte, perm os.FileMode) error {
+		if path == target {
+			return errInjected
+		}
+		return previous(path, data, perm)
+	}
+	t.Cleanup(func() { migrateWrite = previous })
+}
+
+// migrateSources is the repro from #350, widened: sentinels the assertions
+// can count, spread across five registry rows so "the third of five failed"
+// has a middle to fail in. Loop order is agents.All()'s: claude, cursor,
+// copilot, windsurf, aider.
+var migrateSources = []struct{ rel, body string }{
+	{"CLAUDE.md", "# mine\n\nMY_CLAUDE_CONVENTIONS\n"},
+	{".cursorrules", "# mine\n\nMY_CURSOR_CONVENTIONS\n"},
+	{".github/copilot-instructions.md", "MY_COPILOT_NOTES\n"},
+	{".windsurfrules", "MY_WINDSURF_NOTES\n"},
+	{"CONVENTIONS.md", "MY_AIDER_NOTES\n"},
+}
+
+// seedMigrateRepo writes a current AGENTS.md (so the EnsureAgentsMD call at
+// the top of MigrateToAgentsMD no-ops rather than erroring for an unrelated
+// reason) plus every source, and returns the exact bytes of each path so a
+// later comparison is against what was really on disk.
+func seedMigrateRepo(t *testing.T) (dir string, before map[string]string) {
+	t.Helper()
+	dir = t.TempDir()
+	writeAgentFile(t, dir, "AGENTS.md", agentsMDTemplate())
+	before = map[string]string{"AGENTS.md": agentsMDTemplate()}
+	for _, s := range migrateSources {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, s.rel)), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", s.rel, err)
+		}
+		writeAgentFile(t, dir, s.rel, s.body)
+		before[s.rel] = s.body
+	}
+	return dir, before
+}
+
+// assertSourcesUnchanged is the assertion the issue is about: not "the file
+// still exists", not "it still mentions the sentinel" — byte-identical to
+// what was there before the command ran.
+func assertSourcesUnchanged(t *testing.T, dir string, before map[string]string) {
+	t.Helper()
+	for _, s := range migrateSources {
+		if got := readAgentFile(t, dir, s.rel); got != before[s.rel] {
+			t.Errorf("%s was modified by a failed migration:\n got: %q\nwant: %q",
+				s.rel, got, before[s.rel])
+		}
+	}
+}
+
+// assertMigrated is the CONTROL every failure assertion above is measured
+// against: on a clean run each sentinel moves — once — into AGENTS.md and
+// leaves its source a stub. Without this, "stop migrating entirely" would
+// satisfy every other test in this file.
+func assertMigrated(t *testing.T, dir string) {
+	t.Helper()
+	agentsBody := readAgentFile(t, dir, "AGENTS.md")
+	for _, s := range migrateSources {
+		sentinel := strings.TrimSpace(strings.TrimPrefix(s.body, "# mine\n\n"))
+		if n := strings.Count(agentsBody, sentinel); n != 1 {
+			t.Errorf("AGENTS.md contains %s %d times; want exactly 1", sentinel, n)
+		}
+		got := readAgentFile(t, dir, s.rel)
+		if strings.Contains(got, sentinel) {
+			t.Errorf("%s still holds %s after a successful migration: %q", s.rel, sentinel, got)
+		}
+		if !IsStub(got) {
+			t.Errorf("%s is not a stub after a successful migration: %q", s.rel, got)
+		}
+	}
+}
+
+// TestMigrateToAgentsMD_FinalWriteFails_SourcesByteIdentical is the mutation
+// target: the preserving write fails for a reason nothing could have checked
+// for, and every source must still hold its own bytes. Moving the stub write
+// back ahead of the AGENTS.md write turns this red on all five files.
+func TestMigrateToAgentsMD_FinalWriteFails_SourcesByteIdentical(t *testing.T) {
+	dir, before := seedMigrateRepo(t)
+	failMigrateWriteOn(t, filepath.Join(dir, agentsMDName))
+
+	_, _, _, err := MigrateToAgentsMD(dir)
+
+	if !errors.Is(err, errInjected) {
+		t.Fatalf("MigrateToAgentsMD err = %v; want the injected write failure", err)
+	}
+	assertSourcesUnchanged(t, dir, before)
+	if got := readAgentFile(t, dir, "AGENTS.md"); got != before["AGENTS.md"] {
+		t.Errorf("AGENTS.md changed despite the write failing:\n got: %q\nwant: %q",
+			got, before["AGENTS.md"])
+	}
+}
+
+// TestMigrateToAgentsMD_HappyPathStillMigrates is the control for the test
+// above, run against the same seed with nothing injected. It is what makes
+// "byte-identical" evidence of an ordering fix rather than of a migration
+// that stopped working.
+func TestMigrateToAgentsMD_HappyPathStillMigrates(t *testing.T) {
+	dir, _ := seedMigrateRepo(t)
+
+	msgs, _, refused, err := MigrateToAgentsMD(dir)
+
+	if err != nil {
+		t.Fatalf("MigrateToAgentsMD: %v", err)
+	}
+	if len(refused) != 0 {
+		t.Errorf("refused = %+v; want none on the happy path", refused)
+	}
+	assertMigrated(t, dir)
+	// Both messages per source, and the stub line still follows its own
+	// migrated line — the phases moved, the reported order did not.
+	want := []string{
+		"✓ Migrated Claude Code (CLAUDE.md) content into AGENTS.md",
+		"✓ CLAUDE.md replaced with stub",
+		"✓ Migrated Cursor (.cursorrules) content into AGENTS.md",
+		"✓ .cursorrules replaced with stub",
+	}
+	joined := strings.Join(msgs, "\n")
+	if !strings.Contains(joined, strings.Join(want, "\n")) {
+		t.Errorf("message order changed:\ngot:\n%s\nwant it to contain:\n%s",
+			joined, strings.Join(want, "\n"))
+	}
+}
+
+// TestMigrateToAgentsMD_UnreadableSourceAbortsWholeMigration is the
+// all-or-nothing ruling, pinned. The THIRD of five sources cannot be read;
+// the first two must not have been consolidated, because a tree where half
+// the instructions moved and nothing says which half is worse to hand back
+// than a refusal naming the file.
+func TestMigrateToAgentsMD_UnreadableSourceAbortsWholeMigration(t *testing.T) {
+	dir, before := seedMigrateRepo(t)
+	third := filepath.Join(dir, filepath.FromSlash(migrateSources[2].rel))
+	if err := os.Chmod(third, 0o000); err != nil {
+		t.Fatalf("chmod third source: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(third, 0o644) })
+	// CONTROL: root ignores the mode, and the test would then be asserting
+	// on a successful migration. Prove the read really fails first.
+	if _, err := os.ReadFile(third); err == nil {
+		t.Skip("this user can read a 0000 file (root?); the read failure cannot be staged")
+	}
+
+	_, _, _, err := MigrateToAgentsMD(dir)
+
+	if err == nil {
+		t.Fatal("MigrateToAgentsMD succeeded with an unreadable source")
+	}
+	if !strings.Contains(err.Error(), "copilot-instructions.md") {
+		t.Errorf("error does not name the file that stopped the migration: %v", err)
+	}
+	if err := os.Chmod(third, 0o644); err != nil {
+		t.Fatalf("restore mode for comparison: %v", err)
+	}
+	assertSourcesUnchanged(t, dir, before)
+	if got := readAgentFile(t, dir, "AGENTS.md"); got != before["AGENTS.md"] {
+		t.Errorf("AGENTS.md was written by an aborted migration:\n got: %q\nwant: %q",
+			got, before["AGENTS.md"])
+	}
+}
+
+// TestMigrateToAgentsMD_SymlinkedAGENTSMD_LeavesSourcesIntact is the
+// reproduction from the issue, asserted where the harm was: not on the
+// symlink's target (symlink_write_test.go already covers that) but on the
+// per-tool files, which the old ordering stubbed on the way to a refusal.
+func TestMigrateToAgentsMD_SymlinkedAGENTSMD_LeavesSourcesIntact(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	dir, before := seedMigrateRepo(t)
+	// Re-point AGENTS.md at a real, already-current file outside the repo,
+	// so EnsureAgentsMD no-ops and the refusal comes from the append write.
+	realAgents := filepath.Join(t.TempDir(), "agents-real.md")
+	writeAgentFile(t, filepath.Dir(realAgents), filepath.Base(realAgents), agentsMDTemplate())
+	if err := os.Remove(filepath.Join(dir, agentsMDName)); err != nil {
+		t.Fatalf("remove seeded AGENTS.md: %v", err)
+	}
+	if err := os.Symlink(realAgents, filepath.Join(dir, agentsMDName)); err != nil {
+		t.Fatalf("plant AGENTS.md symlink: %v", err)
+	}
+
+	_, _, _, err := MigrateToAgentsMD(dir)
+
+	if err == nil {
+		t.Fatal("MigrateToAgentsMD did not error on a symlinked AGENTS.md")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	assertSourcesUnchanged(t, dir, before)
+	if got, rerr := os.ReadFile(realAgents); rerr != nil || string(got) != agentsMDTemplate() {
+		t.Errorf("the symlink's target changed: %q (err %v)", got, rerr)
+	}
+}
+
+// TestMigrateToAgentsMD_SymlinkedSourceLeavesEarlierSourcesIntact covers the
+// other late guard on this path. The refusal for a symlinked per-tool file
+// used to live in its own stub write, halfway through the loop — so a link
+// on the FOURTH file was found after the first three had been consolidated.
+// Hoisting it into the plan phase is what makes the abort all-or-nothing.
+func TestMigrateToAgentsMD_SymlinkedSourceLeavesEarlierSourcesIntact(t *testing.T) {
+	skipSymlinkTestsOnWindows(t)
+
+	dir, before := seedMigrateRepo(t)
+	linked := filepath.Join(dir, filepath.FromSlash(migrateSources[3].rel))
+	outside := filepath.Join(t.TempDir(), "real-windsurfrules")
+	const outsideBody = "USER_SENTINEL_OUTSIDE_THE_REPO\n"
+	writeAgentFile(t, filepath.Dir(outside), filepath.Base(outside), outsideBody)
+	if err := os.Remove(linked); err != nil {
+		t.Fatalf("remove seeded source: %v", err)
+	}
+	if err := os.Symlink(outside, linked); err != nil {
+		t.Fatalf("plant source symlink: %v", err)
+	}
+	before[migrateSources[3].rel] = outsideBody // read through the link
+
+	_, _, _, err := MigrateToAgentsMD(dir)
+
+	if err == nil {
+		t.Fatal("MigrateToAgentsMD did not error on a symlinked per-tool file")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error does not name the actual cause (symlink): %v", err)
+	}
+	assertSourcesUnchanged(t, dir, before)
+	if got := readAgentFile(t, dir, "AGENTS.md"); got != before["AGENTS.md"] {
+		t.Errorf("AGENTS.md was written by an aborted migration:\n got: %q\nwant: %q",
+			got, before["AGENTS.md"])
+	}
+}
+
+// TestMigrateToAgentsMD_StubWriteFailsAfterPreserve_ContentSurvives states
+// the remaining failure mode out loud rather than leaving it emergent. Once
+// AGENTS.md holds the content, a source that will not take the stub leaves
+// the user's words in TWO places. That is duplication, and it is the price
+// of the ordering: the same failure under the old ordering left them in
+// none.
+func TestMigrateToAgentsMD_StubWriteFailsAfterPreserve_ContentSurvives(t *testing.T) {
+	dir, before := seedMigrateRepo(t)
+	stubborn := filepath.Join(dir, filepath.FromSlash(migrateSources[1].rel))
+	failMigrateWriteOn(t, stubborn)
+
+	_, _, _, err := MigrateToAgentsMD(dir)
+
+	if !errors.Is(err, errInjected) {
+		t.Fatalf("MigrateToAgentsMD err = %v; want the injected write failure", err)
+	}
+	agentsBody := readAgentFile(t, dir, "AGENTS.md")
+	if !strings.Contains(agentsBody, "MY_CURSOR_CONVENTIONS") {
+		t.Errorf("the preserving write did not run before the stub write; AGENTS.md: %q", agentsBody)
+	}
+	if got := readAgentFile(t, dir, migrateSources[1].rel); got != before[migrateSources[1].rel] {
+		t.Errorf("the source that refused the stub was modified anyway:\n got: %q\nwant: %q",
+			got, before[migrateSources[1].rel])
+	}
+}

--- a/internal/inserter/symlink_write_test.go
+++ b/internal/inserter/symlink_write_test.go
@@ -233,6 +233,14 @@ func TestRefreshMarkerBlockFile_RefusesSymlinkedTarget(t *testing.T) {
 // EnsureAgentsMD(repoRoot) call no-ops (no diff to refresh) rather than
 // erroring for an unrelated reason — the append write further down is what
 // this test exercises.
+//
+// SCOPE, because this test was green throughout #350: it asserts the link's
+// TARGET was not written through, and that is all it ever asserted. The
+// .cursorrules it seeds was being stubbed on the way to this refusal, and
+// nothing here looked. What happens to the SOURCES when this write refuses
+// is owned by TestMigrateToAgentsMD_SymlinkedAGENTSMD_LeavesSourcesIntact in
+// migrate_ordering_test.go — do not re-assert it here, but do not read this
+// test as covering it either.
 func TestMigrateToAgentsMD_RefusesSymlinkedAGENTSMD(t *testing.T) {
 	skipSymlinkTestsOnWindows(t)
 


### PR DESCRIPTION
Closes #350. Data loss on an error path, found by the release-candidate panel and reproduced by the orchestrator.

## The defect

`MigrateToAgentsMD` stubbed each per-tool file **inside the loop** and wrote `AGENTS.md` **after**. The user's content existed only in an in-memory slice, which the error return discarded.

```
before:  .cursorrules 54b ("MY CURSOR CONVENTIONS"), .windsurfrules 46b ("MY WINDSURF NOTES")
$ logmind agents migrate          # AGENTS.md is a symlink, so the final write refuses
Error: refusing to write …/AGENTS.md: it is a symlink to agents-real.md …   exit 1
after:   both 226b, user lines survive = 0 — content in neither place
```

**The control is what makes this an ordering defect rather than a design one:** where the final write succeeds, the migration is correct — content lands in `AGENTS.md` (1 hit) and is gone from `.cursorrules` (0). It does the right thing whenever nothing fails.

## The fix

Three phases: **PLAN** (read, refuse, classify — writes nothing) → **PRESERVE** (write `AGENTS.md`) → **STUB** (replace sources).

The invariant is carried by the **ordering**, not by a check. Nothing has to predict a full disk or a symlink planted mid-window: every PRESERVE failure happens while the sources are intact, every STUB failure happens after `AGENTS.md` already holds the content. **The words exist somewhere at every instant.**

Rejected: staging every write and committing atomically — N renames is still N renames, so it moves the window rather than closing it, and leaves temp litter on failure.

Also **deleted**: a pre-flight `RefuseSymlink(agentsPath)` the lane had written. It duplicated the check already inside `atomicio.WriteFile` with no observable difference, no mutant could kill it, and it read as though the invariant rested on it. Good judgement — an unkillable guard is a comment pretending to be code.

## Two more late guards, hoisted

- The **per-source** symlink refusal fired inside each file's own stub write, so a link on file 4 was found *after* three had been consolidated. Now in PLAN, before the read — a link also made `ReadRedirectOwner` classify some other file's bytes.
- `AGENTS.md`'s read moved ahead of all destruction by the same reordering.

## Partial mid-loop failure: all-or-nothing, stated rather than emergent

An unreadable source now aborts the whole run (`cannot migrate %s: %w`) instead of silently `continue`-ing. Free, because nothing is written yet — and half a consolidation with no record of which half is worse than "fix it and re-run".

Residual, documented: a STUB failure *after* PRESERVE leaves duplication, never loss.

## Mutations — 5, each compiling, `go build && go vet` gated

| mutant | killed by |
|---|---|
| stub before the AGENTS.md write (the shipped bug) | 3 tests |
| drop the hoisted per-source symlink refusal | `SymlinkedSourceLeavesEarlierSourcesIntact` |
| all-or-nothing → skip | `UnreadableSourceAbortsWholeMigration` |
| stop stubbing | `HappyPathStillMigrates` +3 |
| stop preserving | `FinalWriteFails…` +6 |

The first mutant's forced failure is a **generic injected write error, not the symlink** — deliberately, because a fix that only hoisted the symlink guard would pass a symlink test and still lose content.

## Verified by the orchestrator

Repro re-run against a binary built from this branch: `.cursorrules` and `.windsurfrules` both **sha256-identical** before and after the refusal, user lines intact. Control on the happy path: content in `AGENTS.md` = 1, left behind = 0.

Full suite `EXIT=0` (`internal/cli 1266s`, `internal/inserter 3.8s`), `go vet` clean, `gofmt -l` empty.

## Orchestration note, not a code finding

The lane discovered the scratchpad root is **shared across all four live lanes** — it found another lane's `mutate_b1.py` there and had its own harness executed concurrently while it was rewriting source under its own measurements. It voided that window, added an `O_EXCL` lock, re-ran everything, and proved restore by `shasum` against a private copy. That is my briefing error, not the lane's, and the other lanes have been warned.

## Found, not fixed

`docs/ai-agent-files.md:91,142` describes `migrate` but says nothing about ordering or the all-or-nothing failure policy — now user-visible behaviour and undocumented. Outside this lane's file set.