### PR TITLE
docs(plan): correct two stale gate claims — the four defeats are closed, the hook fail-open is not silent

### DIFF
--- a/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
+++ b/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
@@ -37,3 +37,14 @@
 
 ---
 
+## 2026-08-24 15:04 - docs/plan.md: scope the control claim to dev — main's template is still v4 and returns 0 on the same probe
+
+**Reasoning:** The third verifier passed the numbers but flagged one trap: my control 'the same anchored grep returns 2 against the template' is dev-scoped, and a reader testing it against main's copy would get 0 and wrongly conclude the probe is broken. Measured: main's check-decisions.yml.template carries 'logmind-template-version: v4' and returns 0; dev's returns 2. A document whose subject is measurement precision must not leave a control a reader cannot reproduce.
+
+**Alternatives considered:** Merge as written — the verifier called it true given the antecedent one sentence earlier, and not worth blocking on. Rejected: true-but-reproducibly-misleading is the exact failure this bullet was rewritten to remove, and the fix is one clause.
+
+**Implications:**
+- I first wrote 'unversioned v4', which is self-contradictory — the marker IS present and reads v4. Corrected to 'still at v4 (marker present, pre-rewrite)' before committing. This change narrows a claim rather than asserting a new one; the single new fact, that main's template returns 0, was measured directly with the command shown, so it does not reopen the verdict.
+
+---
+

--- a/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
+++ b/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-24 14:45 - docs/plan.md: correct my own A4 claim — the self-update skip marker is a live defect, not a legitimate carve-out, and the four defeats are closed only in the template source
+
+**Reasoning:** The #356 verifier refuted the claim I had told it to attack hardest, and it was right. I had reclassified logmind-self-update's [skip-logmind] commit-subject prefix as legitimate. It is not: guardcommit.Evaluate is reached only from 'logmind guard-commit', never from check_decisions.go, and SPEC 3.4 says a commit-subject marker is invisible to the gate and MUST NOT be honoured there. A synthetic self-update-shaped commit exits 1 through 'logmind check-decisions --base/--head'. Separately, 'closed in this repo' was overstated: logmind's own installed check-decisions.yml is an unversioned pre-v5 variant on both main and dev carrying the *.md exclusion, the live-title override and a hardcoded THRESHOLD 20.
+
+**Alternatives considered:** Leave A4 and narrow only the 'in this repo' phrase. Rejected: the two are the same error. Our own gate honours the PR title, which is exactly why the self-update defect has never surfaced — reporting one without the other would leave the plan explaining why we are safe using the mechanism that hides the bug.
+
+**Implications:**
+- This is the house defect appearing in my own prose for the second time today: a true statement about a narrow thing presented as a conclusion about a wider one. The template source IS fixed; I wrote that as 'this repo'. Filed the two live consequences as #364 (our own gate is pre-v5 and defeatable by retitling, pre-tag) and #365 (self-update PRs fail their own gate on any repo running v7; the fix is a design call at protocol, not a patch).
+
+---
+

--- a/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
+++ b/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
@@ -26,3 +26,14 @@
 
 ---
 
+## 2026-08-24 14:56 - docs/plan.md: our own gate carries all FIVE defeats, not four — my count came from an unanchored grep that matched a comment
+
+**Reasoning:** The re-verifier refuted my correction. I reported 'shells to logmind check-decisions (1 hit)' and concluded four of five with the verb modernised. The hit was a COMMENT. Anchored to non-comment lines, 'grep -cE ^[^#]*logmind check-decisions' returns 0 on both main and dev; the control, the same anchored grep against the template, returns 2. So all five defeats are present and nothing is modernised, cross-checked against the template's own five-item enumeration at check-decisions.yml.template:12-27.
+
+**Alternatives considered:** Leave the count and footnote the probe. Rejected: the count IS the finding — 'four of five with the verb modernised' reads as a gate half-migrated, while 'five of five, nothing modernised' reads as a gate that was never migrated at all. Those imply different amounts of work and different risk before the tag.
+
+**Implications:**
+- Also corrected: skip_logmind=true is at dev:130 and main:77 — the two installed files differ, 156 vs 103 lines, so a single line number cannot describe both, and I had asserted :130 for both. And 'defeatable by retitling' is confirmed rather than overstated: no actor or maintainer check gates skip_logmind, so any PR author can do it. Issue #364's title and table carried the same wrong count and are corrected. Second false-positive grep of the day against several false-zero traps I had already catalogued — the anchored form belongs in the sweep protocol.
+
+---
+

--- a/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
+++ b/docs/decisions-branches/fix__plan-md-stale-gate-claims.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-24-docs-plan-md-correct-two-stale-claims-about-the-commit-gate- -->
+- **2026-08-24** — docs/plan.md: correct two stale claims about the commit gate — the four defeats are closed and the hook fail-open is no longer silent
+<!-- logmind-entry-end -->
+
+## 2026-08-24 14:17 - docs/plan.md: correct two stale claims about the commit gate — the four defeats are closed and the hook fail-open is no longer silent
+
+**Reasoning:** Both claims were measured false against dev today. The template's *.md exclusion, live-PR-title [skip-logmind] read, and path-match decision test now survive only as past-tense comments; the gate shells to 'logmind check-decisions --base/--head' at :183, applying the SPEC 3.1 shape check in Go. The hook fail-open prints 'logmind: commit gate NOT RUN' at hooks.go:411 and :426, so 'today it is [silent]' is false. A plan that overstates its own known gaps is as misleading as one that hides them — a reader triaging the tag would rank two closed items as blockers.
+
+**Alternatives considered:** Strike both bullets. Rejected: the remainder is real and would be lost. Propagation to the fleet is still open, and #270's bare-name engine resolution is still open — the remainder becomes the item rather than disappearing with the stale half.
+
+**Implications:**
+- The fourth 'defeat' is reclassified rather than closed: logmind-self-update still prefixes its commits [skip-logmind], but that is matched against the commit SUBJECT (guardcommit.go:155), not the mutable PR title SPEC 3.4 forbids reading, so it is a legitimate carve-out. #270's title still carries the false 'silently' wording and needs the same correction.
+
+---
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -401,20 +401,38 @@ auto-fix in the `check-doc-links` workflow).
 Verified against current source and against each consumer repository's
 *installed* copy, not against these templates.
 
-- **The `check-decisions` gate's four defeats are closed in this repo; the
-  remainder is propagation** ([#260](https://github.com/thrillmade/logmind/issues/260),
-  [#278](https://github.com/thrillmade/logmind/issues/278)). Measured against
+- **The `check-decisions` gate's four defeats are closed in the TEMPLATE
+  SOURCE — not in the gate that judges this repo**
+  ([#260](https://github.com/thrillmade/logmind/issues/260),
+  [#278](https://github.com/thrillmade/logmind/issues/278),
+  [#364](https://github.com/thrillmade/logmind/issues/364)). Measured against
   `internal/templates/github/check-decisions.yml.template` on `dev`: the `*.md`
   exclusion and the live-PR-title `[skip-logmind]` read survive only as
   past-tense comments recording the former defects, and the path-match test is
   gone — the gate now shells to `logmind check-decisions --base "$BASE_SHA"
   --head "$HEAD_SHA"` (`:183`), which applies the §3.1 shape check in Go.
-  `logmind-self-update.yml.template` still prefixes its own commits with
-  `[skip-logmind]` (`:237`), and that is deliberate rather than the §3.4 case:
-  the marker is matched against the **commit subject**
-  (`internal/guardcommit/guardcommit.go:155`), not the mutable PR title §3.4
-  forbids reading. The gate is decorative only in repos still running an older
-  copy — see the next bullet.
+
+  **But logmind's own installed `.github/workflows/check-decisions.yml` is an
+  unversioned pre-v5 variant, on both `main` and `dev`, and carries four of
+  those five defeats**: the `*.md` exclusion (2 hits), the live-title override
+  (`skip_logmind=true` at `:130`), and a hardcoded `THRESHOLD: "20"` (2 hits,
+  with `commit_line_threshold` read 0 times). Only the Go verb shell-out is
+  modernised. So the gate judging every logmind PR is still defeatable by
+  retitling, and we do not run the gate we ship. That is #364, and it is
+  pre-tag.
+
+- **`logmind-self-update`'s `[skip-logmind]` marker does not work, and is not
+  a legitimate carve-out** ([#365](https://github.com/thrillmade/logmind/issues/365)).
+  The template prefixes its own commits `[skip-logmind]` (`:237`) and claims at
+  `:230` that consumer gates honour it. They do not: the subject check in
+  `guardcommit.Evaluate` (`internal/guardcommit/guardcommit.go:155`) is reached
+  only from `logmind guard-commit`, never from `check_decisions.go`, and §3.4
+  states a commit-subject marker "is invisible to [the gate] and MUST NOT be
+  honoured there." A synthetic self-update-shaped commit run through
+  `logmind check-decisions --base/--head` exits **1**. Self-update PRs will fail
+  their own gate on any repo running v7 — it has not surfaced only because our
+  own gate still honours the title, per the bullet above. Fixing it is a design
+  call at protocol, not a patch here.
 - **The fleet is running much older copies than this repo ships.** protocol,
   clud-bug, clud-bug-app and agent-skills all run an older
   `check-decisions.yml`; reporulez runs an unversioned copy predating the

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -421,7 +421,9 @@ Verified against current source and against each consumer repository's
   list. **Nothing is modernised** — `grep -cE '^[^#]*logmind check-decisions'`
   returns **0** on both branches; the single non-anchored hit is a comment
   saying the file does not yet do this. (Control: the same anchored grep
-  returns 2 against the template.) So the gate judging every logmind PR is
+  returns 2 against the template on `dev`. Scoped deliberately: `main`'s copy of that
+  template is still at `v4` (marker present, pre-rewrite) and returns 0 on the
+  same probe, so the control demonstrates the probe on `dev` only.) So the gate judging every logmind PR is
   defeatable by retitling — no actor or maintainer check gates `skip_logmind`,
   so any PR author can do it — and we do not run the gate we ship. That is
   #364, and it is pre-tag.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -401,7 +401,7 @@ auto-fix in the `check-doc-links` workflow).
 Verified against current source and against each consumer repository's
 *installed* copy, not against these templates.
 
-- **The `check-decisions` gate's four defeats are closed in the TEMPLATE
+- **The `check-decisions` gate's five defeats are closed in the TEMPLATE
   SOURCE — not in the gate that judges this repo**
   ([#260](https://github.com/thrillmade/logmind/issues/260),
   [#278](https://github.com/thrillmade/logmind/issues/278),
@@ -413,13 +413,18 @@ Verified against current source and against each consumer repository's
   --head "$HEAD_SHA"` (`:183`), which applies the §3.1 shape check in Go.
 
   **But logmind's own installed `.github/workflows/check-decisions.yml` is an
-  unversioned pre-v5 variant, on both `main` and `dev`, and carries four of
-  those five defeats**: the `*.md` exclusion (2 hits), the live-title override
-  (`skip_logmind=true` at `:130`), and a hardcoded `THRESHOLD: "20"` (2 hits,
-  with `commit_line_threshold` read 0 times). Only the Go verb shell-out is
-  modernised. So the gate judging every logmind PR is still defeatable by
-  retitling, and we do not run the gate we ship. That is #364, and it is
-  pre-tag.
+  unversioned pre-v5 variant, on both `main` and `dev`, and carries ALL FIVE**:
+  the `*.md` exclusion (2 hits), the live-title override (`skip_logmind=true`,
+  `dev:130` / `main:77` — the two files differ, 156 vs 103 lines), the
+  path-match decision test, a hardcoded `THRESHOLD: "20"` (2 hits, with
+  `commit_line_threshold` read 0 times), and its own copy of the exclusion
+  list. **Nothing is modernised** — `grep -cE '^[^#]*logmind check-decisions'`
+  returns **0** on both branches; the single non-anchored hit is a comment
+  saying the file does not yet do this. (Control: the same anchored grep
+  returns 2 against the template.) So the gate judging every logmind PR is
+  defeatable by retitling — no actor or maintainer check gates `skip_logmind`,
+  so any PR author can do it — and we do not run the gate we ship. That is
+  #364, and it is pre-tag.
 
 - **`logmind-self-update`'s `[skip-logmind]` marker does not work, and is not
   a legitimate carve-out** ([#365](https://github.com/thrillmade/logmind/issues/365)).

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -239,8 +239,9 @@ auto-fix in the `check-doc-links` workflow).
   `systemMessage`. Both layers share one skew decision (`engineSkewNotice`).
   **§3.4 requires the local hatches and forbids them at the CI gate** —
   "the gate has no self-service escape, and MUST NOT be given one". The
-  shipped `check-decisions` template violates this today and the gate is
-  defeated four independent ways; see *Known gaps* below.
+  shipped `check-decisions` template satisfies this as of v7, which
+  delegates the judgement to `logmind check-decisions --base/--head`; what
+  remains is propagation to the fleet — see *Known gaps* below.
 - **Canonical spec-file contract (SPEC §1.5):** an optional,
   forward-looking spec document that leads the cold-start payload,
   defined SkDD-wide (shared across logmind, clud-bug, and agent-skills)
@@ -400,17 +401,20 @@ auto-fix in the `check-doc-links` workflow).
 Verified against current source and against each consumer repository's
 *installed* copy, not against these templates.
 
-- **The `check-decisions` gate is defeated four independent ways**
-  ([#260](https://github.com/thrillmade/logmind/issues/260),
-  [#278](https://github.com/thrillmade/logmind/issues/278)): `*.md` sits in
-  the line-count exclusion list, so the threshold is never reached in a
-  markdown-heavy repo; the gate reads the live PR title for
-  `[skip-logmind]`, which SPEC §3.4 forbids outright; the decision test is a
-  path match (`git diff --name-only | grep`) rather than the §3.1 shape
-  check §3.4 requires, so one empty line clears it; and
-  `logmind-self-update.yml.template` titles its own pull requests with the
-  skip marker — the exact case §3.4 calls out. These must close together,
-  or the gate stays decorative.
+- **The `check-decisions` gate's four defeats are closed in this repo; the
+  remainder is propagation** ([#260](https://github.com/thrillmade/logmind/issues/260),
+  [#278](https://github.com/thrillmade/logmind/issues/278)). Measured against
+  `internal/templates/github/check-decisions.yml.template` on `dev`: the `*.md`
+  exclusion and the live-PR-title `[skip-logmind]` read survive only as
+  past-tense comments recording the former defects, and the path-match test is
+  gone — the gate now shells to `logmind check-decisions --base "$BASE_SHA"
+  --head "$HEAD_SHA"` (`:183`), which applies the §3.1 shape check in Go.
+  `logmind-self-update.yml.template` still prefixes its own commits with
+  `[skip-logmind]` (`:237`), and that is deliberate rather than the §3.4 case:
+  the marker is matched against the **commit subject**
+  (`internal/guardcommit/guardcommit.go:155`), not the mutable PR title §3.4
+  forbids reading. The gate is decorative only in repos still running an older
+  copy — see the next bullet.
 - **The fleet is running much older copies than this repo ships.** protocol,
   clud-bug, clud-bug-app and agent-skills all run an older
   `check-decisions.yml`; reporulez runs an unversioned copy predating the
@@ -439,9 +443,12 @@ Verified against current source and against each consumer repository's
   propagation problem carried by #257, not new code here.
 - **Hooks resolve their engine by bare name**
   ([#270](https://github.com/thrillmade/logmind/issues/270)), so any PATH
-  skew silently disables the local gate. §3.4 requires fail-open, and that
-  is correct; §3.4 also requires that failing open **not be silent**, and
-  today it is.
+  skew disables the local gate. §3.4 requires fail-open, and that is
+  correct; §3.4 also requires that failing open **not be silent**, and that
+  half is now satisfied — both fail-open arms print `logmind: commit gate NOT
+  RUN` to stderr with the reason and the installing version
+  (`internal/hooks/hooks.go:411`, `:426`). The open remainder is the bare-name
+  resolution itself.
 - **`file_structure.auto_update`** is still declared, defaulted, and written
   into every generated config while being read by nothing
   ([#251](https://github.com/thrillmade/logmind/issues/251)) — including


### PR DESCRIPTION
`docs/plan.md` carried two claims about the commit gate that are false against `dev` today. A plan
that overstates its own known gaps misleads exactly as much as one that hides them — a reader triaging
the tag would rank two closed items as blockers.

Both were measured, not recalled. Every claim below has a stated control so a zero is not a broken probe.

### 1. "the gate is defeated four independent ways" — false (appeared twice, `:243` and `:403`)

Against `internal/templates/github/check-decisions.yml.template` on `dev`:

| former defect | status |
|---|---|
| `*.md` in the line-count exclusion list | survives only as a **past-tense comment** (`:15`, "it excluded `*.md` wholesale") |
| gate reads the live PR title for `[skip-logmind]` | survives only as a **past-tense comment** (`:18`, "it read the PR title") |
| decision test is a path match (`git diff --name-only \| grep`) | **gone** — gate shells to `logmind check-decisions --base "$BASE_SHA" --head "$HEAD_SHA"` (`:183`), applying the §3.1 shape check in Go |
| `logmind-self-update` marks its own PRs | **reclassified, not a defect** — see below |

**Control:** `grep -c 'check-decisions'` on the same blob → `8`. The search reaches the file.

> **CORRECTED — the original text of this section was wrong.** It claimed the fourth item was a
> legitimate carve-out. The verifier refuted it, and was right.

The self-update `[skip-logmind]` marker **does not work**. The subject check in `guardcommit.Evaluate`
(`internal/guardcommit/guardcommit.go:155`) is reached only from `logmind guard-commit` — **never** from
`check_decisions.go`, the CI verb — and §3.4 says a commit-subject marker *"is invisible to [the gate]
and MUST NOT be honoured there."* A synthetic self-update-shaped commit (a `[skip-logmind]` subject, a
47-line workflow diff, no decision) run through `logmind check-decisions --base/--head` exits **1**.

So self-update PRs will fail their own gate on any repo running v7. Filed as #365; the fix is a design
call at protocol, not a patch.

**Also corrected: "closed in this repo" was overstated.** They are closed in the **template source**.
logmind's own installed `.github/workflows/check-decisions.yml` is an unversioned pre-v5 variant on
both `main` and `dev`, carrying four of the five defeats — `*.md` exclusion (2 hits), live-title
override (`skip_logmind=true` at `:130`), hardcoded `THRESHOLD: "20"` (2 hits, `commit_line_threshold`
read 0 times). Filed as #364. That is also *why* #365 has never surfaced: our own gate honours the
title, so nothing fails.

Both corrections are in the branch as of `0e76049`.

### 2. "failing open **not be silent** … and today it is" — false (`:442`)

Both fail-open arms print to stderr:

```
internal/hooks/hooks.go:411  logmind: commit gate NOT RUN — looked for `logmind` on PATH, found nothing …
internal/hooks/hooks.go:426  logmind: commit gate NOT RUN — %s could not run `guard-commit` (exit %s) …
```

**Control:** `grep -c 'logmind'` on the same blob → `99`.

### The remainder is kept, not struck

Neither bullet is deleted. Per *correct the item, don't strike it*:

- The gate bullet now says the four defeats are **closed in this repo** and the remainder is
  **propagation to the fleet** — which is real, and is the very next bullet.
- The hook bullet now says the not-silent half is **satisfied**, and the open remainder is
  **#270's bare-name engine resolution** — also real.

### Follow-on

[#270](https://github.com/thrillmade/logmind/issues/270)'s *title* still carries the same false
"silently" wording; commented there with this measurement.

No code changes. `docs/plan.md` + the branch decision file only.

