### PR TITLE
fix(guard-commit,doctor): scope the decision-file predicate to the two real layouts; report absent enforcement gates as DRIFT

### DIFF
--- a/docs/decisions-branches/fix__gate-scope-and-doctor-absence.md
+++ b/docs/decisions-branches/fix__gate-scope-and-doctor-absence.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-24 16:24 - gate + doctor: one Layout primitive both the writer and the gate route through; ask git where hooks live; treat inert gates as absent
+
+**Reasoning:** The panel blocked this PR twice over. B1: the predicate matched the literal docs/decisions.md while the writer used filepath.Join(cwd,'docs'), so on a case-insensitive FS with a pre-existing Docs/ dir, or with logmind initialised below the git root, logmind log's own output became uncommittable — measured 65, now 0, with the decoys internal/x/decisions.md and internal/x/docs/decisions.md still 65. The shared-constants claim was false where it mattered: DocsDirName had one consumer and the writer never read it. There is now one Layout that owns the docs dir, resolved through the filesystem via os.SameFile rather than inferred from the platform. B3: doctor reported OK with core.hooksPath set (and doctor --fix wrote a hook git never reads, manufacturing a false OK), with an empty or chmod -x hook, and with a workflow gutted below an intact marker. Hooks now ask 'git rev-parse --git-path hooks'; inert is treated as absent.
+
+**Alternatives considered:** Patch each call site and keep the constants. Rejected: a constant only one side reads is not a shared owner, and that is precisely how the docs-dir half drifted. Also rejected for F5: requiring the job to invoke 'logmind check-decisions', which wrongly reported this repo's own installed gate — the check is now 'has a pull-request trigger and a step that runs something'.
+
+**Implications:**
+- Stated limits. The read paths (Collect, timeline, search, context, pulse, skill) still join filepath.Join(cwd,'docs') and are not routed through Layout — no divergence today, but not closed. logmind log still resolves from cwd rather than the git root, so running it in a plain subdirectory still errors. init/self-update/install-hook still PRINT the literal .git/hooks/<name> even though they now write where git reads. The Claude PreToolUse guard's inertness is still presence-only. A workflow job that runs 'exit 0' is still not detectable. gate_absences is now [] on every path; the four sibling lists still serialize null. THIS ENTRY ALSO CORRECTS the earlier one on this branch, which is now false in two places: the predicate is built from a shared Layout, not shared constants, and hook rows are no longer suppressed in linked worktrees — worktrees now answer correctly.
+
+---
+

--- a/docs/decisions-branches/fix__gate-scope-and-doctor-absence.md
+++ b/docs/decisions-branches/fix__gate-scope-and-doctor-absence.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-24-guard-commit-scope-the-decision-file-predicate-to-the-two-re -->
+- **2026-08-24** — guard-commit: scope the decision-file predicate to the two real layouts; doctor: report absent enforcement gates as DRIFT
+<!-- logmind-entry-end -->
+
+## 2026-08-24 14:20 - guard-commit: scope the decision-file predicate to the two real layouts; doctor: report absent enforcement gates as DRIFT
+
+**Reasoning:** Two independent gate holes. B1: isDecisionFile matched any path ending '/decisions.md', so a well-formed entry at internal/x/decisions.md cleared the commit gate — measured exit 0 on dev, exit 65 now, with a must-pass control (a real entry in docs/decisions-branches/main.md) staying exit 0 on both. The predicate is now the exact image of resolveDecisionsPath, built from shared layout constants. B3: doctor excluded 'missing' and 'markerless' from DRIFT, so a repo with all three enforcement surfaces deleted reported Stack status OK exit 0 — SPEC 3.4 says failing open MUST NOT be silent. GateAbsences is now the only non-advisory list and flips Overall.
+
+**Alternatives considered:** For B1, a suffix rule with a denylist — rejected: it enumerates what to reject rather than what to accept, and the next unanticipated layout reopens the hole. For B3, a second config key to opt out of absence reporting — rejected: git.enforce_commits already means 'logmind does not gate commits here' to guard-commit, the config template and AGENTS.md; a second key is a second owner for one fact. Cost accepted: local-off/CI-on is not expressible.
+
+**Implications:**
+- The rename/copy half of #335 is NOT closed and this predicate cannot close it: a pathspec limits git's tree walk before rename detection, so a staged rename renders as new-file with every line added. Documented in situ at guardcommit.go with both candidate mechanisms and their costs — --find-copies-harder silently disables past diff.renameLimit, which is fail-open under load and SPEC 3.4 forbids it. Named as a design fork, not picked. B3 is scoped to three surfaces and suppressed in linked worktrees, where .git is a file and probeHook cannot see the shared hooks dir.
+
+---
+

--- a/internal/cli/check_decisions.go
+++ b/internal/cli/check_decisions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/guardcommit"
 )
@@ -203,7 +204,7 @@ func runCheckDecisions(opts checkDecisionsOpts, stdout io.Writer) error {
 	// The scope is this run's: the staged index, or the base...head range.
 	// addedHunks carries that distinction, so the shared judgement never
 	// has to know which surface called it.
-	evidence, err := guardcommit.DecisionRecorded(names, func(path string) ([]gitcli.AddedHunk, error) {
+	evidence, err := guardcommit.DecisionRecorded(decisions.ResolveLayout(repoRoot), names, func(path string) ([]gitcli.AddedHunk, error) {
 		return addedHunks(repoRoot, path, opts)
 	})
 	if err != nil {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -215,13 +215,19 @@ func residualCause(wf doctor.WorkflowStatus) string {
 	}
 }
 
-// driftCount counts probe rows that are "stale" — the drift signal that flips
-// Overall to DRIFT (see doctor.CollectStatus). "missing" (benign in a fresh
-// repo) and "markerless" (a main-canonical migration advisory, not a hard
-// drift) are excluded so the QUIET `ok doctor …` receipt stays consistent
-// with `overall` (e.g. overall=OK never pairs with drift>0).
+// driftCount counts what flips Overall to DRIFT (see doctor.CollectStatus):
+// probe rows that are "stale", PLUS each absent §3.4/§6.2 enforcement gate.
+// A generic "missing" (benign in a fresh repo) and "markerless" (a
+// main-canonical migration advisory, not a hard drift) stay excluded.
+//
+// The gate absences are counted here for the invariant this comment already
+// claimed and would otherwise have lost: the QUIET `ok doctor …` receipt
+// stays consistent with `overall`. A repo whose three enforcement surfaces
+// were deleted has no stale row at all, so counting only "stale" would emit
+// `overall=DRIFT drift=0` — a receipt that reports the failure and its own
+// count as contradicting each other.
 func driftCount(r doctor.StatusReport) int {
-	n := 0
+	n := len(r.GateAbsences)
 	for _, t := range r.Tools {
 		for _, wf := range t.Workflows {
 			if wf.Drift == "stale" {
@@ -254,24 +260,14 @@ func residualProbes(r doctor.StatusReport) []doctor.WorkflowStatus {
 // claudeAgentEnabledFromConfig resolves whether Layer 1 of commit
 // enforcement (the Claude Code harness's PreToolUse guard; see
 // internal/claudehook) should be installed/refreshed for this repo.
-// Mirrors agents.DefaultEnabled's "claude" default (enabled) — a repo
-// with no `agents.claude` key at all, or an unparseable config, gets the
-// same default-true behavior config.LoadAsMap already applies. Only an
-// EXPLICIT `agents.claude: false` opts a repo out.
+//
+// The RULE moved to config.ClaudeAgentEnabled — `logmind doctor` now reads
+// it too, to decide whether a missing PreToolUse guard is a gate this repo
+// lost or one it never asked for, and the writer and the reader disagreeing
+// about that is the #299 class. This name stays as the cli-local spelling
+// its two callers already use.
 func claudeAgentEnabledFromConfig(cwd string) bool {
-	m, err := config.LoadAsMap(cwd)
-	if err != nil {
-		return true
-	}
-	v, ok := config.GetPath(m, "agents.claude")
-	if !ok {
-		return true
-	}
-	b, ok := v.(bool)
-	if !ok {
-		return true
-	}
-	return b
+	return config.ClaudeAgentEnabled(cwd)
 }
 
 // formatDoctorFixOK renders the single quiet `ok` summary line.

--- a/internal/cli/doctor_hookspath_test.go
+++ b/internal/cli/doctor_hookspath_test.go
@@ -1,0 +1,121 @@
+// doctor_hookspath_test.go — `logmind doctor --fix` must not write a hook
+// to a path this repository never reads, and must not then report OK over
+// the gate it did not install.
+//
+// Measured on the release candidate, in a repository with
+// `core.hooksPath = .githooks` and no hook there:
+//
+//	logmind doctor        → DRIFT, "commit-msg hook is not installed"   (true)
+//	logmind doctor --fix  → exit 0, wrote .git/hooks/commit-msg          (unread)
+//	logmind doctor        → Stack status: OK, exit 0                     (false)
+//	git commit  (30 lines, no decision)  → exit 0
+//
+// The last two lines are the defect. A --fix that manufactures an OK is
+// worse than no --fix at all: the operator is told the gate is back.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
+)
+
+func TestDoctorFix_InstallsTheHookWhereGitReadsIt(t *testing.T) {
+	mustGit := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runDoctor := func(t *testing.T, args ...string) (string, error) {
+		t.Helper()
+		root := NewRootCmd()
+		root.SetArgs(args)
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		// Execute FIRST: a `return out.String(), root.Execute()` evaluates
+		// the buffer before the command has written to it.
+		err := root.Execute()
+		return out.String(), err
+	}
+
+	dir := withTempCwd(t, func(dir string) {
+		testgit.InitRepo(t, dir, "-q", "--initial-branch=main")
+		mustGit(t, dir, "config", "user.email", "test@example.com")
+		mustGit(t, dir, "config", "user.name", "Test")
+		mustGit(t, dir, "config", "commit.gpgsign", "false")
+		if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+			t.Fatalf("write seed: %v", err)
+		}
+		mustGit(t, dir, "add", "seed.txt")
+		mustGit(t, dir, "commit", "-m", "seed", "--no-verify")
+
+		if _, err := runDoctor(t, "init", "--github-actions=false"); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+
+		// Relocate the hooks directory and leave it EMPTY — the state where
+		// the gate is genuinely gone and the naive join cannot see that.
+		if err := os.MkdirAll(filepath.Join(dir, ".githooks"), 0o755); err != nil {
+			t.Fatalf("mkdir .githooks: %v", err)
+		}
+		mustGit(t, dir, "config", "core.hooksPath", ".githooks")
+		_ = os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg"))
+
+		// CONTROL: the gate really is gone, and doctor really does say so.
+		// Without this the assertion after --fix is passed by a doctor that
+		// reports nothing at all.
+		before, _ := runDoctor(t, "doctor", "--offline", "--exit-zero")
+		if !strings.Contains(before, "Enforcement gates absent") ||
+			!strings.Contains(before, "commit-msg") {
+			t.Fatalf("control: doctor did not report the missing commit-msg gate before --fix:\n%s", before)
+		}
+
+		out, err := runDoctor(t, "doctor", "--fix", "--offline")
+		if err != nil {
+			t.Fatalf("doctor --fix: %v\n%s", err, out)
+		}
+	})
+
+	// The hook is where git reads it…
+	if _, err := os.Stat(filepath.Join(dir, ".githooks", "commit-msg")); err != nil {
+		t.Errorf(".githooks/commit-msg was not installed: %v — `doctor --fix` wrote to a "+
+			"directory this repository does not read", err)
+	}
+	// …and NOT where it does not.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "commit-msg")); err == nil {
+		t.Errorf("a hook was written to .git/hooks/commit-msg; core.hooksPath is .githooks, so " +
+			"git never runs it — this is the write that manufactured a false OK")
+	}
+
+	// And the OK that follows is a true one: assert the report, not just
+	// the file, because "OK" is what the operator actually reads.
+	out, err := func() (string, error) {
+		orig, _ := os.Getwd()
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		defer func() { _ = os.Chdir(orig) }()
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline", "--exit-zero"})
+		var buf bytes.Buffer
+		root.SetOut(&buf)
+		root.SetErr(&buf)
+		err := root.Execute()
+		return buf.String(), err
+	}()
+	if err != nil {
+		t.Fatalf("doctor after --fix: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "Enforcement gates absent") {
+		t.Errorf("doctor still reports an absent gate after --fix installed one:\n%s", out)
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -9,11 +9,13 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/thrillmade/logmind/internal/templates"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 func TestDoctor_OfflineRendersTextByDefault(t *testing.T) {
@@ -169,19 +171,30 @@ func TestDoctor_SpecAdvisory_HumanTableAndJSON(t *testing.T) {
 func TestDoctor_AbsentEnforcementGatesExitNonZero(t *testing.T) {
 	// Isolate PATH so probePathResolution cannot supply the DRIFT verdict
 	// from a stale host binary — the assertion below has to be about the
-	// gates and nothing else.
+	// gates and nothing else. GIT is linked in, and only git: the hook
+	// probes resolve their directory through `git rev-parse --git-path
+	// hooks` now, so an empty PATH would make every hook row report
+	// "missing" for the wrong reason.
+	binDir := t.TempDir()
+	if git, err := exec.LookPath("git"); err == nil {
+		if err := os.Symlink(git, filepath.Join(binDir, "git")); err != nil {
+			t.Fatalf("symlink git into the isolated PATH: %v", err)
+		}
+	}
 	origPath := os.Getenv("PATH")
 	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
-	_ = os.Setenv("PATH", t.TempDir())
+	_ = os.Setenv("PATH", binDir)
 
 	plant := func(t *testing.T, d string) {
 		t.Helper()
 		// `logmind init`'s sentinel: this repository was initialised.
 		mustWriteUnder(t, d, ".logmind/config.yml", "git:\n  enforce_commits: true\n")
-		// A git repository, so a commit can actually be made from it.
-		if err := os.MkdirAll(filepath.Join(d, ".git", "hooks"), 0o755); err != nil {
-			t.Fatalf("mkdir .git/hooks: %v", err)
-		}
+		// A REAL git repository, so a commit can actually be made from it
+		// AND git can answer where its hooks live. A hand-made `.git`
+		// directory is not a repository git will answer about, and the
+		// commit-msg row would then say "logmind cannot tell" rather than
+		// "the gate is gone" — which is a different verdict, correctly.
+		testgit.InitRepo(t, d, "-q", "--initial-branch=main")
 		// check-decisions.yml's SIBLING workflows, which is what says this
 		// repository is on GitHub Actions at all — `logmind init
 		// --github-actions=false` installs none of them and records that

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/templates"
 )
 
 func TestDoctor_OfflineRendersTextByDefault(t *testing.T) {
@@ -145,5 +147,110 @@ func TestDoctor_SpecAdvisory_HumanTableAndJSON(t *testing.T) {
 		mustContain(t, body, `"spec_advisories"`)
 		mustContain(t, body, "missing")
 		mustContain(t, body, `"overall": "OK"`)
+	})
+}
+
+// TestDoctor_AbsentEnforcementGatesExitNonZero is the `logmind doctor`
+// end of the B3 regression: an initialised repository whose §3.4/§6.2
+// enforcement surfaces are gone must SAY so and must exit non-zero.
+//
+// Measured on the release candidate before the fix: `logmind init`, then
+// `rm .git/hooks/commit-msg .claude/settings.json
+// .github/workflows/check-decisions.yml`, then `logmind doctor` printed
+// "Stack status: OK" and exited 0 — while the same repo with one stale
+// template marker printed DRIFT and exited 1 (TestDoctor_DriftExitsNonZero
+// above is that control, and it is what says doctor was never blind
+// generally). SPEC §3.4: "Failing open MUST NOT be silent."
+//
+// The quiet receipt is asserted in the same test on purpose. `ok doctor
+// overall=DRIFT drift=0` would report the failure and its own count as
+// contradicting each other, and a caller that branches on drift= would
+// read the repo as clean.
+func TestDoctor_AbsentEnforcementGatesExitNonZero(t *testing.T) {
+	// Isolate PATH so probePathResolution cannot supply the DRIFT verdict
+	// from a stale host binary — the assertion below has to be about the
+	// gates and nothing else.
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	_ = os.Setenv("PATH", t.TempDir())
+
+	plant := func(t *testing.T, d string) {
+		t.Helper()
+		// `logmind init`'s sentinel: this repository was initialised.
+		mustWriteUnder(t, d, ".logmind/config.yml", "git:\n  enforce_commits: true\n")
+		// A git repository, so a commit can actually be made from it.
+		if err := os.MkdirAll(filepath.Join(d, ".git", "hooks"), 0o755); err != nil {
+			t.Fatalf("mkdir .git/hooks: %v", err)
+		}
+		// check-decisions.yml's SIBLING workflows, which is what says this
+		// repository is on GitHub Actions at all — `logmind init
+		// --github-actions=false` installs none of them and records that
+		// choice nowhere, so the merge-gate row stays silent without them
+		// (doctor.gateSurfaces). Deliberately NOT check-decisions.yml: that
+		// is the gate this test is about, and it must be the missing one.
+		for _, name := range []string{
+			"regen-timeline.yml", "check-doc-links.yml", "logmind-self-update.yml",
+		} {
+			mustWriteUnder(t, d, ".github/workflows/"+name, templates.Workflow(name+".template"))
+		}
+	}
+
+	withTempCwd(t, func(d string) {
+		plant(t, d)
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		err := root.Execute()
+		if !errors.Is(err, ErrSilent) {
+			t.Fatalf("doctor over three absent gates returned %v; want ErrSilent (exit 1)", err)
+		}
+		body := out.String()
+		mustContain(t, body, "Stack status: DRIFT")
+		mustContain(t, body, "Enforcement gates absent (3)")
+		mustContain(t, body, ".git/hooks/commit-msg")
+		mustContain(t, body, ".github/workflows/check-decisions.yml")
+		mustContain(t, body, ".claude/settings.json")
+		// The remedy AND the deliberate opt-out, or the reader is nagged
+		// with no way to answer.
+		mustContain(t, body, "logmind doctor --fix")
+		mustContain(t, body, "git.enforce_commits: false")
+	})
+
+	withTempCwd(t, func(d string) {
+		plant(t, d)
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--quiet", "--offline", "--exit-zero"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor --quiet: %v\n%s", err, errOut.String())
+		}
+		mustContain(t, out.String(), "overall=DRIFT drift=3")
+	})
+
+	// CONTROL: the same tree minus the initialised marker. Nothing was
+	// installed there to lose, so doctor must stay quiet and exit 0 —
+	// without this, a collector that reported unconditionally would pass
+	// every assertion above.
+	withTempCwd(t, func(d string) {
+		if err := os.MkdirAll(filepath.Join(d, ".git", "hooks"), 0o755); err != nil {
+			t.Fatalf("mkdir .git/hooks: %v", err)
+		}
+		root := NewRootCmd()
+		root.SetArgs([]string{"doctor", "--offline"})
+		var out, errOut bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&errOut)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("doctor on an uninitialised directory: %v\n%s", err, errOut.String())
+		}
+		body := out.String()
+		mustContain(t, body, "Stack status: OK")
+		if strings.Contains(body, "Enforcement gates absent") {
+			t.Errorf("a directory that never ran `logmind init` was nagged:\n%s", body)
+		}
 	})
 }

--- a/internal/cli/headline.go
+++ b/internal/cli/headline.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/timeline"
 )
 
@@ -67,6 +68,7 @@ func runHeadline(cwd, summary, fileOverride string, quiet bool, stdout, stderr i
 		return ErrSilent
 	}
 	cfg, _ := config.Load(cwd)
+	layout := decisions.ResolveLayout(cwd)
 
 	var target string
 	if fileOverride != "" {
@@ -78,7 +80,7 @@ func runHeadline(cwd, summary, fileOverride string, quiet bool, stdout, stderr i
 		target = filepath.Clean(target)
 		// Only branch detail files carry timeline markers — refuse to splice a
 		// marker into decisions.md/archive or anything outside the branches dir.
-		if filepath.Dir(target) != filepath.Join(cwd, "docs", "decisions-branches") {
+		if filepath.Dir(target) != filepath.Join(layout.Dir(), decisions.BranchDirName) {
 			q.fail("--file must target a file under docs/decisions-branches/ (got %s).\n", fileOverride)
 			return ErrSilent
 		}
@@ -87,8 +89,7 @@ func runHeadline(cwd, summary, fileOverride string, quiet bool, stdout, stderr i
 			return ErrSilent
 		}
 	} else {
-		docsPath := filepath.Join(cwd, "docs")
-		t, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+		t, isBranchFile := resolveDecisionsPath(cwd, layout, cfg)
 		if !branchSummaryApplies(isBranchFile) {
 			// Not a default-branch refusal — the default branch gets a summary
 			// like every other branch. This is the case where `logmind log`

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -64,6 +64,7 @@ import (
 	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitattr"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/hooks"
@@ -114,7 +115,12 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 	if err != nil {
 		return err
 	}
-	docsPath := filepath.Join(cwd, "docs")
+	// Resolved rather than joined, for the same reason `logmind log` does it
+	// (decisions.Layout): on a case-folding volume a repository that already
+	// has a `Docs/` directory takes every write below into it, and the name
+	// git then reports is the one the commit gate has to recognise.
+	layout := decisions.ResolveLayout(cwd)
+	docsPath := layout.Dir()
 	logmindDir := filepath.Join(cwd, ".logmind")
 	configPath := filepath.Join(logmindDir, "config.yml")
 
@@ -351,7 +357,7 @@ func runInit(cmd *cobra.Command, f *initFlags) error {
 
 	// First decision log entry — into the file `logmind log` would write on
 	// this branch (docs/decisions-branches/main.md in a fresh repo).
-	firstDecisionPath, err := logFirstDecision(cwd, docsPath)
+	firstDecisionPath, err := logFirstDecision(cwd, layout)
 	if err != nil {
 		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: first decision log failed:", err)
 	} else {
@@ -1211,9 +1217,9 @@ func ensureGitignoreBlock(path string) (bool, error) {
 // Byte-format note: the entry is appended immediately after whatever preamble
 // is already present, no intervening blank line, so the output matches
 // Python's logger.log line-for-line.
-func logFirstDecision(cwd, docsPath string) (string, error) {
+func logFirstDecision(cwd string, layout decisions.Layout) (string, error) {
 	cfg, _ := config.Load(cwd)
-	path, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+	path, isBranchFile := resolveDecisionsPath(cwd, layout, cfg)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}

--- a/internal/cli/install_hook.go
+++ b/internal/cli/install_hook.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,6 +12,7 @@ import (
 	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/clierr"
 	"github.com/thrillmade/logmind/internal/gitcli"
+	"github.com/thrillmade/logmind/internal/hooks"
 )
 
 // newInstallHookCmd wires the `logmind install-hook` subcommand.
@@ -94,7 +94,16 @@ func runInstallHook(cwd string, force bool, stdout io.Writer) error {
 		top = cwd
 	}
 
-	hookPath := filepath.Join(top, ".git", "hooks", "pre-commit")
+	// The directory git READS hooks from, never a `.git/hooks` join —
+	// `core.hooksPath` moves it, and a hook written where git does not look
+	// is installed as far as this command is concerned and dead as far as
+	// git is concerned. hooks.Path is the one owner of that resolution;
+	// `logmind init` and `doctor --fix` write through the same answer.
+	hookPath, ok := hooks.Path(top, "pre-commit")
+	if !ok {
+		fmt.Fprintln(stdout, "Error: git could not resolve this repository's hooks directory.")
+		return ErrSilent
+	}
 
 	data, readErr := os.ReadFile(hookPath)
 	switch {

--- a/internal/cli/install_hook_test.go
+++ b/internal/cli/install_hook_test.go
@@ -68,6 +68,37 @@ func TestInstallHook_FreshInstall(t *testing.T) {
 	}
 }
 
+// TestInstallHook_HonoursHooksPath — `logmind install-hook` is the third
+// writer of a git hook (after `logmind init` and `doctor --fix`), and all
+// three now resolve the directory git READS through hooks.Path. A hook
+// written under .git/hooks in a repository whose core.hooksPath points
+// elsewhere is installed as far as this command is concerned and dead as
+// far as git is concerned — the command reports success over a hook that
+// will never run.
+func TestInstallHook_HonoursHooksPath(t *testing.T) {
+	repo := initRepo(t)
+	relocated := filepath.Join(repo, ".githooks")
+	if err := os.MkdirAll(relocated, 0o755); err != nil {
+		t.Fatalf("mkdir .githooks: %v", err)
+	}
+	cmd := exec.Command("git", "config", "core.hooksPath", ".githooks")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config core.hooksPath: %v\n%s", err, out)
+	}
+
+	var stdout bytes.Buffer
+	if err := runInstallHook(repo, false, &stdout); err != nil {
+		t.Fatalf("runInstallHook: %v\n%s", err, stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(relocated, "pre-commit")); err != nil {
+		t.Errorf("no hook at %s, the directory git reads: %v", relocated, err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".git", "hooks", "pre-commit")); err == nil {
+		t.Errorf("a hook was written to .git/hooks/pre-commit, which this repository never reads")
+	}
+}
+
 // TestInstallHook_AlreadyInstalled exercises the idempotency path —
 // running install-hook twice in a row must produce the "already
 // installed" message on the second run.

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -224,7 +224,11 @@ Example:
 // printed to stdout, or a regular error for plumbing failures.
 func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	q := newQout(quiet, stdout, stderr)
-	docsPath := filepath.Join(cwd, "docs")
+	// Resolved, not joined: the docs directory is the one component of the
+	// layout a repository may already have spelled differently, and the
+	// commit gate has to agree about it. See decisions.Layout.
+	layout := decisions.ResolveLayout(cwd)
+	docsPath := layout.Dir()
 	if !pathExists(docsPath) {
 		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
 		return ErrSilent
@@ -308,7 +312,7 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 	}
 
 	// Resolve target file based on git state + config.branch_aware.
-	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+	target, isBranchFile := resolveDecisionsPath(cwd, layout, cfg)
 
 	// Serialize concurrent `logmind log` invocations against this repo.
 	// Without this, two concurrent logs both read the pre-write content
@@ -619,8 +623,13 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 // docs/decisions.md. Detached HEAD is the case that yields "" — symbolic-ref
 // exits non-zero there because HEAD holds a raw SHA, not a ref.
 // Both halves are pinned by TestResolveDecisionsPathUnbornVsDetached.
-func resolveDecisionsPath(cwd, docsPath string, cfg config.Config) (target string, isBranchFile bool) {
-	branchlessPath := filepath.Join(docsPath, decisions.LegacyFileName)
+// The PATHS themselves come from the layout, not from a join spelled here:
+// this function owns the routing RULE (which of the two files), and
+// decisions.Layout owns where either one is — see its doc comment for the
+// two configurations in which a local join disagreed with the commit gate
+// about a file logmind had just written.
+func resolveDecisionsPath(cwd string, layout decisions.Layout, cfg config.Config) (target string, isBranchFile bool) {
+	branchlessPath := layout.LegacyFile()
 	if !cfg.Decisions.BranchAware {
 		return branchlessPath, false
 	}
@@ -633,9 +642,7 @@ func resolveDecisionsPath(cwd, docsPath string, cfg config.Config) (target strin
 		// there; see this function's doc comment.
 		return branchlessPath, false
 	}
-	branchFile := filepath.Join(docsPath, decisions.BranchDirName,
-		sanitizeBranchName(branch)+".md")
-	return branchFile, true
+	return layout.BranchFile(sanitizeBranchName(branch)), true
 }
 
 // DELIBERATELY ABSENT: a defaultBranchDecisionsPath helper.

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -90,6 +90,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/thrillmade/logmind/internal/config"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/linkcheck"
 	"github.com/thrillmade/logmind/internal/templates"
@@ -619,7 +620,7 @@ func runLog(cwd, summary string, f *logFlags, quiet bool, stdin io.Reader, stdou
 // exits non-zero there because HEAD holds a raw SHA, not a ref.
 // Both halves are pinned by TestResolveDecisionsPathUnbornVsDetached.
 func resolveDecisionsPath(cwd, docsPath string, cfg config.Config) (target string, isBranchFile bool) {
-	branchlessPath := filepath.Join(docsPath, "decisions.md")
+	branchlessPath := filepath.Join(docsPath, decisions.LegacyFileName)
 	if !cfg.Decisions.BranchAware {
 		return branchlessPath, false
 	}
@@ -632,7 +633,7 @@ func resolveDecisionsPath(cwd, docsPath string, cfg config.Config) (target strin
 		// there; see this function's doc comment.
 		return branchlessPath, false
 	}
-	branchFile := filepath.Join(docsPath, "decisions-branches",
+	branchFile := filepath.Join(docsPath, decisions.BranchDirName,
 		sanitizeBranchName(branch)+".md")
 	return branchFile, true
 }

--- a/internal/cli/log_gate_agreement_test.go
+++ b/internal/cli/log_gate_agreement_test.go
@@ -1,0 +1,241 @@
+// log_gate_agreement_test.go — the WRITER and the commit GATE must agree
+// about WHERE a decision lives, and this file pins that agreement on the
+// thing an operator can see: `logmind log` writes an entry, `git add`
+// stages it, and `guard-commit` allows the commit that carries it.
+//
+// A unit test on either half alone passes its own mutation and still goes
+// green while the two disagree — which is exactly how this shipped. The
+// gate scoped its predicate to the literal `docs/decisions.md`; the writer
+// builds its target from `filepath.Join(cwd, "docs")`, which is neither
+// resolved against the git root nor spelled the way the filesystem spells
+// it. Two configurations where logmind's own output was uncommittable:
+//
+//   - a repository that already had a `Docs/` directory on a case-folding
+//     volume — `logmind log` reports success, git stages `Docs/decisions.md`,
+//     and the gate exits 65 on a decision it just wrote;
+//   - `logmind init` run below the git root (it exits 0 there), so the
+//     entry lands at `pkg/api/docs/decisions.md` and the gate, which only
+//     ever sees repo-root-relative paths, does not recognise it.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/guardcommit"
+	"github.com/thrillmade/logmind/internal/testgit"
+)
+
+// foldsCase reports whether dir's filesystem answers to a spelling that is
+// not the one on disk. The `Docs/` case below is only reachable where it
+// does, so the test skips rather than asserting something the platform
+// cannot produce.
+func foldsCase(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("mkdir probe: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(probe) }()
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
+}
+
+func TestLogWritesWhereTheCommitGateLooks(t *testing.T) {
+	mustGit := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	stagedNames := func(t *testing.T, dir string) []string {
+		t.Helper()
+		cmd := exec.Command("git", "diff", "--cached", "--name-only")
+		cmd.Dir = dir
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git diff --cached: %v", err)
+		}
+		return strings.Fields(string(out))
+	}
+
+	cases := []struct {
+		name string
+		// layout puts the repository into the configuration under test and
+		// returns the directory `logmind log` runs in.
+		layout func(t *testing.T, root string) string
+		// detach routes the entry to the branchless log instead of the
+		// branch file — the half the old suffix rule forgave and this one
+		// does not.
+		detach bool
+		// wantStaged is the path git must report for the entry. Asserted
+		// before the gate is asked, so a setup that quietly stopped
+		// producing the configuration fails loudly instead of passing.
+		wantStaged string
+		// docsRel is the whole decision record, unstaged wholesale for the
+		// control. `logmind init` writes a first decision of its own, so
+		// unstaging only wantStaged would leave that one in the index and
+		// the control would pass on the wrong file.
+		docsRel string
+		// wantReceipt is what `logmind log`'s own quiet receipt must name.
+		// Relative to the directory the command ran in, which is the
+		// project root — not the repository root git reports against.
+		wantReceipt string
+	}{
+		{
+			name:       "pre-existing Docs directory, branchless route",
+			layout:     layoutCaseFoldedDocs,
+			detach:     true,
+			wantStaged: "Docs/decisions.md", docsRel: "Docs", wantReceipt: "Docs/decisions.md",
+		},
+		{
+			name:       "pre-existing Docs directory, branch route",
+			layout:     layoutCaseFoldedDocs,
+			wantStaged: "Docs/decisions-branches/main.md", docsRel: "Docs", wantReceipt: "Docs/decisions-branches/main.md",
+		},
+		{
+			name:       "logmind project below the git root, branchless route",
+			layout:     layoutNestedProject,
+			detach:     true,
+			wantStaged: "pkg/api/docs/decisions.md", docsRel: "pkg/api/docs", wantReceipt: "docs/decisions.md",
+		},
+		{
+			name:       "logmind project below the git root, branch route",
+			layout:     layoutNestedProject,
+			wantStaged: "pkg/api/docs/decisions-branches/main.md", docsRel: "pkg/api/docs", wantReceipt: "docs/decisions-branches/main.md",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := withTempCwd(t, func(root string) {
+				testgit.InitRepo(t, root, "--initial-branch=main")
+				mustGit(t, root, "config", "user.email", "test@example.com")
+				mustGit(t, root, "config", "user.name", "Test")
+				mustGit(t, root, "config", "commit.gpgsign", "false")
+				if err := os.WriteFile(filepath.Join(root, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+					t.Fatalf("write seed: %v", err)
+				}
+				mustGit(t, root, "add", "seed.txt")
+				mustGit(t, root, "commit", "-m", "seed")
+
+				project := tc.layout(t, root)
+				if tc.detach {
+					mustGit(t, root, "checkout", "--detach", "HEAD")
+				}
+
+				// Well over git.commit_line_threshold, so the gate has
+				// something to refuse if the decision does not count.
+				if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+					t.Fatalf("mkdir src: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(root, "src", "big.go"),
+					[]byte(strings.Repeat("// a substantive line\n", 302)), 0o644); err != nil {
+					t.Fatalf("write big.go: %v", err)
+				}
+
+				if err := os.Chdir(project); err != nil {
+					t.Fatalf("chdir %s: %v", project, err)
+				}
+				// Quiet, so the receipt names the file: the path logmind
+				// PRINTS must be the path git reports, or the operator is
+				// told to look somewhere the entry is not. On a case-folding
+				// volume `filepath.Join(cwd, "docs")` writes into `Docs/` and
+				// reports `docs/` — the same split that made the gate refuse
+				// it, showing up in the output instead of the exit code.
+				t.Setenv("LOGMIND_QUIET", "1")
+				var out bytes.Buffer
+				withFakeTTY(t, false, func() {
+					cmd := NewRootCmd()
+					cmd.SetArgs([]string{"log", "Gate agreement probe", "-r", "Why", "--no-commit"})
+					cmd.SetOut(&out)
+					cmd.SetErr(&out)
+					if err := cmd.Execute(); err != nil {
+						t.Fatalf("log: %v\n%s", err, out.String())
+					}
+				})
+				if want := "path=" + tc.wantReceipt + " "; !strings.Contains(out.String(), want) {
+					t.Errorf("`logmind log` receipt does not carry %q; got %q", want, out.String())
+				}
+				if err := os.Chdir(root); err != nil {
+					t.Fatalf("chdir back: %v", err)
+				}
+				mustGit(t, root, "add", "-A")
+			})
+
+			names := stagedNames(t, root)
+			if !stagedContains(names, tc.wantStaged) {
+				t.Fatalf("git staged %v; want %s among them — the configuration under test is not the one that was set up, so the gate assertion below would prove nothing",
+					names, tc.wantStaged)
+			}
+
+			// CONTROL first: the same 302 lines with the decision file
+			// UNSTAGED must be refused, or "allowed" below is not evidence
+			// that the decision was what allowed it.
+			mustGit(t, root, "reset", "-q", "--", tc.docsRel)
+			if d := guardcommit.Evaluate(root, "subject", 20, guardcommit.StagedOnly); d.Allow {
+				t.Fatalf("control: Decision = %+v; want Block with the decision unstaged — 302 lines of Go would land undocumented", d)
+			}
+			mustGit(t, root, "add", "-A")
+
+			d := guardcommit.Evaluate(root, "subject", 20, guardcommit.StagedOnly)
+			if !d.Allow || d.CarveOut != guardcommit.CarveOutDecisionRecorded {
+				t.Fatalf("Decision = %+v; want Allow via CarveOutDecisionRecorded — `logmind log` wrote a well-formed entry to %s and the commit carrying it must not be refused",
+					d, tc.wantStaged)
+			}
+		})
+	}
+}
+
+// layoutCaseFoldedDocs scaffolds into a `Docs/` directory that already
+// exists — the one component of the layout a user can spell, and the one
+// the writer resolves through the filesystem rather than naming.
+func layoutCaseFoldedDocs(t *testing.T, root string) string {
+	t.Helper()
+	if !foldsCase(t, root) {
+		t.Skip("filesystem is case-sensitive: `Docs/` and `docs/` are two directories here, so this configuration cannot arise")
+	}
+	if err := os.Mkdir(filepath.Join(root, "Docs"), 0o755); err != nil {
+		t.Fatalf("mkdir Docs: %v", err)
+	}
+	scaffoldDocs(t)
+	return root
+}
+
+// layoutNestedProject runs `logmind init` below the git root — which exits
+// 0 today — so the decision record hangs off pkg/api rather than the
+// repository root the gate judges paths against.
+func layoutNestedProject(t *testing.T, root string) string {
+	t.Helper()
+	project := filepath.Join(root, "pkg", "api")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("mkdir pkg/api: %v", err)
+	}
+	origin, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir %s: %v", project, err)
+	}
+	scaffoldDocs(t)
+	if err := os.Chdir(origin); err != nil {
+		t.Fatalf("chdir back: %v", err)
+	}
+	return project
+}
+
+func stagedContains(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/self_update_test.go
+++ b/internal/cli/self_update_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 func TestSelfUpdate_FreshRepoNoChanges(t *testing.T) {
@@ -35,10 +37,12 @@ func TestSelfUpdate_FreshRepoNoChanges(t *testing.T) {
 
 func TestSelfUpdate_RefreshesStaleHook(t *testing.T) {
 	dir := withTempCwd(t, func(_ string) {
-		// Simulate an existing .git/hooks/ dir with a stale logmind hook.
-		if err := os.MkdirAll(filepath.Join(".git", "hooks"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		// A REAL repository with a stale logmind hook in it. `git init`
+		// rather than a hand-made `.git/hooks`: the installers resolve
+		// their target with `git rev-parse --git-path hooks` (hooks.Dir)
+		// now, so a directory git will not answer about gets no hook
+		// written to it at all.
+		testgit.InitRepo(t, "", "-q", "--initial-branch=main")
 		stale := "#!/bin/sh\n# logmind post-merge hook\n# logmind-hook-version: 0.1.0\necho stale\n"
 		if err := os.WriteFile(filepath.Join(".git", "hooks", "post-merge"), []byte(stale), 0o755); err != nil {
 			t.Fatal(err)
@@ -107,9 +111,7 @@ func TestSelfUpdate_PinVersionSet_NoOps(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(".logmind", "config.yml"), []byte("pinVersion: \"1.2.3\"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(filepath.Join(".git", "hooks"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		testgit.InitRepo(t, "", "-q", "--initial-branch=main")
 		stale := "#!/bin/sh\n# logmind post-merge hook\n# logmind-hook-version: 0.1.0\necho stale\n"
 		if err := os.WriteFile(filepath.Join(".git", "hooks", "post-merge"), []byte(stale), 0o755); err != nil {
 			t.Fatal(err)
@@ -152,9 +154,7 @@ func TestSelfUpdate_PinVersionSet_NoOps(t *testing.T) {
 // — the fix must not accidentally gate the unset case.
 func TestSelfUpdate_PinVersionUnset_RunsNormally(t *testing.T) {
 	dir := withTempCwd(t, func(_ string) {
-		if err := os.MkdirAll(filepath.Join(".git", "hooks"), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		testgit.InitRepo(t, "", "-q", "--initial-branch=main")
 		stale := "#!/bin/sh\n# logmind post-merge hook\n# logmind-hook-version: 0.1.0\necho stale\n"
 		if err := os.WriteFile(filepath.Join(".git", "hooks", "post-merge"), []byte(stale), 0o755); err != nil {
 			t.Fatal(err)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -443,14 +443,15 @@ func writeBriefEntries(stdout io.Writer, entries []showJSONEntry, grouped bool) 
 // runShow implements `logmind show`.
 func runShow(cwd string, all, brief, jsonOut, quiet bool, stdout, stderr io.Writer) error {
 	q := newQout(quiet, stdout, stderr)
-	docsPath := filepath.Join(cwd, "docs")
+	layout := decisions.ResolveLayout(cwd)
+	docsPath := layout.Dir()
 	if !pathExists(docsPath) {
 		q.fail("Error: docs/ directory not found. Run 'logmind init' first.\n")
 		return ErrSilent
 	}
 
 	cfg, _ := config.Load(cwd)
-	target, isBranchFile := resolveDecisionsPath(cwd, docsPath, cfg)
+	target, isBranchFile := resolveDecisionsPath(cwd, layout, cfg)
 	rel := relForOk(cwd, target)
 
 	baseLabel := "legacy"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -443,6 +443,33 @@ func DefaultMap() *OrderedMap {
 	return root
 }
 
+// ClaudeAgentEnabled resolves whether this repository wants Layer 1 of
+// commit enforcement — the Claude Code harness's PreToolUse guard (see
+// internal/claudehook). Mirrors agents.DefaultEnabled's "claude" default
+// (enabled): a repo with no `agents.claude` key at all, or an unparseable
+// config, gets true. Only an EXPLICIT `agents.claude: false` opts out.
+//
+// It lives here rather than beside either caller because BOTH the WRITER
+// (`logmind init` / `doctor --fix`, via internal/cli) and the READER
+// (`logmind doctor`'s enforcement-gate absence check, internal/doctor) ask
+// it, and the two answering differently about one file is the #299 class:
+// doctor would report a gate absent that init deliberately never installs.
+func ClaudeAgentEnabled(repoRoot string) bool {
+	m, err := LoadAsMap(repoRoot)
+	if err != nil {
+		return true
+	}
+	v, ok := GetPath(m, "agents.claude")
+	if !ok {
+		return true
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return true
+	}
+	return b
+}
+
 // LoadAsMap loads .logmind/config.yml under repoRoot into an
 // OrderedMap shape with defaults merged in (user values override
 // defaults leafwise). Falls back to defaults on missing file or

--- a/internal/decisions/decisions.go
+++ b/internal/decisions/decisions.go
@@ -31,35 +31,23 @@ import (
 
 // The decision record's on-disk layout (SPEC §3.2), owned here.
 //
-// One owner, because THREE different questions are asked of the same fact
-// and they must not answer differently:
+// These are the NAMES. Layout (layout.go) is what resolves them into a
+// directory and into the predicate that tests a staged path against it —
+// read its doc comment for why a shared constant was not enough on its own,
+// and for the two configurations where the writer and the gate disagreed
+// about a file logmind had just written.
 //
-//   - `logmind log` BUILDS a path from it (resolveDecisionsPath in
-//     internal/cli/log.go, which owns the routing RULE);
-//   - every read path ENUMERATES against it (ListSources below);
-//   - the commit gate TESTS a staged path against it (isDecisionFile in
-//     internal/guardcommit).
-//
-// The gate used to approximate the third question with a `/decisions.md`
-// filename suffix, which matched a decisions.md in ANY directory. Measured
-// on the release candidate: a well-formed entry at internal/x/decisions.md
-// plus 302 lines of new Go cleared `guard-commit --layer git-hook` (exit 0,
-// "allowed (decision-recorded)") where the identical tree without that file
-// was refused (exit 65). Three lines in a file no read path enumerates
-// defeated all three enforcement surfaces. A predicate written against
-// these constants cannot drift from the writer that way.
-//
-// None of the three is configurable. `docs` is joined onto the repo root as
-// a literal by every caller; .logmind/config.yml has no key that renames it
-// or either file below (grep: no docs_dir / docs_path key exists).
+// None of the three is configurable. .logmind/config.yml has no key that
+// renames the docs directory or either file below (grep: no docs_dir /
+// docs_path key exists); what the FILESYSTEM may spell differently is the
+// docs directory, and Layout resolves that.
 //
 // Deliberately NOT swept through this file's own literals (NonBranchSources,
-// ListSources) or the seven other `filepath.Join(cwd, "docs")` call sites.
-// That sweep is the obvious tidy-up and it is a SEPARATE change: those lines
-// are under concurrent edit, the substitutions are string-identical so they
-// buy nothing today, and a rename would break the build at every one of them
-// anyway. What must not drift is the WRITER (resolveDecisionsPath) and the
-// GATE (isDecisionFile), and those two are the ones routed here.
+// ListSources) or the other `filepath.Join(cwd, "docs")` call sites. That
+// sweep is the obvious tidy-up and it is a SEPARATE change: the
+// substitutions are string-identical so they buy nothing today, and a rename
+// would break the build at every one of them anyway. What must not drift is
+// the WRITER and the GATE, and those two route through Layout.
 const (
 	// DocsDirName is the repo-relative directory logmind scaffolds.
 	DocsDirName = "docs"

--- a/internal/decisions/decisions.go
+++ b/internal/decisions/decisions.go
@@ -29,6 +29,52 @@ import (
 	"time"
 )
 
+// The decision record's on-disk layout (SPEC §3.2), owned here.
+//
+// One owner, because THREE different questions are asked of the same fact
+// and they must not answer differently:
+//
+//   - `logmind log` BUILDS a path from it (resolveDecisionsPath in
+//     internal/cli/log.go, which owns the routing RULE);
+//   - every read path ENUMERATES against it (ListSources below);
+//   - the commit gate TESTS a staged path against it (isDecisionFile in
+//     internal/guardcommit).
+//
+// The gate used to approximate the third question with a `/decisions.md`
+// filename suffix, which matched a decisions.md in ANY directory. Measured
+// on the release candidate: a well-formed entry at internal/x/decisions.md
+// plus 302 lines of new Go cleared `guard-commit --layer git-hook` (exit 0,
+// "allowed (decision-recorded)") where the identical tree without that file
+// was refused (exit 65). Three lines in a file no read path enumerates
+// defeated all three enforcement surfaces. A predicate written against
+// these constants cannot drift from the writer that way.
+//
+// None of the three is configurable. `docs` is joined onto the repo root as
+// a literal by every caller; .logmind/config.yml has no key that renames it
+// or either file below (grep: no docs_dir / docs_path key exists).
+//
+// Deliberately NOT swept through this file's own literals (NonBranchSources,
+// ListSources) or the seven other `filepath.Join(cwd, "docs")` call sites.
+// That sweep is the obvious tidy-up and it is a SEPARATE change: those lines
+// are under concurrent edit, the substitutions are string-identical so they
+// buy nothing today, and a rename would break the build at every one of them
+// anyway. What must not drift is the WRITER (resolveDecisionsPath) and the
+// GATE (isDecisionFile), and those two are the ones routed here.
+const (
+	// DocsDirName is the repo-relative directory logmind scaffolds.
+	DocsDirName = "docs"
+	// LegacyFileName is the docs-relative branchless log — the file
+	// resolveDecisionsPath routes to in exactly the three states where it
+	// cannot resolve a branch name to route by, and the pre-§3.2 main log
+	// a repository that predates the collapse still carries.
+	LegacyFileName = "decisions.md"
+	// BranchDirName is the docs-relative directory holding one
+	// `<sanitized-branch>.md` per branch. Flat: ListBranchFiles skips
+	// subdirectories, so a decision written under one is invisible to
+	// every read path.
+	BranchDirName = "decisions-branches"
+)
+
 // Entry is one parsed decision header.
 type Entry struct {
 	Date        time.Time

--- a/internal/decisions/layout.go
+++ b/internal/decisions/layout.go
@@ -1,0 +1,248 @@
+package decisions
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Layout owns WHERE a repository's decision record lives for the two sides
+// that must never disagree about it — because when they do, the artefact is
+// a decision logmind wrote that logmind's own gate refuses:
+//
+//   - `logmind log` BUILDS a path from it (resolveDecisionsPath,
+//     internal/cli/log.go, which owns the routing RULE — which file, given
+//     the branch and the config), and `logmind init` scaffolds into it;
+//   - the commit gate TESTS a staged path against it (IsDecisionRel, called
+//     by guardcommit.DecisionRecorded for both the commit-msg hook and the
+//     §6.2 workflow).
+//
+// SCOPE, stated because "one owner" invites a wider reading than is true:
+// the READ paths (Collect, ListSources, `timeline`, `search`, `context`,
+// `pulse`) still join `filepath.Join(cwd, "docs")` themselves. That is not a
+// second answer today — on a case-folding volume the literal join opens the
+// same directory, and a nested project is read from its own cwd — but it is
+// not routed here either. See the note above the layout constants in
+// decisions.go for why that sweep is a separate change.
+//
+// A SHARED CONSTANT WAS NOT ENOUGH, and the gap was measured. The three
+// names below have always been constants, but the gate consumed all three
+// and the writer only two: it spelled the docs directory itself, as
+// `filepath.Join(cwd, "docs")`. So the half neither shared was the half
+// that broke, in both directions the join can be wrong:
+//
+//   - AGAINST WHAT ROOT. `cwd`, not the repository root git reports staged
+//     paths against. `logmind init` below the git root exits 0, and
+//     `logmind log` run there writes pkg/api/docs/decisions.md, which the
+//     gate did not recognise.
+//   - SPELLED HOW. `docs` as a literal, on a filesystem that folds case. A
+//     repository that already had a `Docs/` directory took the write into
+//     it; git stages `Docs/decisions.md`; the gate compared against
+//     `docs/decisions.md`.
+//
+// Both configurations wrote the decision to disk, reported success, and
+// produced an index the gate exited 65 on.
+//
+// WHAT LAYOUT DOES ABOUT EACH, which is not symmetric. The spelling it
+// resolves once, through the filesystem, and both sides use the answer. The
+// root it does NOT relocate: `logmind log` still resolves from its working
+// directory, because moving the writer up to the git root would refuse the
+// nested project outright rather than fix it. What changes is that the GATE
+// can now recognise a record hanging off a nested logmind project, and
+// nothing else — see IsDecisionRel.
+type Layout struct {
+	// Root is the absolute directory the docs tree hangs off. For the
+	// writer that is its working directory; for the gate it is the
+	// repository root, because that is what git reports paths against.
+	Root string
+
+	// docsName is DocsDirName as the filesystem under Root actually spells
+	// it — `Docs` where a case-folding volume already had one. Unexported:
+	// a caller that could set it could set it to something the filesystem
+	// does not answer to, which is the state this type exists to remove.
+	docsName string
+
+	// foldCase records that Root's filesystem answered to a spelling other
+	// than the one on disk. It is a property of the volume, not a policy
+	// choice: where the filesystem cannot tell `Docs` from `docs`, neither
+	// side of the gate can either.
+	foldCase bool
+}
+
+// ResolveLayout resolves the decision-record layout for root.
+//
+// Cheap and non-failing by design — it is on `logmind log`'s hot path and
+// on the commit gate's. At most three stats and one directory read, and
+// every failure degrades to the literal `docs`, which is what the two
+// sides did unconditionally before.
+func ResolveLayout(root string) Layout {
+	l := Layout{Root: root, docsName: DocsDirName}
+	st, err := os.Stat(filepath.Join(root, DocsDirName))
+	if err != nil || !st.IsDir() {
+		return l
+	}
+	// WHICH entry did the literal `docs` actually resolve to? Asked of the
+	// filesystem rather than inferred from the platform: os.SameFile is the
+	// only thing that can say "these two names are one directory", and the
+	// answer differs per VOLUME (a case-sensitive APFS image mounted on a
+	// case-folding macOS) rather than per GOOS.
+	if entries, err := os.ReadDir(root); err == nil {
+		for _, e := range entries {
+			if e.Name() == DocsDirName || !strings.EqualFold(e.Name(), DocsDirName) {
+				continue
+			}
+			info, err := os.Stat(filepath.Join(root, e.Name()))
+			if err != nil || !os.SameFile(st, info) {
+				continue
+			}
+			l.docsName = e.Name()
+			l.foldCase = true
+			return l
+		}
+	}
+	// The on-disk spelling IS `docs`, which says nothing about the volume —
+	// and it still matters, because git may report the INDEX's spelling
+	// rather than the working tree's when the two differ in case only. Ask
+	// directly.
+	if up, err := os.Stat(filepath.Join(root, strings.ToUpper(DocsDirName))); err == nil {
+		l.foldCase = os.SameFile(st, up)
+	}
+	return l
+}
+
+// docs returns the docs directory's on-disk name, tolerating a zero Layout
+// so a caller that never resolved one still gets the documented default
+// rather than an empty path component.
+func (l Layout) docs() string {
+	if l.docsName == "" {
+		return DocsDirName
+	}
+	return l.docsName
+}
+
+// Dir is the absolute docs directory — what `logmind log` writes under and
+// what `logmind init` scaffolded.
+func (l Layout) Dir() string { return filepath.Join(l.Root, l.docs()) }
+
+// LegacyFile is the absolute branchless decision log: the file the routing
+// rule falls back to in exactly the states where it cannot resolve a branch
+// name, and the pre-§3.2 main log a repository that predates the collapse
+// still carries.
+func (l Layout) LegacyFile() string { return filepath.Join(l.Dir(), LegacyFileName) }
+
+// BranchFile is the absolute per-branch decision log for an
+// already-sanitized branch name (sanitizeBranchName owns that transform;
+// this owns the path it lands in).
+func (l Layout) BranchFile(sanitized string) string {
+	return filepath.Join(l.Dir(), BranchDirName, sanitized+".md")
+}
+
+// IsDecisionRel reports whether rel — a path relative to Root, spelled the
+// way git reports a staged file (forward slashes on every platform) — is
+// one `logmind log` writes a decision to. It is the IMAGE of LegacyFile and
+// BranchFile above, which is why it lives beside them.
+//
+// Two shapes, and a prefix rule:
+//
+//   - <docs>/decisions.md — the branchless log.
+//   - <docs>/decisions-branches/<name>.md — one branch's log. Any <name>,
+//     because the gate cannot know which branch it is judging; but a SINGLE
+//     path component ending `.md`, because ListBranchFiles skips
+//     subdirectories and a file under one is invisible to every read path.
+//   - the prefix in front of <docs> is empty (the repository root, where
+//     SPEC §3.2 puts the record) or names a NESTED logmind project — a
+//     directory `logmind init` has run in, which is the only other place
+//     `logmind log` can write.
+//
+// SCOPED, not suffixed, and the difference was a live gate hole. The
+// predicate this replaces accepted a `/decisions.md` suffix in ANY
+// directory: measured on the release candidate, a well-formed §3.1 entry at
+// internal/x/decisions.md plus 302 lines of new Go cleared `guard-commit
+// --layer git-hook` (exit 0, "allowed (decision-recorded)") where the
+// identical index without that file was refused (exit 65). Three lines in a
+// file no read path enumerates cleared all three enforcement surfaces — a
+// cheaper bypass than the content-free pointer this release exists to
+// close, because the decoy does not even have to look like logmind's own
+// file. It stays closed here: internal/x/decisions.md has no <docs>
+// component, and internal/x/docs/decisions.md has one but no logmind
+// project behind it.
+//
+// docs/decisions-archive.md is deliberately NOT a shape. Nothing writes it
+// in any state (NonBranchSources) — the read paths surface it where it
+// lies, and a gate that honours a path logmind will never write is the same
+// approximation, one filename narrower.
+func (l Layout) IsDecisionRel(rel string) bool {
+	prefix, ok := l.trimRecordSuffix(rel)
+	if !ok {
+		return false
+	}
+	if prefix == "" {
+		return true
+	}
+	return l.nestedProject(prefix)
+}
+
+// trimRecordSuffix splits rel into the project root it hangs off and
+// whether the remainder is one of the two shapes the writer produces.
+//
+// The DOCS component is matched under the volume's case rules and the two
+// logmind-owned names with it: where the filesystem cannot distinguish
+// `Docs` from `docs`, `filepath.Join` lands in whichever exists and git
+// reports whichever is recorded, so insisting on one spelling would refuse
+// logmind's own file.
+//
+// The `.md` SUFFIX is matched exactly, foldCase or not, and the asymmetry
+// is deliberate: ListBranchFiles filters entries on a literal `.md`, so a
+// branch file named `x.MD` is one no read path enumerates. Folding here
+// would re-open the hole this predicate closes, one extension wider.
+func (l Layout) trimRecordSuffix(rel string) (prefix string, ok bool) {
+	rel = path.Clean(rel)
+	if rel == "" || rel == "." || path.IsAbs(rel) {
+		return "", false
+	}
+	parts := strings.Split(rel, "/")
+	for _, p := range parts {
+		// git reports paths from the repository root and never emits these,
+		// but a caller that hand-built one must not be able to walk out of
+		// the repository into a `.logmind` somewhere else on the machine.
+		if p == ".." {
+			return "", false
+		}
+	}
+	n := len(parts)
+	if n >= 3 && l.eq(parts[n-3], l.docs()) && l.eq(parts[n-2], BranchDirName) &&
+		len(parts[n-1]) > len(".md") && strings.HasSuffix(parts[n-1], ".md") {
+		return strings.Join(parts[:n-3], "/"), true
+	}
+	if n >= 2 && l.eq(parts[n-2], l.docs()) && l.eq(parts[n-1], LegacyFileName) {
+		return strings.Join(parts[:n-2], "/"), true
+	}
+	return "", false
+}
+
+// eq compares one path component under the volume's case rules.
+func (l Layout) eq(got, want string) bool {
+	if l.foldCase {
+		return strings.EqualFold(got, want)
+	}
+	return got == want
+}
+
+// nestedProject reports whether prefix names a logmind project INSIDE this
+// repository — a directory `logmind init` has run in, and so the only place
+// other than the repository root where `logmind log` can write.
+//
+// `.logmind/config.yml` is the evidence because it is what init writes and
+// what config.Load reads: a directory that has one is a project whose
+// `logmind log` writes a real decision record, and a directory that does
+// not is somewhere a decision-shaped file was merely placed. The repository
+// root does NOT need it — SPEC §3.2 puts the record there by definition,
+// and a repo whose docs/ predates init would otherwise have its own log
+// refused.
+func (l Layout) nestedProject(prefix string) bool {
+	dir := filepath.Join(l.Root, filepath.FromSlash(prefix))
+	// The path config.Load joins (internal/config, Load).
+	st, err := os.Stat(filepath.Join(dir, ".logmind", "config.yml"))
+	return err == nil && !st.IsDir()
+}

--- a/internal/decisions/layout_test.go
+++ b/internal/decisions/layout_test.go
@@ -1,0 +1,213 @@
+// layout_test.go — the WRITER and the commit GATE ask Layout the same
+// question, so the tests that matter here are the ones that would catch the
+// two answering differently. The end-to-end pin is
+// TestLogWritesWhereTheCommitGateLooks (internal/cli), which drives
+// `logmind log` and then `guard-commit` over a real index; these are the
+// same properties one level down, where each rule can be isolated.
+package decisions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// foldsCase reports whether dir's filesystem answers to a spelling that is
+// not the one on disk. Measured, not assumed from GOOS: a case-sensitive
+// volume can be mounted on a case-folding platform and the rules that
+// matter here are the volume's.
+func foldsCase(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0o755); err != nil {
+		t.Fatalf("mkdir probe: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(probe) }()
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
+}
+
+// TestLayout_PredicateIsTheImageOfTheWriter is the fence: for every path
+// Layout hands the WRITER, the same Layout must accept the repo-relative
+// spelling from the GATE. It carries no copy of the two shapes — it asks
+// for them — so a rename, a re-root or a re-spelling moves both sides
+// together or fails here.
+//
+// Run over each layout a repository can actually be in, because the
+// property held for the plain one and not for the other two, which is
+// precisely how a decision logmind had just written became uncommittable.
+func TestLayout_PredicateIsTheImageOfTheWriter(t *testing.T) {
+	cases := []struct {
+		name string
+		// setup prepares the repository and returns the directory the
+		// WRITER resolves from — which is not always the repository root.
+		setup func(t *testing.T, repo string) string
+	}{
+		{
+			name: "docs at the repository root",
+			setup: func(t *testing.T, repo string) string {
+				mkdirAll(t, filepath.Join(repo, "docs"))
+				return repo
+			},
+		},
+		{
+			name: "a Docs directory the repository already had",
+			setup: func(t *testing.T, repo string) string {
+				if !foldsCase(t, repo) {
+					t.Skip("filesystem is case-sensitive: `Docs/` and `docs/` are two directories here, so this configuration cannot arise")
+				}
+				mkdirAll(t, filepath.Join(repo, "Docs"))
+				return repo
+			},
+		},
+		{
+			name: "a logmind project below the repository root",
+			setup: func(t *testing.T, repo string) string {
+				project := filepath.Join(repo, "pkg", "api")
+				mkdirAll(t, filepath.Join(project, "docs"))
+				mkdirAll(t, filepath.Join(project, ".logmind"))
+				writeFileT(t, filepath.Join(project, ".logmind", "config.yml"), "decisions:\n  branch_aware: true\n")
+				return project
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			project := tc.setup(t, repo)
+
+			writer := ResolveLayout(project)
+			gate := ResolveLayout(repo)
+			for _, abs := range []string{writer.LegacyFile(), writer.BranchFile("main"), writer.BranchFile("fix__gate")} {
+				// Written for real: the gate judges paths git reports, and
+				// git reports what is on disk.
+				mkdirAll(t, filepath.Dir(abs))
+				writeFileT(t, abs, "## 2026-01-01 00:00 - probe\n")
+
+				rel, err := filepath.Rel(repo, abs)
+				if err != nil {
+					t.Fatalf("Rel(%q): %v", abs, err)
+				}
+				rel = filepath.ToSlash(rel)
+				if !gate.IsDecisionRel(rel) {
+					t.Errorf("IsDecisionRel(%q) = false; the writer puts a decision there", rel)
+				}
+			}
+		})
+	}
+}
+
+// TestLayout_RejectsWhatTheWriterNeverProduces is the other half — without
+// it, a predicate that answers true to everything scores identically above.
+//
+// Every row except README.md and src/decisions.txt used to be accepted: the
+// predicate this replaces took a `/decisions.md` suffix in ANY directory,
+// and a well-formed entry at internal/x/decisions.md alongside 302 lines of
+// new Go cleared the commit gate.
+func TestLayout_RejectsWhatTheWriterNeverProduces(t *testing.T) {
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, "docs"))
+	layout := ResolveLayout(repo)
+
+	for _, rel := range []string{
+		"internal/x/decisions.md",
+		"nested/path/decisions.md",
+		"decisions.md",
+		"vendor/docs/decisions.md",
+		// A docs/ shape with no logmind project behind it. The nearest miss
+		// there is: the decoy only has to add one directory level.
+		"internal/x/docs/decisions.md",
+		"internal/x/docs/decisions-branches/main.md",
+		// Under the branch dir but not a file any read path enumerates —
+		// ListBranchFiles skips subdirectories.
+		"docs/decisions-branches/nested/other.md",
+		// Under the branch dir but not markdown, and the empty stem.
+		"docs/decisions-branches/notes.txt",
+		"docs/decisions-branches/.md",
+		"docs/decisions-archive.md",
+		"README.md",
+		"src/decisions.txt",
+		// Nothing may reach outside the repository to find a project root.
+		"../elsewhere/docs/decisions.md",
+	} {
+		if layout.IsDecisionRel(rel) {
+			t.Errorf("IsDecisionRel(%q) = true; `logmind log` never writes there", rel)
+		}
+	}
+}
+
+// TestLayout_NestedProjectNeedsAProjectBehindIt pins the ONE thing that
+// separates the two nearest-miss paths above and below: pkg/api/docs/... is
+// accepted because `logmind init` ran in pkg/api, and internal/x/docs/... is
+// not because nothing did. Both rows in one test, because "accepted" and
+// "rejected" are only evidence as a pair.
+func TestLayout_NestedProjectNeedsAProjectBehindIt(t *testing.T) {
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, "docs"))
+	layout := ResolveLayout(repo)
+
+	const rel = "pkg/api/docs/decisions.md"
+	if layout.IsDecisionRel(rel) {
+		t.Fatalf("IsDecisionRel(%q) = true before pkg/api is a logmind project — a decision-shaped path is not a decision record", rel)
+	}
+	mkdirAll(t, filepath.Join(repo, "pkg", "api", ".logmind"))
+	writeFileT(t, filepath.Join(repo, "pkg", "api", ".logmind", "config.yml"), "decisions:\n  branch_aware: true\n")
+	if !layout.IsDecisionRel(rel) {
+		t.Fatalf("IsDecisionRel(%q) = false after `logmind init` ran in pkg/api — `logmind log` there writes exactly this path", rel)
+	}
+}
+
+// TestResolveLayout_ReportsTheSpellingOnDisk pins the half the operator
+// reads rather than the half the gate does: `logmind log`'s receipt names
+// the file it wrote, and on a case-folding volume the literal join names one
+// that does not exist as spelled.
+func TestResolveLayout_ReportsTheSpellingOnDisk(t *testing.T) {
+	repo := t.TempDir()
+	if !foldsCase(t, repo) {
+		t.Skip("filesystem is case-sensitive: `Docs/` and `docs/` are two directories here, so this configuration cannot arise")
+	}
+	mkdirAll(t, filepath.Join(repo, "Docs"))
+
+	layout := ResolveLayout(repo)
+	if got, want := layout.Dir(), filepath.Join(repo, "Docs"); got != want {
+		t.Errorf("Dir() = %q; want %q — the directory the write actually lands in", got, want)
+	}
+	// And the gate takes either spelling here, because the filesystem
+	// cannot tell them apart and git may report the index's rather than the
+	// working tree's.
+	for _, rel := range []string{"Docs/decisions.md", "docs/decisions.md"} {
+		if !layout.IsDecisionRel(rel) {
+			t.Errorf("IsDecisionRel(%q) = false; on this volume that is the same file logmind wrote", rel)
+		}
+	}
+}
+
+// TestResolveLayout_DoesNotInventADocsDirectory: a repository with no docs
+// directory at all still gets the documented name, because `logmind init`
+// is about to create it and `logmind log` prints its absence as an error
+// naming `docs/`.
+func TestResolveLayout_DoesNotInventADocsDirectory(t *testing.T) {
+	repo := t.TempDir()
+	layout := ResolveLayout(repo)
+	if got, want := layout.Dir(), filepath.Join(repo, DocsDirName); got != want {
+		t.Errorf("Dir() = %q; want %q", got, want)
+	}
+	if !layout.IsDecisionRel(DocsDirName + "/" + LegacyFileName) {
+		t.Error("the repository-root record is not recognised before docs/ exists")
+	}
+}
+
+func mkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+func writeFileT(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -149,6 +149,37 @@ type WorkflowStatus struct {
 	// One owner for the fact — probeWorkflow computes it, callers read it,
 	// nobody re-derives it by sniffing the prose in Marker.
 	Displaced bool `json:"-"`
+
+	// Inert says WHY an artifact that IS installed cannot enforce anything
+	// — empty when it can, a reason phrased for the reader when it cannot.
+	//
+	// Drift and Inert answer different questions and both answers are true
+	// at once: a commit-msg hook carrying the current marker with its
+	// execute bit cleared is `drift: current` (it IS the version this
+	// binary writes) and inert (git never runs it). Reporting only the
+	// first is how a repository with an emptied hook and a repository with
+	// a working one looked identical — `overall: OK`, `gate_absences: []`,
+	// and a 30-line raw commit through both.
+	//
+	// EXISTENCE was the whole check before, which is the #298 class exactly:
+	// the artifact is there, so the feature is on. Only the enforcement
+	// surfaces compute it (see gateSurfaces); a post-merge hook that lost
+	// its execute bit has lost convenience, not a gate, and saying so on
+	// every row is how doctor becomes noise.
+	//
+	// Not serialized, for Displaced's reason: the JSON field names are a
+	// cross-repo contract, and this is an explanation carried into
+	// StatusReport.GateAbsences rather than a verdict a consumer branches
+	// on.
+	Inert string `json:"-"`
+
+	// Path is the file the probe actually READ, repo-relative where it
+	// sits inside the repository. A hook's path is not knowable from its
+	// name — `core.hooksPath` moves it — so the row carries where it
+	// looked, and the absence report names that rather than a
+	// `.git/hooks/<name>` the repository may never read. Empty for probes
+	// with no single file behind them. Not serialized (see Displaced).
+	Path string `json:"-"`
 }
 
 // ToolStatus aggregates per-tool fields (currently just `logmind`;
@@ -204,6 +235,17 @@ type StatusReport struct {
 	// "missing" stays benign — a repo that never wanted the merge driver,
 	// or dependabot, is not drifted, and turning each optional template
 	// into DRIFT is how doctor becomes noise people stop reading.
+	//
+	// ABSENT AND INERT ARE ONE VERDICT here. A gate is reported when the
+	// file is gone AND when it is present and cannot enforce: an emptied or
+	// non-executable commit-msg hook, a check-decisions.yml whose job was
+	// deleted under an intact marker. Checking EXISTENCE was the whole
+	// check once, and a repository with each of those reported OK with a
+	// raw 30-line commit going through it. See WorkflowStatus.Inert.
+	//
+	// Serialized as `[]` rather than `null` when empty — the only list here
+	// that is, because it is the only one whose emptiness a reader branches
+	// on. See collectGateAbsences.
 	GateAbsences []string `json:"gate_absences"`
 
 	// AutoAdvisories is an ADVISORY list (#241) about `.logmind/auto.yml`,
@@ -427,12 +469,6 @@ func readCludBugReview(path string) (map[string]any, bool) {
 // else belongs here: the post-merge / post-rewrite / pre-commit hooks keep
 // derived docs in step, the merge driver resolves conflicts, and a repo
 // missing any of them has lost convenience, not a gate.
-// hookBacked marks a surface whose probe reads <repoRoot>/.git/hooks/…
-// directly. That join is wrong in a linked WORKTREE, where `.git` is a
-// file pointing at the common directory and the hooks live there — see
-// collectGateAbsences for why such a surface is skipped rather than
-// reported.
-//
 // siblings names rows installed in the SAME pass as this surface, used as
 // the recoverable evidence that the pass ever ran here. Only the workflow
 // carries them, and only because its opt-out is not recorded anywhere else:
@@ -446,15 +482,19 @@ func readCludBugReview(path string) (map[string]any, bool) {
 // after a clone is the NORMAL state (git hooks are not cloned) and it is
 // exactly the thing worth saying; and the Claude guard's opt-out IS
 // recorded, as `agents.claude`.
+// `path` is what the report NAMES when the probe row carries no path of its
+// own. The commit-msg row always does — core.hooksPath and linked worktrees
+// both move the file, so the row reports where it actually looked and the
+// spelling here is only the fallback for a repository git could not answer
+// about.
 var gateSurfaces = []struct {
 	row, path, role string
-	hookBacked      bool
 	siblings        []string
 }{
 	{row: rowClaudeGuard, path: ".claude/settings.json",
 		role: "SPEC §3.4's harness interception point (PreToolUse)"},
 	{row: rowCommitMsgHook, path: ".git/hooks/commit-msg",
-		role: "SPEC §3.4's commit-msg interception point", hookBacked: true},
+		role: "SPEC §3.4's commit-msg interception point"},
 	{row: rowCheckDecisionsWorkflow, path: ".github/workflows/check-decisions.yml",
 		role: "SPEC §6.2's merge gate",
 		siblings: []string{
@@ -505,37 +545,31 @@ var gateSurfaces = []struct {
 // and the writer answer from config.ClaudeAgentEnabled, one rule, so
 // doctor cannot report a gate absent that init would refuse to create.
 func collectGateAbsences(projectRoot string, workflows []WorkflowStatus) []string {
+	// EMPTY, not nil, on every path out of here — `gate_absences` is the
+	// one list on StatusReport a consumer branches on (it is the only one
+	// that moves `overall` and therefore the exit code), so `null` and `[]`
+	// meaning the same thing is a distinction the reader has to know about
+	// to get right. Its four neighbours still serialize `null` when empty;
+	// that is the pre-existing shape of a cross-repo contract and changing
+	// it belongs to whoever changes what those lists mean.
+	none := []string{}
 	// Never ran `logmind init` here → nothing was installed to lose.
 	if _, err := os.Stat(filepath.Join(projectRoot, ".logmind", "config.yml")); err != nil {
-		return nil
+		return none
 	}
 	// Not a git repository → no commit can be made from it, so no gate is
 	// failing open. probeHook reports "missing" for this and for a deleted
-	// hook identically, so the distinction has to be made here.
-	gitPath, err := os.Stat(filepath.Join(projectRoot, ".git"))
-	if err != nil {
-		return nil
+	// hook identically, so the distinction has to be made here. `.git` as a
+	// FILE counts: that is a linked worktree, which commits like any other
+	// checkout and whose hooks probeHook now finds, because the probe and
+	// hooks.Install* resolve the directory the way git does rather than
+	// joining `.git/hooks`.
+	if _, err := os.Stat(filepath.Join(projectRoot, ".git")); err != nil {
+		return none
 	}
-	// A linked worktree: `.git` is a FILE naming the common directory, and
-	// the hooks live there and fire normally. probeHook joins
-	// <repoRoot>/.git/hooks/<name> literally, so it cannot see them and
-	// reports "missing" for a hook that is installed and running —
-	// measured in this repository's own agent worktrees, where
-	// `git rev-parse --git-path hooks` resolves to the main checkout's
-	// .git/hooks and commit-msg is sitting in it.
-	//
-	// Skipped, not reported. An absence check that fires where the probe
-	// cannot establish absence is worse than one that stays quiet: it is
-	// wrong, it flips a whole class of working repositories to DRIFT, and
-	// `doctor --fix` could not clear it anyway — hooks.Install* joins the
-	// same wrong path and no-ops there. The honest fix is to resolve the
-	// hooks directory the way git does, in the WRITER and the READER
-	// together; until then a worktree gets no hook-absence report, and the
-	// two file-backed surfaces below still report normally.
-	hooksProbeReliable := gitPath.IsDir()
 	cfg, _ := config.Load(projectRoot)
 	if !cfg.Git.EnforceCommits {
-		return nil
+		return none
 	}
 	claudeWanted := config.ClaudeAgentEnabled(projectRoot)
 
@@ -544,12 +578,9 @@ func collectGateAbsences(projectRoot string, workflows []WorkflowStatus) []strin
 		byRow[wf.Name] = wf
 	}
 
-	var out []string
+	out := none
 	for _, surface := range gateSurfaces {
 		if surface.row == rowClaudeGuard && !claudeWanted {
-			continue
-		}
-		if surface.hookBacked && !hooksProbeReliable {
 			continue
 		}
 		if len(surface.siblings) > 0 && !anyInstalled(byRow, surface.siblings) {
@@ -564,12 +595,49 @@ func collectGateAbsences(projectRoot string, workflows []WorkflowStatus) []strin
 				surface.path, surface.role))
 			continue
 		}
-		if wf.Drift != "missing" {
+		// A "missing" row with no Path is a probe that could not work out
+		// WHERE the artifact would be — git declining to resolve a hooks
+		// directory, because there is no git binary or `.git` names a
+		// common directory that is not there. That is "cannot establish",
+		// not "absent", and an absence check that fires where it cannot
+		// establish absence is worse than one that stays quiet: it is
+		// wrong, and `doctor --fix` cannot clear it either, because the
+		// installer resolves the same way and no-ops for the same reason.
+		if wf.Drift == "missing" && wf.Path == "" {
 			continue
 		}
-		out = append(out, fmt.Sprintf("%s — %s is not installed", surface.path, surface.role))
+		where := surface.path
+		if wf.Path != "" {
+			where = relativeToRoot(projectRoot, wf.Path)
+		}
+		// GONE and PRESENT-BUT-INERT are one verdict here, because they are
+		// one outcome: the surface stops nothing — a commit for the two
+		// local gates, a merge for §6.2's. Splitting them would let the
+		// second keep passing as OK, which is what it did: an emptied
+		// commit-msg hook and one with its execute bit cleared both landed
+		// on a drift value this filter used to let through, with a 30-line
+		// raw commit going in behind each, and a check-decisions.yml whose
+		// job had been deleted reported `drift: current`.
+		switch {
+		case wf.Drift == "missing":
+			out = append(out, fmt.Sprintf("%s — %s is not installed", where, surface.role))
+		case wf.Inert != "":
+			out = append(out, fmt.Sprintf("%s — %s: %s", where, surface.role, wf.Inert))
+		}
 	}
 	return out
+}
+
+// relativeToRoot renders a probe's path the way a person would type it,
+// falling back to the absolute path when it lies outside the repository —
+// which a hooks directory legitimately can, in a linked worktree or under
+// an absolute core.hooksPath.
+func relativeToRoot(projectRoot, path string) string {
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
 }
 
 // anyInstalled reports whether at least one of rows is present on disk —
@@ -762,14 +830,21 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 	workflows = append(workflows, probeAgentsMD(projectRoot))
 	workflows = append(workflows, probeMergeDriverAttrs(projectRoot))
 	workflows = append(workflows, probeMergeDriverConfig(projectRoot))
-	workflows = append(workflows, probePostMergeHook(projectRoot))
-	workflows = append(workflows, probePostRewriteHook(projectRoot))
-	workflows = append(workflows, probeCommitMsgHook(projectRoot))
+	// ONE resolution for the four hook probes, and it is git's own answer
+	// rather than a `<projectRoot>/.git/hooks` join: core.hooksPath and a
+	// linked worktree both move the directory, and a probe that looks in
+	// the wrong place reports a working hook missing — after which the
+	// tool's own `doctor --fix` writes a replacement somewhere git never
+	// reads and the next run says OK. See hooks.Dir.
+	hooksDir, _ := hooks.Dir(projectRoot)
+	workflows = append(workflows, probePostMergeHook(hooksDir))
+	workflows = append(workflows, probePostRewriteHook(hooksDir))
+	workflows = append(workflows, probeCommitMsgHook(hooksDir))
 	// v2.0.0 L2a probe — the pin-preservation pre-commit hook. Sits right
 	// after commit-msg (the other commit-time git hook) and right before
 	// the Claude Code harness guard (L2b uses the same restore, different
 	// layer) since all three are part of the same enforcement/pin story.
-	workflows = append(workflows, probePreCommitHook(projectRoot))
+	workflows = append(workflows, probePreCommitHook(hooksDir))
 	// v2.0.0 Layer 1 probe — the Claude Code harness's PreToolUse guard
 	// entry in .claude/settings.json. Sits right after the commit-msg row
 	// (Layer 2) since the two are the enforcement feature's matched pair.
@@ -828,6 +903,19 @@ func StaleCount(projectRoot string) int {
 // handful of stat/read syscalls: single-digit milliseconds, safe to run on
 // EVERY `logmind log` invocation.
 //
+// ONE EXCEPTION, and it is deliberate: hooks.Dir runs `git rev-parse
+// --git-path hooks` once per call. The alternative was for the reader to
+// keep joining `<projectRoot>/.git/hooks` while the writer resolved
+// properly, and a doctor that disagrees with the installer about where a
+// hook lives is the defect this budget was protecting nothing from — it
+// reported a working hook missing under core.hooksPath, and `--fix` then
+// wrote one where git does not read. `rev-parse --git-path` touches no
+// objects and no index; `logmind log`, which is what pays for this path,
+// already forks git several times on the same invocation. Measured on a
+// darwin/arm64 laptop, where a process spawn is the whole cost: 31 ms for
+// the rev-parse, against a `logmind log --no-commit` that went 403 ms →
+// 442 ms. One spawn, on a verb that already pays for several.
+//
 // EXCLUDED, and why:
 //
 //   - probePathResolution: does `exec.LookPath("logmind")` followed by a
@@ -853,10 +941,11 @@ func collectLogmindStatusFast(projectRoot string) []WorkflowStatus {
 	}
 	workflows = append(workflows, probeAgentsMD(projectRoot))
 	workflows = append(workflows, probeMergeDriverAttrs(projectRoot)) // file read only (.gitattributes) — safe
-	workflows = append(workflows, probePostMergeHook(projectRoot))
-	workflows = append(workflows, probePostRewriteHook(projectRoot))
-	workflows = append(workflows, probeCommitMsgHook(projectRoot))
-	workflows = append(workflows, probePreCommitHook(projectRoot))
+	hooksDir, _ := hooks.Dir(projectRoot)
+	workflows = append(workflows, probePostMergeHook(hooksDir))
+	workflows = append(workflows, probePostRewriteHook(hooksDir))
+	workflows = append(workflows, probeCommitMsgHook(hooksDir))
+	workflows = append(workflows, probePreCommitHook(hooksDir))
 	workflows = append(workflows, probeClaudePreToolUseHook(projectRoot))
 	return workflows
 }
@@ -911,11 +1000,114 @@ func bundledLogmindMarker(workflowName string) *string {
 }
 
 func readWorkflow(projectRoot, name string) (string, bool) {
-	data, err := os.ReadFile(filepath.Join(projectRoot, ".github", "workflows", name))
+	data, err := os.ReadFile(workflowPath(projectRoot, name))
 	if err != nil {
 		return "", false
 	}
 	return string(data), true
+}
+
+func workflowPath(projectRoot, name string) string {
+	return filepath.Join(projectRoot, ".github", "workflows", name)
+}
+
+// pullRequestTrigger and the step markers below are what make
+// check-decisions.yml a GATE rather than a file in the right directory with
+// the right marker on line 1.
+//
+// probeWorkflow's verdict comes from inserter.ExtractTemplateMarker alone —
+// unlike probeHook it has no content-diff fast-path, because a workflow is
+// RENDERED (the default branch is substituted in) and a repository is
+// entitled to have edited one. Measured: deleting the whole `jobs:` block
+// while leaving line 1 intact reported `drift: current` and
+// `gate_absences: []`. The §6.2 merge gate was gone and doctor called the
+// stack fine.
+const pullRequestTrigger = "pull_request"
+
+// workflowTriggerPrefixes are the shapes an `on:` subscription to a pull
+// request takes — the mapping key, the list item, and the two inline forms.
+//
+// Matched at the START of a trimmed line, never as a substring of it. The
+// job body is full of `github.event.pull_request.base.sha`, so a `Contains`
+// over the file answers "subscribed" for a workflow whose trigger has been
+// replaced outright — which is the case this is for.
+var workflowTriggerPrefixes = []string{
+	pullRequestTrigger + ":",
+	pullRequestTrigger + "_target:",
+	"- " + pullRequestTrigger,
+	"on:",
+}
+
+// workflowStepPrefixes are the two ways a GitHub Actions step does
+// anything. A `jobs:` block containing neither runs nothing.
+var workflowStepPrefixes = []string{"run:", "uses:", "- run:", "- uses:"}
+
+// workflowInertReason answers "this workflow is installed — CAN it stop a
+// merge?", and only for the one workflow that is supposed to.
+//
+// TWO CONDITIONS, and they are exactly the two a reader can settle from the
+// file: does it subscribe to a pull-request event, and does it define a
+// step that runs anything. A workflow failing either cannot judge a pull
+// request under any circumstances.
+//
+// WHAT IT DELIBERATELY DOES NOT ASK is whether the job ENFORCES. An earlier
+// draft required the job to invoke `logmind check-decisions` and reported
+// anything else as "no pull request is judged by it" — which is false, and
+// logmind's own repository is the counter-example: its installed copy is
+// the pre-v5 bash gate, which does not call the verb and does trip. That
+// copy IS a §3.4 problem (the SPEC's "Both interception points and the gate
+// MUST use this one list") and it is a DIFFERENT problem from the gate
+// being absent. Reporting the second as the first is a true statement about
+// a narrow thing dressed as a conclusion about a wider one, and there is no
+// way to tell an enforcing job from an `exit 0` one by reading it.
+//
+// Read from NON-COMMENT lines, which is the whole reliability of it: the
+// template's own prose names `pull_request` a dozen times, so a substring
+// search over the file is satisfied by exactly the gutted copy it is meant
+// to catch.
+//
+// The other three workflows (regen-timeline, check-doc-links, self-update)
+// keep derived docs in step; a repository that edited one has customised a
+// convenience, and reporting that as a failing gate is how doctor becomes
+// noise people stop reading.
+func workflowInertReason(name, content string) string {
+	if name != rowCheckDecisionsWorkflow {
+		return ""
+	}
+	var trigger, step bool
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		for _, prefix := range workflowTriggerPrefixes {
+			if !strings.HasPrefix(trimmed, prefix) {
+				continue
+			}
+			// `on:` only counts when the subscription is on the same line
+			// (`on: pull_request`, `on: [push, pull_request]`); the block
+			// form's keys are matched by the prefixes above instead.
+			if prefix == "on:" && !strings.Contains(trimmed, pullRequestTrigger) {
+				continue
+			}
+			trigger = true
+			break
+		}
+		for _, prefix := range workflowStepPrefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				step = true
+				break
+			}
+		}
+	}
+	switch {
+	case !trigger:
+		return "it is present but subscribes to no `" + pullRequestTrigger +
+			"` event, so it never runs on a pull request"
+	case !step:
+		return "it is present but defines no step that runs anything, so a pull request passes it unjudged"
+	}
+	return ""
 }
 
 // classifyMarker compares an installed workflow's template marker against
@@ -952,7 +1144,10 @@ func classifyMarker(marker, bundled *string) string {
 func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 	content, ok := readWorkflow(projectRoot, name)
 	if !ok {
-		return WorkflowStatus{Name: name, Installed: false, Marker: nil, BundledMarker: bundled, Drift: "missing"}
+		return WorkflowStatus{
+			Name: name, Installed: false, Marker: nil, BundledMarker: bundled,
+			Drift: "missing", Path: workflowPath(projectRoot, name),
+		}
 	}
 	found := inserter.ExtractTemplateMarker(content)
 
@@ -984,6 +1179,8 @@ func probeWorkflow(projectRoot, name string, bundled *string) WorkflowStatus {
 		Name: name, Installed: true, Marker: display,
 		BundledMarker: bundled, Drift: classifyMarker(owned, bundled),
 		Displaced: displaced,
+		Inert:     workflowInertReason(name, content),
+		Path:      workflowPath(projectRoot, name),
 	}
 }
 
@@ -1129,66 +1326,118 @@ func probeMergeDriverConfig(projectRoot string) WorkflowStatus {
 }
 
 // probeHook is the shared helper behind post-merge / post-rewrite /
-// commit-msg probes. `installedBody` is the canonical body the current
-// Go binary would write; content drift means installed bytes != bundled.
-func probeHook(projectRoot, displayName, hookFile string, bundledBody string) WorkflowStatus {
+// commit-msg probes. `bundledBody` is the canonical body the current Go
+// binary would write; content drift means installed bytes != bundled.
+//
+// hooksDir is where git actually reads hooks from, resolved ONCE per probe
+// set by hooks.Dir — never joined here. "" means there is no hooks
+// directory to read (not a repository, or git could not answer), which is
+// the state the `<projectRoot>/.git` stat used to stand in for.
+//
+// `enforces`, when non-empty, is the invocation that makes this hook an
+// enforcement surface. A hook missing it, or one git will not execute, is
+// reported INERT: present, current, and enforcing nothing.
+func probeHook(hooksDir, displayName, hookFile, bundledBody, enforces string) WorkflowStatus {
 	current := version.Version
-	if _, err := os.Stat(filepath.Join(projectRoot, ".git")); err != nil {
+	if hooksDir == "" {
 		return WorkflowStatus{
 			Name: displayName, Installed: false,
 			Marker: nil, BundledMarker: nil, Drift: "missing",
 		}
 	}
-	path := filepath.Join(projectRoot, ".git", "hooks", hookFile)
-	if _, err := os.Stat(path); err != nil {
+	path := filepath.Join(hooksDir, hookFile)
+	info, err := os.Stat(path)
+	if err != nil {
 		return WorkflowStatus{
 			Name: displayName, Installed: false,
-			Marker: nil, BundledMarker: &current, Drift: "missing",
+			Marker: nil, BundledMarker: &current, Drift: "missing", Path: path,
 		}
 	}
+	installedBody, readErr := os.ReadFile(path)
+	inert := hookInertReason(info, string(installedBody), readErr, enforces)
+
 	hookVer, ok := hooks.ExtractVersion(path)
 	if !ok {
 		marker := "markerless (pre-v0.6.10)"
 		return WorkflowStatus{
 			Name: displayName, Installed: true,
 			Marker: &marker, BundledMarker: &current, Drift: "markerless",
+			Inert: inert, Path: path,
 		}
 	}
 	if hookVer != current {
 		return WorkflowStatus{
 			Name: displayName, Installed: true,
 			Marker: &hookVer, BundledMarker: &current, Drift: "stale",
+			Inert: inert, Path: path,
 		}
 	}
 	// Content-diff fast-path (v0.6.14).
-	installedBody, err := os.ReadFile(path)
-	if err == nil && string(installedBody) != bundledBody {
+	if readErr == nil && string(installedBody) != bundledBody {
 		marker := hookVer + " (content drift)"
 		return WorkflowStatus{
 			Name: displayName, Installed: true,
 			Marker: &marker, BundledMarker: &current, Drift: "stale",
+			Inert: inert, Path: path,
 		}
 	}
 	return WorkflowStatus{
 		Name: displayName, Installed: true,
 		Marker: &hookVer, BundledMarker: &current, Drift: "current",
+		Inert: inert, Path: path,
 	}
 }
 
-func probePostMergeHook(projectRoot string) WorkflowStatus {
-	return probeHook(projectRoot, "post-merge hook", "post-merge", hooks.BuildPostMergeBody())
+// hookInertReason answers "this file is here — will it stop anything?" for
+// a hook that is an enforcement surface, and "" for one that is not.
+//
+// Two ways to be present and useless, both measured on a repository doctor
+// called OK:
+//
+//   - NOT EXECUTABLE. git runs a hook as a program; without the bit it is
+//     skipped, silently, with no message anywhere. `chmod -x` on a
+//     byte-perfect commit-msg hook left `drift: current` and let a 30-line
+//     raw commit through.
+//   - NOT DELEGATING. `: > .git/hooks/commit-msg` leaves a file that IS
+//     the hook by every existence test and runs nothing. So does replacing
+//     the body with `exit 0`, or gutting it and keeping the comment that
+//     names the command.
+//
+// An unreadable hook is reported inert too — not as an accusation but
+// because doctor cannot establish that it enforces, and §3.4's "failing
+// open MUST NOT be silent" is about exactly the case where the tool does
+// not know.
+func hookInertReason(info os.FileInfo, body string, readErr error, enforces string) string {
+	if enforces == "" {
+		return ""
+	}
+	if info.Mode()&0o111 == 0 {
+		return "it is present but not executable, so git never runs it"
+	}
+	if readErr != nil {
+		return "it is present but could not be read, so logmind cannot tell whether it still enforces anything"
+	}
+	if !strings.Contains(body, enforces) {
+		return "it is present but no longer runs `logmind " + enforces + "`, so it enforces nothing"
+	}
+	return ""
 }
 
-func probePostRewriteHook(projectRoot string) WorkflowStatus {
-	return probeHook(projectRoot, "post-rewrite hook", "post-rewrite", hooks.BuildPostRewriteBody())
+func probePostMergeHook(hooksDir string) WorkflowStatus {
+	return probeHook(hooksDir, "post-merge hook", "post-merge", hooks.BuildPostMergeBody(), "")
+}
+
+func probePostRewriteHook(hooksDir string) WorkflowStatus {
+	return probeHook(hooksDir, "post-rewrite hook", "post-rewrite", hooks.BuildPostRewriteBody(), "")
 }
 
 // probeCommitMsgHook reports the v0.6.16 commit-msg hook state. When
 // the hook isn't yet installed (older logmind installs), `missing` is
 // the natural state — the next `logmind init` or `logmind self-update`
 // will install it.
-func probeCommitMsgHook(projectRoot string) WorkflowStatus {
-	return probeHook(projectRoot, rowCommitMsgHook, "commit-msg", hooks.BuildCommitMsgBody())
+func probeCommitMsgHook(hooksDir string) WorkflowStatus {
+	return probeHook(hooksDir, rowCommitMsgHook, "commit-msg", hooks.BuildCommitMsgBody(),
+		hooks.CommitMsgInvocation)
 }
 
 // probePreCommitHook reports drift for L2a of the v2.0.0 derived-docs
@@ -1206,16 +1455,16 @@ func probeCommitMsgHook(projectRoot string) WorkflowStatus {
 //
 // File-read only (stat + read, no subprocess) — safe for the fast path;
 // see StaleCountFast's doc comment for why that matters.
-func probePreCommitHook(projectRoot string) WorkflowStatus {
+func probePreCommitHook(hooksDir string) WorkflowStatus {
 	const displayName = "pre-commit hook (derived-docs pin)"
 	current := version.Version
-	if _, err := os.Stat(filepath.Join(projectRoot, ".git")); err != nil {
+	if hooksDir == "" {
 		return WorkflowStatus{
 			Name: displayName, Installed: false,
 			Marker: nil, BundledMarker: nil, Drift: "missing",
 		}
 	}
-	path := filepath.Join(projectRoot, ".git", "hooks", "pre-commit")
+	path := filepath.Join(hooksDir, "pre-commit")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return WorkflowStatus{
@@ -1271,30 +1520,35 @@ func probePreCommitHook(projectRoot string) WorkflowStatus {
 func probeClaudePreToolUseHook(projectRoot string) WorkflowStatus {
 	current := version.Version
 	const displayName = rowClaudeGuard
+	// The file this row is about, always — see WorkflowStatus.Path: an
+	// empty Path on a "missing" row means the probe could not work out
+	// where to look, which is a different thing from the artifact being
+	// absent, and collectGateAbsences distinguishes them by exactly this.
+	settingsPath := filepath.Join(projectRoot, ".claude", "settings.json")
 	state := claudehook.Inspect(projectRoot)
 	if !state.SettingsPresent || !state.EntryPresent {
 		return WorkflowStatus{
 			Name: displayName, Installed: false,
-			Marker: nil, BundledMarker: &current, Drift: "missing",
+			Marker: nil, BundledMarker: &current, Drift: "missing", Path: settingsPath,
 		}
 	}
 	if !state.HasMarker {
 		marker := "markerless (pre-v2.0.0)"
 		return WorkflowStatus{
 			Name: displayName, Installed: true,
-			Marker: &marker, BundledMarker: &current, Drift: "markerless",
+			Marker: &marker, BundledMarker: &current, Drift: "markerless", Path: settingsPath,
 		}
 	}
 	installed := state.Version
 	if installed != current {
 		return WorkflowStatus{
 			Name: displayName, Installed: true,
-			Marker: &installed, BundledMarker: &current, Drift: "stale",
+			Marker: &installed, BundledMarker: &current, Drift: "stale", Path: settingsPath,
 		}
 	}
 	return WorkflowStatus{
 		Name: displayName, Installed: true,
-		Marker: &installed, BundledMarker: &current, Drift: "current",
+		Marker: &installed, BundledMarker: &current, Drift: "current", Path: settingsPath,
 	}
 }
 
@@ -1488,7 +1742,10 @@ func RenderStatus(r StatusReport) string {
 		for _, g := range r.GateAbsences {
 			lines = append(lines, fmt.Sprintf("  • %s", g))
 		}
-		lines = append(lines, "  Reinstall with `logmind doctor --fix` — or set git.enforce_commits: false")
+		lines = append(lines, "  `logmind doctor --fix` reinstalls a gate that is missing, and restores the")
+		lines = append(lines, "  execute bit on one of its own hooks. A file it does not recognise as its own")
+		lines = append(lines, "  it leaves alone (SPEC §5.2), so an emptied or replaced hook, and an edited")
+		lines = append(lines, "  workflow, are yours to restore or delete. Or set git.enforce_commits: false")
 		lines = append(lines, "  in .logmind/config.yml to run this repository without them deliberately.")
 	}
 	if len(r.Suggestions) > 0 {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -79,13 +79,24 @@ import (
 	"github.com/thrillmade/logmind/internal/version"
 )
 
+// Probe-row names for the three SPEC §3.4 / §6.2 ENFORCEMENT surfaces.
+// Named constants, not literals, because collectGateAbsences finds these
+// rows BY NAME: a rename at the probe alone would silently unhook the
+// absence check and put doctor straight back to reporting OK over a
+// missing gate.
+const (
+	rowCheckDecisionsWorkflow = "check-decisions.yml"
+	rowCommitMsgHook          = "commit-msg hook"
+	rowClaudeGuard            = "Claude Code PreToolUse guard"
+)
+
 // Workflow filename constants — matches src/logmind/core/doctor.py
 // LOGMIND_WORKFLOWS / CLUD_BUG_WORKFLOWS.
 var LogmindWorkflows = []string{
 	"regen-timeline.yml",
 	"check-doc-links.yml",
 	"logmind-self-update.yml",
-	"check-decisions.yml",
+	rowCheckDecisionsWorkflow,
 }
 
 // Marker regexes match Python's compiled patterns at the source.
@@ -175,6 +186,26 @@ type StatusReport struct {
 	// the spec fold-in is a nice-to-have, not a gate.
 	SpecAdvisories []string `json:"spec_advisories"`
 
+	// GateAbsences names the SPEC §3.4 / §6.2 enforcement surfaces this
+	// repository INSTALLED and no longer has: the commit-msg hook, the
+	// Claude Code PreToolUse guard, the check-decisions workflow.
+	//
+	// NOT an advisory, and it is the only list on this struct that isn't.
+	// SummariesNeeded / SpecAdvisories / AutoAdvisories are nudges about
+	// things that would be nice to have; a removed gate is an enforcement
+	// point failing open, permanently, and SPEC §3.4 is explicit that
+	// "Failing open MUST NOT be silent." So a non-empty list here flips
+	// Overall to DRIFT and `logmind doctor` exits 1 — which is the whole
+	// point: before this, deleting all three left `Stack status: OK` and
+	// exit 0 (measured), while a single stale template marker correctly
+	// reported DRIFT. doctor was not blind; it simply never counted gone.
+	//
+	// Scoped to those three surfaces and no others. Every other probe's
+	// "missing" stays benign — a repo that never wanted the merge driver,
+	// or dependabot, is not drifted, and turning each optional template
+	// into DRIFT is how doctor becomes noise people stop reading.
+	GateAbsences []string `json:"gate_absences"`
+
 	// AutoAdvisories is an ADVISORY list (#241) about `.logmind/auto.yml`,
 	// the standing directive `logmind auto <profile>` writes: a directive
 	// that predates the current bundled policy, one written for a profile
@@ -234,12 +265,23 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 	}
 	tools := []ToolStatus{collectLogmindStatus(projectRoot)}
 
+	// Computed from the probe rows collectLogmindStatus just produced, not
+	// from a second stat of the same files: one probe per surface means the
+	// row and the verdict can never disagree about whether it is there.
+	gateAbsences := collectGateAbsences(projectRoot, tools[0].Workflows)
+
 	overall := "OK"
 	for _, t := range tools {
 		if t.Drift == "stale" {
 			overall = "DRIFT"
 			break
 		}
+	}
+	// A gate that was installed and is gone is drift by itself, with no
+	// stale row anywhere — that combination is exactly the state doctor
+	// used to report OK over. See StatusReport.GateAbsences.
+	if len(gateAbsences) > 0 {
+		overall = "DRIFT"
 	}
 	if overall == "OK" {
 		for _, t := range tools {
@@ -281,6 +323,7 @@ func CollectStatus(projectRoot string, offline bool) StatusReport {
 		SpecAdvisories:  collectSpecAdvisories(projectRoot),
 		AutoAdvisories:  collectAutoAdvisories(projectRoot),
 		GateAdvisories:  collectGateAdvisories(projectRoot),
+		GateAbsences:    gateAbsences,
 	}
 }
 
@@ -374,6 +417,171 @@ func readCludBugReview(path string) (map[string]any, bool) {
 		return nil, false
 	}
 	return doc.Review, doc.Review != nil
+}
+
+// gateSurfaces are the SPEC §3.4 / §6.2 enforcement surfaces — the three
+// places a substantive commit is actually stopped — paired with the file
+// whose absence means the surface is gone. §3.4 names the two local
+// interception points; §6.2 names "the one that actually blocks a merge."
+// Nothing else on the probe list is an enforcement surface, and nothing
+// else belongs here: the post-merge / post-rewrite / pre-commit hooks keep
+// derived docs in step, the merge driver resolves conflicts, and a repo
+// missing any of them has lost convenience, not a gate.
+// hookBacked marks a surface whose probe reads <repoRoot>/.git/hooks/…
+// directly. That join is wrong in a linked WORKTREE, where `.git` is a
+// file pointing at the common directory and the hooks live there — see
+// collectGateAbsences for why such a surface is skipped rather than
+// reported.
+//
+// siblings names rows installed in the SAME pass as this surface, used as
+// the recoverable evidence that the pass ever ran here. Only the workflow
+// carries them, and only because its opt-out is not recorded anywhere else:
+// `logmind init --github-actions=false` installs no workflows at all and
+// writes nothing to config.yml saying so, so a repository that is simply
+// not on GitHub Actions would otherwise be told forever that its merge gate
+// is missing, with `git.enforce_commits: false` — which also silences the
+// two LOCAL gates it presumably still wants — as its only escape.
+//
+// The two hooks-and-settings surfaces deliberately have none. Their absence
+// after a clone is the NORMAL state (git hooks are not cloned) and it is
+// exactly the thing worth saying; and the Claude guard's opt-out IS
+// recorded, as `agents.claude`.
+var gateSurfaces = []struct {
+	row, path, role string
+	hookBacked      bool
+	siblings        []string
+}{
+	{row: rowClaudeGuard, path: ".claude/settings.json",
+		role: "SPEC §3.4's harness interception point (PreToolUse)"},
+	{row: rowCommitMsgHook, path: ".git/hooks/commit-msg",
+		role: "SPEC §3.4's commit-msg interception point", hookBacked: true},
+	{row: rowCheckDecisionsWorkflow, path: ".github/workflows/check-decisions.yml",
+		role: "SPEC §6.2's merge gate",
+		siblings: []string{
+			"regen-timeline.yml", "check-doc-links.yml", "logmind-self-update.yml",
+		}},
+}
+
+// collectGateAbsences reports which enforcement surfaces this repository
+// installed and no longer has. It reads the probe rows CollectStatus
+// already produced rather than re-statting the same files.
+//
+// "INSTALLED AND NOW MISSING" vs "NEVER INSTALLED" is the whole question,
+// and the repo state does answer it — but only at repository granularity,
+// not per surface. `.logmind/config.yml` is what `logmind init` writes, and
+// init installs all three surfaces in the same pass, so its presence means
+// "this repo ran init" and therefore "these three were installed." A
+// directory that never ran init has no config.yml and is never nagged.
+//
+// TWO CASES THAT COST, both deliberate and both erring toward reporting:
+//
+//   - A repo initialised by a logmind that PREDATES one of these surfaces
+//     (the commit-msg hook and the PreToolUse guard are v2.0) has a
+//     config.yml and never had the file. It is reported. That is the right
+//     side to be wrong on: the repository genuinely has no gate there
+//     today, the remediation is the same single command, and the row
+//     clears permanently once it runs.
+//   - A FRESH CLONE of an initialised repo reports the commit-msg hook,
+//     because git hooks are not cloned. That is not noise — it is the most
+//     valuable thing here. Every fresh clone of a logmind repo is a working
+//     copy with no local enforcement at all, and §3.4's "failing open MUST
+//     NOT be silent" is precisely about not letting that pass quietly.
+//     `.claude/settings.json` and the workflow ARE committed, so a clean
+//     clone reports exactly one row, and `logmind doctor --fix` clears it.
+//
+// THE DELIBERATE OPT-OUT is `git.enforce_commits: false` — the key that
+// already means "logmind does not gate commits in this repository" to
+// guard-commit (internal/cli/guard_commit.go), to config.yml.template's own
+// comment, and to AGENTS.md. Set it and all three rows go quiet. It is one
+// key rather than a new doctor-specific one on purpose: a second key for
+// the same intent is a second owner for one fact, and the state it would
+// describe — "I want the gates enforced but I don't want them installed" —
+// is not a position anybody holds. The cost is real and worth naming: a
+// repo that wants local enforcement off but the CI gate on cannot say so
+// with this key, and silences the §6.2 row too.
+//
+// `agents.claude: false` silences the PreToolUse row on its own, because
+// init deliberately never installs that guard for such a repo — the reader
+// and the writer answer from config.ClaudeAgentEnabled, one rule, so
+// doctor cannot report a gate absent that init would refuse to create.
+func collectGateAbsences(projectRoot string, workflows []WorkflowStatus) []string {
+	// Never ran `logmind init` here → nothing was installed to lose.
+	if _, err := os.Stat(filepath.Join(projectRoot, ".logmind", "config.yml")); err != nil {
+		return nil
+	}
+	// Not a git repository → no commit can be made from it, so no gate is
+	// failing open. probeHook reports "missing" for this and for a deleted
+	// hook identically, so the distinction has to be made here.
+	gitPath, err := os.Stat(filepath.Join(projectRoot, ".git"))
+	if err != nil {
+		return nil
+	}
+	// A linked worktree: `.git` is a FILE naming the common directory, and
+	// the hooks live there and fire normally. probeHook joins
+	// <repoRoot>/.git/hooks/<name> literally, so it cannot see them and
+	// reports "missing" for a hook that is installed and running —
+	// measured in this repository's own agent worktrees, where
+	// `git rev-parse --git-path hooks` resolves to the main checkout's
+	// .git/hooks and commit-msg is sitting in it.
+	//
+	// Skipped, not reported. An absence check that fires where the probe
+	// cannot establish absence is worse than one that stays quiet: it is
+	// wrong, it flips a whole class of working repositories to DRIFT, and
+	// `doctor --fix` could not clear it anyway — hooks.Install* joins the
+	// same wrong path and no-ops there. The honest fix is to resolve the
+	// hooks directory the way git does, in the WRITER and the READER
+	// together; until then a worktree gets no hook-absence report, and the
+	// two file-backed surfaces below still report normally.
+	hooksProbeReliable := gitPath.IsDir()
+	cfg, _ := config.Load(projectRoot)
+	if !cfg.Git.EnforceCommits {
+		return nil
+	}
+	claudeWanted := config.ClaudeAgentEnabled(projectRoot)
+
+	byRow := make(map[string]WorkflowStatus, len(workflows))
+	for _, wf := range workflows {
+		byRow[wf.Name] = wf
+	}
+
+	var out []string
+	for _, surface := range gateSurfaces {
+		if surface.row == rowClaudeGuard && !claudeWanted {
+			continue
+		}
+		if surface.hookBacked && !hooksProbeReliable {
+			continue
+		}
+		if len(surface.siblings) > 0 && !anyInstalled(byRow, surface.siblings) {
+			continue
+		}
+		wf, ok := byRow[surface.row]
+		// Absent from the probe set at all is a wiring bug, not a repo
+		// state; say so rather than passing over it silently.
+		if !ok {
+			out = append(out, fmt.Sprintf(
+				"%s — %s: no probe reported on it, so logmind cannot tell whether it is installed",
+				surface.path, surface.role))
+			continue
+		}
+		if wf.Drift != "missing" {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s — %s is not installed", surface.path, surface.role))
+	}
+	return out
+}
+
+// anyInstalled reports whether at least one of rows is present on disk —
+// the evidence that the install pass which writes them ran in this
+// repository at all. See gateSurfaces.siblings.
+func anyInstalled(byRow map[string]WorkflowStatus, rows []string) bool {
+	for _, name := range rows {
+		if wf, ok := byRow[name]; ok && wf.Installed {
+			return true
+		}
+	}
+	return false
 }
 
 // collectAutoAdvisories returns the ADVISORY list for `.logmind/auto.yml`
@@ -589,6 +797,13 @@ func collectLogmindStatus(projectRoot string) ToolStatus {
 // package (see classifyLogmindDrift), so a caller that only cares about
 // "does this repo need `doctor --fix`" should only count the same signal
 // doctor itself gates on.
+//
+// That exclusion is about the VERSION-drift count, and it is not the whole
+// story about "missing" any more. A missing §3.4/§6.2 ENFORCEMENT surface
+// in a repository that ran `logmind init` is drift, and CollectStatus flips
+// Overall to DRIFT for it — see collectGateAbsences. It is counted there
+// and not here because this function answers "how many components are stale
+// against this binary", which a deleted gate is not.
 //
 // This is the FULL probe set — including probePathResolution (a PATH lookup
 // + a live subprocess) and probeMergeDriverConfig (a `git config` shell-out)
@@ -973,7 +1188,7 @@ func probePostRewriteHook(projectRoot string) WorkflowStatus {
 // the natural state — the next `logmind init` or `logmind self-update`
 // will install it.
 func probeCommitMsgHook(projectRoot string) WorkflowStatus {
-	return probeHook(projectRoot, "commit-msg hook", "commit-msg", hooks.BuildCommitMsgBody())
+	return probeHook(projectRoot, rowCommitMsgHook, "commit-msg", hooks.BuildCommitMsgBody())
 }
 
 // probePreCommitHook reports drift for L2a of the v2.0.0 derived-docs
@@ -1055,7 +1270,7 @@ func probePreCommitHook(projectRoot string) WorkflowStatus {
 // `doctor --fix` / `logmind init` remain the remediation either way.
 func probeClaudePreToolUseHook(projectRoot string) WorkflowStatus {
 	current := version.Version
-	const displayName = "Claude Code PreToolUse guard"
+	const displayName = rowClaudeGuard
 	state := claudehook.Inspect(projectRoot)
 	if !state.SettingsPresent || !state.EntryPresent {
 		return WorkflowStatus{
@@ -1264,6 +1479,18 @@ func RenderStatus(r StatusReport) string {
 	}
 
 	lines = append(lines, fmt.Sprintf("Stack status: %s", r.Overall))
+	// Printed directly under the verdict it CAUSED, ahead of the advisory
+	// sections below, because unlike those it is the reason the run exits 1.
+	if len(r.GateAbsences) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf(
+			"Enforcement gates absent (%d) — SPEC §3.4: \"Failing open MUST NOT be silent.\"", len(r.GateAbsences)))
+		for _, g := range r.GateAbsences {
+			lines = append(lines, fmt.Sprintf("  • %s", g))
+		}
+		lines = append(lines, "  Reinstall with `logmind doctor --fix` — or set git.enforce_commits: false")
+		lines = append(lines, "  in .logmind/config.yml to run this repository without them deliberately.")
+	}
 	if len(r.Suggestions) > 0 {
 		lines = append(lines, "Suggested:")
 		for _, s := range r.Suggestions {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -11,6 +11,7 @@ package doctor
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/inserter"
 	"github.com/thrillmade/logmind/internal/templates"
+	"github.com/thrillmade/logmind/internal/testgit"
 	"github.com/thrillmade/logmind/internal/version"
 )
 
@@ -50,11 +52,27 @@ func freshRepo(t *testing.T) string {
 // <ver>)` line the old pattern couldn't) is what unmasked this latent
 // non-hermeticity: before it, every host binary silently classified
 // markerless and never perturbed Overall.
+//
+// GIT IS LINKED IN, and only git. The hook probes resolve their directory
+// with `git rev-parse --git-path hooks` (hooks.Dir) now, so an isolated
+// PATH with nothing on it makes every hook row report "missing" — the test
+// would then be measuring an empty PATH rather than the repository. A
+// symlink to the one binary is what keeps the property this function exists
+// for: the isolated directory still resolves NO `logmind`, which is the
+// thing that must not leak in from the host (and which often lives in the
+// same directory as git, so putting git's whole directory on PATH would
+// undo it).
 func isolatePathHermetic(t *testing.T) {
 	t.Helper()
+	binDir := t.TempDir()
+	if git, err := exec.LookPath("git"); err == nil {
+		if err := os.Symlink(git, filepath.Join(binDir, "git")); err != nil {
+			t.Fatalf("symlink git into the isolated PATH: %v", err)
+		}
+	}
 	origPath := os.Getenv("PATH")
 	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
-	_ = os.Setenv("PATH", t.TempDir())
+	_ = os.Setenv("PATH", binDir)
 }
 
 func mustWrite(t *testing.T, path, content string) {
@@ -691,7 +709,7 @@ func TestProbeCommitMsgHook_CurrentAfterInstall(t *testing.T) {
 	if _, err := hooks.InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}
-	row := probeCommitMsgHook(dir)
+	row := probeCommitMsgHook(hooksDirOf(t, dir))
 	if row.Drift != "current" {
 		t.Errorf("Drift = %q; want current — a correctly-installed hook must not be reported as drifted", row.Drift)
 	}
@@ -714,7 +732,7 @@ func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
 	if _, err := hooks.InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}
-	path := filepath.Join(dir, ".git", "hooks", "commit-msg")
+	path := filepath.Join(hooksDirOf(t, dir), "commit-msg")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read commit-msg: %v", err)
@@ -725,7 +743,7 @@ func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
 	}
 	mustWrite(t, path, edited)
 
-	row := probeCommitMsgHook(dir)
+	row := probeCommitMsgHook(hooksDirOf(t, dir))
 	if row.Drift != "stale" {
 		t.Errorf("Drift = %q; want stale — a hand-edited hook body must be detected", row.Drift)
 	}
@@ -741,10 +759,12 @@ func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
 
 // --- probePreCommitHook (L2a / v2.0.0 derived-docs pin-preservation) -----
 
-// fakeGitDir plants a bare `.git/hooks/` directory under dir — enough for
-// probePreCommitHook's (and probeHook's) `.git`-presence check, without
-// needing a real `git init`. File-read-only probes only ever stat/read
-// paths, so this is a faithful, hermetic fixture.
+// realGitDir turns dir into an actual git repository, which the hook probes
+// now REQUIRE: they read the directory git reports for `rev-parse
+// --git-path hooks` (hooks.Dir) rather than joining `.git/hooks`, and a
+// hand-made `.git` directory is not something git will answer about. The
+// hand-made shell this replaces was hermetic and wrong in the same way the
+// probe was — it could only ever have measured the join.
 //
 // Enough for a PROBE-ROW assertion, but NOT for an Overall one. An
 // initialised repo with a .git and no enforcement surfaces installed is
@@ -753,17 +773,27 @@ func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
 // are actually there, or it asserts nothing about the row it names. The
 // four tests here that assert Overall use gatedRepo (gate_absence_test.go)
 // for that reason; the ones that assert only a row keep this fixture.
-func fakeGitDir(t *testing.T, dir string) {
+func realGitDir(t *testing.T, dir string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
-		t.Fatalf("mkdir .git/hooks: %v", err)
+	testgit.InitRepo(t, dir, "-q", "--initial-branch=main")
+}
+
+// hooksDirOf is the directory git reads hooks from for dir — what the hook
+// probes take now, resolved exactly as production resolves it rather than
+// rebuilt in the test.
+func hooksDirOf(t *testing.T, dir string) string {
+	t.Helper()
+	path, ok := hooks.Dir(dir)
+	if !ok {
+		t.Fatalf("hooks.Dir(%s): git could not resolve a hooks directory — the fixture is not a repository", dir)
 	}
+	return path
 }
 
 func TestProbePreCommitHook_MissingOnFreshRepo(t *testing.T) {
 	dir := freshRepo(t)
-	fakeGitDir(t, dir)
-	row := probePreCommitHook(dir)
+	realGitDir(t, dir)
+	row := probePreCommitHook(hooksDirOf(t, dir))
 	if row.Drift != "missing" {
 		t.Errorf("Drift = %q; want missing", row.Drift)
 	}
@@ -781,9 +811,9 @@ func TestProbePreCommitHook_MissingOnFreshRepo(t *testing.T) {
 func TestProbePreCommitHook_ForeignHookLeftAlone(t *testing.T) {
 	dir := gatedRepo(t)
 	foreign := "#!/bin/sh\n# logmind check-decisions — hang-guarded (issue #213)\nlogmind check-decisions\n"
-	mustWrite(t, filepath.Join(dir, ".git", "hooks", "pre-commit"), foreign)
+	mustWrite(t, filepath.Join(hooksDirOf(t, dir), "pre-commit"), foreign)
 
-	row := probePreCommitHook(dir)
+	row := probePreCommitHook(hooksDirOf(t, dir))
 	if row.Drift != "foreign" {
 		t.Errorf("Drift = %q; want foreign", row.Drift)
 	}
@@ -799,11 +829,11 @@ func TestProbePreCommitHook_ForeignHookLeftAlone(t *testing.T) {
 
 func TestProbePreCommitHook_CurrentAfterInstall(t *testing.T) {
 	dir := freshRepo(t)
-	fakeGitDir(t, dir)
+	realGitDir(t, dir)
 	if _, err := hooks.InstallPreCommit(dir); err != nil {
 		t.Fatalf("InstallPreCommit: %v", err)
 	}
-	row := probePreCommitHook(dir)
+	row := probePreCommitHook(hooksDirOf(t, dir))
 	if row.Drift != "current" {
 		t.Errorf("Drift = %q; want current", row.Drift)
 	}
@@ -814,7 +844,7 @@ func TestProbePreCommitHook_CurrentAfterInstall(t *testing.T) {
 
 func TestProbePreCommitHook_StaleOnRevertedMarker(t *testing.T) {
 	dir := freshRepo(t)
-	fakeGitDir(t, dir)
+	realGitDir(t, dir)
 	if _, err := hooks.InstallPreCommit(dir); err != nil {
 		t.Fatalf("InstallPreCommit: %v", err)
 	}
@@ -828,7 +858,7 @@ func TestProbePreCommitHook_StaleOnRevertedMarker(t *testing.T) {
 		t.Fatalf("write reverted pre-commit: %v", err)
 	}
 
-	row := probePreCommitHook(dir)
+	row := probePreCommitHook(hooksDirOf(t, dir))
 	if row.Drift != "stale" {
 		t.Errorf("Drift = %q; want stale", row.Drift)
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -687,8 +687,7 @@ func revertClaudeHookMarker(t *testing.T, dir string) {
 // byte of hand-editing is STALE.
 
 func TestProbeCommitMsgHook_CurrentAfterInstall(t *testing.T) {
-	dir := freshRepo(t)
-	fakeGitDir(t, dir)
+	dir := gatedRepo(t)
 	if _, err := hooks.InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}
@@ -711,8 +710,7 @@ func TestProbeCommitMsgHook_CurrentAfterInstall(t *testing.T) {
 // gate would reach for — leaving the version marker untouched, so only the
 // byte-compare can catch it.
 func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
-	dir := freshRepo(t)
-	fakeGitDir(t, dir)
+	dir := gatedRepo(t)
 	if _, err := hooks.InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}
@@ -747,6 +745,14 @@ func TestProbeCommitMsgHook_ContentDriftOnHandEdit(t *testing.T) {
 // probePreCommitHook's (and probeHook's) `.git`-presence check, without
 // needing a real `git init`. File-read-only probes only ever stat/read
 // paths, so this is a faithful, hermetic fixture.
+//
+// Enough for a PROBE-ROW assertion, but NOT for an Overall one. An
+// initialised repo with a .git and no enforcement surfaces installed is
+// DRIFT now, and correctly so (collectGateAbsences) — so a test that says
+// "this row must not flip Overall" has to start from a repo whose gates
+// are actually there, or it asserts nothing about the row it names. The
+// four tests here that assert Overall use gatedRepo (gate_absence_test.go)
+// for that reason; the ones that assert only a row keep this fixture.
 func fakeGitDir(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
@@ -773,8 +779,7 @@ func TestProbePreCommitHook_MissingOnFreshRepo(t *testing.T) {
 // classifyLogmindDrift treats it exactly like a missing hook (benign, never
 // flips Overall to DRIFT) instead of "stale" (which WOULD flip it).
 func TestProbePreCommitHook_ForeignHookLeftAlone(t *testing.T) {
-	dir := freshRepo(t)
-	fakeGitDir(t, dir)
+	dir := gatedRepo(t)
 	foreign := "#!/bin/sh\n# logmind check-decisions — hang-guarded (issue #213)\nlogmind check-decisions\n"
 	mustWrite(t, filepath.Join(dir, ".git", "hooks", "pre-commit"), foreign)
 

--- a/internal/doctor/gate_absence_test.go
+++ b/internal/doctor/gate_absence_test.go
@@ -1,0 +1,372 @@
+// gate_absence_test.go — exercises collectGateAbsences / the
+// CollectStatus.GateAbsences field: a §3.4/§6.2 enforcement surface that
+// `logmind init` installed and something later removed.
+//
+// Unlike every other list on StatusReport, these are NOT advisory. A gate
+// that is gone is an enforcement point failing open, permanently, and
+// SPEC §3.4 says "Failing open MUST NOT be silent" — so Overall must flip
+// to DRIFT and `logmind doctor` must exit non-zero.
+//
+// Measured on the release candidate, and the reason this file exists:
+// `logmind init`, then `rm .git/hooks/commit-msg .claude/settings.json
+// .github/workflows/check-decisions.yml`, then `logmind doctor` printed
+// "Stack status: OK" and exited 0. The same repo with one stale template
+// marker correctly printed DRIFT and exited 1 — doctor was not blind, it
+// simply never counted gone.
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/claudehook"
+	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// gatedRepo is freshRepo plus the state `logmind init` leaves behind: a
+// .git directory and all three enforcement surfaces installed. Tests
+// delete from it, which is the shape the bug lives in — freshRepo has no
+// .git at all, and a directory that cannot make a commit has no gate
+// failing open (see collectGateAbsences).
+func gatedRepo(t *testing.T) string {
+	t.Helper()
+	dir := freshRepo(t)
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/hooks: %v", err)
+	}
+	if _, err := hooks.InstallCommitMsg(dir); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	if _, err := claudehook.EnsurePreToolUseGuard(dir); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	// All four workflows, as init writes them in one pass — the other three
+	// are what tell collectGateAbsences that this repository is on GitHub
+	// Actions at all (gateSurfaces.siblings).
+	for _, name := range LogmindWorkflows {
+		mustWrite(t, filepath.Join(dir, ".github", "workflows", name),
+			templates.Workflow(name+".template"))
+	}
+	return dir
+}
+
+// gatePaths are the files gatedRepo installs, keyed by the sentence
+// fragment collectGateAbsences reports them under.
+var gatePaths = []string{
+	filepath.Join(".claude", "settings.json"),
+	filepath.Join(".git", "hooks", "commit-msg"),
+	filepath.Join(".github", "workflows", "check-decisions.yml"),
+}
+
+// TestGateAbsences_FullyInstalled_IsSilent is the control every other case
+// in this file is measured against. Without it, a collector that reported
+// all three unconditionally would score identically on the case below.
+func TestGateAbsences_FullyInstalled_IsSilent(t *testing.T) {
+	dir := gatedRepo(t)
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — all three surfaces are installed", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK", r.Overall)
+	}
+}
+
+// TestGateAbsences_DeletedGatesAreDrift is the regression pin, and it pins
+// the OUTPUT the operator saw: the rendered "Stack status:" line and the
+// verdict driving the process exit, not the collector underneath them.
+func TestGateAbsences_DeletedGatesAreDrift(t *testing.T) {
+	dir := gatedRepo(t)
+	for _, rel := range gatePaths {
+		if err := os.Remove(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("remove %s: %v", rel, err)
+		}
+	}
+
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 3 {
+		t.Fatalf("GateAbsences = %v; want all three surfaces reported", r.GateAbsences)
+	}
+	if r.Overall != "DRIFT" {
+		t.Fatalf("Overall = %q; want DRIFT — three enforcement gates are gone and "+
+			"SPEC §3.4 forbids failing open silently", r.Overall)
+	}
+
+	// Each absence must name the FILE, or the reader cannot act on it.
+	joined := strings.Join(r.GateAbsences, "\n")
+	for _, rel := range gatePaths {
+		if !strings.Contains(joined, filepath.ToSlash(rel)) {
+			t.Errorf("GateAbsences = %v; want %s named", r.GateAbsences, rel)
+		}
+	}
+
+	// And it has to reach the surface a person reads. The rendered table
+	// is what `logmind doctor` prints; a report field nothing renders is
+	// exactly as silent as the bug was.
+	body := RenderStatus(r)
+	if !strings.Contains(body, "Stack status: DRIFT") {
+		t.Errorf("rendered body says OK over three deleted gates:\n%s", body)
+	}
+	for _, want := range []string{
+		"Enforcement gates absent (3)",
+		"Failing open MUST NOT be silent",
+		"logmind doctor --fix",
+		"git.enforce_commits: false",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestGateAbsences_EachSurfaceCountsOnItsOwn — one deletion, one row. A
+// collector that only fired when ALL of them were gone would pass the test
+// above and still miss the single-gate case, which is the common one (a
+// fresh clone has no commit-msg hook).
+func TestGateAbsences_EachSurfaceCountsOnItsOwn(t *testing.T) {
+	for _, rel := range gatePaths {
+		t.Run(rel, func(t *testing.T) {
+			dir := gatedRepo(t)
+			if err := os.Remove(filepath.Join(dir, rel)); err != nil {
+				t.Fatalf("remove %s: %v", rel, err)
+			}
+			r := CollectStatus(dir, true)
+			if len(r.GateAbsences) != 1 {
+				t.Fatalf("GateAbsences = %v; want exactly 1 (%s deleted)", r.GateAbsences, rel)
+			}
+			if !strings.Contains(r.GateAbsences[0], filepath.ToSlash(rel)) {
+				t.Errorf("GateAbsences[0] = %q; want it to name %s", r.GateAbsences[0], rel)
+			}
+			if r.Overall != "DRIFT" {
+				t.Errorf("Overall = %q; want DRIFT (%s is gone)", r.Overall, rel)
+			}
+		})
+	}
+}
+
+// TestGateAbsences_EnforceCommitsFalseIsRespected — the deliberate
+// opt-out. `git.enforce_commits: false` already means "logmind does not
+// gate commits here" to guard-commit; doctor must not nag a repo that has
+// said so, or the escape hatch does not exist.
+func TestGateAbsences_EnforceCommitsFalseIsRespected(t *testing.T) {
+	dir := gatedRepo(t)
+	for _, rel := range gatePaths {
+		if err := os.Remove(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("remove %s: %v", rel, err)
+		}
+	}
+	// CONTROL first: without the key, this exact tree is DRIFT.
+	if r := CollectStatus(dir, true); r.Overall != "DRIFT" {
+		t.Fatalf("control: Overall = %q; want DRIFT before the opt-out is written", r.Overall)
+	}
+
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"),
+		"git:\n  auto_commit: true\n  enforce_commits: false\n")
+
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — git.enforce_commits is false", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK — the repo opted out deliberately", r.Overall)
+	}
+}
+
+// TestGateAbsences_ClaudeAgentDisabled — the reader must agree with the
+// writer. `logmind init` never installs the PreToolUse guard for a repo
+// with `agents.claude: false`, so doctor must not report it absent; the
+// OTHER two surfaces still count, or the flag would silence more than it
+// covers.
+func TestGateAbsences_ClaudeAgentDisabled(t *testing.T) {
+	dir := gatedRepo(t)
+	mustWrite(t, filepath.Join(dir, ".logmind", "config.yml"),
+		"git:\n  auto_commit: true\nagents:\n  claude: false\n")
+	if err := os.Remove(filepath.Join(dir, ".claude", "settings.json")); err != nil {
+		t.Fatalf("remove settings.json: %v", err)
+	}
+
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Fatalf("GateAbsences = %v; want none — this repo never asked for the guard", r.GateAbsences)
+	}
+
+	// The flag covers the guard and nothing else.
+	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+		t.Fatalf("remove commit-msg: %v", err)
+	}
+	r = CollectStatus(dir, true)
+	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "commit-msg") {
+		t.Fatalf("GateAbsences = %v; want the commit-msg hook alone — agents.claude "+
+			"silences the harness guard, not the whole set", r.GateAbsences)
+	}
+}
+
+// TestGateAbsences_NeverInitialised_IsSilent — absence is only drift where
+// something was installed to lose. A directory that never ran `logmind
+// init` has no .logmind/config.yml and must never be nagged, which is the
+// line between "a choice" and "drift".
+func TestGateAbsences_NeverInitialised_IsSilent(t *testing.T) {
+	dir := t.TempDir()
+	isolatePathHermetic(t)
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/hooks: %v", err)
+	}
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — this directory never ran `logmind init`", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK", r.Overall)
+	}
+}
+
+// TestGateAbsences_NonRepo_IsSilent — an initialised directory that is not
+// a git repository cannot make a commit, so nothing is failing open there.
+// probeHook reports "missing" for a deleted hook and for an absent .git
+// identically, so this distinction is made in collectGateAbsences and has
+// to be pinned separately.
+func TestGateAbsences_NonRepo_IsSilent(t *testing.T) {
+	dir := freshRepo(t) // .logmind/config.yml, but no .git
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — not a git repository", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK", r.Overall)
+	}
+}
+
+// TestGateAbsences_NonEnforcementMissingIsStillBenign — the scope fence.
+// Turning every optional template into DRIFT is how doctor becomes noise
+// people stop reading, so a missing NON-enforcement artifact must stay
+// exactly as benign as it was.
+func TestGateAbsences_NonEnforcementMissingIsStillBenign(t *testing.T) {
+	dir := gatedRepo(t)
+	for _, rel := range []string{
+		filepath.Join(".github", "workflows", "regen-timeline.yml"),
+		filepath.Join(".github", "workflows", "check-doc-links.yml"),
+		filepath.Join(".github", "workflows", "logmind-self-update.yml"),
+		"AGENTS.md",
+		".gitattributes",
+	} {
+		mustWrite(t, filepath.Join(dir, rel), "placeholder\n")
+		if err := os.Remove(filepath.Join(dir, rel)); err != nil {
+			t.Fatalf("remove %s: %v", rel, err)
+		}
+	}
+	// The post-merge / post-rewrite / pre-commit hooks were never installed
+	// by gatedRepo, so they are already absent here.
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — none of those is a §3.4/§6.2 "+
+			"enforcement surface", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK — missing optional templates are not drift", r.Overall)
+	}
+}
+
+// TestGateAbsences_LinkedWorktreeDoesNotReportHooks — the false positive
+// that nearly shipped with this feature, and the reason `logmind doctor`
+// must not treat every "missing" hook row as evidence.
+//
+// In a linked git worktree `.git` is a FILE naming the common directory,
+// the hooks live there, and they fire normally. probeHook joins
+// <repoRoot>/.git/hooks/<name> literally, so it reports "missing" for a
+// hook that is installed and running — measured in this repository's own
+// agent worktrees. Escalating that row to DRIFT would flip every worktree
+// of every logmind repo to exit 1 over a gate that is not absent, and
+// `doctor --fix` could not clear it (hooks.Install* joins the same wrong
+// path and no-ops there).
+//
+// The two FILE-backed surfaces are unaffected and must still report, or
+// this guard would silence more than the unreliable probe.
+func TestGateAbsences_LinkedWorktreeDoesNotReportHooks(t *testing.T) {
+	dir := gatedRepo(t)
+
+	// CONTROL: as a normal checkout, the deleted hook IS reported.
+	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+		t.Fatalf("remove commit-msg: %v", err)
+	}
+	if r := CollectStatus(dir, true); len(r.GateAbsences) != 1 {
+		t.Fatalf("control: GateAbsences = %v; want the commit-msg hook reported "+
+			"while .git is a directory", r.GateAbsences)
+	}
+
+	// Now make it a worktree: `.git` becomes a file (the hooks it names are
+	// elsewhere and outside this probe's reach).
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf("rm .git: %v", err)
+	}
+	mustWrite(t, filepath.Join(dir, ".git"), "gitdir: /elsewhere/.git/worktrees/wt\n")
+
+	r := CollectStatus(dir, true)
+	for _, g := range r.GateAbsences {
+		if strings.Contains(g, "commit-msg") {
+			t.Errorf("GateAbsences = %v; a linked worktree's hooks are not visible to "+
+				"this probe, so their absence must not be claimed", r.GateAbsences)
+		}
+	}
+
+	// …but the file-backed surfaces still report there.
+	if err := os.Remove(filepath.Join(dir, ".github", "workflows", "check-decisions.yml")); err != nil {
+		t.Fatalf("remove check-decisions.yml: %v", err)
+	}
+	r = CollectStatus(dir, true)
+	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "check-decisions.yml") {
+		t.Fatalf("GateAbsences = %v; want the merge gate reported — a worktree hides "+
+			"the hooks, not the workflow", r.GateAbsences)
+	}
+}
+
+// TestGateAbsences_NoWorkflowsAtAll_IsSilent — `logmind init
+// --github-actions=false` installs no workflows and records that choice
+// nowhere, so the merge-gate row must fall silent when its siblings are
+// absent too. Otherwise a repository that is simply not on GitHub Actions
+// is told forever that its gate is missing, and the only escape
+// (git.enforce_commits: false) also silences the two LOCAL gates it still
+// wants.
+//
+// The CONTROL is the reproduced case, and it is what stops this guard from
+// swallowing the bug: with the sibling workflows present, deleting
+// check-decisions.yml alone is still DRIFT.
+func TestGateAbsences_NoWorkflowsAtAll_IsSilent(t *testing.T) {
+	dir := gatedRepo(t)
+
+	// CONTROL: siblings present, the gate alone deleted → reported.
+	if err := os.Remove(filepath.Join(dir, ".github", "workflows", "check-decisions.yml")); err != nil {
+		t.Fatalf("remove check-decisions.yml: %v", err)
+	}
+	r := CollectStatus(dir, true)
+	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "check-decisions.yml") {
+		t.Fatalf("control: GateAbsences = %v; want the merge gate reported while its "+
+			"siblings are installed", r.GateAbsences)
+	}
+
+	// Now no logmind workflows at all — this repo never took that path.
+	if err := os.RemoveAll(filepath.Join(dir, ".github", "workflows")); err != nil {
+		t.Fatalf("rm workflows: %v", err)
+	}
+	r = CollectStatus(dir, true)
+	if len(r.GateAbsences) != 0 {
+		t.Errorf("GateAbsences = %v; want none — no logmind workflow was ever "+
+			"installed here", r.GateAbsences)
+	}
+	if r.Overall != "OK" {
+		t.Errorf("Overall = %q; want OK", r.Overall)
+	}
+
+	// …and the LOCAL gates are unaffected by that: they are per-clone and
+	// their absence still counts.
+	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+		t.Fatalf("remove commit-msg: %v", err)
+	}
+	r = CollectStatus(dir, true)
+	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "commit-msg") {
+		t.Fatalf("GateAbsences = %v; want the commit-msg hook reported — no-workflows "+
+			"is a statement about CI, not about the local interception points", r.GateAbsences)
+	}
+}

--- a/internal/doctor/gate_absence_test.go
+++ b/internal/doctor/gate_absence_test.go
@@ -17,6 +17,7 @@ package doctor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"github.com/thrillmade/logmind/internal/claudehook"
 	"github.com/thrillmade/logmind/internal/hooks"
 	"github.com/thrillmade/logmind/internal/templates"
+	"github.com/thrillmade/logmind/internal/testgit"
 )
 
 // gatedRepo is freshRepo plus the state `logmind init` leaves behind: a
@@ -34,9 +36,11 @@ import (
 func gatedRepo(t *testing.T) string {
 	t.Helper()
 	dir := freshRepo(t)
-	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
-		t.Fatalf("mkdir .git/hooks: %v", err)
-	}
+	// A REAL repository, because the hook installers and the hook probes
+	// both resolve their directory through git now (hooks.Dir) — against a
+	// hand-made `.git` every Install* below no-ops and every probe reports
+	// missing, which is the fixture measuring the bug rather than the code.
+	realGitDir(t, dir)
 	if _, err := hooks.InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}
@@ -194,7 +198,7 @@ func TestGateAbsences_ClaudeAgentDisabled(t *testing.T) {
 	}
 
 	// The flag covers the guard and nothing else.
-	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+	if err := os.Remove(filepath.Join(hooksDirOf(t, dir), "commit-msg")); err != nil {
 		t.Fatalf("remove commit-msg: %v", err)
 	}
 	r = CollectStatus(dir, true)
@@ -211,9 +215,7 @@ func TestGateAbsences_ClaudeAgentDisabled(t *testing.T) {
 func TestGateAbsences_NeverInitialised_IsSilent(t *testing.T) {
 	dir := t.TempDir()
 	isolatePathHermetic(t)
-	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
-		t.Fatalf("mkdir .git/hooks: %v", err)
-	}
+	realGitDir(t, dir)
 	r := CollectStatus(dir, true)
 	if len(r.GateAbsences) != 0 {
 		t.Errorf("GateAbsences = %v; want none — this directory never ran `logmind init`", r.GateAbsences)
@@ -269,35 +271,85 @@ func TestGateAbsences_NonEnforcementMissingIsStillBenign(t *testing.T) {
 	}
 }
 
-// TestGateAbsences_LinkedWorktreeDoesNotReportHooks — the false positive
-// that nearly shipped with this feature, and the reason `logmind doctor`
-// must not treat every "missing" hook row as evidence.
+// TestGateAbsences_LinkedWorktreeSeesTheHooksGitReads — the false positive
+// that shipped with this feature's first draft, now fixed at the cause
+// rather than suppressed.
 //
 // In a linked git worktree `.git` is a FILE naming the common directory,
-// the hooks live there, and they fire normally. probeHook joins
-// <repoRoot>/.git/hooks/<name> literally, so it reports "missing" for a
-// hook that is installed and running — measured in this repository's own
-// agent worktrees. Escalating that row to DRIFT would flip every worktree
-// of every logmind repo to exit 1 over a gate that is not absent, and
-// `doctor --fix` could not clear it (hooks.Install* joins the same wrong
-// path and no-ops there).
-//
-// The two FILE-backed surfaces are unaffected and must still report, or
-// this guard would silence more than the unreliable probe.
-func TestGateAbsences_LinkedWorktreeDoesNotReportHooks(t *testing.T) {
-	dir := gatedRepo(t)
+// the hooks live THERE, and they fire normally. The probe used to join
+// <repoRoot>/.git/hooks/<name>, so it reported "missing" for a hook that
+// was installed and running — measured in this repository's own agent
+// worktrees. The first fix was to say nothing in a worktree at all, which
+// bought silence at the price of never reporting a genuinely absent hook
+// there. The probe now resolves the directory the way git does
+// (hooks.Dir), so both halves are answerable, and both are asserted here:
+// an installed hook is FOUND from the worktree, and a deleted one is
+// REPORTED from the worktree.
+func TestGateAbsences_LinkedWorktreeSeesTheHooksGitReads(t *testing.T) {
+	main := gatedRepo(t)
+	mustWrite(t, filepath.Join(main, "seed.txt"), "seed\n")
+	gitInRepo(t, main, "config", "user.email", "test@example.com")
+	gitInRepo(t, main, "config", "user.name", "Test")
+	gitInRepo(t, main, "config", "commit.gpgsign", "false")
+	gitInRepo(t, main, "add", "seed.txt")
+	gitInRepo(t, main, "commit", "-q", "-m", "seed", "--no-verify")
 
-	// CONTROL: as a normal checkout, the deleted hook IS reported.
-	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+	linked := filepath.Join(t.TempDir(), "wt")
+	gitInRepo(t, main, "worktree", "add", "-q", "-b", "wt", linked)
+	testgit.DisableMaintenance(t, linked)
+
+	// The worktree is a checkout, not a logmind project — give it the same
+	// surfaces gatedRepo gave the main checkout, minus the hook, which is
+	// SHARED and is exactly what this test is about.
+	mustWrite(t, filepath.Join(linked, ".logmind", "config.yml"), "git:\n  auto_commit: true\n")
+	mustWrite(t, filepath.Join(linked, "docs", "decisions.md"), "# Decisions\n")
+	if _, err := claudehook.EnsurePreToolUseGuard(linked); err != nil {
+		t.Fatalf("EnsurePreToolUseGuard: %v", err)
+	}
+	for _, name := range LogmindWorkflows {
+		mustWrite(t, filepath.Join(linked, ".github", "workflows", name),
+			templates.Workflow(name+".template"))
+	}
+
+	// Precondition: `.git` really is a FILE here, or this test is a second
+	// copy of the normal-checkout case.
+	info, err := os.Lstat(filepath.Join(linked, ".git"))
+	if err != nil || info.IsDir() {
+		t.Fatalf("precondition: %s/.git is not a worktree pointer file (err=%v)", linked, err)
+	}
+
+	if r := CollectStatus(linked, true); len(r.GateAbsences) != 0 {
+		t.Fatalf("GateAbsences = %v; want none — the commit-msg hook is installed in the "+
+			"common directory and fires for commits made from this worktree", r.GateAbsences)
+	}
+
+	// …and the absence IS reported from here, which the previous
+	// worktree-wide silence could never have said.
+	hooksDir, ok := hooks.Dir(linked)
+	if !ok {
+		t.Fatal("hooks.Dir could not resolve the worktree's hooks directory")
+	}
+	if err := os.Remove(filepath.Join(hooksDir, "commit-msg")); err != nil {
 		t.Fatalf("remove commit-msg: %v", err)
 	}
-	if r := CollectStatus(dir, true); len(r.GateAbsences) != 1 {
-		t.Fatalf("control: GateAbsences = %v; want the commit-msg hook reported "+
-			"while .git is a directory", r.GateAbsences)
+	r := CollectStatus(linked, true)
+	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "commit-msg") {
+		t.Fatalf("GateAbsences = %v; want the commit-msg hook reported — it is genuinely "+
+			"gone from the directory git reads for this worktree", r.GateAbsences)
 	}
+}
 
-	// Now make it a worktree: `.git` becomes a file (the hooks it names are
-	// elsewhere and outside this probe's reach).
+// TestGateAbsences_UnresolvableGitDirIsSilent — the other side of the same
+// rule. When git cannot say where the hooks live (a `.git` pointer at a
+// common directory that is not there), logmind cannot establish that a hook
+// is absent, and "cannot establish" must not be reported as "absent":
+// `doctor --fix` would not clear it either, because the installer resolves
+// the same way and no-ops for the same reason.
+//
+// The FILE-backed surfaces still report, or this guard would silence more
+// than the unanswerable probe.
+func TestGateAbsences_UnresolvableGitDirIsSilent(t *testing.T) {
+	dir := gatedRepo(t)
 	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
 		t.Fatalf("rm .git: %v", err)
 	}
@@ -306,19 +358,28 @@ func TestGateAbsences_LinkedWorktreeDoesNotReportHooks(t *testing.T) {
 	r := CollectStatus(dir, true)
 	for _, g := range r.GateAbsences {
 		if strings.Contains(g, "commit-msg") {
-			t.Errorf("GateAbsences = %v; a linked worktree's hooks are not visible to "+
-				"this probe, so their absence must not be claimed", r.GateAbsences)
+			t.Errorf("GateAbsences = %v; git cannot resolve a hooks directory here, so "+
+				"the hook's absence is not established and must not be claimed", r.GateAbsences)
 		}
 	}
 
-	// …but the file-backed surfaces still report there.
 	if err := os.Remove(filepath.Join(dir, ".github", "workflows", "check-decisions.yml")); err != nil {
 		t.Fatalf("remove check-decisions.yml: %v", err)
 	}
 	r = CollectStatus(dir, true)
 	if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], "check-decisions.yml") {
-		t.Fatalf("GateAbsences = %v; want the merge gate reported — a worktree hides "+
-			"the hooks, not the workflow", r.GateAbsences)
+		t.Fatalf("GateAbsences = %v; want the merge gate reported — an unanswerable git "+
+			"hides the hooks, not the workflow", r.GateAbsences)
+	}
+}
+
+// gitInRepo runs `git <args>` in dir, failing the test on a non-zero exit.
+func gitInRepo(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
 	}
 }
 
@@ -361,7 +422,7 @@ func TestGateAbsences_NoWorkflowsAtAll_IsSilent(t *testing.T) {
 
 	// …and the LOCAL gates are unaffected by that: they are per-clone and
 	// their absence still counts.
-	if err := os.Remove(filepath.Join(dir, ".git", "hooks", "commit-msg")); err != nil {
+	if err := os.Remove(filepath.Join(hooksDirOf(t, dir), "commit-msg")); err != nil {
 		t.Fatalf("remove commit-msg: %v", err)
 	}
 	r = CollectStatus(dir, true)

--- a/internal/doctor/gate_function_test.go
+++ b/internal/doctor/gate_function_test.go
@@ -1,0 +1,261 @@
+// gate_function_test.go — an enforcement surface is ABSENT when it cannot
+// enforce, not only when the file is gone. Companion to
+// gate_absence_test.go, which covers the deleted-file half.
+//
+// Three states measured on the release candidate, every one reporting
+// `Stack status: OK`, `gate_absences: null`, exit 0:
+//
+//	: > .git/hooks/commit-msg                  → 30-line raw commit through
+//	chmod -x .git/hooks/commit-msg             → 30-line raw commit through
+//	delete check-decisions.yml's jobs: block   → §6.2 merge gate defanged
+//
+// plus a fourth, which is the worst of them because the tool causes it:
+// with core.hooksPath set, doctor reported a working hook missing, and its
+// own `--fix` then wrote a replacement to .git/hooks — a path git never
+// reads — after which doctor reported OK over a repository with no gate.
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thrillmade/logmind/internal/hooks"
+	"github.com/thrillmade/logmind/internal/templates"
+)
+
+// TestGateAbsences_InertCommitMsgHookIsReported — present, and enforcing
+// nothing. Each case carries the CONTROL in the same run: the untouched
+// hook must be silent, or a check that reports everything scores the same.
+func TestGateAbsences_InertCommitMsgHookIsReported(t *testing.T) {
+	cases := []struct {
+		name string
+		// break_ turns the installed hook into an inert one.
+		break_ func(t *testing.T, path string)
+		want   string
+	}{
+		{
+			name: "emptied",
+			break_: func(t *testing.T, path string) {
+				mustWrite(t, path, "")
+				if err := os.Chmod(path, 0o755); err != nil {
+					t.Fatalf("chmod: %v", err)
+				}
+			},
+			want: "no longer runs",
+		},
+		{
+			name: "replaced with exit 0",
+			break_: func(t *testing.T, path string) {
+				mustWrite(t, path, "#!/bin/sh\n# logmind commit-msg hook\nexit 0\n")
+				if err := os.Chmod(path, 0o755); err != nil {
+					t.Fatalf("chmod: %v", err)
+				}
+			},
+			want: "no longer runs",
+		},
+		{
+			name: "execute bit cleared",
+			break_: func(t *testing.T, path string) {
+				if err := os.Chmod(path, 0o644); err != nil {
+					t.Fatalf("chmod: %v", err)
+				}
+			},
+			want: "not executable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := gatedRepo(t)
+			path := filepath.Join(hooksDirOf(t, dir), "commit-msg")
+
+			// CONTROL: as installed, nothing is reported.
+			if r := CollectStatus(dir, true); len(r.GateAbsences) != 0 {
+				t.Fatalf("control: GateAbsences = %v; want none before the hook is broken", r.GateAbsences)
+			}
+
+			tc.break_(t, path)
+			r := CollectStatus(dir, true)
+			if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], tc.want) {
+				t.Fatalf("GateAbsences = %v; want one row saying %q — the hook is present and stops nothing",
+					r.GateAbsences, tc.want)
+			}
+			if !strings.Contains(r.GateAbsences[0], "commit-msg") {
+				t.Errorf("GateAbsences = %v; the row must name the file", r.GateAbsences)
+			}
+			if r.Overall != "DRIFT" {
+				t.Errorf("Overall = %q; want DRIFT — SPEC §3.4: failing open MUST NOT be silent", r.Overall)
+			}
+		})
+	}
+}
+
+// TestGateAbsences_DefangedMergeGateIsReported — the §6.2 gate with its
+// marker intact and its job gone. probeWorkflow's verdict comes from the
+// marker alone, so this reported `drift: current` and nothing else.
+//
+// The last case is the FENCE against over-reporting, and it is not
+// hypothetical: an earlier draft required the job to invoke `logmind
+// check-decisions`, and logmind's own repository — whose installed copy is
+// the pre-v5 bash gate that trips without calling the verb — was reported
+// as judging no pull request at all. It does judge; it judges by a second
+// list. That is a different fault and this check does not claim it.
+func TestGateAbsences_DefangedMergeGateIsReported(t *testing.T) {
+	full := templates.Workflow("check-decisions.yml.template")
+
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "jobs block deleted, marker intact",
+			content: full[:strings.Index(full, "\njobs:")+1],
+			want:    "defines no step that runs anything",
+		},
+		{
+			name:    "no pull-request trigger",
+			content: strings.ReplaceAll(full, "pull_request_target:", "workflow_dispatch:"),
+			want:    "subscribes to no `pull_request` event",
+		},
+		{
+			name:    "customised but still a gate",
+			content: strings.ReplaceAll(full, "logmind check-decisions", "./scripts/our-own-gate"),
+			want:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := gatedRepo(t)
+			path := filepath.Join(dir, ".github", "workflows", "check-decisions.yml")
+
+			if r := CollectStatus(dir, true); len(r.GateAbsences) != 0 {
+				t.Fatalf("control: GateAbsences = %v; want none before the workflow is edited", r.GateAbsences)
+			}
+			// The premise of every case: line 1 still carries the marker
+			// probeWorkflow judges by, so only a functional check can catch
+			// anything here.
+			if !strings.HasPrefix(tc.content, "# logmind-template-version:") {
+				t.Fatalf("fixture lost the line-1 marker, so this case no longer tests what it claims")
+			}
+			mustWrite(t, path, tc.content)
+
+			r := CollectStatus(dir, true)
+			if tc.want == "" {
+				if len(r.GateAbsences) != 0 {
+					t.Fatalf("GateAbsences = %v; want none — a repository may run its own gate on "+
+						"a pull request, and logmind cannot read whether a job enforces", r.GateAbsences)
+				}
+				return
+			}
+			if len(r.GateAbsences) != 1 || !strings.Contains(r.GateAbsences[0], tc.want) {
+				t.Fatalf("GateAbsences = %v; want one row saying %q", r.GateAbsences, tc.want)
+			}
+			if r.Overall != "DRIFT" {
+				t.Errorf("Overall = %q; want DRIFT", r.Overall)
+			}
+		})
+	}
+}
+
+// TestHooksPath_ProbeAndInstallerAgreeWithGit — core.hooksPath, both
+// halves. The probe must SEE a hook where git reads it, and the installer
+// must WRITE there; a tool whose reader and writer disagree with git about
+// one path is how `doctor --fix` came to manufacture an OK over a
+// repository with no gate at all.
+func TestHooksPath_ProbeAndInstallerAgreeWithGit(t *testing.T) {
+	dir := gatedRepo(t)
+
+	// Relocate, and MOVE the working hook the way a person would.
+	relocated := filepath.Join(dir, ".githooks")
+	if err := os.MkdirAll(relocated, 0o755); err != nil {
+		t.Fatalf("mkdir .githooks: %v", err)
+	}
+	gitInRepo(t, dir, "config", "core.hooksPath", ".githooks")
+	installed := filepath.Join(dir, ".git", "hooks", "commit-msg")
+	body, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatalf("read installed hook: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(relocated, "commit-msg"), body, 0o755); err != nil {
+		t.Fatalf("write relocated hook: %v", err)
+	}
+	if err := os.Remove(installed); err != nil {
+		t.Fatalf("remove old hook: %v", err)
+	}
+
+	// Precondition: git really reads .githooks now.
+	if got := hooksDirOf(t, dir); filepath.Clean(got) != filepath.Clean(relocated) {
+		t.Fatalf("hooks.Dir = %q; want %q — the fixture did not relocate anything", got, relocated)
+	}
+
+	// READER: no false absence over a hook that is installed and running.
+	if r := CollectStatus(dir, true); len(r.GateAbsences) != 0 {
+		t.Fatalf("GateAbsences = %v; want none — the commit-msg hook is in the directory "+
+			"git reads and fires normally", r.GateAbsences)
+	}
+
+	// WRITER: --fix's install path must not resurrect the unread location.
+	if err := os.Remove(filepath.Join(relocated, "commit-msg")); err != nil {
+		t.Fatalf("remove relocated hook: %v", err)
+	}
+	changed, err := hooks.InstallCommitMsg(dir)
+	if err != nil || !changed {
+		t.Fatalf("InstallCommitMsg = %v, %v; want (true, nil)", changed, err)
+	}
+	if _, err := os.Stat(filepath.Join(relocated, "commit-msg")); err != nil {
+		t.Errorf("the hook was not written to %s, the directory git reads: %v", relocated, err)
+	}
+	if _, err := os.Stat(installed); err == nil {
+		t.Errorf("a hook was written to .git/hooks/commit-msg, which this repository never reads — " +
+			"that is the write that manufactured a false OK")
+	}
+}
+
+// TestGateAbsences_SerializeAsAListWhenEmpty — `gate_absences` is the one
+// list on StatusReport whose emptiness a reader branches on (it is the only
+// one that moves `overall` and therefore the exit code), so it must not
+// arrive as `null` on a healthy repository and `[]` on a broken one.
+func TestGateAbsences_SerializeAsAListWhenEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		repo func(t *testing.T) string
+	}{
+		{"fully installed", gatedRepo},
+		{"never initialised", func(t *testing.T) string {
+			dir := t.TempDir()
+			isolatePathHermetic(t)
+			realGitDir(t, dir)
+			return dir
+		}},
+		{"not a git repository", freshRepo},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := tc.repo(t)
+			r := CollectStatus(dir, true)
+			if len(r.GateAbsences) != 0 {
+				t.Fatalf("GateAbsences = %v; this case is supposed to have none", r.GateAbsences)
+			}
+			js, err := r.ToJSON()
+			if err != nil {
+				t.Fatalf("ToJSON: %v", err)
+			}
+			if !strings.Contains(js, `"gate_absences": []`) {
+				t.Errorf("gate_absences did not serialize as an empty list; got:\n%s",
+					gateAbsencesLine(js))
+			}
+		})
+	}
+}
+
+func gateAbsencesLine(js string) string {
+	for _, line := range strings.Split(js, "\n") {
+		if strings.Contains(line, "gate_absences") {
+			return line
+		}
+	}
+	return "(no gate_absences key at all)"
+}

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -27,7 +27,6 @@ package guardcommit
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -187,7 +186,11 @@ func Evaluate(repoRoot, subject string, threshold int, mode DiffMode) Decision {
 	// staged. The index is the right scope in both modes: this asks what
 	// the commit about to be made will carry, and a decision file sitting
 	// unstaged carries nothing into it.
-	evidence, _ := DecisionRecorded(gitcli.DiffCachedNames(repoRoot), func(path string) ([]gitcli.AddedHunk, error) {
+	// Resolved against repoRoot, because that is the root git reports
+	// staged paths against — the same resolution `logmind log` makes from
+	// its working directory. See decisions.Layout.
+	layout := decisions.ResolveLayout(repoRoot)
+	evidence, _ := DecisionRecorded(layout, gitcli.DiffCachedNames(repoRoot), func(path string) ([]gitcli.AddedHunk, error) {
 		// DiffCachedAddedHunks is best-effort by contract (nil on any git
 		// failure), so there is no error to propagate here — a git that
 		// cannot answer yields no added lines, which fails CLOSED into the
@@ -304,9 +307,10 @@ type DecisionEvidence struct {
 //
 // Two halves, and BOTH are required:
 //
-//   - the path is one logmind itself writes decisions to
-//     (isDecisionFile — the image of resolveDecisionsPath, not a filename
-//     suffix), and
+//   - the path is one logmind itself writes decisions to — asked of
+//     decisions.Layout, which is also what `logmind log` builds its target
+//     from, so the gate cannot answer differently from the writer about a
+//     file the writer just produced; and
 //   - the lines the change ADDED to it carry an entry that is well-formed
 //     under §3.1 (WellFormedDecisionAdded).
 //
@@ -329,10 +333,10 @@ type DecisionEvidence struct {
 // The error is addedHunks' own and is returned unwrapped, so the gate's
 // loud-on-failure contract (an unresolvable ref must not read as an empty
 // diff) survives the trip through here.
-func DecisionRecorded(names []string, addedHunks AddedHunksFunc) (DecisionEvidence, error) {
+func DecisionRecorded(layout decisions.Layout, names []string, addedHunks AddedHunksFunc) (DecisionEvidence, error) {
 	var ev DecisionEvidence
 	for _, path := range names {
-		if !isDecisionFile(path) {
+		if !layout.IsDecisionRel(path) {
 			continue
 		}
 		hunks, err := addedHunks(path)
@@ -347,62 +351,7 @@ func DecisionRecorded(names []string, addedHunks AddedHunksFunc) (DecisionEviden
 	return ev, nil
 }
 
-// legacyDecisionPath and branchDecisionDir are the two shapes
-// resolveDecisionsPath (internal/cli/log.go) can produce, spelled from the
-// layout constants that function itself builds from — so the gate AGREES
-// with the writer rather than approximating it.
-var (
-	legacyDecisionPath = decisions.DocsDirName + "/" + decisions.LegacyFileName
-	branchDecisionDir  = decisions.DocsDirName + "/" + decisions.BranchDirName + "/"
-)
-
-// isDecisionFile reports whether rel — a repo-relative path exactly as git
-// reports it, forward-slashed on every platform — is a file logmind itself
-// writes decisions to. That is the whole rule, and it is the IMAGE of
-// resolveDecisionsPath, which owns where a decision lands:
-//
-//   - docs/decisions.md — the branchless log. Still reachable (branch_aware
-//     off, non-git, detached HEAD) and still the real main log in a
-//     repository that predates §3.2, so an entry appended there has
-//     recorded a decision by any reading of §3.4.
-//   - docs/decisions-branches/<name>.md — one branch's log. Any <name>,
-//     because the gate cannot know which branch it is judging; but a single
-//     path component ending .md, because ListBranchFiles skips
-//     subdirectories and a file under one is invisible to every read path.
-//
-// SCOPED, not suffixed, and the difference was a live gate hole. This
-// predicate used to accept a `/decisions.md` suffix in ANY directory:
-// measured on the release candidate, a well-formed §3.1 entry at
-// internal/x/decisions.md plus 302 lines of new Go cleared
-// `guard-commit --layer git-hook` (exit 0, "allowed (decision-recorded)")
-// where the identical index without that file was refused (exit 65). Three
-// lines in a file no read path enumerates cleared all three enforcement
-// surfaces — a cheaper bypass than the content-free pointer this release
-// exists to close, because the decoy does not even have to look like
-// logmind's own file.
-//
-// docs/decisions-archive.md is deliberately NOT here. Nothing writes it in
-// any state (decisions.NonBranchSources) — the read paths surface it where
-// it lies, and a gate that honours a path logmind will never write is the
-// same approximation, one filename narrower.
-//
-// UNEXPORTED on purpose, and the constants above are the only thing shared
-// with the writer. It answers "is this the kind of file a decision lives
-// in", which is only ever half of "did this change record a decision" — and
-// the half that a content-free file passes. It was exported once, one
-// caller asked it alone, and that caller was the commit gate.
-// DecisionRecorded is the exported question; this is an implementation
-// detail of it, and there is still no exported way to ask the path half.
-func isDecisionFile(rel string) bool {
-	rel = path.Clean(rel)
-	if rel == legacyDecisionPath {
-		return true
-	}
-	dir, file := path.Split(rel)
-	return dir == branchDecisionDir && strings.HasSuffix(file, ".md")
-}
-
-// STILL OPEN, and this predicate does not close it: a staged RENAME or
+// STILL OPEN, and the layout predicate does not close it: a staged RENAME or
 // COPY of an existing decision file clears the gate (#335, plus the copy
 // half a panel raised). Measured on this head, both with 302 lines of new
 // Go alongside:
@@ -412,7 +361,7 @@ func isDecisionFile(rel string) bool {
 //	cp   docs/decisions-branches/main.md docs/decisions-branches/feat__x.md
 //	  → exit 0, same carve-out
 //
-// The scoping above closes the SHAPE where the destination is not a
+// decisions.Layout closes the SHAPE where the destination is not a
 // decision path (`git mv docs/decisions-branches/main.md
 // internal/x/decisions.md` went from exit 0 to exit 65), but a
 // rename/copy WITHIN docs/decisions-branches/ lands on a path logmind

--- a/internal/guardcommit/guardcommit.go
+++ b/internal/guardcommit/guardcommit.go
@@ -27,6 +27,7 @@ package guardcommit
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -303,7 +304,9 @@ type DecisionEvidence struct {
 //
 // Two halves, and BOTH are required:
 //
-//   - the path is a decision file (isDecisionFile), and
+//   - the path is one logmind itself writes decisions to
+//     (isDecisionFile — the image of resolveDecisionsPath, not a filename
+//     suffix), and
 //   - the lines the change ADDED to it carry an entry that is well-formed
 //     under §3.1 (WellFormedDecisionAdded).
 //
@@ -344,35 +347,106 @@ func DecisionRecorded(names []string, addedHunks AddedHunksFunc) (DecisionEviden
 	return ev, nil
 }
 
-// isDecisionFile reports whether path is a decision-log file:
+// legacyDecisionPath and branchDecisionDir are the two shapes
+// resolveDecisionsPath (internal/cli/log.go) can produce, spelled from the
+// layout constants that function itself builds from — so the gate AGREES
+// with the writer rather than approximating it.
+var (
+	legacyDecisionPath = decisions.DocsDirName + "/" + decisions.LegacyFileName
+	branchDecisionDir  = decisions.DocsDirName + "/" + decisions.BranchDirName + "/"
+)
+
+// isDecisionFile reports whether rel — a repo-relative path exactly as git
+// reports it, forward-slashed on every platform — is a file logmind itself
+// writes decisions to. That is the whole rule, and it is the IMAGE of
+// resolveDecisionsPath, which owns where a decision lands:
 //
-//   - exact path "docs/decisions.md"
-//   - suffix "/decisions.md" (covers nested decisions.md)
-//   - prefix "docs/decisions-branches/" (per-branch decision files)
+//   - docs/decisions.md — the branchless log. Still reachable (branch_aware
+//     off, non-git, detached HEAD) and still the real main log in a
+//     repository that predates §3.2, so an entry appended there has
+//     recorded a decision by any reading of §3.4.
+//   - docs/decisions-branches/<name>.md — one branch's log. Any <name>,
+//     because the gate cannot know which branch it is judging; but a single
+//     path component ending .md, because ListBranchFiles skips
+//     subdirectories and a file under one is invisible to every read path.
 //
-// UNEXPORTED on purpose. It answers "is this the kind of file a decision
-// lives in", which is only ever half of "did this change record a
-// decision" — and the half that a content-free file passes. It was
-// exported once, one caller asked it alone, and that caller was the
-// commit gate. DecisionRecorded is the exported question; this is an
-// implementation detail of it.
+// SCOPED, not suffixed, and the difference was a live gate hole. This
+// predicate used to accept a `/decisions.md` suffix in ANY directory:
+// measured on the release candidate, a well-formed §3.1 entry at
+// internal/x/decisions.md plus 302 lines of new Go cleared
+// `guard-commit --layer git-hook` (exit 0, "allowed (decision-recorded)")
+// where the identical index without that file was refused (exit 65). Three
+// lines in a file no read path enumerates cleared all three enforcement
+// surfaces — a cheaper bypass than the content-free pointer this release
+// exists to close, because the decoy does not even have to look like
+// logmind's own file.
 //
-// docs/decisions.md stays on the list even though nothing writes it since
-// §3.2: a repository that predates the collapse carries a real decision
-// log at that path, and a change that appends an entry there has recorded
-// a decision by any reading of §3.4.
-func isDecisionFile(path string) bool {
-	if path == "docs/decisions.md" {
+// docs/decisions-archive.md is deliberately NOT here. Nothing writes it in
+// any state (decisions.NonBranchSources) — the read paths surface it where
+// it lies, and a gate that honours a path logmind will never write is the
+// same approximation, one filename narrower.
+//
+// UNEXPORTED on purpose, and the constants above are the only thing shared
+// with the writer. It answers "is this the kind of file a decision lives
+// in", which is only ever half of "did this change record a decision" — and
+// the half that a content-free file passes. It was exported once, one
+// caller asked it alone, and that caller was the commit gate.
+// DecisionRecorded is the exported question; this is an implementation
+// detail of it, and there is still no exported way to ask the path half.
+func isDecisionFile(rel string) bool {
+	rel = path.Clean(rel)
+	if rel == legacyDecisionPath {
 		return true
 	}
-	if strings.HasSuffix(path, "/decisions.md") {
-		return true
-	}
-	if strings.HasPrefix(path, "docs/decisions-branches/") {
-		return true
-	}
-	return false
+	dir, file := path.Split(rel)
+	return dir == branchDecisionDir && strings.HasSuffix(file, ".md")
 }
+
+// STILL OPEN, and this predicate does not close it: a staged RENAME or
+// COPY of an existing decision file clears the gate (#335, plus the copy
+// half a panel raised). Measured on this head, both with 302 lines of new
+// Go alongside:
+//
+//	git mv docs/decisions-branches/main.md docs/decisions-branches/feat__x.md
+//	  → guard-commit --layer git-hook exit 0 "allowed (decision-recorded)"
+//	cp   docs/decisions-branches/main.md docs/decisions-branches/feat__x.md
+//	  → exit 0, same carve-out
+//
+// The scoping above closes the SHAPE where the destination is not a
+// decision path (`git mv docs/decisions-branches/main.md
+// internal/x/decisions.md` went from exit 0 to exit 65), but a
+// rename/copy WITHIN docs/decisions-branches/ lands on a path logmind
+// genuinely writes, so no path rule can reach it.
+//
+// The cause is one level down, in the diff READER, and it is not a rename
+// heuristic being wrong — it is one never being asked. Measured:
+//
+//	git diff --cached --name-status                 → R100 old new
+//	git diff --cached -U0 -- <new>                  → "new file mode", every
+//	                                                  line rendered as added
+//
+// A pathspec limits the tree walk BEFORE rename detection runs, so
+// restricting the diff to the destination hides the source and the file
+// reads as freshly written; a copy is worse still, since git does not look
+// for copies at all without -C --find-copies-harder. Either way
+// WellFormedDecisionAdded sees a real §3.1 entry among the "added" lines
+// and answers yes to a change that wrote nothing.
+//
+// Two mechanisms would close it and the choice between them is a real
+// fork, so it is named here rather than guessed at:
+//
+//   - Ask git. `--name-status` already reports R for a rename at no cost,
+//     and DecisionRecorded could skip a path that arrived by one. Copy
+//     needs `-C --find-copies-harder`, which is O(added × tree) and, past
+//     diff.renameLimit, git silently turns detection OFF — a gate that
+//     stops detecting when the diff gets big is failing open silently,
+//     which is the thing §3.4 forbids.
+//   - Ask the record. An added entry clears the gate only if it is not
+//     already in the decision record at the base of the comparison (HEAD
+//     for an index, `base` for a range). Heuristic-free, closes rename,
+//     copy and cross-file paste together, and costs one read of the
+//     decision files at a ref — but it needs a new reader and a second
+//     scope-carrying parameter on DecisionRecorded.
 
 // reasoningMarker opens SPEC §3.1's reasoning section. §3.1 lets a
 // producer omit an empty section's header entirely, so a marker present

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/thrillmade/logmind/internal/agents"
+	"github.com/thrillmade/logmind/internal/decisions"
 	"github.com/thrillmade/logmind/internal/gitcli"
 	"github.com/thrillmade/logmind/internal/templates"
 	"github.com/thrillmade/logmind/internal/testgit"
@@ -533,21 +534,112 @@ func TestEvaluate_InProgressStateBeatsDecisionFileCheck(t *testing.T) {
 // the half alone cost). The path rules below are still worth pinning: a
 // path this predicate rejects can never record a decision no matter what
 // the change wrote into it.
+//
+// The two `true` rows are the ONLY two shapes resolveDecisionsPath
+// produces. Every `false` row below except README.md / src/decisions.txt
+// used to be `true`: the predicate accepted a `/decisions.md` suffix in any
+// directory and any depth under docs/decisions-branches/, which is the hole
+// TestEvaluate_DecoyDecisionFileElsewhereStillBlocks measures end to end.
 
 func TestIsDecisionFile(t *testing.T) {
 	cases := map[string]bool{
-		"docs/decisions.md":                       true,
-		"nested/path/decisions.md":                true,
-		"docs/decisions-branches/feature.md":      true,
-		"docs/decisions-branches/nested/other.md": true,
-		"docs/decisions-archive.md":               false,
-		"README.md":                               false,
-		"src/decisions.txt":                       false,
+		"docs/decisions.md":                  true,
+		"docs/decisions-branches/feature.md": true,
+		// Named for a branch with a slash in it — sanitizeBranchName turns
+		// `fix/gate` into `fix__gate`, so this is a real write target.
+		"docs/decisions-branches/fix__gate.md": true,
+
+		// The reproduced bypass: a decision-shaped file anywhere else.
+		"internal/x/decisions.md":  false,
+		"nested/path/decisions.md": false,
+		"decisions.md":             false,
+		"vendor/docs/decisions.md": false,
+		// Under the branch dir but not a file any read path enumerates —
+		// ListBranchFiles skips subdirectories.
+		"docs/decisions-branches/nested/other.md": false,
+		// Under the branch dir but not markdown.
+		"docs/decisions-branches/notes.txt": false,
+
+		"docs/decisions-archive.md": false,
+		"README.md":                 false,
+		"src/decisions.txt":         false,
 	}
 	for path, want := range cases {
 		if got := isDecisionFile(path); got != want {
 			t.Errorf("isDecisionFile(%q) = %v; want %v", path, got, want)
 		}
+	}
+}
+
+// TestIsDecisionFile_AgreesWithResolveDecisionsPath is the fence that keeps
+// the gate and the writer from drifting apart again. It cannot import
+// internal/cli (that would be an import cycle), so it asserts the two
+// shapes against the LAYOUT CONSTANTS resolveDecisionsPath builds from — if
+// a future edit renames docs/, decisions.md or decisions-branches/ in one
+// place only, this fails.
+func TestIsDecisionFile_AgreesWithResolveDecisionsPath(t *testing.T) {
+	// resolveDecisionsPath's branchlessPath: filepath.Join(docsPath, LegacyFileName).
+	branchless := decisions.DocsDirName + "/" + decisions.LegacyFileName
+	// resolveDecisionsPath's branchFile: filepath.Join(docsPath, BranchDirName, sanitized+".md").
+	branchFile := decisions.DocsDirName + "/" + decisions.BranchDirName + "/main.md"
+	for _, p := range []string{branchless, branchFile} {
+		if !isDecisionFile(p) {
+			t.Errorf("isDecisionFile(%q) = false; resolveDecisionsPath writes there", p)
+		}
+	}
+}
+
+// TestEvaluate_DecoyDecisionFileElsewhereStillBlocks is the regression pin
+// for the reproduced bypass, and it pins the OUTPUT the operator saw rather
+// than the helper underneath it: a well-formed §3.1 entry written to
+// internal/x/decisions.md — a path no read path enumerates and `logmind
+// log` will never write — alongside 302 lines of new Go cleared
+// `guard-commit --layer git-hook` with exit 0 "allowed (decision-recorded)"
+// while the identical index without the decoy was refused with exit 65.
+//
+// The CONTROL is in the same test on purpose. "Blocked" is only evidence
+// if the same tree minus the decoy is also blocked for the same reason and
+// the same tree with a REAL entry passes — otherwise a predicate that
+// rejects everything scores identically.
+func TestEvaluate_DecoyDecisionFileElsewhereStillBlocks(t *testing.T) {
+	decoys := []string{
+		"internal/x/decisions.md",
+		"decisions.md",
+		"docs/decisions-branches/nested/other.md",
+	}
+	for _, decoy := range decoys {
+		t.Run(decoy, func(t *testing.T) {
+			for _, mode := range []DiffMode{StagedOnly, WorkingTreeUnion} {
+				dir := initRepo(t)
+				writeFile(t, dir, "big.go", linesOf(302))
+				writeFile(t, dir, decoy, wellFormedEntry)
+				run(t, dir, "add", "big.go", decoy)
+
+				if d := Evaluate(dir, "subject", 20, mode); d.Allow {
+					t.Fatalf("mode=%v: Decision = %+v; want Block — %s is not a file logmind "+
+						"records decisions in, so 302 lines of Go would land undocumented",
+						mode, d, decoy)
+				}
+			}
+		})
+	}
+
+	// CONTROL: the same 302 lines with the same entry written where
+	// `logmind log` actually writes it still passes. Without this, the test
+	// above is also passed by a predicate that answers false to everything.
+	for _, real := range []string{"docs/decisions.md", "docs/decisions-branches/feature.md"} {
+		t.Run("control "+real, func(t *testing.T) {
+			dir := initRepo(t)
+			writeFile(t, dir, "big.go", linesOf(302))
+			writeFile(t, dir, real, wellFormedEntry)
+			run(t, dir, "add", "big.go", real)
+
+			d := Evaluate(dir, "subject", 20, StagedOnly)
+			if !d.Allow || d.CarveOut != CarveOutDecisionRecorded {
+				t.Fatalf("Decision = %+v; want Allow via CarveOutDecisionRecorded — an entry "+
+					"appended to %s IS a recorded decision", d, real)
+			}
+		})
 	}
 }
 

--- a/internal/guardcommit/guardcommit_test.go
+++ b/internal/guardcommit/guardcommit_test.go
@@ -320,7 +320,7 @@ func TestDecisionRecorded_IsTheOnlyQuestion(t *testing.T) {
 	entry := []gitcli.AddedHunk{strings.Split(strings.TrimRight(wellFormedEntry, "\n"), "\n")}
 
 	t.Run("a well-formed entry in a decision file records a decision", func(t *testing.T) {
-		ev, err := DecisionRecorded([]string{"src/main.go", "docs/decisions-branches/feature.md"},
+		ev, err := DecisionRecorded(decisions.Layout{}, []string{"src/main.go", "docs/decisions-branches/feature.md"},
 			func(path string) ([]gitcli.AddedHunk, error) { return entry, nil })
 		if err != nil || !ev.Recorded {
 			t.Fatalf("DecisionRecorded = %+v, %v; want Recorded", ev, err)
@@ -331,7 +331,7 @@ func TestDecisionRecorded_IsTheOnlyQuestion(t *testing.T) {
 	})
 
 	t.Run("the same entry in a NON-decision file records nothing", func(t *testing.T) {
-		ev, err := DecisionRecorded([]string{"README.md"},
+		ev, err := DecisionRecorded(decisions.Layout{}, []string{"README.md"},
 			func(path string) ([]gitcli.AddedHunk, error) { return entry, nil })
 		if err != nil || ev.Recorded {
 			t.Fatalf("DecisionRecorded = %+v, %v; want not Recorded", ev, err)
@@ -339,7 +339,7 @@ func TestDecisionRecorded_IsTheOnlyQuestion(t *testing.T) {
 	})
 
 	t.Run("a decision file with nothing well-formed added is Touched, not Recorded", func(t *testing.T) {
-		ev, err := DecisionRecorded([]string{"docs/decisions.md"},
+		ev, err := DecisionRecorded(decisions.Layout{}, []string{"docs/decisions.md"},
 			func(path string) ([]gitcli.AddedHunk, error) {
 				return []gitcli.AddedHunk{{"# Decision Log", "no entries here"}}, nil
 			})
@@ -353,7 +353,7 @@ func TestDecisionRecorded_IsTheOnlyQuestion(t *testing.T) {
 
 	t.Run("the reader's error is propagated, not swallowed", func(t *testing.T) {
 		want := errors.New("bad ref")
-		ev, err := DecisionRecorded([]string{"docs/decisions.md"},
+		ev, err := DecisionRecorded(decisions.Layout{}, []string{"docs/decisions.md"},
 			func(path string) ([]gitcli.AddedHunk, error) { return nil, want })
 		if !errors.Is(err, want) {
 			t.Fatalf("err = %v; want %v — a diff git could not read must not report as 'no decision'", err, want)
@@ -365,7 +365,7 @@ func TestDecisionRecorded_IsTheOnlyQuestion(t *testing.T) {
 
 	t.Run("only decision files are read at all", func(t *testing.T) {
 		var asked []string
-		if _, err := DecisionRecorded([]string{"src/main.go", "docs/plan.md", "docs/decisions.md"},
+		if _, err := DecisionRecorded(decisions.Layout{}, []string{"src/main.go", "docs/plan.md", "docs/decisions.md"},
 			func(path string) ([]gitcli.AddedHunk, error) { asked = append(asked, path); return nil, nil }); err != nil {
 			t.Fatalf("DecisionRecorded: %v", err)
 		}
@@ -526,14 +526,15 @@ func TestEvaluate_InProgressStateBeatsDecisionFileCheck(t *testing.T) {
 	}
 }
 
-// --- isDecisionFile / SubstantiveLines (moved verbatim from
+// --- the path half / SubstantiveLines (moved verbatim from
 // check_decisions.go — behavior-preserving unit coverage lives here now) --
 //
-// isDecisionFile is HALF of the gate's question (see DecisionRecorded, and
+// The path half is HALF of the gate's question (see DecisionRecorded, and
 // TestEvaluate_StagedDecisionFileWithNoEntryStillBlocks for what shipping
-// the half alone cost). The path rules below are still worth pinning: a
-// path this predicate rejects can never record a decision no matter what
-// the change wrote into it.
+// the half alone cost). It is decisions.Layout's to answer — the writer
+// builds from the same type — and the rules are pinned there too. What is
+// pinned HERE is what THIS gate accepts, because a path it rejects can
+// never record a decision no matter what the change wrote into it.
 //
 // The two `true` rows are the ONLY two shapes resolveDecisionsPath
 // produces. Every `false` row below except README.md / src/decisions.txt
@@ -541,7 +542,7 @@ func TestEvaluate_InProgressStateBeatsDecisionFileCheck(t *testing.T) {
 // directory and any depth under docs/decisions-branches/, which is the hole
 // TestEvaluate_DecoyDecisionFileElsewhereStillBlocks measures end to end.
 
-func TestIsDecisionFile(t *testing.T) {
+func TestGateAcceptsOnlyTheWritersPaths(t *testing.T) {
 	cases := map[string]bool{
 		"docs/decisions.md":                  true,
 		"docs/decisions-branches/feature.md": true,
@@ -554,6 +555,10 @@ func TestIsDecisionFile(t *testing.T) {
 		"nested/path/decisions.md": false,
 		"decisions.md":             false,
 		"vendor/docs/decisions.md": false,
+		// A docs/ shape with no logmind project behind it — the nearest
+		// miss, one directory level away from a path logmind does write.
+		"internal/x/docs/decisions.md":                  false,
+		"internal/x/docs/decisions-branches/feature.md": false,
 		// Under the branch dir but not a file any read path enumerates —
 		// ListBranchFiles skips subdirectories.
 		"docs/decisions-branches/nested/other.md": false,
@@ -564,27 +569,37 @@ func TestIsDecisionFile(t *testing.T) {
 		"README.md":                 false,
 		"src/decisions.txt":         false,
 	}
+	// Rooted at an EMPTY directory, not at the zero Layout: the nested-
+	// project rows below are answered by a stat under the layout's root, so
+	// a zero Root would resolve them against whatever directory the test
+	// binary happens to run in.
+	layout := decisions.ResolveLayout(t.TempDir())
 	for path, want := range cases {
-		if got := isDecisionFile(path); got != want {
-			t.Errorf("isDecisionFile(%q) = %v; want %v", path, got, want)
+		if got := layout.IsDecisionRel(path); got != want {
+			t.Errorf("IsDecisionRel(%q) = %v; want %v", path, got, want)
 		}
 	}
 }
 
-// TestIsDecisionFile_AgreesWithResolveDecisionsPath is the fence that keeps
-// the gate and the writer from drifting apart again. It cannot import
-// internal/cli (that would be an import cycle), so it asserts the two
-// shapes against the LAYOUT CONSTANTS resolveDecisionsPath builds from — if
-// a future edit renames docs/, decisions.md or decisions-branches/ in one
-// place only, this fails.
-func TestIsDecisionFile_AgreesWithResolveDecisionsPath(t *testing.T) {
-	// resolveDecisionsPath's branchlessPath: filepath.Join(docsPath, LegacyFileName).
-	branchless := decisions.DocsDirName + "/" + decisions.LegacyFileName
-	// resolveDecisionsPath's branchFile: filepath.Join(docsPath, BranchDirName, sanitized+".md").
-	branchFile := decisions.DocsDirName + "/" + decisions.BranchDirName + "/main.md"
-	for _, p := range []string{branchless, branchFile} {
-		if !isDecisionFile(p) {
-			t.Errorf("isDecisionFile(%q) = false; resolveDecisionsPath writes there", p)
+// TestGateAcceptsWhateverTheLayoutWrites is the fence that keeps the gate
+// and the writer from drifting apart again, and it is deliberately not a
+// second copy of the two shapes: it asks decisions.Layout for the paths it
+// WRITES and requires this gate to accept them. A rename, a re-root or a
+// re-spelling moves both sides together or fails here.
+//
+// TestLayout_PredicateIsTheImageOfTheWriter (internal/decisions) is the
+// same fence one level down, over a real directory tree; this one pins that
+// the GATE is the side asking.
+func TestGateAcceptsWhateverTheLayoutWrites(t *testing.T) {
+	layout := decisions.ResolveLayout("/repo")
+	for _, abs := range []string{layout.LegacyFile(), layout.BranchFile("main")} {
+		rel, err := filepath.Rel("/repo", abs)
+		if err != nil {
+			t.Fatalf("Rel(%q): %v", abs, err)
+		}
+		rel = filepath.ToSlash(rel)
+		if !layout.IsDecisionRel(rel) {
+			t.Errorf("IsDecisionRel(%q) = false; the writer puts a decision there", rel)
 		}
 	}
 }

--- a/internal/hooks/commit_msg_enforce_test.go
+++ b/internal/hooks/commit_msg_enforce_test.go
@@ -249,10 +249,7 @@ func TestCommitMsgHook_NoEngineOnPath_FailsOpenLoudly(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX sh hook body; not applicable on Windows")
 	}
-	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	dir := initRealGitRepo(t)
 	if _, err := InstallCommitMsg(dir); err != nil {
 		t.Fatalf("InstallCommitMsg: %v", err)
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,5 +1,7 @@
 // Package hooks builds the canonical bodies for logmind's git hooks
-// (`post-merge`, `post-rewrite`) and installs them under `.git/hooks/`.
+// (`post-merge`, `post-rewrite`) and installs them in the directory git
+// actually reads them from — see Dir, which is `git rev-parse --git-path
+// hooks` and not the `.git/hooks` join it replaced.
 //
 // The hook BODIES are kept byte-identical to the Python v0.6.14 output
 // of src/logmind/core/gitattributes._build_post_merge_hook_body and
@@ -37,6 +39,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/thrillmade/logmind/internal/gitcli"
 
 	"github.com/thrillmade/logmind/internal/atomicio"
 	"github.com/thrillmade/logmind/internal/version"
@@ -588,51 +593,141 @@ func BuildPreCommitBody() string {
 		"exit 0\n"
 }
 
-// InstallPostMerge writes `.git/hooks/post-merge` to the current
-// binary's canonical body. Returns (true, nil) if the file was
-// created or rewritten, (false, nil) if a logmind-marked hook was
-// already present at the exact byte content (idempotent no-op).
+// CommitMsgInvocation is the line the commit-msg body delegates the
+// enforce/allow decision on — the one thing that makes the file a §3.4
+// interception point rather than a shell script sitting in the right place.
+//
+// Exported for the READER: `logmind doctor` asks whether an installed hook
+// still carries it, because a hook that has been emptied, or replaced with
+// `exit 0`, is present and enforcing nothing. Matched against the RUN line
+// and not a substring of the body's prose — the comment above it names
+// `logmind guard-commit --layer git-hook` too, and a check satisfied by a
+// surviving comment is satisfied by exactly the gutting it exists to catch.
+// TestCommitMsgBodyCarriesItsOwnInvocation pins that the body this package
+// writes actually contains it.
+const CommitMsgInvocation = "guard-commit --layer git-hook --msg-file"
+
+// Dir resolves the directory git will actually READ hooks from for
+// repoRoot, and it is the ONE owner of that path: every Install* below
+// writes into it, `logmind install-hook` appends into it, and `logmind
+// doctor` probes it. (What is NOT routed here is the PROSE — `logmind
+// init`, `self-update` and `install-hook --help` still print the literal
+// `.git/hooks/<name>` in their receipts, so under core.hooksPath the hook
+// lands in the right place and the message names the wrong one.)
+//
+// `git rev-parse --git-path hooks` rather than `<repoRoot>/.git/hooks`,
+// because the naive join is wrong in two states that both ship today:
+//
+//   - core.hooksPath. A repository that relocates its hooks — `.githooks`
+//     is the common spelling — has NOTHING at .git/hooks. Measured before
+//     this: `logmind doctor` reported the commit-msg hook missing while a
+//     working one sat in .githooks, and `doctor --fix` then wrote a fresh
+//     hook to .git/hooks, a path git never reads. doctor reported OK
+//     afterwards and a 30-line raw commit went through at exit 0. A --fix
+//     that manufactures a false OK is worse than no --fix at all.
+//   - a linked WORKTREE, where `.git` is a FILE naming the common
+//     directory and the hooks live there.
+//
+// Returns ("", false) when git cannot answer — not a repository, or no git
+// binary. Callers treat that as "there is no hooks directory", which is the
+// same thing the `.git` stat used to say.
+//
+// ONE subprocess, and a cheap one: no object access, no index read, so on
+// a warm repository it is process-spawn cost and nothing else. It is on
+// `logmind log`'s pulse path
+// (doctor.StaleCountFast), which is documented as subprocess-free — see
+// collectLogmindStatusFast for why that budget moved rather than this
+// resolution being skipped there.
+func Dir(repoRoot string) (string, bool) {
+	out, _, err := gitcli.RunCaptured(repoRoot, "rev-parse", "--git-path", "hooks")
+	if err != nil {
+		return "", false
+	}
+	path := strings.TrimSpace(out)
+	if path == "" {
+		return "", false
+	}
+	// `--git-path` answers relative to the working directory it ran in
+	// unless the repository was found by an absolute path.
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repoRoot, path)
+	}
+	return path, true
+}
+
+// Path is Dir joined with one hook's filename — the full path git will run,
+// and the path doctor reports so a person is sent to the file that matters
+// rather than to .git/hooks/<name> on a repository that reads elsewhere.
+func Path(repoRoot, hookFile string) (string, bool) {
+	dir, ok := Dir(repoRoot)
+	if !ok {
+		return "", false
+	}
+	return filepath.Join(dir, hookFile), true
+}
+
+// InstallPostMerge writes the `post-merge` hook to the current binary's
+// canonical body, into the directory git reads (see Dir). Returns
+// (true, nil) if the file was created or rewritten, (false, nil) if a
+// logmind-marked hook was already present at the exact byte content
+// (idempotent no-op).
 //
 // Refuses to overwrite a foreign hook — returns (false, nil) and
 // lets logmind doctor flag the state instead. Mirrors the Python
 // install_post_merge_hook semantics line-for-line.
 func InstallPostMerge(repoRoot string) (bool, error) {
+	path, ok := Path(repoRoot, "post-merge")
+	if !ok {
+		return false, nil
+	}
 	return installHook(
-		filepath.Join(repoRoot, ".git", "hooks", "post-merge"),
+		path,
 		BuildPostMergeBody(),
 		PostMergeMarker,
 	)
 }
 
-// InstallPostRewrite writes `.git/hooks/post-rewrite`. See
+// InstallPostRewrite writes the `post-rewrite` hook. See
 // InstallPostMerge for the contract.
 func InstallPostRewrite(repoRoot string) (bool, error) {
+	path, ok := Path(repoRoot, "post-rewrite")
+	if !ok {
+		return false, nil
+	}
 	return installHook(
-		filepath.Join(repoRoot, ".git", "hooks", "post-rewrite"),
+		path,
 		BuildPostRewriteBody(),
 		PostRewriteMarker,
 	)
 }
 
-// InstallCommitMsg writes `.git/hooks/commit-msg`. See InstallPostMerge
+// InstallCommitMsg writes the `commit-msg` hook. See InstallPostMerge
 // for the contract. v0.6.16+.
 func InstallCommitMsg(repoRoot string) (bool, error) {
+	path, ok := Path(repoRoot, "commit-msg")
+	if !ok {
+		return false, nil
+	}
 	return installHook(
-		filepath.Join(repoRoot, ".git", "hooks", "commit-msg"),
+		path,
 		BuildCommitMsgBody(),
 		CommitMsgMarker,
 	)
 }
 
-// InstallPreCommit writes `.git/hooks/pre-commit`. See InstallPostMerge for
+// InstallPreCommit writes the `pre-commit` hook. See InstallPostMerge for
 // the shared contract — including the conservative-interop behavior that
 // matters most here: a pre-commit hook that already exists WITHOUT
 // PreCommitMarker (a hand-written hook, OR the separate, opt-in
 // `logmind check-decisions` body `logmind install-hook` writes — see
 // PreCommitMarker's doc comment) is left completely alone. v2.0.0+.
 func InstallPreCommit(repoRoot string) (bool, error) {
+	path, ok := Path(repoRoot, "pre-commit")
+	if !ok {
+		return false, nil
+	}
 	return installHook(
-		filepath.Join(repoRoot, ".git", "hooks", "pre-commit"),
+		path,
 		BuildPreCommitBody(),
 		PreCommitMarker,
 	)
@@ -646,7 +741,9 @@ func InstallPreCommit(repoRoot string) (bool, error) {
 //	hooks dir missing  → (false, nil) — caller is not in a git repo
 //	                                    or the hooks dir was nuked
 //	hook absent        → write body + chmod 0755, return (true, nil)
-//	hook present, ours, body matches  → (false, nil) — no-op
+//	hook present, ours, body matches  → (false, nil) — no-op, EXCEPT when
+//	                                    the execute bit is clear: chmod
+//	                                    0755 + (true, nil)
 //	hook present, ours, body differs  → overwrite + chmod, (true, nil)
 //	hook present, foreign             → (false, nil) — leave alone
 //
@@ -673,6 +770,18 @@ func installHook(hookPath, body, marker string) (bool, error) {
 			return false, nil // foreign hook; don't trample
 		}
 		if string(existing) == body {
+			// Byte-identical, but a hook without the execute bit is
+			// SILENTLY never run — git skips it with a hint nobody reads.
+			// `doctor` reports that as an absent gate, so `doctor --fix`
+			// has to be able to clear it; returning "already current" here
+			// meant the tool named a fault and then declined to fix its
+			// own file. Re-assert the mode and say the file changed.
+			if info, statErr := os.Stat(hookPath); statErr == nil && info.Mode()&0o111 == 0 {
+				if chmodErr := os.Chmod(hookPath, 0o755); chmodErr != nil {
+					return false, chmodErr
+				}
+				return true, nil
+			}
 			return false, nil // already current
 		}
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -948,15 +948,93 @@ func TestExtractVersion_PreV0610Hook(t *testing.T) {
 	}
 }
 
+// TestCommitMsgBodyCarriesItsOwnInvocation is the fence behind
+// CommitMsgInvocation: `logmind doctor` reports a commit-msg hook that does
+// not contain that string as INERT, so a change to the body that renames or
+// re-shapes the delegation would make doctor call every correctly-installed
+// hook in the fleet a failing gate. The two move together or this fails.
+//
+// Also pinned: the string appears ONCE. The body's prose names `logmind
+// guard-commit --layer git-hook` on its own, so a needle that matched a
+// comment would be satisfied by exactly the gutted hook the check exists to
+// catch — and a second occurrence would mean the needle had drifted back
+// into prose.
+func TestCommitMsgBodyCarriesItsOwnInvocation(t *testing.T) {
+	body := BuildCommitMsgBody()
+	if n := strings.Count(body, CommitMsgInvocation); n != 1 {
+		t.Fatalf("BuildCommitMsgBody() contains CommitMsgInvocation %d times; want exactly 1 "+
+			"(the run line, never a comment)", n)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.Contains(line, CommitMsgInvocation) {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			t.Fatalf("the only occurrence of CommitMsgInvocation is a COMMENT, so an emptied "+
+				"hook that kept its prose would still read as enforcing: %q", line)
+		}
+	}
+}
+
+// TestInstallCommitMsg_RestoresAClearedExecuteBit — the loop `logmind
+// doctor` closes on itself. doctor reports a non-executable commit-msg hook
+// as an absent enforcement gate (git skips such a hook silently, with a
+// hint nobody reads) and points the operator at `doctor --fix`; the
+// installer used to see byte-identical content and return "already
+// current", so the tool named a fault in its OWN file and then declined to
+// repair it.
+//
+// The CONTROL is the second half: a byte-identical hook that IS executable
+// must still be a no-op, or "fixed" would just mean "rewritten every run".
+func TestInstallCommitMsg_RestoresAClearedExecuteBit(t *testing.T) {
+	repo := tempRepoWithHooks(t)
+	if _, err := InstallCommitMsg(repo); err != nil {
+		t.Fatalf("InstallCommitMsg: %v", err)
+	}
+	path := filepath.Join(repo, ".git", "hooks", "commit-msg")
+
+	// CONTROL: nothing to do on a healthy hook.
+	changed, err := InstallCommitMsg(repo)
+	if err != nil || changed {
+		t.Fatalf("InstallCommitMsg = %v, %v on an unchanged hook; want (false, nil)", changed, err)
+	}
+
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	changed, err = InstallCommitMsg(repo)
+	if err != nil || !changed {
+		t.Fatalf("InstallCommitMsg = %v, %v over a non-executable hook; want (true, nil)", changed, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("hook mode = %v; git never runs a hook without the execute bit", info.Mode())
+	}
+	// The body is untouched: this restores a MODE, it does not rewrite a
+	// file the repository may have hardlinked or shared.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(body) != BuildCommitMsgBody() {
+		t.Errorf("the body changed while only the mode should have")
+	}
+}
+
 // --- helpers -------------------------------------------------------------
 
+// tempRepoWithHooks is a REAL git repository, and it has to be: the
+// installers resolve their target with `git rev-parse --git-path hooks`
+// (hooks.Dir) rather than joining `.git/hooks`, so a hand-made `.git`
+// directory is not a repository git will answer about and every Install*
+// no-ops against it. It used to be exactly that hand-made shell, which
+// meant these tests measured the join and never the resolution.
 func tempRepoWithHooks(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755); err != nil {
-		t.Fatalf("mkdir .git/hooks: %v", err)
-	}
-	return dir
+	return initRealGitRepo(t)
 }
 
 // initRealGitRepo creates a fresh, REAL git working repo (not just the


### PR DESCRIPTION
Two independent holes in the enforcement layer. Both fixed, both mutation-tested (18 mutants, all
compiled, all killed), full suite green from an isolated worktree.

## B1 — the commit gate accepted a decision file anywhere in the tree

`isDecisionFile` matched any path ending `/decisions.md`, so a **well-formed** entry written to
`internal/x/decisions.md` satisfied the gate. It is now the exact image of `resolveDecisionsPath`,
built from shared layout constants in `internal/decisions`: `docs/decisions.md`, or a single `.md`
directly under `docs/decisions-branches/`.

**Verified independently by me**, not taken from the lane's report — two binaries, one built from
`origin/dev` (`0f78a04`), one from this branch, run against freshly-scaffolded repos:

| case | dev binary | this branch |
|---|---|---|
| entry in `docs/decisions-branches/main.md` + 302 Go lines — **must pass** | exit 0 ✓ allowed | exit 0 ✓ allowed |
| identical entry at `internal/x/decisions.md` + 302 Go lines — **decoy** | **exit 0 — bypass** | **exit 65 — blocked** |

The must-pass row is the control: it stays green on both binaries, so the fix blocks the decoy without
over-blocking the legitimate layout. (Two earlier harness attempts of mine were invalid — one built
both binaries from the same tree, one omitted `--msg-file` so every run died on argument parsing
before reaching the gate. Recording that so the matrix is read as the third, working harness.)

`check-decisions` agrees on both scopes — the decoy was exit 0 in range mode pre-fix, exit 1 now, so
the §6.2 merge gate was open to the same decoy.

### Explicitly NOT closed by this PR

A staged **rename or copy** of an existing decision file still clears the gate (#335). This predicate
cannot close it: a pathspec limits git's tree walk *before* rename detection, so a rename renders as
`new file mode` with every line added, and no path rule ever sees it. Documented in situ with both
candidate mechanisms and their costs — `--name-status` is cheap for renames, but
`--find-copies-harder` silently disables past `diff.renameLimit`, i.e. fails open under load, which
§3.4 forbids. Named as a design fork rather than picked.

## B3 — `doctor` reported OK with every enforcement gate deleted

`missing` and `markerless` were excluded from DRIFT, so deleting all three enforcement surfaces
produced `Stack status: OK`, exit 0. SPEC §3.4: *"Failing open MUST NOT be silent."*

New `StatusReport.GateAbsences` (`json:"gate_absences"`) is the only non-advisory list and flips
`Overall`. Scoped to three surfaces, reported only when the repo is initialised, is a git repo, and
`git.enforce_commits` is true.

```
before: Stack status: OK      exit 0
after:  Stack status: DRIFT   exit 1
        Enforcement gates absent (3) — SPEC §3.4: "Failing open MUST NOT be silent."
          • .claude/settings.json / .git/hooks/commit-msg / .github/workflows/check-decisions.yml
```

Suppressed for `agents.claude:false`, for no sibling workflow installed, and in **linked worktrees** —
there `.git` is a file, `probeHook` cannot see the shared hooks dir, and this repo's own worktrees were
measured reporting a hook that is in fact installed and firing. Escalating that would flip every
worktree to exit 1 over a present gate, unfixable by `--fix`.

Opt-out is `git.enforce_commits: false`, which already means "logmind does not gate commits here" to
guard-commit, the config template and AGENTS.md. A second key would be a second owner for one fact.
Accepted cost: local-off/CI-on is not expressible.

## Notes for review

- **`internal/decisions/decisions.go`** is one additive hunk — 46 insertions, 0 deletions, 0 modified
  lines. Three further literal-routings were reverted because they sat on lines PR #346's lane is
  editing; the deferral is noted in the const doc.
- **Textual conflict with #330/#346 expected**, not a design clash: `GateAbsences` (drift) vs
  `GateAdvisories` (advisory) — different names, different semantics, mechanical reconcile.
- Full suite `go test ./... -count=1 -timeout 45m` → exit 0 from isolated `wt-b13`; `go vet` clean;
  `gofmt -l .` empty. Source sha identical start→end of the run.

Filed separately from this lane's out-of-brief findings: #353 (hooks resolve the default branch in
shell, hard-fallback `main`) and #270 (bare-name engine resolution).
