### PR TITLE
fix(check-derived-docs): v15 — accept either merge-base state and compare content by blob id

### DIFF
--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -123,13 +123,35 @@ name: logmind / check-derived-docs
 #
 # So a SECOND state is accepted, and it is the one SPEC §3.3 actually
 # names: the file holds its merge-base-with-the-DEFAULT-branch content.
-# That is the pin the specification defines the invariant against, it is
-# what `logmind warp` restores to, and it is conflict-free for the same
-# reason the first state is — only one side of the merge has changed the
-# file, so git takes that side and there is nothing to resolve. It is not a
-# self-service escape (§6.3): the accepted bytes are a blob from the BASE
-# repository's own history, at a commit the forge computes, so a pull
-# request cannot author the content that would let it pass.
+# That is the pin the specification defines the invariant against, and it
+# is what `logmind warp` restores to. It is not a self-service escape
+# (§6.3): the accepted bytes are a blob from the BASE repository's own
+# history, at a commit the forge computes, so a pull request cannot author
+# the content that would let it pass.
+#
+# The two rules are NOT conflict-free for the same reason, and v15 first
+# shipped saying they were (logmind#361 — the sentence claimed "only one
+# side of the merge has changed the file" of BOTH). Rule A is genuinely
+# unconditional: the head side is unchanged, so git takes the base's side
+# whatever the base branch has done since, and no state of it can produce a
+# conflict. Rule B CHANGES the head side. It is one-sided only while the
+# base branch still holds its merge-base content — and neither merge-base
+# the gate computes moves when the base branch commits, so the rule cannot
+# see that happen. The condition therefore has to be READ: rule B accepts
+# only when the base branch's TIP blob is still the merge-base blob (the
+# base has not touched the file) or is already the head blob (the base has
+# arrived at the same content).
+#
+# The hole that closes is not a stale green, it is a permanent one. Once a
+# repair PR has gone green and the base branch then edits the same derived
+# doc, a `synchronize` re-run recomputes the identical two merge-bases and
+# the identical three blob ids, so it stays green while `git merge` stops on
+# a conflict marker — and two such pull requests merged in sequence give one
+# clean merge and one conflict. What the gate cannot do is decide the case
+# where BOTH sides changed the file: it reports that (`raced`) and hands it
+# back, with the one remedy that works — merge the base branch in, redo the
+# repair, which moves the merge base up and makes the repair one-sided
+# again.
 #
 # v14's remedy also named the wrong ref, which is why protocol#106 failed
 # even by v14's own rule: `git checkout origin/<default> -- …` restores the
@@ -138,6 +160,16 @@ name: logmind / check-derived-docs
 # moment anything merges. The message now names the merge-base — `logmind
 # warp`, or the `git merge-base` form by hand — and says outright that a
 # tip-restore lands straight back here.
+#
+# And the remedy has to be one that RUNS. `git checkout <merge-base> -- <all
+# three paths>` does not, whenever a branch carries a derived doc the merge
+# base does not: pathspec checkout is all-or-nothing, so it exits 1 on the
+# missing path and restores NONE of the others. `logmind warp` does not
+# close that case either — it restores per path, so it fixes every doc that
+# exists at the merge base, but it cannot DELETE one the branch added
+# (logmind#362). The message now names a per-path loop that checks out what
+# exists there and `git rm`s what does not, says which of the two `logmind
+# warp` covers, and no longer claims warp "does exactly that".
 #
 # Fail-closed, stated because the obvious one-liner is not: a blob read
 # that fails with any status other than 404 aborts the job. Two empty
@@ -318,7 +350,19 @@ jobs:
           echo "merge-base with '$BASE_REF' (the merge this PR will perform): $base_mb"
           echo "merge-base with '$DEFAULT_BRANCH' (the SPEC §3.3 pin): $pin_mb"
 
+          # Rule A below (head equals the merge-base with '$BASE_REF') is
+          # unconditional and needs no further input: it leaves the HEAD side
+          # of the merge unchanged, so git takes the base's side whatever
+          # '$BASE_REF' has done since, and no state of the base branch can
+          # make it conflict.
+          #
+          # Rule B is not that, and v15 shipped asserting it was (logmind#361).
+          # Rule B CHANGES the head side, so it is conflict-free only while
+          # the BASE side is still the one at the merge base — and neither
+          # merge-base above moves when '$BASE_REF' commits, so on its own
+          # the rule cannot see the base branch move. It has to be read.
           diverged=""
+          raced=""
           for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do
             head_blob="$(blob "$HEAD_SHA" "$f")"
             base_blob="$(blob "$base_mb" "$f")"
@@ -329,17 +373,37 @@ jobs:
             if [ "$head_blob" = "$base_blob" ]; then
               echo "$f: byte-identical to the merge-base with '$BASE_REF' — this merge cannot touch it."
             elif [ "$head_blob" = "$pin_blob" ]; then
-              echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. Only one side of this merge changes it, so it still cannot conflict."
+              # The base branch's TIP — the one input the two merge-bases
+              # cannot supply. Rule B is one-sided, and therefore safe, in
+              # exactly two states: the base has not touched this file since
+              # the merge base (so only the head side changed it), or the base
+              # has already arrived at the same content (so neither side
+              # changes it). Anything else and BOTH sides changed the file.
+              base_tip_blob="$(blob "$BASE_REF" "$f")"
+              if [ "$base_tip_blob" = "$base_blob" ] || [ "$base_tip_blob" = "$head_blob" ]; then
+                echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. '$BASE_REF' still holds either the merge-base content or this same content, so at most one side of this merge changes it and it cannot conflict."
+              else
+                raced="$raced $f"
+              fi
             else
               diverged="$diverged $f"
             fi
           done
 
+          # Two failures, two different remedies, so two messages. Reporting a
+          # raced repair as a divergence would print an untrue sentence — the
+          # content IS the pin — and send the author to restore a file that is
+          # already correct.
+          if [ -n "$raced" ]; then
+            echo "::error title=The base branch moved a derived doc this PR also changes::This PR's copy of$raced holds its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, which this gate accepts — but '$BASE_REF' has ITSELF changed that file since the merge base with this pull request ($base_mb). Both sides of the merge now change it, so merging would stop on a conflict marker. The repair is right; its merge base is stale. Fix: bring '$BASE_REF' in and redo the repair — 'git fetch origin $BASE_REF && git merge origin/$BASE_REF' (resolve any derived-doc conflict whichever way you like), then 'logmind warp', then commit. That moves this pull request's merge base up to the tip of '$BASE_REF', which is what makes the repair one-sided again."
+          fi
           if [ -n "$diverged" ]; then
-            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content — 'logmind warp' does exactly that — or by hand: 'git fetch origin $DEFAULT_BRANCH && git checkout \"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content. 'logmind warp' does that for every one of them that EXISTS at the merge base; it cannot DELETE a derived doc this branch ADDED, so a doc that is new on this branch has to go by hand (logmind#362). By hand, covering both: 'git fetch origin $DEFAULT_BRANCH && mb=\"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" && for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do if git cat-file -e \"\$mb:\$f\" 2>/dev/null; then git checkout \"\$mb\" -- \"\$f\"; else git rm -q --ignore-unmatch -- \"\$f\"; fi; done' — then commit. One 'git checkout <merge-base> -- <all three paths>' is NOT the same command and is why this message used to name a remedy that did nothing: pathspec checkout is all-or-nothing, so it exits 1 and restores NONE of them when any one path is absent at the merge base. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+          fi
+          if [ -n "$raced$diverged" ]; then
             exit 1
           fi
-          echo "Every derived doc holds its merge-base content — the merge cannot conflict on them."
+          echo "Every derived doc is changed by at most one side of this merge — it cannot conflict on them."
 
   regen-on-main:
     name: regen-on-main

--- a/.github/workflows/regen-timeline.yml
+++ b/.github/workflows/regen-timeline.yml
@@ -97,6 +97,61 @@ name: logmind / check-derived-docs
 # job actually gets, on a fork pull request too. The gate needs no write and
 # now cannot have one.
 #
+# v15 (logmind#345): the pull-request gate compares CONTENT, and it accepts
+# the REPAIR as well as the untouched state. Two changes; the second is the
+# one that unsticks a branch that has already drifted.
+#
+# What v14 asked was whether the pull request's DIFF mentions a derived
+# doc. That is very nearly the right question — `gh pr diff` is the forge's
+# three-dot diff, so a file appears in it only when its bytes at the head
+# differ from its bytes at the merge base — and "very nearly" is doing real
+# work in that sentence. The question is now asked outright: the gate reads
+# a blob id at each ref and compares those. A blob id IS a content hash, so
+# the check cannot be re-read as a file-list test by the next person, it
+# does not rest on an undocumented property of `gh pr diff`, and it does
+# not flag a file whose MODE changed while its content did not.
+#
+# The second change is the fix. v14 accepted exactly ONE state — "unchanged
+# since the merge-base with the branch you are merging into" — and a
+# repository with an integration branch can reach a state no commit
+# satisfies. Once `dev` itself carries a divergent timeline, the promotion
+# pull request `dev` -> `main` is red, and every pull request opened to
+# REPAIR `dev` changes a derived doc relative to `dev`, so it is red too.
+# The rule forbids the only remedy for the state it is reporting.
+# (thrillmade/protocol#102, and #106 which did nothing but the revert the
+# error message named and failed on it.)
+#
+# So a SECOND state is accepted, and it is the one SPEC §3.3 actually
+# names: the file holds its merge-base-with-the-DEFAULT-branch content.
+# That is the pin the specification defines the invariant against, it is
+# what `logmind warp` restores to, and it is conflict-free for the same
+# reason the first state is — only one side of the merge has changed the
+# file, so git takes that side and there is nothing to resolve. It is not a
+# self-service escape (§6.3): the accepted bytes are a blob from the BASE
+# repository's own history, at a commit the forge computes, so a pull
+# request cannot author the content that would let it pass.
+#
+# v14's remedy also named the wrong ref, which is why protocol#106 failed
+# even by v14's own rule: `git checkout origin/<default> -- …` restores the
+# default branch's TIP, and the default branch REGENERATES these files on
+# every merge, so its tip is not the merge-base and stops being it the
+# moment anything merges. The message now names the merge-base — `logmind
+# warp`, or the `git merge-base` form by hand — and says outright that a
+# tip-restore lands straight back here.
+#
+# Fail-closed, stated because the obvious one-liner is not: a blob read
+# that fails with any status other than 404 aborts the job. Two empty
+# strings compare EQUAL, so `|| echo ""` over a rate-limit or a 500 is a
+# gate that reports PASS exactly when it could not evaluate. A 404 is a
+# real answer — the repository does not carry that doc at that ref — and
+# absent on both sides is agreement.
+#
+# v15 also drops `pull-requests: read`. It was granted for `gh pr diff`,
+# and nothing reads a pull-request endpoint now: the head SHA and the base
+# ref come from the event payload, and every blob id comes from
+# `repos/…/contents` and `repos/…/compare`, which are `contents: read`. A
+# grant whose stated reason is gone is a grant nobody re-reads.
+#
 # NOTE on the version number: this was v12 until logmind#301 round 5 caught
 # it colliding with a DIFFERENT, already in-flight v12 (logmind#314) — two
 # branches independently bumped v11 to v12 with unrelated content, and nothing
@@ -140,10 +195,16 @@ on:
 
 permissions:
   contents: read         # every job reads; only regen-on-main writes, and it asks for that itself
-  pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
   # NOTE: specifying ANY permission zeroes all others (GitHub default), so
-  # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
-  # the gate fails-closed on EVERY PR, not just violators.
+  # every scope a job needs MUST be listed here explicitly — a missing one is
+  # a 403, and a 403 in the gate is a fail-closed red on EVERY pull request,
+  # not just on violators.
+  #
+  # `pull-requests: read` used to sit here, for `gh pr diff`. v15's gate
+  # reads no pull-request endpoint at all: the head SHA and the base ref
+  # arrive in the event payload, and every blob id it compares comes from
+  # `repos/…/contents` and `repos/…/compare`, both of which `contents: read`
+  # covers. Putting the grant back would be granting it for nothing.
   #
   # `contents: write` used to live here, at workflow level, where it reached
   # both jobs. Under `pull_request` that cost nothing — the forge forced a
@@ -160,22 +221,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # NO checkout, deliberately — and that is a statement about the
-      # WORKSPACE only. This job needs the PR's file list and nothing else,
-      # and `gh pr diff` gets it from the API. Under `pull_request_target`
-      # §6.3 additionally REQUIRES the absence: "a gate taking the second
-      # route MUST NOT check out the pull request's content." Adding a
-      # checkout here is not a convenience, it is the hazard the trigger is
-      # known for.
+      # WORKSPACE only. This job needs a handful of blob ids and nothing
+      # else, and `repos/…/contents` and `repos/…/compare` hand them over at
+      # an explicit ref. Under `pull_request_target` §6.3 additionally
+      # REQUIRES the absence: "a gate taking the second route MUST NOT check
+      # out the pull request's content." Adding a checkout here is not a
+      # convenience, it is the hazard the trigger is known for.
+      #
+      # Reading a blob ID is not checking the pull request's content out:
+      # nothing is written into a workspace and nothing is executed — the
+      # value compared is a hash the forge computed. That distinction is
+      # exactly what lets v15 compare CONTENT while staying checkout-free.
       #
       # What being checkout-free does NOT buy — this used to claim otherwise,
       # and the claim is why nobody looked again — is immunity for the gate
       # ITSELF. That is bought one line up, by the trigger: `pull_request`
       # would have the forge read this whole file from the branch's own merge
       # commit, workspace or no workspace.
-      - name: Assert the branch did not edit the derived docs
+      - name: Assert the derived docs hold their merge-base content
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          # The pull request's head commit, taken from the event rather than
+          # from a workspace. It is reachable through the BASE repository's
+          # API even when it lives in a fork — the forge keeps it as
+          # refs/pull/N/head — so a fork pull request needs no special case
+          # anywhere below.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # The branch this pull request MERGES INTO, which is not always the
+          # default branch: a repository with a `dev` integration branch
+          # opens most of its pull requests against `dev`.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           # The live default branch, and the one baked into `on: push:` when
           # this workflow was scaffolded. They are compared below: a rename
           # of the default branch leaves the regen trigger pointing at a
@@ -187,12 +262,84 @@ jobs:
           if [ "$SCAFFOLDED_BRANCH" != "$DEFAULT_BRANCH" ]; then
             echo "::warning title=Derived-doc regen is wired to the wrong branch::This workflow's 'on: push:' filter was scaffolded for '$SCAFFOLDED_BRANCH', but this repository's default branch is now '$DEFAULT_BRANCH'. The regen job therefore never fires, and the derived docs on '$DEFAULT_BRANCH' will drift stale — silently, because nothing else reports it. Fix: run 'logmind init --refresh' to rewrite the trigger."
           fi
-          changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
-          if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|timeline-archive|file-structure)\.md'; then
-            echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md, docs/timeline-archive.md and/or docs/file-structure.md. These are DERIVED, default-branch-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to the default branch's version — run 'logmind warp', or 'git checkout origin/$DEFAULT_BRANCH -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+
+          err="$(mktemp)"
+
+          # blob <ref> <path> — the git blob id of <path> at <ref>, or the
+          # empty string when <path> does not exist there. A blob id IS a
+          # content hash, which is what makes every comparison below a
+          # comparison of CONTENT rather than of a file list.
+          #
+          # It is a function, not a `|| echo ""` on one line, for one
+          # reason: two empty strings compare EQUAL. Swallowing a rate-limit
+          # or a 500 the way that one-liner does turns "the gate could not
+          # evaluate" into "the gate passed", so anything that is not a 404
+          # fails the job here. A 404 is a real answer — this repository
+          # does not carry that doc at that ref — and absent on both sides
+          # is agreement.
+          blob() {
+            local out
+            if out="$(gh api "repos/$GITHUB_REPOSITORY/contents/$2?ref=$1" --jq .sha 2>"$err")"; then
+              printf '%s' "$out"
+              return 0
+            fi
+            if grep -q '(HTTP 404)' "$err"; then
+              return 0
+            fi
+            cat "$err" >&2
+            # >&2, and that is not a style choice: every caller reads this
+            # function through `$(...)`, which captures STDOUT. An annotation
+            # echoed to stdout would be swallowed into a variable and never
+            # reach the log, so the job would fail closed — correctly — with
+            # nothing on the run saying why.
+            echo "::error title=Derived-doc gate could not evaluate::Reading '$2' at ref '$1' failed with a status other than 404 (the response is in the log above). The gate is failing CLOSED: an unreadable ref must not be mistaken for agreement." >&2
+            return 1
+          }
+
+          # merge_base <ref> — the commit where <ref> and this pull request's
+          # head last agreed, computed by the forge from the BASE
+          # repository's history. Nothing inside the pull request can move
+          # it, which is what keeps §6.3 satisfied while the gate reads
+          # content.
+          merge_base() {
+            gh api "repos/$GITHUB_REPOSITORY/compare/$1...$HEAD_SHA" --jq .merge_base_commit.sha
+          }
+
+          base_mb="$(merge_base "$BASE_REF")"
+          # SPEC §3.3 pins each derived file to its merge-base with the
+          # DEFAULT branch, and that is the ref 'logmind warp' restores to.
+          # When the pull request already targets the default branch the two
+          # bases are the same commit, so the second round-trip is skipped
+          # rather than paid on every run.
+          pin_mb="$base_mb"
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            pin_mb="$(merge_base "$DEFAULT_BRANCH")"
+          fi
+          echo "merge-base with '$BASE_REF' (the merge this PR will perform): $base_mb"
+          echo "merge-base with '$DEFAULT_BRANCH' (the SPEC §3.3 pin): $pin_mb"
+
+          diverged=""
+          for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do
+            head_blob="$(blob "$HEAD_SHA" "$f")"
+            base_blob="$(blob "$base_mb" "$f")"
+            pin_blob="$base_blob"
+            if [ "$pin_mb" != "$base_mb" ]; then
+              pin_blob="$(blob "$pin_mb" "$f")"
+            fi
+            if [ "$head_blob" = "$base_blob" ]; then
+              echo "$f: byte-identical to the merge-base with '$BASE_REF' — this merge cannot touch it."
+            elif [ "$head_blob" = "$pin_blob" ]; then
+              echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. Only one side of this merge changes it, so it still cannot conflict."
+            else
+              diverged="$diverged $f"
+            fi
+          done
+
+          if [ -n "$diverged" ]; then
+            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content — 'logmind warp' does exactly that — or by hand: 'git fetch origin $DEFAULT_BRANCH && git checkout \"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
             exit 1
           fi
-          echo "Branch did not edit the derived docs — the merge cannot conflict on them."
+          echo "Every derived doc holds its merge-base content — the merge cannot conflict on them."
 
   regen-on-main:
     name: regen-on-main

--- a/docs/decisions-branches/fix__derived-docs-content-check.md
+++ b/docs/decisions-branches/fix__derived-docs-content-check.md
@@ -1,0 +1,17 @@
+← back to [docs/timeline.md](../timeline.md)
+
+<!-- logmind-entry-start: 2026-08-24-check-derived-docs-v15-accept-either-merge-base-state-and-co -->
+- **2026-08-24** — check-derived-docs v15: accept either merge-base state and compare content by blob id, so a warp'd repair off a drifted integration branch has a reachable passing commit
+<!-- logmind-entry-end -->
+
+## 2026-08-24 14:33 - check-derived-docs v15: accept either merge-base state and compare content by blob id, so a warp'd repair off a drifted integration branch has a reachable passing commit
+
+**Reasoning:** v14 accepted only ONE state, so a branch forked before the default branch's last regen had no commit that could pass: warp writes merge-base content, the gate demanded the tip's. Measured on protocol#106 — head blob 0d6e21b vs merge-base df14fab. v15 accepts (A) equal to merge-base with base.ref and (B) equal to merge-base with default_branch, the SPEC 3.3 pin and exactly what warp writes; when base IS default they collapse to one. Content is compared via the compare API's merge_base_commit.sha plus contents?ref blob ids — git content hashes, no workspace and no execution, so SPEC 6.3 still holds. Case 5 goes FAIL to PASS and the real merge was clean.
+
+**Alternatives considered:** Compare against origin/<default> tip. Rejected: the tip is a moving target — green at 10:00, red at 10:05 after an unrelated merge — and a tip-equal branch is precisely what conflicts on the next merge. SPEC 3.3 says merge-base, and pinning there is what makes the gate and warp agree instead of contradict.
+
+**Implications:**
+- Two corrections to my own brief, both measured by the lane. warp.go needs NO functional change — the repair at :150 already computes DefaultBranchMergeBase and restores to it; :79 is the separate read-refresh loop, and my earlier 'code uses the tip' read came from line 79 in isolation. And gh pr diff is the forge's three-dot diff, so v14's file list already WAS a merge-base comparison; the defect was the single accepted state and a remedy that named the tip, not the absence of a content check. Marker v14 to v15 with fingerprint and digestRegionA repinned; regions B/D/F unmoved, which is evidence the change is confined to the gate.
+
+---
+

--- a/docs/decisions-branches/fix__derived-docs-content-check.md
+++ b/docs/decisions-branches/fix__derived-docs-content-check.md
@@ -15,3 +15,14 @@
 
 ---
 
+## 2026-08-24 15:55 - check-derived-docs v15: check rule B's conflict-freedom instead of asserting it, and print a remedy that actually runs
+
+**Reasoning:** The panel found the house defect inside the fix. Rule A is unconditionally conflict-free — the head side is unchanged, so git takes the base's side. Rule B CHANGES the head side, so it is conflict-free only if the base TIP blob still matches its merge-base blob, which the gate never read. Measured: dev drifts, a PR warps green, dev drifts again, gate still exits 0 saying 'the merge cannot conflict on them', and git merge conflicts — with no re-trigger, because neither merge-base moves. The gate now reads base_tip_blob and accepts rule B only when it equals base_blob or head_blob. Row 5, the entire reason v15 exists, still PASSES.
+
+**Alternatives considered:** Require branches up to date before merging and drop rule B. Rejected: that is a repo setting we cannot ship in a template, and it forces a rebase on every unrelated push to the integration branch — the friction v2.0.0 exists to remove. Also rejected: comparing merge RESULTS rather than blobs, which would need a workspace and break SPEC 6.3's checkout-free requirement.
+
+**Implications:**
+- Stated limits, not claims. The base branch moving AFTER the last check run is not closed — pull_request_target fires on head changes only, so the window shrinks from forever to since-the-last-run; only 'require branches up to date' closes it. F1b's rule incoherence is unchanged: a branch that merged main in makes pin_mb main's tip, so rule B accepts tip content while the message forbids restoring to the tip — measured conflict-correct but incoherent, and it sits with #362/#363. Errors now lean false-RED: two sides editing different hunks that git would auto-merge are reported raced, because the gate compares blobs not merge results. Marker stays v15 rather than bumping to v16 — origin/dev carries v14, so v15 was never shipped; digestRegionA repinned, B/D/F unmoved. The PR body's G3 row claim was wrong: the true set against shipped v15 is {2,3}, not {2,3,4,7}.
+
+---
+

--- a/internal/cli/warp.go
+++ b/internal/cli/warp.go
@@ -48,6 +48,16 @@ UNRESOLVED gap (see BuildPreCommitBody's doc comment, internal/hooks/
 hooks.go); a raw 'git commit' instead of 'logmind log' hits the exact same
 hook and has the same exposure.
 
+warp's output has TWO layers holding DIFFERENT content, and which one you
+commit is up to you. The read-refresh leaves origin/<default>'s TIP content
+in the working tree, unstaged; the repair leaves MERGE-BASE content in the
+index. 'logmind log' and a plain 'git commit' both do the right thing — the
+first reverts the unstaged copies to HEAD, the second takes only the index —
+but 'git commit -a' (or 'git add -A') sweeps the refreshed tip copies in as
+well, and on any branch that forked before the default branch's last regen
+the tip is NOT the merge-base, so CI's check-derived-docs rejects the
+result. Commit what warp STAGED, not what it refreshed.
+
 logmind log's own restore (and the harness guard) target HEAD rather than
 the merge-base on their OWN hot path — cheap and offline, but unable to
 repair a divergence that already happened — precisely because warp is the

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -1,4 +1,4 @@
-# logmind-template-version: v14
+# logmind-template-version: v15
 name: logmind / check-derived-docs
 
 # v2.0.0 derived-docs-on-main. The derived docs are regenerated ONLY here on
@@ -98,6 +98,61 @@ name: logmind / check-derived-docs
 # job actually gets, on a fork pull request too. The gate needs no write and
 # now cannot have one.
 #
+# v15 (logmind#345): the pull-request gate compares CONTENT, and it accepts
+# the REPAIR as well as the untouched state. Two changes; the second is the
+# one that unsticks a branch that has already drifted.
+#
+# What v14 asked was whether the pull request's DIFF mentions a derived
+# doc. That is very nearly the right question — `gh pr diff` is the forge's
+# three-dot diff, so a file appears in it only when its bytes at the head
+# differ from its bytes at the merge base — and "very nearly" is doing real
+# work in that sentence. The question is now asked outright: the gate reads
+# a blob id at each ref and compares those. A blob id IS a content hash, so
+# the check cannot be re-read as a file-list test by the next person, it
+# does not rest on an undocumented property of `gh pr diff`, and it does
+# not flag a file whose MODE changed while its content did not.
+#
+# The second change is the fix. v14 accepted exactly ONE state — "unchanged
+# since the merge-base with the branch you are merging into" — and a
+# repository with an integration branch can reach a state no commit
+# satisfies. Once `dev` itself carries a divergent timeline, the promotion
+# pull request `dev` -> `main` is red, and every pull request opened to
+# REPAIR `dev` changes a derived doc relative to `dev`, so it is red too.
+# The rule forbids the only remedy for the state it is reporting.
+# (thrillmade/protocol#102, and #106 which did nothing but the revert the
+# error message named and failed on it.)
+#
+# So a SECOND state is accepted, and it is the one SPEC §3.3 actually
+# names: the file holds its merge-base-with-the-DEFAULT-branch content.
+# That is the pin the specification defines the invariant against, it is
+# what `logmind warp` restores to, and it is conflict-free for the same
+# reason the first state is — only one side of the merge has changed the
+# file, so git takes that side and there is nothing to resolve. It is not a
+# self-service escape (§6.3): the accepted bytes are a blob from the BASE
+# repository's own history, at a commit the forge computes, so a pull
+# request cannot author the content that would let it pass.
+#
+# v14's remedy also named the wrong ref, which is why protocol#106 failed
+# even by v14's own rule: `git checkout origin/<default> -- …` restores the
+# default branch's TIP, and the default branch REGENERATES these files on
+# every merge, so its tip is not the merge-base and stops being it the
+# moment anything merges. The message now names the merge-base — `logmind
+# warp`, or the `git merge-base` form by hand — and says outright that a
+# tip-restore lands straight back here.
+#
+# Fail-closed, stated because the obvious one-liner is not: a blob read
+# that fails with any status other than 404 aborts the job. Two empty
+# strings compare EQUAL, so `|| echo ""` over a rate-limit or a 500 is a
+# gate that reports PASS exactly when it could not evaluate. A 404 is a
+# real answer — the repository does not carry that doc at that ref — and
+# absent on both sides is agreement.
+#
+# v15 also drops `pull-requests: read`. It was granted for `gh pr diff`,
+# and nothing reads a pull-request endpoint now: the head SHA and the base
+# ref come from the event payload, and every blob id comes from
+# `repos/…/contents` and `repos/…/compare`, which are `contents: read`. A
+# grant whose stated reason is gone is a grant nobody re-reads.
+#
 # NOTE on the version number: this was v12 until logmind#301 round 5 caught
 # it colliding with a DIFFERENT, already in-flight v12 (logmind#314) — two
 # branches independently bumped v11 to v12 with unrelated content, and nothing
@@ -141,10 +196,16 @@ on:
 
 permissions:
   contents: read         # every job reads; only regen-on-main writes, and it asks for that itself
-  pull-requests: read    # the PR gate reads the PR file list via `gh pr diff`
   # NOTE: specifying ANY permission zeroes all others (GitHub default), so
-  # pull-requests MUST be listed explicitly — without it `gh pr diff` 403s and
-  # the gate fails-closed on EVERY PR, not just violators.
+  # every scope a job needs MUST be listed here explicitly — a missing one is
+  # a 403, and a 403 in the gate is a fail-closed red on EVERY pull request,
+  # not just on violators.
+  #
+  # `pull-requests: read` used to sit here, for `gh pr diff`. v15's gate
+  # reads no pull-request endpoint at all: the head SHA and the base ref
+  # arrive in the event payload, and every blob id it compares comes from
+  # `repos/…/contents` and `repos/…/compare`, both of which `contents: read`
+  # covers. Putting the grant back would be granting it for nothing.
   #
   # `contents: write` used to live here, at workflow level, where it reached
   # both jobs. Under `pull_request` that cost nothing — the forge forced a
@@ -161,22 +222,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # NO checkout, deliberately — and that is a statement about the
-      # WORKSPACE only. This job needs the PR's file list and nothing else,
-      # and `gh pr diff` gets it from the API. Under `pull_request_target`
-      # §6.3 additionally REQUIRES the absence: "a gate taking the second
-      # route MUST NOT check out the pull request's content." Adding a
-      # checkout here is not a convenience, it is the hazard the trigger is
-      # known for.
+      # WORKSPACE only. This job needs a handful of blob ids and nothing
+      # else, and `repos/…/contents` and `repos/…/compare` hand them over at
+      # an explicit ref. Under `pull_request_target` §6.3 additionally
+      # REQUIRES the absence: "a gate taking the second route MUST NOT check
+      # out the pull request's content." Adding a checkout here is not a
+      # convenience, it is the hazard the trigger is known for.
+      #
+      # Reading a blob ID is not checking the pull request's content out:
+      # nothing is written into a workspace and nothing is executed — the
+      # value compared is a hash the forge computed. That distinction is
+      # exactly what lets v15 compare CONTENT while staying checkout-free.
       #
       # What being checkout-free does NOT buy — this used to claim otherwise,
       # and the claim is why nobody looked again — is immunity for the gate
       # ITSELF. That is bought one line up, by the trigger: `pull_request`
       # would have the forge read this whole file from the branch's own merge
       # commit, workspace or no workspace.
-      - name: Assert the branch did not edit the derived docs
+      - name: Assert the derived docs hold their merge-base content
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          # The pull request's head commit, taken from the event rather than
+          # from a workspace. It is reachable through the BASE repository's
+          # API even when it lives in a fork — the forge keeps it as
+          # refs/pull/N/head — so a fork pull request needs no special case
+          # anywhere below.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # The branch this pull request MERGES INTO, which is not always the
+          # default branch: a repository with a `dev` integration branch
+          # opens most of its pull requests against `dev`.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           # The live default branch, and the one baked into `on: push:` when
           # this workflow was scaffolded. They are compared below: a rename
           # of the default branch leaves the regen trigger pointing at a
@@ -188,12 +263,84 @@ jobs:
           if [ "$SCAFFOLDED_BRANCH" != "$DEFAULT_BRANCH" ]; then
             echo "::warning title=Derived-doc regen is wired to the wrong branch::This workflow's 'on: push:' filter was scaffolded for '$SCAFFOLDED_BRANCH', but this repository's default branch is now '$DEFAULT_BRANCH'. The regen job therefore never fires, and the derived docs on '$DEFAULT_BRANCH' will drift stale — silently, because nothing else reports it. Fix: run 'logmind init --refresh' to rewrite the trigger."
           fi
-          changed=$(gh pr diff "$PR" --name-only --repo "$GITHUB_REPOSITORY")
-          if printf '%s\n' "$changed" | grep -qxE 'docs/(timeline|timeline-archive|file-structure)\.md'; then
-            echo "::error title=Derived docs were edited on this branch::This PR modifies docs/timeline.md, docs/timeline-archive.md and/or docs/file-structure.md. These are DERIVED, default-branch-only artifacts; editing them on a branch causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: revert them to the default branch's version — run 'logmind warp', or 'git checkout origin/$DEFAULT_BRANCH -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+
+          err="$(mktemp)"
+
+          # blob <ref> <path> — the git blob id of <path> at <ref>, or the
+          # empty string when <path> does not exist there. A blob id IS a
+          # content hash, which is what makes every comparison below a
+          # comparison of CONTENT rather than of a file list.
+          #
+          # It is a function, not a `|| echo ""` on one line, for one
+          # reason: two empty strings compare EQUAL. Swallowing a rate-limit
+          # or a 500 the way that one-liner does turns "the gate could not
+          # evaluate" into "the gate passed", so anything that is not a 404
+          # fails the job here. A 404 is a real answer — this repository
+          # does not carry that doc at that ref — and absent on both sides
+          # is agreement.
+          blob() {
+            local out
+            if out="$(gh api "repos/$GITHUB_REPOSITORY/contents/$2?ref=$1" --jq .sha 2>"$err")"; then
+              printf '%s' "$out"
+              return 0
+            fi
+            if grep -q '(HTTP 404)' "$err"; then
+              return 0
+            fi
+            cat "$err" >&2
+            # >&2, and that is not a style choice: every caller reads this
+            # function through `$(...)`, which captures STDOUT. An annotation
+            # echoed to stdout would be swallowed into a variable and never
+            # reach the log, so the job would fail closed — correctly — with
+            # nothing on the run saying why.
+            echo "::error title=Derived-doc gate could not evaluate::Reading '$2' at ref '$1' failed with a status other than 404 (the response is in the log above). The gate is failing CLOSED: an unreadable ref must not be mistaken for agreement." >&2
+            return 1
+          }
+
+          # merge_base <ref> — the commit where <ref> and this pull request's
+          # head last agreed, computed by the forge from the BASE
+          # repository's history. Nothing inside the pull request can move
+          # it, which is what keeps §6.3 satisfied while the gate reads
+          # content.
+          merge_base() {
+            gh api "repos/$GITHUB_REPOSITORY/compare/$1...$HEAD_SHA" --jq .merge_base_commit.sha
+          }
+
+          base_mb="$(merge_base "$BASE_REF")"
+          # SPEC §3.3 pins each derived file to its merge-base with the
+          # DEFAULT branch, and that is the ref 'logmind warp' restores to.
+          # When the pull request already targets the default branch the two
+          # bases are the same commit, so the second round-trip is skipped
+          # rather than paid on every run.
+          pin_mb="$base_mb"
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            pin_mb="$(merge_base "$DEFAULT_BRANCH")"
+          fi
+          echo "merge-base with '$BASE_REF' (the merge this PR will perform): $base_mb"
+          echo "merge-base with '$DEFAULT_BRANCH' (the SPEC §3.3 pin): $pin_mb"
+
+          diverged=""
+          for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do
+            head_blob="$(blob "$HEAD_SHA" "$f")"
+            base_blob="$(blob "$base_mb" "$f")"
+            pin_blob="$base_blob"
+            if [ "$pin_mb" != "$base_mb" ]; then
+              pin_blob="$(blob "$pin_mb" "$f")"
+            fi
+            if [ "$head_blob" = "$base_blob" ]; then
+              echo "$f: byte-identical to the merge-base with '$BASE_REF' — this merge cannot touch it."
+            elif [ "$head_blob" = "$pin_blob" ]; then
+              echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. Only one side of this merge changes it, so it still cannot conflict."
+            else
+              diverged="$diverged $f"
+            fi
+          done
+
+          if [ -n "$diverged" ]; then
+            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content — 'logmind warp' does exactly that — or by hand: 'git fetch origin $DEFAULT_BRANCH && git checkout \"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
             exit 1
           fi
-          echo "Branch did not edit the derived docs — the merge cannot conflict on them."
+          echo "Every derived doc holds its merge-base content — the merge cannot conflict on them."
 
   regen-on-main:
     name: regen-on-main

--- a/internal/templates/github/regen-timeline.yml.template
+++ b/internal/templates/github/regen-timeline.yml.template
@@ -124,13 +124,35 @@ name: logmind / check-derived-docs
 #
 # So a SECOND state is accepted, and it is the one SPEC §3.3 actually
 # names: the file holds its merge-base-with-the-DEFAULT-branch content.
-# That is the pin the specification defines the invariant against, it is
-# what `logmind warp` restores to, and it is conflict-free for the same
-# reason the first state is — only one side of the merge has changed the
-# file, so git takes that side and there is nothing to resolve. It is not a
-# self-service escape (§6.3): the accepted bytes are a blob from the BASE
-# repository's own history, at a commit the forge computes, so a pull
-# request cannot author the content that would let it pass.
+# That is the pin the specification defines the invariant against, and it
+# is what `logmind warp` restores to. It is not a self-service escape
+# (§6.3): the accepted bytes are a blob from the BASE repository's own
+# history, at a commit the forge computes, so a pull request cannot author
+# the content that would let it pass.
+#
+# The two rules are NOT conflict-free for the same reason, and v15 first
+# shipped saying they were (logmind#361 — the sentence claimed "only one
+# side of the merge has changed the file" of BOTH). Rule A is genuinely
+# unconditional: the head side is unchanged, so git takes the base's side
+# whatever the base branch has done since, and no state of it can produce a
+# conflict. Rule B CHANGES the head side. It is one-sided only while the
+# base branch still holds its merge-base content — and neither merge-base
+# the gate computes moves when the base branch commits, so the rule cannot
+# see that happen. The condition therefore has to be READ: rule B accepts
+# only when the base branch's TIP blob is still the merge-base blob (the
+# base has not touched the file) or is already the head blob (the base has
+# arrived at the same content).
+#
+# The hole that closes is not a stale green, it is a permanent one. Once a
+# repair PR has gone green and the base branch then edits the same derived
+# doc, a `synchronize` re-run recomputes the identical two merge-bases and
+# the identical three blob ids, so it stays green while `git merge` stops on
+# a conflict marker — and two such pull requests merged in sequence give one
+# clean merge and one conflict. What the gate cannot do is decide the case
+# where BOTH sides changed the file: it reports that (`raced`) and hands it
+# back, with the one remedy that works — merge the base branch in, redo the
+# repair, which moves the merge base up and makes the repair one-sided
+# again.
 #
 # v14's remedy also named the wrong ref, which is why protocol#106 failed
 # even by v14's own rule: `git checkout origin/<default> -- …` restores the
@@ -139,6 +161,16 @@ name: logmind / check-derived-docs
 # moment anything merges. The message now names the merge-base — `logmind
 # warp`, or the `git merge-base` form by hand — and says outright that a
 # tip-restore lands straight back here.
+#
+# And the remedy has to be one that RUNS. `git checkout <merge-base> -- <all
+# three paths>` does not, whenever a branch carries a derived doc the merge
+# base does not: pathspec checkout is all-or-nothing, so it exits 1 on the
+# missing path and restores NONE of the others. `logmind warp` does not
+# close that case either — it restores per path, so it fixes every doc that
+# exists at the merge base, but it cannot DELETE one the branch added
+# (logmind#362). The message now names a per-path loop that checks out what
+# exists there and `git rm`s what does not, says which of the two `logmind
+# warp` covers, and no longer claims warp "does exactly that".
 #
 # Fail-closed, stated because the obvious one-liner is not: a blob read
 # that fails with any status other than 404 aborts the job. Two empty
@@ -319,7 +351,19 @@ jobs:
           echo "merge-base with '$BASE_REF' (the merge this PR will perform): $base_mb"
           echo "merge-base with '$DEFAULT_BRANCH' (the SPEC §3.3 pin): $pin_mb"
 
+          # Rule A below (head equals the merge-base with '$BASE_REF') is
+          # unconditional and needs no further input: it leaves the HEAD side
+          # of the merge unchanged, so git takes the base's side whatever
+          # '$BASE_REF' has done since, and no state of the base branch can
+          # make it conflict.
+          #
+          # Rule B is not that, and v15 shipped asserting it was (logmind#361).
+          # Rule B CHANGES the head side, so it is conflict-free only while
+          # the BASE side is still the one at the merge base — and neither
+          # merge-base above moves when '$BASE_REF' commits, so on its own
+          # the rule cannot see the base branch move. It has to be read.
           diverged=""
+          raced=""
           for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do
             head_blob="$(blob "$HEAD_SHA" "$f")"
             base_blob="$(blob "$base_mb" "$f")"
@@ -330,17 +374,37 @@ jobs:
             if [ "$head_blob" = "$base_blob" ]; then
               echo "$f: byte-identical to the merge-base with '$BASE_REF' — this merge cannot touch it."
             elif [ "$head_blob" = "$pin_blob" ]; then
-              echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. Only one side of this merge changes it, so it still cannot conflict."
+              # The base branch's TIP — the one input the two merge-bases
+              # cannot supply. Rule B is one-sided, and therefore safe, in
+              # exactly two states: the base has not touched this file since
+              # the merge base (so only the head side changed it), or the base
+              # has already arrived at the same content (so neither side
+              # changes it). Anything else and BOTH sides changed the file.
+              base_tip_blob="$(blob "$BASE_REF" "$f")"
+              if [ "$base_tip_blob" = "$base_blob" ] || [ "$base_tip_blob" = "$head_blob" ]; then
+                echo "$f: restored to its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, accepted. '$BASE_REF' still holds either the merge-base content or this same content, so at most one side of this merge changes it and it cannot conflict."
+              else
+                raced="$raced $f"
+              fi
             else
               diverged="$diverged $f"
             fi
           done
 
+          # Two failures, two different remedies, so two messages. Reporting a
+          # raced repair as a divergence would print an untrue sentence — the
+          # content IS the pin — and send the author to restore a file that is
+          # already correct.
+          if [ -n "$raced" ]; then
+            echo "::error title=The base branch moved a derived doc this PR also changes::This PR's copy of$raced holds its merge-base-with-'$DEFAULT_BRANCH' content — the SPEC §3.3 repair, which this gate accepts — but '$BASE_REF' has ITSELF changed that file since the merge base with this pull request ($base_mb). Both sides of the merge now change it, so merging would stop on a conflict marker. The repair is right; its merge base is stale. Fix: bring '$BASE_REF' in and redo the repair — 'git fetch origin $BASE_REF && git merge origin/$BASE_REF' (resolve any derived-doc conflict whichever way you like), then 'logmind warp', then commit. That moves this pull request's merge base up to the tip of '$BASE_REF', which is what makes the repair one-sided again."
+          fi
           if [ -n "$diverged" ]; then
-            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content — 'logmind warp' does exactly that — or by hand: 'git fetch origin $DEFAULT_BRANCH && git checkout \"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" -- docs/timeline.md docs/timeline-archive.md docs/file-structure.md' — then commit. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+            echo "::error title=Derived docs diverge from their merge-base content::This PR's copy of$diverged matches NEITHER the merge-base with '$BASE_REF' ($base_mb) NOR the merge-base with '$DEFAULT_BRANCH' ($pin_mb). These are DERIVED, default-branch-only artifacts; a branch that carries its own version of them is what causes the cross-PR merge conflicts v2.0.0 eliminates. Fix: restore them to their MERGE-BASE content. 'logmind warp' does that for every one of them that EXISTS at the merge base; it cannot DELETE a derived doc this branch ADDED, so a doc that is new on this branch has to go by hand (logmind#362). By hand, covering both: 'git fetch origin $DEFAULT_BRANCH && mb=\"\$(git merge-base origin/$DEFAULT_BRANCH HEAD)\" && for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do if git cat-file -e \"\$mb:\$f\" 2>/dev/null; then git checkout \"\$mb\" -- \"\$f\"; else git rm -q --ignore-unmatch -- \"\$f\"; fi; done' — then commit. One 'git checkout <merge-base> -- <all three paths>' is NOT the same command and is why this message used to name a remedy that did nothing: pathspec checkout is all-or-nothing, so it exits 1 and restores NONE of them when any one path is absent at the merge base. Do NOT restore to 'origin/$DEFAULT_BRANCH' itself: '$DEFAULT_BRANCH' REGENERATES these files on every merge, so its tip is not the merge-base and a tip-restore lands straight back here (logmind#345). Their real content regenerates on '$DEFAULT_BRANCH' after merge."
+          fi
+          if [ -n "$raced$diverged" ]; then
             exit 1
           fi
-          echo "Every derived doc holds its merge-base content — the merge cannot conflict on them."
+          echo "Every derived doc is changed by at most one side of this merge — it cannot conflict on them."
 
   regen-on-main:
     name: regen-on-main

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -276,10 +276,13 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	// the v12 tests below assert are still there, and are asserted there.
 	// v13 → v14: the PR gate's trigger moves to `pull_request_target` and
 	// `contents: write` narrows to the job that pushes (logmind#261). What
-	// the gate DECIDES is untouched — every assertion in this function is
-	// v13's, unchanged, which is the evidence for that claim.
-	if !strings.Contains(body, "# logmind-template-version: v14") {
-		t.Errorf("regen-timeline template missing v14 marker")
+	// the gate DECIDED was untouched by that bump — every assertion in this
+	// function was v13's, unchanged, which was the evidence for the claim.
+	// v14 → v15 (logmind#345) is the opposite kind of bump: what the gate
+	// decides is exactly what changed, so the two assertions that named the
+	// old mechanism moved with it and are called out where they sit.
+	if !strings.Contains(body, "# logmind-template-version: v15") {
+		t.Errorf("regen-timeline template missing v15 marker")
 	}
 	// The required-check name MUST stay check-derived-docs (ruleset matching),
 	// and the main regen is a distinct job.
@@ -294,17 +297,92 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	if !strings.Contains(body, "exit 1") {
 		t.Errorf("regen-timeline v10 PR gate must `exit 1` on a derived-doc edit (blocking)")
 	}
-	// The gate detects the edit via the PR's own file list (GitHub's 3-dot
-	// diff = branch-vs-merge-base, fork-correct) and matches ONLY the two
-	// derived docs as whole lines.
-	if !strings.Contains(body, "gh pr diff") || !strings.Contains(body, "--name-only") {
-		t.Errorf("regen-timeline v10 PR gate must use `gh pr diff --name-only`")
+	// v15: the gate compares CONTENT, at explicit refs, via blob ids.
+	//
+	// v14 read the PR's file list (`gh pr diff --name-only`). That was not
+	// as wrong as it looks — `gh pr diff` is the forge's three-dot diff, so
+	// a file appears in it only when its bytes at the head differ from its
+	// bytes at the merge base — but it left the gate's actual question
+	// unstated, resting on an undocumented property of a CLI, and it flags a
+	// file whose mode changed while its content did not. The blob id is a
+	// content hash; comparing two of them says what the gate means.
+	if !strings.Contains(body, "gh api \"repos/$GITHUB_REPOSITORY/contents/$2?ref=$1\" --jq .sha") {
+		t.Errorf("regen-timeline v15 PR gate must read a BLOB ID at an explicit ref — that is what " +
+			"makes it a content comparison rather than a file-list test (logmind#345)")
+	}
+	// Read the EXECUTABLE content for the two bans below: the v15 header
+	// note and the permissions block both name what they removed, and
+	// naming it is the point. stripYAMLComments (not stripCommentLines) is
+	// the right knife here — it keeps `#` lines inside a `run:` block,
+	// which are shell text rather than YAML comments, so the ban still
+	// reaches every byte the runner is handed.
+	active := stripYAMLComments(body)
+	if strings.Contains(active, "gh pr diff") {
+		t.Errorf("regen-timeline v15 PR gate must not decide on the PR's file list — the file list " +
+			"cannot distinguish a branch that EDITED a derived doc from one that RESTORED it, " +
+			"which is the state protocol#106 could not get out of")
+	}
+	// The merge base is computed by the FORGE from the base repository's
+	// history (`compare`'s merge_base_commit), never handed in by the pull
+	// request — §6.3, a gate's input comes from the base ref.
+	if !strings.Contains(body, "--jq .merge_base_commit.sha") {
+		t.Errorf("regen-timeline v15 must resolve the merge base from the compare API's " +
+			"merge_base_commit — the tip of the default branch is NOT the merge base, and " +
+			"restoring to it is what left protocol#106 permanently red")
+	}
+	// …and both refs the gate COMPARES AGAINST must be that merge base,
+	// which is a separate assertion from "the function exists". Swapping
+	// `base_mb` to the branch NAME leaves `merge_base` defined and called
+	// (for the pin), so the check above stays green while the gate starts
+	// comparing against a tip — a mutation that fails a healthy branch and
+	// passes a tip-restore, i.e. exactly logmind#345 inverted.
+	for _, ref := range []string{
+		`base_mb="$(merge_base "$BASE_REF")"`,
+		`pin_mb="$(merge_base "$DEFAULT_BRANCH")"`,
+	} {
+		if !strings.Contains(body, ref) {
+			t.Errorf("regen-timeline v15 must compare against a MERGE BASE, not a branch tip: "+
+				"expected the gate to resolve %s. The default branch regenerates these files on "+
+				"every merge, so its tip differs from the merge-base for any branch that forked "+
+				"before the last regen — comparing against it fails every healthy branch and "+
+				"accepts every tip-restore.", ref)
+		}
 	}
 	// All THREE derived docs of SPEC §3.3 — "the history, its archive, or
-	// the map" — as whole lines. A gate that names only two leaves the
-	// omitted one editable on a branch, undetected.
-	if !strings.Contains(body, `grep -qxE 'docs/(timeline|timeline-archive|file-structure)\.md'`) {
-		t.Errorf("regen-timeline PR gate must match exactly the three derived docs as whole lines")
+	// the map". A gate that names only two leaves the omitted one editable
+	// on a branch, undetected.
+	if !strings.Contains(body, "for f in docs/timeline.md docs/timeline-archive.md docs/file-structure.md; do") {
+		t.Errorf("regen-timeline PR gate must check exactly the three derived docs of SPEC §3.3")
+	}
+	// The SECOND accepted state, and the whole of logmind#345: a file
+	// restored to its merge-base-with-the-default-branch content passes.
+	// Without it a repository whose integration branch has drifted has no
+	// commit that reaches a passing state — the repair edits a derived doc
+	// relative to that branch, so the rule forbids its own remedy.
+	if !strings.Contains(body, `elif [ "$head_blob" = "$pin_blob" ]; then`) {
+		t.Errorf("regen-timeline v15 must ACCEPT a derived doc restored to its " +
+			"merge-base-with-the-default-branch content (the SPEC §3.3 pin, and what " +
+			"`logmind warp` writes) — otherwise a drifted branch is permanently red")
+	}
+	// Fail-closed. Two empty strings compare equal, so a blob read that
+	// failed for any reason other than "this ref does not carry the file"
+	// must abort rather than silently agree with itself.
+	if !strings.Contains(body, `if grep -q '(HTTP 404)' "$err"; then`) {
+		t.Errorf("regen-timeline v15 must distinguish a 404 (a real answer) from every other " +
+			"API failure — swallowing a 500 or a rate-limit makes the gate report PASS " +
+			"exactly when it could not evaluate")
+	}
+	// The remedy must be one that WORKS. v14's named `origin/<default>` —
+	// the TIP — while the check was against the merge base, so following
+	// it landed the author back on the same red gate (protocol#106).
+	if !strings.Contains(body, "git merge-base origin/$DEFAULT_BRANCH HEAD") {
+		t.Errorf("regen-timeline v15's remediation must name the MERGE-BASE, not the default " +
+			"branch's tip — the default branch regenerates these files on every merge, so a " +
+			"tip-restore is itself a divergence (logmind#345)")
+	}
+	if !strings.Contains(body, "logmind warp") {
+		t.Errorf("regen-timeline PR gate must name `logmind warp` — it is the one surface that " +
+			"fetches and restores to the merge base, i.e. the state this gate accepts")
 	}
 	// Event-gated jobs: gate runs only on the pull-request event, regen only
 	// on push. v14 moved the gate's event to `pull_request_target` (§6.3),
@@ -328,11 +406,24 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	if !strings.Contains(body, "persist-credentials: false") {
 		t.Errorf("regen-timeline v10 must set persist-credentials: false on regen-on-main's checkout")
 	}
-	// The PR gate reads the PR file list via `gh pr diff`, which needs
-	// pull-requests:read. Because specifying ANY permission zeroes the rest,
-	// this MUST be explicit or the gate 403s and fails-closed on every PR.
-	if !strings.Contains(body, "pull-requests: read") {
-		t.Errorf("regen-timeline v10 must grant pull-requests: read (else gh pr diff 403s and blocks every PR)")
+	// v15 removes `pull-requests: read`. It was granted for `gh pr diff`,
+	// which is gone: the head SHA and the base ref arrive in the event
+	// payload, and every blob id comes from `repos/…/contents` and
+	// `repos/…/compare`, which `contents: read` covers. Asserting its
+	// ABSENCE rather than deleting the assertion is the point — a grant
+	// whose stated reason has gone is how an over-broad token survives a
+	// review, and under `pull_request_target` these grants are real on a
+	// fork pull request.
+	if strings.Contains(active, "pull-requests:") {
+		t.Errorf("regen-timeline v15 must not grant pull-requests: — nothing reads a " +
+			"pull-request endpoint any more (logmind#345)")
+	}
+	// …and `contents: read` MUST still be explicit, because specifying ANY
+	// permission zeroes the rest: without it every `gh api` call 403s and
+	// the gate fails-closed on every PR, not just on violators.
+	if !strings.Contains(body, "contents: read") {
+		t.Errorf("regen-timeline must grant contents: read (else the contents/compare reads 403 " +
+			"and block every PR)")
 	}
 	// v14: `contents: write` is the PUSHING job's, not the file's. Under
 	// `pull_request` the distinction cost nothing — the forge forced a
@@ -423,6 +514,12 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	if strings.Contains(body, "has not adopted") {
 		t.Errorf("regen-timeline v10 PR gate must not have a not-adopted pass-through message")
 	}
+	// What v10 removed was an ADOPTION SIGNAL read from the base ref, and
+	// this is the pin against its return. It is not a ban on reading the
+	// base ref at all: v15 reads `pull_request.base.ref` to ask the forge
+	// for a merge base, which is a gate INPUT taken from the base side
+	// exactly as §6.3 requires. The narrower thing still banned is the
+	// PINNED base COMMIT the adoption gate resolved config out of.
 	if strings.Contains(body, "pull_request.base.sha") || strings.Contains(body, "BASE_SHA") {
 		t.Errorf("regen-timeline v10 must not read a base-ref adoption signal — there is nothing left to read")
 	}
@@ -430,8 +527,9 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 	// SECURITY — even with the adoption signal gone, this job must still
 	// never check out the PR: a checkout on a pull_request event lands
 	// refs/pull/N/merge (the PR's own content), and this job has no business
-	// trusting anything from the PR beyond its file list (`gh pr diff`,
-	// which talks to the API, not the workspace).
+	// trusting anything the PR authored. v15 compares blob IDS at explicit
+	// refs, which is a read of hashes over the API and not a checkout — the
+	// bytes never reach a workspace and nothing from the PR is executed.
 	prJob, _, found := strings.Cut(body, "  regen-on-main:")
 	if !found {
 		t.Fatalf("regen-timeline v10: could not locate the regen-on-main job boundary")
@@ -518,7 +616,12 @@ var templateMarkerPins = map[string]struct {
 	// merge-base already carries on `dev`, so an installed v13 is reachable
 	// and a content change under it would be a change no repository could
 	// ever be told about.
-	"regen-timeline.yml.template": {"v14", "8be4b55b27379c92433c1b4b0a3fb82a9287730b50fcde868b378f6d7ea49902"},
+	// Moved v14 → v15 by logmind#345: the PR gate compares blob ids instead
+	// of the PR's file list, and accepts a derived doc restored to its
+	// merge-base-with-the-default-branch content. A bump, not a repin, for
+	// the same reason — v14 is on `dev` and every repo holding it is running
+	// a gate that its own error message cannot get them out of.
+	"regen-timeline.yml.template": {"v15", "ac26c6a4dffd3e5fdff9fc7b57caa5f9bb3484bf2ff5bace5f96c2474996e8c9"},
 }
 
 func TestWorkflowTemplateMarkers_PinnedToContent(t *testing.T) {
@@ -1130,8 +1233,16 @@ func TestRegenTimelineWorkflow_LockstepWithTemplate(t *testing.T) {
 // `regen-on-main` its own `permissions: contents: write`. D and F did not
 // move at all: the checkout stanza and the whole credential chain are
 // untouched.
+//
+// v15 (logmind#345) moved A and ONLY A, and that is this change's evidence
+// in the same shape. The gate's `run:` block was rewritten — blob ids at
+// explicit refs instead of the PR's file list, the SPEC §3.3 repair
+// accepted, the remedy re-aimed at the merge base — and `pull-requests:
+// read` left the workflow-level permissions block with it. B, D and F are
+// byte-for-byte v14's: nothing about how the regen job builds, checks out,
+// authenticates or pushes was touched.
 const (
-	digestRegionA = "a01ac1d4b02eedcf277961b1678da8ee2eb11876ddc50463a89c161d7609cb17"
+	digestRegionA = "b592e6f89dd32204783103f4ed47da8dd8d2091bc9f7e7a8e953c8620e58e272"
 	digestRegionB = "a3c158cdc04d4dc533c0c59bb13bf245e41798fd1c20ef2afa5793aab69d99fc"
 	digestRegionD = "7e2d788d136cdff688f698527cd505c1d70633f4134d4df2951fbff59b7fc612"
 	digestRegionF = "bbe3a145536916b0c0ae850ae84e5e5e0662554d9d7059f79d9c7cd1844e117a"
@@ -1772,7 +1883,13 @@ var bundledTemplateFingerprints = map[string]string{
 	// SHIPPED to `dev` by now, so this is the ordinary case this map is for:
 	// the marker moves with the content, and every repo holding v13 is
 	// refreshed onto v14 because — and only because — the strings differ.
-	"regen-timeline.yml.template": "v14:8be4b55b27379c92433c1b4b0a3fb82a9287730b50fcde868b378f6d7ea49902",
+	//
+	// v15 = v14's body with the gate comparing blob ids at explicit refs and
+	// accepting the SPEC §3.3 repair (logmind#345). Same ordinary case, and
+	// the bump matters more than usual: a repo left on v14 keeps a gate that
+	// goes red on a drifted integration branch and rejects the only commit
+	// that could fix it.
+	"regen-timeline.yml.template": "v15:ac26c6a4dffd3e5fdff9fc7b57caa5f9bb3484bf2ff5bace5f96c2474996e8c9",
 }
 
 // TestWorkflowTemplateMarkers_MoveWithContent enforces the binding above.
@@ -2196,9 +2313,13 @@ func TestRegenTimelineTemplate_V12_DefaultBranchIsResolvedNotHardcoded(t *testin
 		t.Errorf("regen-timeline v12 PR gate must compare the scaffolded trigger against the live " +
 			"default branch — a renamed default branch otherwise silently stops the regen forever")
 	}
-	driftBlock, _, found := strings.Cut(body, "changed=$(gh pr diff")
+	// Everything from the drift comparison up to the gate's first API call
+	// is the drift block. v15 renamed that call — the gate resolves a merge
+	// base now rather than pulling the PR's file list — so the anchor moved
+	// with it; what the block must contain is unchanged.
+	driftBlock, _, found := strings.Cut(body, `err="$(mktemp)"`)
 	if !found {
-		t.Fatalf("regen-timeline v12: could not locate the PR gate's diff call")
+		t.Fatalf("regen-timeline v15: could not locate the end of the PR gate's preamble")
 	}
 	_, driftBlock, _ = strings.Cut(driftBlock, `if [ "$SCAFFOLDED_BRANCH" != "$DEFAULT_BRANCH" ]; then`)
 	if !strings.Contains(driftBlock, "::warning") {

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -364,6 +364,49 @@ func TestRegenTimelineTemplate_V10_UnconditionalBlockingGate(t *testing.T) {
 			"merge-base-with-the-default-branch content (the SPEC §3.3 pin, and what " +
 			"`logmind warp` writes) — otherwise a drifted branch is permanently red")
 	}
+	// …and rule B's conflict-freedom is CONDITIONAL, which v15 asserted and
+	// never checked (logmind#361). Rule A above is genuinely unconditional:
+	// it leaves the HEAD side of the merge unchanged, so git takes the base's
+	// side and no state of the base branch can make it conflict. Rule B
+	// CHANGES the head side, so it is one-sided only while the base branch
+	// still holds its merge-base content — and neither merge-base moves when
+	// the base branch commits, so the arm cannot see that happen without
+	// reading the base branch's TIP.
+	//
+	// Dropping this read is not a stale-green: it is a permanent one. A
+	// `synchronize` re-run after the base branch moves recomputes the same
+	// two merge-bases and the same three blob ids, so the run stays green
+	// while `git merge` stops on a conflict marker — and two such PRs merged
+	// in sequence give one clean merge and one conflict.
+	if !strings.Contains(body, `base_tip_blob="$(blob "$BASE_REF" "$f")"`) {
+		t.Errorf("regen-timeline v15 must read the BASE BRANCH'S TIP before accepting the " +
+			"SPEC §3.3 repair — the two merge-bases are both unmoved by a commit on the base " +
+			"branch, so without this read the gate reports `the merge cannot conflict` about a " +
+			"merge that does (logmind#361)")
+	}
+	// The two states in which rule B is one-sided, and an `||` rather than an
+	// `&&`: the base has not touched the file since the merge base (only the
+	// head side changes it), OR the base has already arrived at the same
+	// content (neither side changes it). An `&&` here demands both at once,
+	// which is the strictly narrower reading — it turns the drifted
+	// integration branch of protocol#106 red again, i.e. re-opens #345.
+	if !strings.Contains(body, `if [ "$base_tip_blob" = "$base_blob" ] || [ "$base_tip_blob" = "$head_blob" ]; then`) {
+		t.Errorf("regen-timeline v15 must accept the SPEC §3.3 repair in EITHER of the two " +
+			"states that keep it one-sided (base unmoved since the merge base, or base already " +
+			"at the head's content) — an `&&` here is the narrower rule that made #345's " +
+			"drifted branch permanently red")
+	}
+	// A raced repair and a divergence are different failures with different
+	// remedies, so they get different messages. Folding the raced case into
+	// `diverged` would print a sentence that is FALSE of it — the content IS
+	// the merge-base-with-the-default-branch pin — and send the author to
+	// restore a file that is already correct.
+	if !strings.Contains(body, `raced="$raced $f"`) ||
+		!strings.Contains(body, "::error title=The base branch moved a derived doc this PR also changes::") {
+		t.Errorf("regen-timeline v15 must report a raced SPEC §3.3 repair SEPARATELY from a " +
+			"divergence — the divergence message's claim (matches neither merge base) is untrue " +
+			"of it, and its remedy (restore to the merge base) is a no-op on a file already there")
+	}
 	// Fail-closed. Two empty strings compare equal, so a blob read that
 	// failed for any reason other than "this ref does not carry the file"
 	// must abort rather than silently agree with itself.
@@ -621,7 +664,13 @@ var templateMarkerPins = map[string]struct {
 	// merge-base-with-the-default-branch content. A bump, not a repin, for
 	// the same reason — v14 is on `dev` and every repo holding it is running
 	// a gate that its own error message cannot get them out of.
-	"regen-timeline.yml.template": {"v15", "ac26c6a4dffd3e5fdff9fc7b57caa5f9bb3484bf2ff5bace5f96c2474996e8c9"},
+	// RE-PINNED, not bumped, by logmind#361: v15's gate accepted its second
+	// rule without checking the one condition that rule needs (the base
+	// branch's tip). v15 has not shipped — `dev` still carries v14 — so no
+	// repository holds the bytes this pin used to name, and minting a v16 for
+	// an edit to v15's own unreleased body would leave a v15 that existed
+	// nowhere. Same ruling as the three v13 re-pins above.
+	"regen-timeline.yml.template": {"v15", "38ebf4d4645a4b3589988c0637778082a288923d0240ec5afd28b8d4707db27b"},
 }
 
 func TestWorkflowTemplateMarkers_PinnedToContent(t *testing.T) {
@@ -1241,8 +1290,15 @@ func TestRegenTimelineWorkflow_LockstepWithTemplate(t *testing.T) {
 // read` left the workflow-level permissions block with it. B, D and F are
 // byte-for-byte v14's: nothing about how the regen job builds, checks out,
 // authenticates or pushes was touched.
+//
+// logmind#361 moved A a second time, still ONLY A. Rule B now reads the base
+// branch's TIP before accepting a repair, and a raced repair is reported
+// separately from a divergence — both inside the gate's `run:` block. B, D
+// and F did not move: the three constants below are unchanged, which is the
+// evidence that a conflict-freedom fix stayed inside the thing that decides
+// conflict-freedom.
 const (
-	digestRegionA = "b592e6f89dd32204783103f4ed47da8dd8d2091bc9f7e7a8e953c8620e58e272"
+	digestRegionA = "d263c9c4b6761e63857df19f51b88c80c5ad8167346f0c3863c241ac4d102573"
 	digestRegionB = "a3c158cdc04d4dc533c0c59bb13bf245e41798fd1c20ef2afa5793aab69d99fc"
 	digestRegionD = "7e2d788d136cdff688f698527cd505c1d70633f4134d4df2951fbff59b7fc612"
 	digestRegionF = "bbe3a145536916b0c0ae850ae84e5e5e0662554d9d7059f79d9c7cd1844e117a"
@@ -1888,8 +1944,11 @@ var bundledTemplateFingerprints = map[string]string{
 	// accepting the SPEC §3.3 repair (logmind#345). Same ordinary case, and
 	// the bump matters more than usual: a repo left on v14 keeps a gate that
 	// goes red on a drifted integration branch and rejects the only commit
-	// that could fix it.
-	"regen-timeline.yml.template": "v15:ac26c6a4dffd3e5fdff9fc7b57caa5f9bb3484bf2ff5bace5f96c2474996e8c9",
+	// that could fix it. Re-pinned WITHOUT a marker move by logmind#361 —
+	// v15's rule B now reads the base branch's tip before accepting a repair.
+	// v15 is still unshipped (`dev` carries v14), so this is the same repin
+	// case as v13's, not a skipped bump.
+	"regen-timeline.yml.template": "v15:38ebf4d4645a4b3589988c0637778082a288923d0240ec5afd28b8d4707db27b",
 }
 
 // TestWorkflowTemplateMarkers_MoveWithContent enforces the binding above.


### PR DESCRIPTION
Closes #345.

`check-derived-docs` v14 accepted exactly **one** state, so a branch that forked before the default
branch's last regen had **no commit that could pass**: `warp` writes merge-base content, the gate
demanded the tip's. v15 accepts either merge-base-derived state and compares **content**, not just a
file list.

## Two corrections to my own brief, both measured by the lane

I briefed this wrong twice. Recording it so neither error propagates.

**1. `warp.go` needs no functional change.** I claimed the doc says merge-base while the code uses the
tip, citing `:79`. That line is the *read-refresh* loop; the **repair** at `:150` already computes
`gitcli.DefaultBranchMergeBase(cwd)` and restores to it (`:162`). Field-proven: after `logmind warp` on
a drifted branch, `docs/timeline.md` is the merge-base blob `f6f715d`, not main's tip `bb23885`.
Mutating it to the tip (`mergeBase := ref`, compiles) kills four existing tests, including
`TestWarp_RepairsAlreadyDivergedBranch`. The only change to `warp.go` here is **+10 lines of Long
text**, no code.

**2. The mechanism of #345 was mis-stated, though the outcome stands.** `gh pr diff` is the forge's
**three-dot** diff, so v14's file list already *was* a merge-base comparison. Verified on protocol#106:
head blob `0d6e21b` ≠ merge-base blob `df14fab` — v14 was **right** to be red there. The real defects
are (a) only one accepted state, and (b) a remedy that named `origin/<default>` — the **tip**, which
regen rewrites on every merge.

## Tip vs merge base — merge base

SPEC §3.3: *"byte-identical to the merge-base with the default branch."* The tip is a moving target —
green at 10:00, red at 10:05 after an unrelated merge — and a tip-equal branch is exactly what
conflicts on the next merge. v15 accepts two states, both merge-base-derived: **(A)** equal to
merge-base with `base.ref`, **(B)** equal to merge-base with `default_branch`, the §3.3 pin and
precisely what `warp` writes. When base *is* default they collapse to one. That is how the gate and
`warp` stop contradicting each other.

## Content without checking out PR content (§6.3 preserved)

`compare/$BASE_REF...$HEAD_SHA --jq .merge_base_commit.sha`, then `contents/$f?ref=$X --jq .sha` — git
blob ids, i.e. content hashes. No workspace, no execution, still checkout-free. Measured fork-safe on
`cli/cli` PR #14245: both endpoints resolve a fork head SHA through the **base** repo. A non-404
failure fails **closed** (case 8). `pull-requests: read` dropped — nothing reads a PR endpoint now.

## End-to-end, scratch repo where `main` regenerates so tip ≠ merge base

| # | case | v14 | v15 |
|---|---|---|---|
| 1 | drifted dev→main | FAIL | FAIL |
| 2 | old remedy (tip-restore)→main | FAIL | FAIL |
| 3 | `logmind warp`→main | PASS | PASS |
| 4 | healthy branch→main | PASS | PASS |
| **5** | **warp'd repair off drifted dev→dev** (protocol#106) | **FAIL** | **PASS** |
| 6 | hand-edited timeline→dev | FAIL | FAIL |
| 7 | tip-restore→dev | FAIL | FAIL |
| 8 | contents API 500 | FAIL | FAIL |
| 9 | archive-only edit→main | FAIL | FAIL |

Case 5's merge was then performed for real: **CLEAN**. Rows 1, 2, 6, 7, 8, 9 are the must-stay-red
controls — v15 is not simply more permissive.

## Mutants — each compiles, each mutation grepped to confirm it landed

`G1` real v14 → row 5 · `G2` drop rule-B arm → row 5 + `templates_test.go:345` · `G3` compare vs
**tip** → rows 2,3,4,7 wrong + `:344` · `G4` swallow non-404 → row 8 + `:353` · `G5` drop archive →
row 9 + `:337` · `G6` remedy re-aimed at tip → `:361`.

`G3` initially **survived** the Go assertions; the lane added a guard pinning
`base_mb="$(merge_base "$BASE_REF")"` rather than accepting the survivor.

## Pins and verification

Marker **v14→v15**; `templateMarkerPins` and `bundledTemplateFingerprints` → `ac26c6a4…`;
`digestRegionA` → `b592e6f8…`. Regions **B/D/F unmoved** — evidence the change is confined to the gate.

`actionlint` on both copies exit 0 (control: a mutant → exit 1). `gofmt -l .` silent, `go vet ./...`
exit 0, both controlled against a known-bad. Full suite from the isolated worktree: `internal/cli
710.589s ok`, exit 0, 0 FAIL lines — the grep was controlled at 4 on a deliberately red run. All four
files restored from private copies (never `git checkout`), all MATCH.

Note this PR moves logmind's own `.github/workflows/regen-timeline.yml` in lockstep with the template,
so the pair-diff test stays honest. This PR is itself judged by the **v14** gate from the base ref.

Follow-ups filed separately: #362 (`warp` has two states where it does not produce a passing commit) and #363 (two docs still describe the gate as a file-list check).
