### PR TITLE
fix(gitcli): resolve the default branch from an unborn HEAD — a non-main repo now scaffolds its own branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,15 @@ A repo with no commits yet is **not** one of the three. `git symbolic-ref
 
 - Prefer table-driven tests over many one-shot functions.
 - For anything that touches branches, init with `git init -b main` so
-  the test is independent of `init.defaultBranch` config.
+  the test is independent of `init.defaultBranch` config. That alone is
+  NOT enough when the test's subject is branch-vs-default behavior (the
+  branch-summary nudge, `onNonDefaultBranch`): `git init` leaves the
+  branch unborn — no commit, no ref — and gitcli.DefaultBranch's
+  unborn-HEAD rung then answers with whatever branch gets checked out
+  next, making the checked-out feature branch its own "default" and the
+  assertion vacuous. Commit once first (`bornDefaultBranch` in
+  `internal/cli/headline_test.go`) so the default branch actually exists
+  before a feature branch is cut from it.
 - Snapshot tests live alongside the package; goldens under
   `<pkg>/testdata/*.golden`. Regenerate with `make snapshot` after a
   deliberate output change, and commit the new goldens.

--- a/docs/decisions-branches/fix__unborn-head-default-branch.md
+++ b/docs/decisions-branches/fix__unborn-head-default-branch.md
@@ -1,5 +1,9 @@
 ← back to [docs/timeline.md](../timeline.md)
 
+<!-- logmind-entry-start: 2026-08-24-gitcli-gate-the-unborn-head-rung-on-an-empty-refs-heads-and- -->
+- **2026-08-24** — gitcli: gate the unborn-HEAD rung on an empty refs/heads, and restore the nudge guard a test had silently stopped covering
+<!-- logmind-entry-end -->
+
 ## 2026-08-24 13:58 - gitcli: resolve the default branch from an unborn HEAD, so a non-main repo scaffolds its own branch
 
 **Reasoning:** DefaultBranch ran a five-step search that never read HEAD, so 'git init -b trunk' followed by 'logmind init' baked branches: [main] into both workflow triggers — byte-identical to a repo actually on main, at exit 0, with doctor reporting the repo healthy. The workflows then never fire. That is the README's own Quick Start on any repo whose default is not main or master, and logmind is meant to work standalone. The function's own doc comment claimed only a repo offering no evidence at all lands on main; an unborn repo created with -b trunk does offer evidence, and logmind reads HEAD correctly elsewhere in the same run.
@@ -8,6 +12,17 @@
 
 **Implications:**
 - The new rung sits fourth, below origin/HEAD, conventional names and single-branch, and above init.defaultBranch. Below the first three so no answer they already give can change — a remote's declared default outranks a local ref that was never pushed. Above init.defaultBranch because that key is what git init consulted to write HEAD in the first place, and -b overrules it. It reads the FULL symbolic-ref rather than --short, because --short shortens refs/custom/x to a branch-looking custom/x, and it tests unborn-ness as 'the ref HEAD names does not exist' rather than 'symbolic-ref failed' — the latter is a trap this repo already fell into once, producing a false unborn-HEAD claim in seven places. Verified by me on three cases: trunk scaffolds trunk, unborn main still gets main, and a clone sitting on sidebranch with origin/HEAD=main still gets main. Three false doc claims in the same comment block corrected. One behaviour change surfaced a pre-existing inconsistency in onNonDefaultBranch rather than a regression: the lane proved the retargeted tests pass both with the fix and with it removed, and that inverting the nudge gate still kills all three.
+
+---
+
+## 2026-08-24 14:51 - gitcli: gate the unborn-HEAD rung on an empty refs/heads, and restore the nudge guard a test had silently stopped covering
+
+**Reasoning:** The panel found this PR had killed a live guard: TestLog_NudgeSkippedWithHeadlineFlag lost its bornDefaultBranch call, so dropping '&& f.headline == ""' from log.go:457 PASSED on this branch and FAILED with the pre-fix resolver — the test was vacuous and the regression was ours. Separately the step-4 comment claimed unborn HEAD is the only state where HEAD names the repository's sole branch; false for 'git checkout --orphan' inside an established repo, which made an orphan branch the default over existing ones. Step 4 is now gated on len(branches)==0, reusing step 3's ref listing.
+
+**Alternatives considered:** Add bornDefaultBranch to every checkoutBranch site in the file. Rejected: only tests whose SUBJECT is branch-vs-default nudge behaviour depend on the default branch being born; the five headline-marker tests do not resolve it at all, and blanket-adding a guard tests do not need hides which ones actually depend on it. Stated as a limit below rather than as proof.
+
+**Implications:**
+- The sweep's completeness rests on reasoning, not measurement: the mutation proved the nudge guard was at risk and is now covered, but nothing was mutated to prove the five headline tests are unaffected. CONTRIBUTING.md now owns the born-branch rule and headline_test.go's helper comment points there instead of restating it — the rule that produced four instances of this class lived in a helper comment test authors never read.
 
 ---
 

--- a/docs/decisions-branches/fix__unborn-head-default-branch.md
+++ b/docs/decisions-branches/fix__unborn-head-default-branch.md
@@ -1,0 +1,13 @@
+← back to [docs/timeline.md](../timeline.md)
+
+## 2026-08-24 13:58 - gitcli: resolve the default branch from an unborn HEAD, so a non-main repo scaffolds its own branch
+
+**Reasoning:** DefaultBranch ran a five-step search that never read HEAD, so 'git init -b trunk' followed by 'logmind init' baked branches: [main] into both workflow triggers — byte-identical to a repo actually on main, at exit 0, with doctor reporting the repo healthy. The workflows then never fire. That is the README's own Quick Start on any repo whose default is not main or master, and logmind is meant to work standalone. The function's own doc comment claimed only a repo offering no evidence at all lands on main; an unborn repo created with -b trunk does offer evidence, and logmind reads HEAD correctly elsewhere in the same run.
+
+**Alternatives considered:** Special-case the unborn repo at each scaffolding call site — rejected; DefaultBranch is the one place that answers this question and every caller should get the right answer from it. Read HEAD unconditionally rather than only when unborn — rejected, and this is the subtle one: it would make every feature branch its own default and collapse onNonDefaultBranch entirely.
+
+**Implications:**
+- The new rung sits fourth, below origin/HEAD, conventional names and single-branch, and above init.defaultBranch. Below the first three so no answer they already give can change — a remote's declared default outranks a local ref that was never pushed. Above init.defaultBranch because that key is what git init consulted to write HEAD in the first place, and -b overrules it. It reads the FULL symbolic-ref rather than --short, because --short shortens refs/custom/x to a branch-looking custom/x, and it tests unborn-ness as 'the ref HEAD names does not exist' rather than 'symbolic-ref failed' — the latter is a trap this repo already fell into once, producing a false unborn-HEAD claim in seven places. Verified by me on three cases: trunk scaffolds trunk, unborn main still gets main, and a clone sitting on sidebranch with origin/HEAD=main still gets main. Three false doc claims in the same comment block corrected. One behaviour change surfaced a pre-existing inconsistency in onNonDefaultBranch rather than a regression: the lane proved the retargeted tests pass both with the fix and with it removed, and that inverting the nudge gate still kills all three.
+
+---
+

--- a/internal/cli/derived.go
+++ b/internal/cli/derived.go
@@ -26,12 +26,19 @@ var derivedDocPaths = []string{"docs/timeline.md", "docs/timeline-archive.md", "
 //
 // An unborn repo is NOT its own case, despite reading like one at a glance:
 // CurrentBranch resolves HEAD's ref before the first commit (see
-// decisions.NonBranchSources), so `git init -b main` returns false only
-// because cur == def (both "main"), and `git init -b feature` returns true —
-// exactly as either would after a commit. Round 9 removed this same false
-// "no branch name" premise from decisions.go, AGENTS.md.template and
-// docs/plan.md; this comment was the ninth copy round 10's panel found still
-// standing.
+// decisions.NonBranchSources), so `git init -b main` returns false because
+// cur == def (both "main") — exactly as it would after a commit. Round 9
+// removed this same false "no branch name" premise from decisions.go,
+// AGENTS.md.template and docs/plan.md; this comment was the ninth copy
+// round 10's panel found still standing.
+//
+// It took until gitcli.DefaultBranch step 4 for the OTHER half to hold. The
+// line above used to add that `git init -b trunk` returns true, "exactly as
+// it would after a commit" — and that was the one illustration in it that
+// was false both ways round: DefaultBranch answered "main" for an unborn
+// `trunk` repo (so: true), while after a single commit the single-branch
+// step answers "trunk" (so: false). Now both sides read the same evidence
+// and an unborn repo genuinely does behave as it will once committed.
 func onNonDefaultBranch(cwd string) bool {
 	if !gitcli.IsRepo(cwd) {
 		return false

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -9,24 +9,15 @@ import (
 )
 
 // bornDefaultBranch gives the repo a default branch that actually EXISTS,
-// as a ref, before a feature branch is cut from it.
+// as a ref, before a feature branch is cut from it. See CONTRIBUTING.md's
+// "Tests" section for why `git init -b main` alone is not enough and every
+// test whose SUBJECT is branch-vs-default behaviour (the branch-summary
+// nudge, onNonDefaultBranch) calls this first — the rule lives there, not
+// here, so this comment doesn't drift from it.
 //
-// initLogTestGitRepo does `git init --initial-branch=main` and never
-// commits, so `checkoutBranch` on top of it leaves a repo with NO REFS AT
-// ALL: HEAD names the feature branch, `main` was never created, and the
-// repo's one and only branch is the feature branch. gitcli.DefaultBranch
-// answers with it (step 4, the unborn-HEAD rung) — correctly, because that
-// is the branch the first commit lands on and what the forge will call the
-// default — so onNonDefaultBranch is false and the branch-summary nudge
-// does not fire. That is not a quirk of the resolver to work around: it is
-// the same answer the single-branch rung gives the moment such a repo
-// commits, and no user is ever in that state anyway (`logmind init`
-// commits before anyone branches).
-//
-// So every test whose SUBJECT is branch-vs-default behaviour calls this
-// first. `git commit --allow-empty` deliberately: it creates the ref and
-// touches neither the index nor the working tree, so the scaffolded docs
-// stay exactly as untracked as the tests already expect. This mirrors what
+// `git commit --allow-empty` deliberately: it creates the ref and touches
+// neither the index nor the working tree, so the scaffolded docs stay
+// exactly as untracked as the tests already expect. This mirrors what
 // TestOnNonDefaultBranch (derived_test.go) — the guard that owns this
 // function's contract — has always done.
 func bornDefaultBranch(t *testing.T, dir string) {
@@ -223,6 +214,7 @@ func TestLog_NudgeSkippedWithHeadlineFlag(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		bornDefaultBranch(t, d)
 		checkoutBranch(t, d, "feat/x")
 		withFakeTTY(t, false, func() {
 			root := NewRootCmd()

--- a/internal/cli/headline_test.go
+++ b/internal/cli/headline_test.go
@@ -8,6 +8,36 @@ import (
 	"testing"
 )
 
+// bornDefaultBranch gives the repo a default branch that actually EXISTS,
+// as a ref, before a feature branch is cut from it.
+//
+// initLogTestGitRepo does `git init --initial-branch=main` and never
+// commits, so `checkoutBranch` on top of it leaves a repo with NO REFS AT
+// ALL: HEAD names the feature branch, `main` was never created, and the
+// repo's one and only branch is the feature branch. gitcli.DefaultBranch
+// answers with it (step 4, the unborn-HEAD rung) — correctly, because that
+// is the branch the first commit lands on and what the forge will call the
+// default — so onNonDefaultBranch is false and the branch-summary nudge
+// does not fire. That is not a quirk of the resolver to work around: it is
+// the same answer the single-branch rung gives the moment such a repo
+// commits, and no user is ever in that state anyway (`logmind init`
+// commits before anyone branches).
+//
+// So every test whose SUBJECT is branch-vs-default behaviour calls this
+// first. `git commit --allow-empty` deliberately: it creates the ref and
+// touches neither the index nor the working tree, so the scaffolded docs
+// stay exactly as untracked as the tests already expect. This mirrors what
+// TestOnNonDefaultBranch (derived_test.go) — the guard that owns this
+// function's contract — has always done.
+func bornDefaultBranch(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "commit", "--allow-empty", "-q", "-m", "root")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("root commit: %v\n%s", err, out)
+	}
+}
+
 // checkoutBranch creates + switches to a feature branch in dir.
 func checkoutBranch(t *testing.T, dir, name string) {
 	t.Helper()
@@ -163,6 +193,7 @@ func TestLog_NudgeAdvisoryOnNonTTY(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		bornDefaultBranch(t, d)
 		checkoutBranch(t, d, "feat/x")
 		withFakeTTY(t, false, func() {
 			root := NewRootCmd()
@@ -214,6 +245,7 @@ func TestLog_NudgeInteractiveEditOnTTY(t *testing.T) {
 	dir := withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		bornDefaultBranch(t, d)
 		checkoutBranch(t, d, "feat/x")
 		withFakeTTY(t, true, func() { // pretend stdin is a TTY
 			root := NewRootCmd()

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1070,7 +1070,7 @@ func renderWorkflowTemplate(text, defaultBranch string) string {
 }
 
 // NOTE on the branch value: gitcli.DefaultBranch owns this fact and its
-// documented 5-step resolution ends in a hard "main" fallback, so it never
+// documented resolution ends in a hard "main" fallback, so it never
 // returns "". This file deliberately does NOT wrap it in a second
 // empty-check — a duplicated fallback is a second copy of the same rule
 // that reads as a safety net while being unreachable, and the invariant

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -895,6 +895,7 @@ func TestLog_NudgeInteractive_ImmediateReply(t *testing.T) {
 	withTempCwd(t, func(d string) {
 		initLogTestGitRepo(t, d)
 		scaffoldDocs(t)
+		bornDefaultBranch(t, d)
 		runGitIn(t, d, "checkout", "-b", "feat/nudge-immediate")
 
 		withFakeTTY(t, true, func() {

--- a/internal/cli/render_default_branch_test.go
+++ b/internal/cli/render_default_branch_test.go
@@ -103,9 +103,9 @@ func TestRenderWorkflowTemplate_SubstitutesDefaultBranch(t *testing.T) {
 // non-`main` one, and checks the trigger that comes out the other end.
 //
 // Deliberately NOT tested here: the "git can tell us nothing" case. It is
-// not environment-independent — gitcli.DefaultBranch's step 4 reads
+// not environment-independent — gitcli.DefaultBranch's step 5 reads
 // ambient `init.defaultBranch`, and macOS's Command Line Tools ships a
-// gitconfig that sets it to `main`, so on a developer machine step 4
+// gitconfig that sets it to `main`, so on a developer machine step 5
 // answers for ANY directory and the hard fallback below it is unreachable.
 // A test asserting a value there would be asserting the toolchain's
 // configuration, and making it deterministic would mean overriding ambient

--- a/internal/cli/render_default_branch_test.go
+++ b/internal/cli/render_default_branch_test.go
@@ -272,3 +272,93 @@ func triggerRegion(body string) string {
 	}
 	return "(no `branches:` line found)"
 }
+
+// TestInstallWorkflowTemplates_RendersUnbornRepoDefaultBranch is the
+// regression for the README's own Quick Start — `mkdir proj && cd proj &&
+// git init && logmind init` — on a repo whose default branch is not `main`.
+//
+// The end-to-end test above seeds a repo by COMMITTING and then renaming, so
+// gitcli.DefaultBranch answers off the single-born-branch rung. That left the
+// case the Quick Start actually produces untested: `git init -b trunk` and
+// nothing else. An unborn repo has no refs at all, so every rung that reads
+// one declined and the scaffold fell through to the hard "main" — writing
+// `branches: [main]` into a repo that has never had a branch by that name.
+// Byte-identical to what a repo really on `main` gets, at exit 0, with
+// `doctor` calling the repo healthy: both workflows install DEAD, and a check
+// that never runs reports nothing at all.
+//
+// The assertion walks BY LINE rather than checking the `on:` trigger alone.
+// Each template carries the placeholder twice — the trigger and the
+// SCAFFOLDED_BRANCH env the drift warning compares against the live default
+// branch — and a substitution that reached only the first would leave the
+// warning permanently firing on a correctly-wired repo. Line indices survive
+// the render because every substitution is in-line, so this covers a third
+// occurrence added later without being told about it.
+func TestInstallWorkflowTemplates_RendersUnbornRepoDefaultBranch(t *testing.T) {
+	const placeholder = "__LOGMIND_DEFAULT_BRANCH__"
+	for _, tc := range []struct {
+		label  string
+		branch string
+	}{
+		// THE DEFECT, and THE CONTROL: the `main` repo's scaffold was
+		// already right and must stay right, or the fix has only moved
+		// which repos get a dead workflow.
+		{"the defect: unborn trunk repo", "trunk"},
+		{"control: unborn main repo", "main"},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			repo := t.TempDir()
+			// `git init -b <branch>` and NOTHING else — no config, no
+			// commit. Through testgit for the maintenance-spawn reason
+			// seedRepo documents above.
+			testgit.InitRepo(t, repo, "-q", "-b", tc.branch)
+			// Errorf, deliberately NOT Fatalf: this reports the CAUSE, and
+			// the assertions below report the SYMPTOM the user actually saw
+			// in the scaffolded file. Stopping here would leave the symptom
+			// unpinned and this test unable to show it ever caught anything.
+			if got := gitcli.DefaultBranch(repo); got != tc.branch {
+				t.Errorf("gitcli.DefaultBranch = %q, want %q", got, tc.branch)
+			}
+
+			if _, _, _, err := installWorkflowTemplates(repo, false); err != nil {
+				t.Fatalf("installWorkflowTemplates: %v", err)
+			}
+
+			substituted := 0
+			for _, name := range templates.ListWorkflowTemplates() {
+				tmplLines := strings.Split(templates.Workflow(name), "\n")
+				body, err := os.ReadFile(filepath.Join(repo, ".github", "workflows",
+					strings.TrimSuffix(name, ".template")))
+				if err != nil {
+					t.Fatalf("read scaffolded %s: %v", name, err)
+				}
+				outLines := strings.Split(string(body), "\n")
+				if len(tmplLines) != len(outLines) {
+					t.Fatalf("%s: template has %d lines, scaffolded file has %d — rendering is "+
+						"no longer line-for-line, so this probe cannot locate the occurrences",
+						name, len(tmplLines), len(outLines))
+				}
+				for i, line := range tmplLines {
+					if !strings.Contains(line, placeholder) {
+						continue
+					}
+					substituted++
+					if strings.Contains(outLines[i], placeholder) {
+						t.Errorf("%s line %d: raw placeholder survived: %q", name, i+1, outLines[i])
+					}
+					if !strings.Contains(outLines[i], tc.branch) {
+						t.Errorf("%s line %d: %q does not carry this repo's default branch %q",
+							name, i+1, outLines[i], tc.branch)
+					}
+				}
+			}
+			// The zero control: a renamed placeholder would make every
+			// assertion above vacuous and this test silently green.
+			if substituted < 4 {
+				t.Fatalf("only %d placeholder occurrence(s) checked — expected at least 4 "+
+					"(a trigger and a SCAFFOLDED_BRANCH in each of two workflows); "+
+					"the placeholder was renamed or the templates stopped carrying it", substituted)
+			}
+		})
+	}
+}

--- a/internal/decisions/decisions.go
+++ b/internal/decisions/decisions.go
@@ -122,10 +122,10 @@ type Source struct {
 // That is the whole point, and it is a regression fence. `search` used to
 // discover the default branch's file by RESOLVING a branch name
 // (gitcli.DefaultBranch) and joining it into a path. That resolver's fallback
-// chain ends "…→ single-branch repo → that branch IS the default → 'main'", so
-// wherever origin/HEAD is unset — a `git clone --single-branch`, an
-// `actions/checkout` working copy, and EVERY locally-created repo (`git init -b
-// trunk` + `git remote add origin`) — the resolved name collapsed onto the
+// chain ends "…→ single-branch repo → that branch IS the default → unborn
+// HEAD → 'main'", so wherever origin/HEAD is unset — a `git clone
+// --single-branch`, an `actions/checkout` working copy, and EVERY
+// locally-created repo — the resolved name collapsed onto the
 // current branch or onto a "main" that does not exist, and the default
 // branch's decision file was silently dropped from the search even though it
 // was sitting on disk. `show --all` and `timeline` never had the bug, because

--- a/internal/gitcli/default_branch_test.go
+++ b/internal/gitcli/default_branch_test.go
@@ -2,7 +2,11 @@ package gitcli
 
 import (
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // TestDefaultBranch_ResolvesRatherThanPrefersMain is the regression for the
@@ -144,4 +148,176 @@ func branchList(t *testing.T, repo string) string {
 		return "(could not list refs: " + err.Error() + ")"
 	}
 	return string(out)
+}
+
+// TestDefaultBranch_UnbornHEADIsEvidence is the regression for step 4. A
+// repo with no commits yet has no refs at all, so steps 1-3 come up empty
+// and the search used to fall through to init.defaultBranch and then to the
+// hard "main" — meaning `git init -b trunk && logmind init` scaffolded
+// `branches: [main]` into a repo that has never had a branch by that name.
+// Byte-identical, at exit 0, to what a repo actually on `main` gets. The
+// workflows simply never fire. That is the README's own Quick Start on any
+// repo whose default branch is neither `main` nor `master`.
+//
+// HEAD is the evidence steps 1-3 cannot see. `git symbolic-ref HEAD`
+// SUCCEEDS before the first commit (see the CurrentBranch contract) and
+// names the branch the first commit will create — which is exactly what the
+// forge will call the default branch.
+//
+// The cases below pin the PLACE of that step as much as its existence: it
+// must lose to origin/HEAD and to a single born branch, beat
+// init.defaultBranch, and never fire for a HEAD that is merely checked out.
+// Nothing here touches ambient git config — where a case needs
+// `init.defaultBranch`, it is set REPO-LOCALLY, which overrides whatever the
+// machine's global config says.
+func TestDefaultBranch_UnbornHEADIsEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T) string
+		want  string
+	}{
+		{
+			// THE DEFECT. `git init -b trunk`, nothing else.
+			name:  "unborn trunk repo resolves to trunk",
+			build: func(t *testing.T) string { return unbornRepo(t, "trunk") },
+			want:  "trunk",
+		},
+		{
+			// THE CONTROL. Same shape on the conventional name: the answer
+			// was already right here and must stay right, or the fix has
+			// merely moved which repos get a wrong workflow trigger.
+			name:  "control: unborn main repo still resolves to main",
+			build: func(t *testing.T) string { return unbornRepo(t, "main") },
+			want:  "main",
+		},
+		{
+			// Step 4 sits BELOW step 1. A clone of a `main` repo, then an
+			// orphan checkout, leaves origin/HEAD naming `main` while the
+			// local HEAD is unborn on `trunk` and no local branch survives —
+			// so this is the one shape where the two steps actually compete.
+			// The remote's declared default outranks a local ref that has
+			// never been pushed.
+			name: "origin/HEAD outranks an unborn local HEAD",
+			build: func(t *testing.T) string {
+				src := initRepo(t)
+				runGit(t, src, "branch", "-M", "main")
+				dst := filepath.Join(t.TempDir(), "clone")
+				testgit.CloneRepo(t, dst, "-q", src)
+				runGit(t, dst, "checkout", "-q", "--orphan", "trunk")
+				runGit(t, dst, "branch", "-q", "-D", "main")
+				// Non-vacuity: if the orphan checkout stopped leaving HEAD
+				// unborn, or the local `main` survived, steps 2-3 would
+				// answer and this case would assert nothing about step 1.
+				if got := unbornHEAD(dst); got != "trunk" {
+					t.Fatalf("setup: want an unborn local HEAD at trunk, got %q — "+
+						"step 1 and step 4 would not be competing here", got)
+				}
+				return dst
+			},
+			want: "main",
+		},
+		{
+			// Step 4 sits BELOW step 3. Commits on `develop`, no origin, no
+			// conventional name: the single born branch is the default, and
+			// an unborn HEAD cannot arise here at all because HEAD names it.
+			name: "commits on develop with no origin resolve to develop",
+			build: func(t *testing.T) string {
+				repo := initRepo(t)
+				runGit(t, repo, "branch", "-M", "develop")
+				return repo
+			},
+			want: "develop",
+		},
+		{
+			// Step 4 sits ABOVE init.defaultBranch. That key is what `git
+			// init` CONSULTED in order to write HEAD, and `-b` overrules it;
+			// HEAD is the answer, the config is the guess it overruled. Set
+			// repo-locally so the case tests the rung deliberately instead of
+			// depending on what the machine's global config happens to say.
+			name: "unborn HEAD beats a conflicting init.defaultBranch",
+			build: func(t *testing.T) string {
+				repo := unbornRepo(t, "trunk")
+				runGit(t, repo, "config", "init.defaultBranch", "master")
+				return repo
+			},
+			want: "trunk",
+		},
+		{
+			// The UNBORN guard, without which every feature branch becomes
+			// its own default and onNonDefaultBranch (internal/cli) collapses
+			// to false everywhere. Two born branches, neither conventional,
+			// no origin: steps 1-3 all decline, so an unguarded HEAD read
+			// would answer `feat/x` here. It must not — HEAD is only evidence
+			// when it names a branch that does not exist yet.
+			name: "a checked-out born branch is not a default branch",
+			build: func(t *testing.T) string {
+				repo := initRepo(t)
+				runGit(t, repo, "branch", "-M", "develop")
+				runGit(t, repo, "checkout", "-q", "-b", "feat/x")
+				runGit(t, repo, "config", "init.defaultBranch", "develop")
+				return repo
+			},
+			want: "develop",
+		},
+		{
+			// A HEAD outside refs/heads/ is not a branch, unborn or
+			// otherwise — git will commit to refs/custom/x quite happily and
+			// `symbolic-ref --short` shortens it to a branch-looking
+			// `custom/x`. Step 4 reads the FULL ref for this reason, so the
+			// search falls through to init.defaultBranch as it would for a
+			// detached HEAD.
+			name: "a HEAD outside refs/heads is not an unborn branch",
+			build: func(t *testing.T) string {
+				repo := initRepo(t)
+				// -M first: initRepo takes whatever the machine's ambient
+				// init.defaultBranch names, and the delete below names a ref.
+				runGit(t, repo, "branch", "-M", "main")
+				runGit(t, repo, "update-ref", "refs/custom/x", "HEAD")
+				runGit(t, repo, "symbolic-ref", "HEAD", "refs/custom/x")
+				// Plumbing, not `git branch -D`: porcelain refuses to delete
+				// the branch it thinks is checked out, and the point of the
+				// case is that refs/heads/ ends up empty.
+				runGit(t, repo, "update-ref", "-d", "refs/heads/main")
+				runGit(t, repo, "config", "init.defaultBranch", "develop")
+				return repo
+			},
+			want: "develop",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := tc.build(t)
+			if got := DefaultBranch(repo); got != tc.want {
+				t.Errorf("DefaultBranch = %q, want %q\nHEAD: %s\nbranches: %s",
+					got, tc.want, headRef(t, repo), branchList(t, repo))
+			}
+		})
+	}
+}
+
+// unbornRepo creates a repo whose HEAD points at branch and that has no
+// commits — the state `git init -b <branch>` leaves behind, and the one
+// every `logmind init` in the README's Quick Start runs against.
+func unbornRepo(t *testing.T, branch string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; skipping integration test")
+	}
+	dir := t.TempDir()
+	testgit.InitRepo(t, dir, "-q", "-b", branch)
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "test")
+	return dir
+}
+
+// headRef renders HEAD's own symbolic ref for a readable failure — the
+// evidence step 4 reads, which branchList cannot show for an unborn repo.
+func headRef(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "symbolic-ref", "HEAD")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "(detached or unreadable: " + err.Error() + ")"
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/gitcli/default_branch_test.go
+++ b/internal/gitcli/default_branch_test.go
@@ -294,6 +294,45 @@ func TestDefaultBranch_UnbornHEADIsEvidence(t *testing.T) {
 	}
 }
 
+// TestDefaultBranch_OrphanCheckoutDoesNotWinInAnEstablishedRepo is the
+// regression for a false premise step 4's own doc comment used to state:
+// "Unborn is the one state where HEAD is ... the only branch this
+// repository has." That is only true when refs/heads/ is EMPTY. A repo
+// that already has branches and then runs `git checkout --orphan` also
+// leaves HEAD unborn — on a name that is NOT the repository's only
+// branch, just a new one nobody has committed to yet, sitting alongside
+// branches that already exist. Pre-gate, step 4 answered with the orphan
+// name anyway, so `git checkout --orphan gh-pages` in a repo with commits
+// on `develop` and `feature` (no origin) silently retargeted the
+// scaffolded workflow trigger at `gh-pages`.
+func TestDefaultBranch_OrphanCheckoutDoesNotWinInAnEstablishedRepo(t *testing.T) {
+	repo := initRepo(t)
+	runGit(t, repo, "branch", "-M", "develop")
+	runGit(t, repo, "branch", "feature")
+
+	// Non-vacuity (part 1): HEAD is born, on develop, before the orphan
+	// checkout — the repo is genuinely established, not already unborn.
+	if got := unbornHEAD(repo); got != "" {
+		t.Fatalf("setup: want HEAD born before the orphan checkout, got unborn %q", got)
+	}
+
+	runGit(t, repo, "checkout", "-q", "--orphan", "gh-pages")
+
+	// Non-vacuity (part 2): the checkout actually left HEAD unborn on
+	// gh-pages — the exact shape the gate has to tell apart from a
+	// genuinely branchless repo, or this test asserts nothing about step 4.
+	if got := unbornHEAD(repo); got != "gh-pages" {
+		t.Fatalf("setup: want an unborn local HEAD at gh-pages after the orphan checkout, got %q — "+
+			"step 4 would not be in play here", got)
+	}
+
+	if got := DefaultBranch(repo); got == "gh-pages" {
+		t.Errorf("DefaultBranch = %q; an orphan checkout inside an established repo "+
+			"(develop, feature already exist, no origin) must not become the default\n"+
+			"branches: %s", got, branchList(t, repo))
+	}
+}
+
 // unbornRepo creates a repo whose HEAD points at branch and that has no
 // commits — the state `git init -b <branch>` leaves behind, and the one
 // every `logmind init` in the README's Quick Start runs against.

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -714,22 +714,26 @@ func LastCommitTime(repoRoot, relPath string) (time.Time, bool) {
 	return t, true
 }
 
-// DefaultBranch resolves the repo's default branch following the same
-// 5-step search Python's git_handler.default_branch uses:
+// DefaultBranch resolves the repo's default branch. The search descends
+// from Python's git_handler.default_branch but is no longer that function:
+// step 2 was rebuilt and step 4 is new (both explained below).
 //
 //  1. refs/remotes/origin/HEAD                  (set by `git clone` or
 //     `git remote set-head`)
 //  2. the conventional names, RESOLVED rather than ranked (see below)
 //  3. single-branch repo: that branch IS the default
-//  4. `git config init.defaultBranch`
-//  5. hard fallback: "main"
+//  4. UNBORN HEAD: the branch the first commit will create
+//  5. `git config init.defaultBranch`
+//  6. hard fallback: "main"
 //
 // Used by `logmind rebase` (B3) when --base isn't supplied, and — since
 // the workflow `on:` filter became a scaffold-time render — by
 // `logmind init`, where a wrong answer installs a workflow that never
-// fires. Same resolution order as Python so a consuming repo configured
-// to point at `master` via `git config init.defaultBranch master` keeps
-// working after the v1 cutover.
+// fires. The init.defaultBranch rung is kept from Python so a consuming
+// repo pointed at `master` via `git config init.defaultBranch master`
+// keeps working after the v1 cutover — and step 4 hands an unborn one of
+// those the same answer anyway, since `git init` reads that very key to
+// decide what to write into HEAD.
 //
 // Step 2 used to be a fixed PREFERENCE — "local `main` if it exists, else
 // `master`" — which answers "main" for a `master` repo that happens to
@@ -739,8 +743,35 @@ func LastCommitTime(repoRoot, relPath string) (time.Time, bool) {
 // into a workflow trigger, because the wrong name there is a check that
 // silently never runs. It now resolves instead: if only one of the two
 // conventional names exists, it IS the answer; when both do, the tie is
-// broken by evidence about which one this repository actually uses,
-// and only a repo that offers no evidence at all still lands on "main".
+// broken by evidence about which one this repository actually uses, and
+// only a tie no evidence can break still resolves to "main".
+//
+// Step 4 exists because a repo with NO COMMITS YET is not a repo with no
+// evidence — the sentence above once claimed the whole search had that
+// property, and this is the case that made it false. `git init -b trunk`
+// writes `trunk` into HEAD; that is where the first commit lands and what
+// the forge will call the default branch. But a repo that has only ever
+// been `git init`-ed carries no refs at all, so steps 1-3 each came up
+// empty and `logmind init` scaffolded `branches: [main]` — a trigger
+// matching no branch the repo will ever have, on the README's own Quick
+// Start, at exit 0.
+//
+// The step is guarded on UNBORN specifically. HEAD read unconditionally
+// would make every feature branch its own default and collapse
+// onNonDefaultBranch (internal/cli/derived.go) to false everywhere; step
+// 2's tiebreak (b) consults HEAD for exactly that reason, and only as a
+// tiebreak. Unborn is the one state where HEAD is not "the branch I happen
+// to be on" but "the only branch this repository has".
+//
+// Its PLACE in the order is the other half of the answer:
+//
+//   - below 1-3, so no answer they already give can change. origin/HEAD
+//     still wins for a clone whose local HEAD points elsewhere, and that is
+//     right on the merits too: the remote's declared default outranks a
+//     local ref that has never been pushed.
+//   - above init.defaultBranch, because that config is what `git init`
+//     CONSULTED in order to write HEAD, and `-b` overrides it. HEAD is the
+//     answer; the config is the guess that may already have been overruled.
 func DefaultBranch(repoRoot string) string {
 	// 1. origin/HEAD
 	if name := RemoteHEAD(repoRoot); name != "" {
@@ -765,13 +796,53 @@ func DefaultBranch(repoRoot string) string {
 		}
 	}
 
-	// 4. init.defaultBranch
+	// 4. Unborn HEAD — the branch the first commit will create.
+	if name := unbornHEAD(repoRoot); name != "" {
+		return name
+	}
+
+	// 5. init.defaultBranch
 	if value, ok := ConfigGet(repoRoot, "init.defaultBranch"); ok && value != "" {
 		return value
 	}
 
-	// 5. Hard fallback
+	// 6. Hard fallback
 	return "main"
+}
+
+// unbornHEAD returns the branch name HEAD points at when that branch does
+// not exist yet — a repo `git init` has created but nothing has committed
+// to. Empty string for every other state: a born branch, a detached HEAD, a
+// HEAD pointing outside refs/heads/, or a directory that is not a repo.
+//
+// Read the CurrentBranch contract above before touching this: `git
+// symbolic-ref HEAD` SUCCEEDS on an unborn repo, resolving HEAD's ref
+// without dereferencing it to a commit. So the probe for unborn-ness is not
+// "does symbolic-ref fail" (it does not; a previous round wrote that false
+// premise into seven places) but "does the ref it names exist yet".
+//
+// The full ref is used rather than CurrentBranch's `--short`: --short
+// answers `custom/x` for a HEAD at refs/custom/x, which git does allow
+// committing to, and which is not a branch. Requiring the refs/heads/
+// prefix keeps this from reporting one as an unborn default branch.
+func unbornHEAD(repoRoot string) string {
+	cmd := exec.Command("git", "symbolic-ref", "HEAD")
+	cmd.Dir = repoRoot
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &bytes.Buffer{}
+	if cmd.Run() != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(stdout.String())
+	name, ok := strings.CutPrefix(ref, "refs/heads/")
+	if !ok || name == "" {
+		return ""
+	}
+	if refExists(repoRoot, ref) {
+		return "" // born: the branch HEAD names already has a commit.
+	}
+	return name
 }
 
 // conventionalDefaultBranches are the two names a repository's default

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -760,8 +760,14 @@ func LastCommitTime(repoRoot, relPath string) (time.Time, bool) {
 // would make every feature branch its own default and collapse
 // onNonDefaultBranch (internal/cli/derived.go) to false everywhere; step
 // 2's tiebreak (b) consults HEAD for exactly that reason, and only as a
-// tiebreak. Unborn is the one state where HEAD is not "the branch I happen
-// to be on" but "the only branch this repository has".
+// tiebreak. Unborn is NOT the one state where HEAD is "the only branch
+// this repository has" — that was the premise here until a repo with
+// commits on `develop` and `feature` (no origin), then `git checkout
+// --orphan gh-pages`, disproved it: HEAD was unborn on gh-pages, and step
+// 4 answered `gh-pages` anyway, though the repository plainly has other
+// branches. Unborn is only evidence of that when refs/heads/ is EMPTY —
+// no born branch exists yet at all — so the step is gated on that,
+// reusing step 3's ref listing rather than re-querying it.
 //
 // Its PLACE in the order is the other half of the answer:
 //
@@ -789,16 +795,24 @@ func DefaultBranch(repoRoot string) string {
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &bytes.Buffer{}
+	var branches []string
 	if cmd.Run() == nil {
-		branches := strings.Fields(out.String())
+		branches = strings.Fields(out.String())
 		if len(branches) == 1 {
 			return branches[0]
 		}
 	}
 
-	// 4. Unborn HEAD — the branch the first commit will create.
-	if name := unbornHEAD(repoRoot); name != "" {
-		return name
+	// 4. Unborn HEAD — the branch the first commit will create. Gated on
+	// refs/heads/ being EMPTY (see the doc comment above): reuses the
+	// listing step 3 already fetched rather than querying it twice. An
+	// established repo — branches already exist — that runs `git checkout
+	// --orphan` also leaves HEAD unborn, on a name that is not the
+	// repository's default, just a new branch nobody has committed to yet.
+	if len(branches) == 0 {
+		if name := unbornHEAD(repoRoot); name != "" {
+			return name
+		}
 	}
 
 	// 5. init.defaultBranch
@@ -874,7 +888,7 @@ var conventionalDefaultBranches = []string{"main", "master"}
 //	   returning it unconditionally would make every feature branch its own
 //	   "default" and collapse onNonDefaultBranch to false everywhere.
 //	c. init.defaultBranch, when it names one of the two. Scoped to the tie
-//	   deliberately — DefaultBranch step 4 already reads this key, but as a
+//	   deliberately — DefaultBranch step 5 already reads this key, but as a
 //	   free-form answer; here it only gets to pick between two branches
 //	   that both exist.
 //	d. the conventional order. A repo with both names, no origin, no


### PR DESCRIPTION
Release blocker found by the #343 panel, reproduced by the orchestrator.

## The defect

`git init -b trunk` then `logmind init` bakes `branches: [main]` into both workflow triggers — **byte-identical to a repo actually on `main`**, at exit 0, with `doctor` reporting the repo healthy. The workflows then never fire.

That is the README's own Quick Start on any repo whose default branch is not `main` or `master`. logmind is meant to work standalone; this is precisely the standalone case.

`gitcli.go` `DefaultBranch` ran a five-step search — `origin/HEAD` → conventional names → single-branch → `init.defaultBranch` → hard `"main"` — and **never read HEAD**. Its own doc comment claimed *"only a repo that offers no evidence at all still lands on `main`"*. An unborn repo created with `-b trunk` does offer evidence: `git symbolic-ref HEAD` returns it, and logmind reads HEAD correctly elsewhere in the same run.

## The fix, and why it sits where it does

A new rung **fourth**: `origin/HEAD` → conventional → single-branch → **unborn HEAD** → `init.defaultBranch` → `"main"`.

- **Below the first three** so no answer they already give can change. A remote's declared default outranks a local ref that was never pushed.
- **Above `init.defaultBranch`** because that key is what `git init` *consulted* to write HEAD, and `-b` overrules it.
- **Guarded on unborn.** Reading HEAD unconditionally would make every feature branch its own default and collapse `onNonDefaultBranch` entirely — that is the subtle failure this guard exists to avoid.
- Reads the **full** `symbolic-ref HEAD`, not `--short`: `--short` shortens `refs/custom/x` to a branch-looking `custom/x`.
- Tests unborn-ness as **"the ref HEAD names does not exist"**, never *"symbolic-ref failed"*. That second reading is a trap this repo already fell into once, producing a false unborn-HEAD claim in seven places.

## Verified by the orchestrator

| case | result |
|---|---|
| unborn `trunk` | `branches: [trunk]` in both workflows |
| unborn `main` (control) | `branches: [main]` — unchanged |
| clone on `sidebranch`, `origin/HEAD=main` (control) | **`main`** — step 1 still outranks step 4 |

Residual `__LOGMIND_DEFAULT_BRANCH__` placeholders across all scaffolded workflows: **0**. Control: the template sources carry 2 each.

## Mutations — 5, each compiling

Delete step 4 (ship the bug) · step 4 above `origin/HEAD` · drop the unborn guard · step 4 below `init.defaultBranch` · `--short` instead of the full ref. **All killed.** The `origin/HEAD` control test carries a non-vacuity `t.Fatalf` so it cannot go green without actually pitting step 1 against step 4.

## Doc comments — three false claims corrected

The "no evidence at all" sentence, plus two stale *"same 5-step search Python uses"* claims. In this project a comment is a claim.

## One behaviour change, and why it is not test-weakening

`onNonDefaultBranch` now returns false for an unborn repo on `feat/x` with no other refs. Three nudge tests pinned the old answer — which was **inconsistent before the fix** (`committed=false → feat/x`, `committed=true → feat/x`; previously `true`/`false` on the same shape). They were retargeted to the shape `TestOnNonDefaultBranch` already uses. Proof it is not weakening: they pass **with the fix and with the fix removed**, and inverting the nudge gate still kills all three.

## Consumers checked

`init.go:846` (the defect) · `rebase.go:80` — unborn `trunk` now refuses self-rebase exactly as `main` already did · `warp.go`, `pulse.go`, `context.go`, `log.go`, `guard_commit.go`, `DefaultBranchMergeBase` — no change in outcome · `headline.go:231` — the change above. **`doctor` has no default-branch logic at all.** **`resolveDecisionsPath` routes by `CurrentBranch`, not `DefaultBranch`** — decision routing untouched.

## Filed, not fixed

**The shell hooks resolve the default branch independently** via `origin/HEAD || "main"`. On a no-origin `trunk` repo they compute `current=trunk default=main → regen skipped`, so post-merge regen never fires locally. Control on `main`: not skipped. Same class, shell layer, pre-existing, outside this lane's files.

## `internal/decisions/decisions.go` — one comment hunk, severable

Four lines: inserts `unborn HEAD →` into a quoted resolver chain and deletes a parenthetical example the fix makes false. Load-bearing for nothing — **drop it at merge if it conflicts** with the other lane in that file.

## Full suite

`FULL_SUITE_EXIT=0` (`internal/cli 747s`, `internal/gitcli 55s`), `go vet` clean, `gofmt -l` 0 files (control: it lists a deliberately malformed file).

## Orchestration note

The shared scratchpad tainted this lane twice — another lane's harness overwrote its mutation script, and a shared binary was rebuilt without this fix mid-measurement. Both windows were discarded and redone from a private directory. My briefing error; the measurements above are all post-quarantine.